### PR TITLE
Add harder difficulty with longer rows and columns

### DIFF
--- a/fe/src/host/HostView.js
+++ b/fe/src/host/HostView.js
@@ -13,6 +13,10 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
 } from '@mui/material';
 import { motion, AnimatePresence } from 'framer-motion';
 import confetti from 'canvas-confetti';
@@ -23,9 +27,11 @@ import { QRCodeSVG } from 'qrcode.react';
 import '../style/animation.scss';
 import { generateRandomTable } from '../utils/utils';
 import { useWebSocket } from '../utils/WebSocketContext';
+import { DIFFICULTIES, DEFAULT_DIFFICULTY } from '../utils/consts';
 
 const HostView = ({ gameCode, users }) => {
   const ws = useWebSocket();
+  const [difficulty, setDifficulty] = useState(DEFAULT_DIFFICULTY);
   const [tableData, setTableData] = useState(generateRandomTable());
   const [timerValue, setTimerValue] = useState('');
   const [remainingTime, setRemainingTime] = useState(null);
@@ -127,7 +133,8 @@ const HostView = ({ gameCode, users }) => {
   // Timer countdown - now synced from server, no local countdown needed
 
   const startGame = () => {
-    const newTable = generateRandomTable();
+    const difficultyConfig = DIFFICULTIES[difficulty];
+    const newTable = generateRandomTable(difficultyConfig.rows, difficultyConfig.cols);
     setTableData(newTable);
     const seconds = timerValue * 60;
     setRemainingTime(seconds);
@@ -763,14 +770,14 @@ const HostView = ({ gameCode, users }) => {
             sx={{
               display: 'grid',
               gridTemplateColumns: {
-                xs: 'repeat(7, minmax(35px, 1fr))',
-                sm: 'repeat(7, 60px)',
-                md: 'repeat(7, 70px)',
+                xs: `repeat(${tableData[0]?.length || 7}, minmax(35px, 1fr))`,
+                sm: `repeat(${tableData[0]?.length || 7}, minmax(40px, 60px))`,
+                md: `repeat(${tableData[0]?.length || 7}, minmax(50px, 70px))`,
               },
               gap: { xs: '6px', sm: '10px', md: '12px' },
               marginBottom: 3,
               width: '100%',
-              maxWidth: { xs: '100%', sm: '500px', md: '580px' },
+              maxWidth: '100%',
             }}
           >
             {tableData.map((row, i) =>
@@ -783,7 +790,7 @@ const HostView = ({ gameCode, users }) => {
                     type: 'spring',
                     stiffness: 260,
                     damping: 20,
-                    delay: (i * 7 + j) * 0.02,
+                    delay: (i * row.length + j) * 0.02,
                   }}
                   whileHover={{ scale: 1.1, rotate: 5 }}
                 >
@@ -819,6 +826,20 @@ const HostView = ({ gameCode, users }) => {
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 200 }}>
             {!gameStarted ? (
               <>
+                <FormControl fullWidth>
+                  <InputLabel>רמת קושי</InputLabel>
+                  <Select
+                    value={difficulty}
+                    label="רמת קושי"
+                    onChange={(e) => setDifficulty(e.target.value)}
+                  >
+                    {Object.keys(DIFFICULTIES).map((key) => (
+                      <MenuItem key={key} value={key}>
+                        {DIFFICULTIES[key].name} ({DIFFICULTIES[key].rows}x{DIFFICULTIES[key].cols})
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
                 <TextField
                   label="טיימר (דקות)"
                   variant="outlined"

--- a/fe/src/player/PlayerView.js
+++ b/fe/src/player/PlayerView.js
@@ -406,13 +406,13 @@ const PlayerView = ({ onShowResults }) => {
               sx={{
                 display: 'grid',
                 gridTemplateColumns: {
-                  xs: 'repeat(7, minmax(35px, 1fr))',
-                  sm: 'repeat(7, 50px)',
-                  md: 'repeat(7, 60px)',
+                  xs: `repeat(${letterGrid[0]?.length || 7}, minmax(35px, 1fr))`,
+                  sm: `repeat(${letterGrid[0]?.length || 7}, minmax(40px, 50px))`,
+                  md: `repeat(${letterGrid[0]?.length || 7}, minmax(45px, 60px))`,
                 },
                 gap: { xs: '6px', sm: '8px' },
                 width: '100%',
-                maxWidth: { xs: '100%', sm: '400px', md: '480px' },
+                maxWidth: '100%',
               }}
             >
               {letterGrid.map((row, i) =>

--- a/fe/src/utils/consts.js
+++ b/fe/src/utils/consts.js
@@ -22,4 +22,14 @@ export const hebrewLetters = [
     "ש",
     "ת",
   ];
+
+export const DIFFICULTIES = {
+  EASY: { name: 'קל', rows: 4, cols: 4, label: 'Easy (4x4)' },
+  MEDIUM: { name: 'בינוני', rows: 5, cols: 5, label: 'Medium (5x5)' },
+  HARD: { name: 'קשה', rows: 7, cols: 7, label: 'Hard (7x7)' },
+  EXPERT: { name: 'מומחה', rows: 9, cols: 9, label: 'Expert (9x9)' },
+  MASTER: { name: 'אמן', rows: 11, cols: 11, label: 'Master (11x11)' },
+};
+
+export const DEFAULT_DIFFICULTY = 'HARD';
   

--- a/fe/src/utils/utils.js
+++ b/fe/src/utils/utils.js
@@ -1,10 +1,16 @@
-import { hebrewLetters } from "./consts";
+import { hebrewLetters, DIFFICULTIES, DEFAULT_DIFFICULTY } from "./consts";
 
-export function generateRandomTable() {
+export function generateRandomTable(rows = null, cols = null) {
+    // Use default difficulty if no rows/cols specified
+    if (rows === null || cols === null) {
+      rows = DIFFICULTIES[DEFAULT_DIFFICULTY].rows;
+      cols = DIFFICULTIES[DEFAULT_DIFFICULTY].cols;
+    }
+
     const newTable = [];
-    for (let i = 0; i < 7; i++) {
+    for (let i = 0; i < rows; i++) {
       const row = [];
-      for (let j = 0; j < 7; j++) {
+      for (let j = 0; j < cols; j++) {
         const randomLetter = hebrewLetters[Math.floor(Math.random() * hebrewLetters.length)];
         row.push(randomLetter);
       }


### PR DESCRIPTION
Implemented multiple difficulty levels with different board dimensions:
- Easy: 4x4
- Medium: 5x5
- Hard: 7x7 (default, maintains backward compatibility)
- Expert: 9x9
- Master: 11x11

Changes:
- Added DIFFICULTIES configuration with Hebrew labels in consts.js
- Updated generateRandomTable() to accept rows/cols parameters
- Added difficulty selector dropdown in Host UI before game start
- Made board grid display dynamic in both Host and Player views
- Backend already supports variable board sizes (uses dynamic rows/cols)

The difficulty selector allows hosts to choose the board size before starting a game, providing more challenge options for players.