### PR TITLE
Fix RateLimiter initialization error

### DIFF
--- a/be/server.js
+++ b/be/server.js
@@ -7,6 +7,7 @@ const path = require("path");
 const cors = require("cors");
 const { initRedis, closeRedis } = require("./redisClient");
 const dictionary = require("./dictionary");
+const RateLimiter = require("./utils/rateLimiter");
 
 const app = express();
 const server = http.createServer(app);
@@ -67,7 +68,6 @@ const {
   handleCloseRoom,
   handleResetGame,
 } = require("./handlers");
-const RateLimiter = require("./utils/rateLimiter");
 
 // Heartbeat mechanism to keep connections alive
 const heartbeatInterval = 30000; // 30 seconds


### PR DESCRIPTION
…ceError

The RateLimiter class was being instantiated on line 45 before being imported on line 70, causing a "Cannot access 'RateLimiter' before initialization" error that crashed the deployment. Moved the import statement to the top with other dependencies to resolve the initialization order issue.