### PR TITLE
fix: Handle game end properly with timer reset and results display

### DIFF
--- a/be/handlers.js
+++ b/be/handlers.js
@@ -356,6 +356,12 @@ const handleEndGame = (host) => {
     words: games[gameCode].playerWordDetails[username]
   }));
 
+  // Send final time update to ensure all clients show 0:00
+  sendAllPlayerAMessage(gameCode, {
+    action: "timeUpdate",
+    remainingTime: 0
+  });
+
   sendAllPlayerAMessage(gameCode, { action: "endGame" });
   sendAllPlayerAMessage(gameCode, {
     action: "finalScores",

--- a/fe/src/player/PlayerView.jsx
+++ b/fe/src/player/PlayerView.jsx
@@ -197,6 +197,19 @@ const PlayerView = ({ onShowResults, initialPlayers = [], username, gameCode }) 
           }, 2000);
           break;
 
+        case 'finalScores':
+          setWaitingForResults(false);
+          toast.success(t('playerView.scoresReady'), { duration: 2000 });
+          setTimeout(() => {
+            if (onShowResults) {
+              onShowResults({
+                scores: message.scores,
+                letterGrid: letterGrid,
+              });
+            }
+          }, 2000);
+          break;
+
         case 'hostLeftRoomClosing':
           clearSession();
           toast.error(message.message || t('playerView.roomClosed'), {


### PR DESCRIPTION
Fixed bug where players stayed on game screen with full timer without indication they were waiting for results.

Changes:
- Added 'finalScores' WebSocket handler in PlayerView to match backend action name
- Added explicit timeUpdate message with remainingTime: 0 in backend handleEndGame to ensure all clients show 0:00 timer
- Ensures smooth transition from game end to results display

This resolves the action name mismatch between backend ('finalScores') and frontend (only handled 'validatedScores'), and eliminates race conditions with timer updates.