### PR TITLE
Add Swedish UI and fix language display

### DIFF
--- a/fe-next/components/Header.jsx
+++ b/fe-next/components/Header.jsx
@@ -14,7 +14,8 @@ const Header = ({ className = '' }) => {
 
     const languages = [
         { code: 'en', name: 'English', flag: '🇺🇸' },
-        { code: 'he', name: 'עברית', flag: '🇮🇱' }
+        { code: 'he', name: 'עברית', flag: '🇮🇱' },
+        { code: 'sv', name: 'Svenska', flag: '🇸🇪' }
     ];
 
     const currentLang = languages.find(l => l.code === language) || languages[0];

--- a/fe-next/host/HostView.jsx
+++ b/fe-next/host/HostView.jsx
@@ -381,7 +381,7 @@ const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [
     if (!word.trim() || !gameStarted || !hostPlaying) return;
 
     const currentLang = roomLanguage;
-    const regex = currentLang === 'he' ? /^[\u0590-\u05FF]+$/ : /^[a-zA-Z]+$/;
+    const regex = currentLang === 'he' ? /^[\u0590-\u05FF]+$/ : currentLang === 'sv' ? /^[a-zA-ZåäöÅÄÖ]+$/ : /^[a-zA-Z]+$/;
     const trimmedWord = word.trim();
 
     // Min length validation
@@ -798,7 +798,7 @@ const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [
             {!gameStarted && (
               <div className="mb-4 flex justify-center">
                 <Badge variant="outline" className="text-lg px-4 py-1 border-cyan-500/50 text-cyan-600 dark:text-cyan-300">
-                  {roomLanguage === 'he' ? '🇮🇱 עברית' : '🇺🇸 English'}
+                  {roomLanguage === 'he' ? '🇮🇱 עברית' : roomLanguage === 'sv' ? '🇸🇪 Svenska' : '🇺🇸 English'}
                 </Badge>
               </div>
             )}
@@ -935,7 +935,7 @@ const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [
                     onWordSubmit={(formedWord) => {
                       if (!hostPlaying) return;
 
-                      const regex = roomLanguage === 'he' ? /^[\u0590-\u05FF]+$/ : /^[a-zA-Z]+$/;
+                      const regex = roomLanguage === 'he' ? /^[\u0590-\u05FF]+$/ : roomLanguage === 'sv' ? /^[a-zA-ZåäöÅÄÖ]+$/ : /^[a-zA-Z]+$/;
 
                       if (formedWord.length < 2) {
                         toast.error(t('playerView.wordTooShort'), { duration: 1000, icon: '⚠️' });


### PR DESCRIPTION
- Add Swedish language option to Header language selector dropdown
- Fix HostView to display "🇸🇪 Svenska" badge for Swedish rooms
- Add Swedish character support (åäöÅÄÖ) to word validation regex in HostView
- Ensure host can submit Swedish words with special characters

This resolves the issue where Swedish rooms showed "English" as the language and ensures all UI components properly support Swedish.