### PR TITLE
Fix achievement tooltips and unnecessary reload prompts

### DIFF
--- a/fe-next/components/AchievementBadge.jsx
+++ b/fe-next/components/AchievementBadge.jsx
@@ -1,37 +1,42 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Badge } from './ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 
-export const AchievementBadge = ({ achievement, index = 0 }) => (
-  <TooltipProvider delayDuration={0}>
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <motion.div
-          initial={{ scale: 0, rotate: -180 }}
-          animate={{ scale: 1, rotate: 0 }}
-          transition={{ delay: index * 0.05 }}
-          whileHover={{ scale: 1.1, rotate: 5 }}
-          whileTap={{ scale: 1.1 }}
+export const AchievementBadge = ({ achievement, index = 0 }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip open={open} onOpenChange={setOpen}>
+        <TooltipTrigger asChild>
+          <motion.div
+            initial={{ scale: 0, rotate: -180 }}
+            animate={{ scale: 1, rotate: 0 }}
+            transition={{ delay: index * 0.05 }}
+            whileHover={{ scale: 1.1, rotate: 5 }}
+            whileTap={{ scale: 1.1 }}
+            onClick={() => setOpen(!open)}
+          >
+            <Badge className="px-4 py-2 text-sm text-white bg-gradient-to-r from-cyan-400 to-purple-500
+                            hover:from-cyan-500 hover:to-purple-600
+                            active:from-cyan-500 active:to-purple-600
+                            transition-all cursor-pointer shadow-lg touch-manipulation">
+              {achievement.icon} {achievement.name}
+            </Badge>
+          </motion.div>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          sideOffset={5}
+          className="z-50"
         >
-          <Badge className="px-4 py-2 text-sm text-white bg-gradient-to-r from-cyan-400 to-purple-500
-                          hover:from-cyan-500 hover:to-purple-600
-                          active:from-cyan-500 active:to-purple-600
-                          transition-all cursor-pointer shadow-lg touch-manipulation">
-            {achievement.icon} {achievement.name}
-          </Badge>
-        </motion.div>
-      </TooltipTrigger>
-      <TooltipContent
-        side="top"
-        sideOffset={5}
-        className="z-50"
-      >
-        <div>
-          <p className="font-bold">{achievement.name}</p>
-          <p className="text-xs">{achievement.description}</p>
-        </div>
-      </TooltipContent>
-    </Tooltip>
-  </TooltipProvider>
-);
+          <div>
+            <p className="font-bold">{achievement.name}</p>
+            <p className="text-xs">{achievement.description}</p>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/fe-next/host/HostView.jsx
+++ b/fe-next/host/HostView.jsx
@@ -29,6 +29,7 @@ import { cn } from '../lib/utils';
 const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [] }) => {
   const { t, language } = useLanguage();
   const ws = useWebSocket();
+  const intentionalExitRef = useRef(false);
   const [difficulty, setDifficulty] = useState(DEFAULT_DIFFICULTY);
   const [tableData, setTableData] = useState(generateRandomTable());
   const [timerValue, setTimerValue] = useState('1');
@@ -120,6 +121,9 @@ const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [
     if (!shouldWarn) return;
 
     const handleBeforeUnload = (e) => {
+      // Don't show warning if user is intentionally exiting
+      if (intentionalExitRef.current) return;
+
       e.preventDefault();
       e.returnValue = ''; // Chrome requires returnValue to be set
       return ''; // Some browsers require a return value
@@ -226,6 +230,7 @@ const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [
           break;
 
         case 'roomClosedDueToInactivity':
+          intentionalExitRef.current = true;
           toast.error(message.message || 'החדר נסגר עקב חוסר פעילות', {
             icon: '⏰',
             duration: 5000,
@@ -336,6 +341,7 @@ const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [
 
   const handleExitRoom = () => {
     if (window.confirm(t('hostView.confirmExit'))) {
+      intentionalExitRef.current = true;
       // Clear session cookie
       clearSession();
       // Send close room message to server first

--- a/fe-next/player/PlayerView.jsx
+++ b/fe-next/player/PlayerView.jsx
@@ -23,6 +23,7 @@ const PlayerView = ({ onShowResults, initialPlayers = [], username, gameCode }) 
   const ws = useWebSocket();
   const inputRef = useRef(null);
   const wordListRef = useRef(null);
+  const intentionalExitRef = useRef(false);
 
   const [word, setWord] = useState('');
   const [foundWords, setFoundWords] = useState([]);
@@ -116,6 +117,9 @@ const PlayerView = ({ onShowResults, initialPlayers = [], username, gameCode }) 
     if (!shouldWarn) return;
 
     const handleBeforeUnload = (e) => {
+      // Don't show warning if user is intentionally exiting
+      if (intentionalExitRef.current) return;
+
       e.preventDefault();
       e.returnValue = ''; // Chrome requires returnValue to be set
       return ''; // Some browsers require a return value
@@ -245,6 +249,7 @@ const PlayerView = ({ onShowResults, initialPlayers = [], username, gameCode }) 
           break;
 
         case 'hostLeftRoomClosing':
+          intentionalExitRef.current = true;
           clearSession();
           toast.error(message.message || t('playerView.roomClosed'), {
             icon: '🚪',
@@ -364,6 +369,7 @@ const PlayerView = ({ onShowResults, initialPlayers = [], username, gameCode }) 
 
   const handleExitRoom = () => {
     if (window.confirm(t('playerView.exitConfirmation'))) {
+      intentionalExitRef.current = true;
       clearSession();
       ws.close();
       window.location.reload();


### PR DESCRIPTION
- Make achievement tooltips work with click/tap on mobile devices by adding controlled state
- Remove unnecessary reload prompts when user intentionally exits room
- Add intentionalExitRef to track when user confirms exit, preventing double confirmation
- Apply fix to both PlayerView and HostView for consistent behavior
- Also suppress reload prompts for forced exits (host left, inactivity timeout)