### PR TITLE
Fix Japanese achievement translations

### DIFF
--- a/fe-next/backend/modules/achievementManager.js
+++ b/fe-next/backend/modules/achievementManager.js
@@ -19,7 +19,7 @@ const ACHIEVEMENT_ICONS = {
 
 // Get localized achievements based on locale
 const getLocalizedAchievements = (locale = 'he') => {
-  const supportedLocale = ['he', 'en', 'sv'].includes(locale) ? locale : 'he';
+  const supportedLocale = ['he', 'en', 'sv', 'ja'].includes(locale) ? locale : 'he';
   const t = translations[supportedLocale].achievements;
 
   const achievements = {};


### PR DESCRIPTION
Previously, when the game was set to Japanese language, achievements would display in Hebrew because the achievementManager only supported 'he', 'en', and 'sv' locales. This fix adds 'ja' to the supported locales array, allowing Japanese achievements to display correctly.

All Japanese achievement translations are already present in the translations file and are verified to be correct.