### PR TITLE
Fix Next.js Turbopack build error

### DIFF
--- a/fe-next/components/GridComponent.jsx
+++ b/fe-next/components/GridComponent.jsx
@@ -584,6 +584,7 @@ const GridComponent = ({
                                         </>
                                     )}
                                 </>
+                            </>
                             )}
                             {cell}
                         </motion.div>


### PR DESCRIPTION
Fixed Turbopack build error by adding the missing </> closing tag for the outer fragment in the isSelected conditional block. The JSX structure had nested fragments that weren't properly closed, causing a parsing error at line 587.