### PR TITLE
Fix gRPC server closing unexpectedly

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,13 +2,17 @@
 
 ## Fixing BuildKit Connection Errors
 
-If you encounter the error:
+If you encounter errors like:
+```
+bc.Build: failed to solve: frontend grpc server closed unexpectedly
+```
+or
 ```
 bc.Build: listing workers for Build: failed to list workers: Unavailable: connection error:
 desc = "error reading server preface: read unix @->/run/buildkit/buildkitd.sock: use of closed network connection"
 ```
 
-This indicates Docker is trying to connect to a BuildKit daemon that's unavailable. Use the solutions below.
+These indicate Docker/BuildKit is experiencing gRPC server crashes or daemon connection issues. Use the solutions below.
 
 ---
 
@@ -139,17 +143,20 @@ export DOCKER_BUILDKIT=0
 
 ### Render.com
 
-The `render.yaml` is configured to use Docker builds by default:
+**Current Configuration:** The `render.yaml` is now configured to use Node.js environment directly to avoid BuildKit gRPC server crashes:
 
 ```yaml
 services:
   - type: web
     name: boggle-game
-    env: docker
-    dockerfilePath: ./Dockerfile
+    env: node
+    buildCommand: npm install && npm run build
+    startCommand: npm start
 ```
 
-If Docker builds fail on Render, uncomment the Node.js alternative in `render.yaml`.
+**Why this works:** This bypasses Docker/BuildKit entirely and builds the application directly with npm, which is more reliable and faster for Node.js applications on Render.
+
+**Alternative:** If you want to use Docker builds (commented out in `render.yaml`), uncomment the Docker service and comment out the Node.js service. However, this may be prone to BuildKit gRPC errors.
 
 ### Railway.app
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,9 +1,11 @@
 services:
+  # Node.js environment (direct build without Docker)
+  # This bypasses Docker/BuildKit to avoid gRPC server issues
   - type: web
     name: boggle-game
-    env: docker
-    dockerfilePath: ./Dockerfile
-    dockerContext: .
+    env: node
+    buildCommand: npm install && npm run build
+    startCommand: npm start
     envVars:
       - key: NODE_ENV
         value: production
@@ -12,13 +14,13 @@ services:
       - key: HOST
         value: 0.0.0.0
 
-  # Alternative: Node.js environment (without Docker)
-  # Uncomment this and comment out the docker service above if Docker builds fail
+  # Docker environment (disabled due to BuildKit gRPC server crashes)
+  # Uncomment this and comment out the node service above if you want to use Docker
   # - type: web
   #   name: boggle-game
-  #   env: node
-  #   buildCommand: npm install && npm run build
-  #   startCommand: npm start
+  #   env: docker
+  #   dockerfilePath: ./Dockerfile
+  #   dockerContext: .
   #   envVars:
   #     - key: NODE_ENV
   #       value: production


### PR DESCRIPTION
…PC crash

This commit resolves the error:
"bc.Build: failed to solve: frontend grpc server closed unexpectedly"

Changes:
- Update render.yaml to use Node.js environment instead of Docker
- Bypass Docker/BuildKit entirely to avoid gRPC server crashes
- Update BUILD.md with gRPC error documentation and solution
- Keep Docker configuration available as commented alternative

The Node.js environment builds directly with npm using the root package.json scripts, which handle the fe-next directory structure correctly. This is more reliable and faster for Node.js deployments on Render.

Build commands:
- buildCommand: npm install && npm run build
- startCommand: npm start