### PR TITLE
Fix room entry flow for invited users

### DIFF
--- a/fe-next/host/HostView.jsx
+++ b/fe-next/host/HostView.jsx
@@ -518,9 +518,9 @@ const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [
 
       {/* Validation Modal */}
       <Dialog open={showValidation} onOpenChange={setShowValidation}>
-        <DialogContent className="max-w-4xl max-h-[90vh] overflow-auto">
+        <DialogContent className="max-w-4xl max-h-[90vh] overflow-auto bg-white dark:bg-slate-800 border-indigo-500/30">
           <DialogHeader>
-            <DialogTitle className="text-center text-2xl sm:text-3xl text-indigo-600 font-bold">
+            <DialogTitle className="text-center text-2xl sm:text-3xl text-indigo-600 dark:text-indigo-400 font-bold">
               ✅ {t('hostView.validation')}
             </DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
- Auto-join room when player has name already set via invitation link
- Keep simple name entry UI for players without saved username
- Make validation screen opaque (solid background instead of transparent)
- Fix: Show 'waiting for new game' instead of 'calculating scores' when player joins after game ended (track participation with wasInActiveGame flag)