### PR TITLE
Reactivate room when host returns to browser

### DIFF
--- a/fe-next/server.js
+++ b/fe-next/server.js
@@ -25,6 +25,8 @@ const {
   handleResetGame,
   broadcastActiveRooms,
   handleChatMessage,
+  handleHostReactivate,
+  handleHostKeepAlive,
 } = require("./backend/handlers");
 
 const dev = process.env.NODE_ENV !== "production";
@@ -172,6 +174,12 @@ app.prepare().then(() => {
             break;
           case "chatMessage":
             handleChatMessage(ws, message.gameCode, message.username, message.message, message.isHost);
+            break;
+          case "hostReactivate":
+            handleHostReactivate(ws, message.gameCode, wss);
+            break;
+          case "hostKeepAlive":
+            handleHostKeepAlive(ws, message.gameCode, wss);
             break;
           default:
             console.warn(`Unknown action: ${action}`);

--- a/fe-next/utils/session.js
+++ b/fe-next/utils/session.js
@@ -10,6 +10,7 @@ const SESSION_EXPIRY_HOURS = 2; // Session expires after 2 hours
  * @param {string} session.username - The username (for players)
  * @param {boolean} session.isHost - Whether the user is a host
  * @param {string} session.roomName - The room name (for hosts)
+ * @param {string} session.language - The room language
  */
 export const saveSession = (session) => {
   const sessionData = {
@@ -17,6 +18,7 @@ export const saveSession = (session) => {
     username: session.username,
     isHost: session.isHost,
     roomName: session.roomName,
+    language: session.language,
     timestamp: Date.now(),
   };
 


### PR DESCRIPTION
- Add host visibility change detection to reactivate room when host returns
- Keep room active for 2 minutes even when host is inactive (grace period)
- Auto-redirect host from different tab to their open room via session
- Fix invitation redirect for reconnecting players with existing names
- Add hostReactivate and hostKeepAlive WebSocket actions
- Include room language in join response for proper reconnection
- Fix auto-join effect to properly trigger when WebSocket becomes ready