### PR TITLE
Fix player state after game ends

### DIFF
--- a/fe-next/JoinView.jsx
+++ b/fe-next/JoinView.jsx
@@ -256,7 +256,7 @@ const JoinView = ({ handleJoin, gameCode, username, setGameCode, setUsername, er
                     className="w-full h-14 text-xl font-bold bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-400 hover:to-emerald-500 hover:shadow-[0_0_25px_rgba(34,197,94,0.5)] transition-all"
                   >
                     <FaGamepad className="mr-3" size={24} />
-                    {t('joinView.enterRoom')}
+                    {t('joinView.joinGame')}
                   </Button>
                 </motion.div>
 

--- a/fe-next/app/[locale]/page.jsx
+++ b/fe-next/app/[locale]/page.jsx
@@ -305,6 +305,17 @@ export default function GamePage() {
       });
     });
 
+    // Handle game reset - keep players in the room for new game
+    newSocket.on('resetGame', () => {
+      console.log('[SOCKET.IO] Game reset - staying in room for new game');
+      setShowResults(false);
+      setResultsData(null);
+      toast.success(t('hostView.newGameReady') || 'New game ready!', {
+        icon: '🎮',
+        duration: 3000,
+      });
+    });
+
     newSocket.on('hostLeftRoomClosing', (data) => {
       toast.error(data.message || t('playerView.roomClosed'), {
         icon: '🚪',

--- a/fe-next/host/HostView.jsx
+++ b/fe-next/host/HostView.jsx
@@ -1059,7 +1059,7 @@ const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [
                   setPlayerWords([]);
                   setPlayerWordCounts({});
 
-                  setTimerValue('');
+                  setTimerValue('1');
 
                   toast.success(`${t('hostView.newGameReady')} 🎮`, {
                     icon: '🔄',
@@ -1211,6 +1211,11 @@ const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [
                         type="number"
                         value={timerValue}
                         onChange={(e) => setTimerValue(e.target.value)}
+                        onBlur={(e) => {
+                          const val = parseInt(e.target.value) || 0;
+                          if (val < 1) setTimerValue('1');
+                        }}
+                        min="1"
                         className="h-10 w-16 text-center text-lg font-bold border-none bg-transparent text-slate-900 dark:text-white placeholder:text-slate-500 focus-visible:ring-0 p-0"
                         placeholder="1"
                       />

--- a/fe-next/translations/index.js
+++ b/fe-next/translations/index.js
@@ -129,6 +129,7 @@ export const translations = {
       welcomeBack: 'Welcome back',
       connectingToRoom: 'Connecting to room...',
       enterRoom: 'Enter Room',
+      joinGame: 'Join Game',
     },
     hostView: {
       waitingForPlayers: 'Waiting for players...',
@@ -499,6 +500,7 @@ export const translations = {
       welcomeBack: 'ברוך שובך',
       connectingToRoom: 'מתחבר לחדר...',
       enterRoom: 'כניסה לחדר',
+      joinGame: 'הצטרף למשחק',
     },
     hostView: {
       waitingForPlayers: 'ממתין לשחקנים...',
@@ -869,6 +871,7 @@ export const translations = {
       welcomeBack: 'Välkommen tillbaka',
       connectingToRoom: 'Ansluter till rummet...',
       enterRoom: 'Gå in i rummet',
+      joinGame: 'Gå med i spelet',
     },
     hostView: {
       waitingForPlayers: 'Väntar på spelare...',
@@ -1239,6 +1242,7 @@ export const translations = {
       welcomeBack: 'おかえりなさい',
       connectingToRoom: 'ルームに接続中...',
       enterRoom: 'ルームに入る',
+      joinGame: 'ゲームに参加',
     },
     hostView: {
       waitingForPlayers: 'プレイヤーを待っています...',


### PR DESCRIPTION
- Add resetGame socket handler in page.jsx to ensure players stay in room after game ends and are ready for new game (instead of showing waiting screen)
- Fix timer input to default to 1 minute after game ends (was empty)
- Add onBlur validation to timer input to ensure minimum value of 1
- Update simplified join UI button text from "Enter Room" to "Join Game"
- Add joinGame translations for all 4 languages (en, he, sv, ja)