### PR TITLE
Fix axis lock word selection direction

### DIFF
--- a/fe-next/components/GridComponent.jsx
+++ b/fe-next/components/GridComponent.jsx
@@ -201,8 +201,8 @@ const GridComponent = ({
         const cells = [];
         const sign = forward ? 1 : -1;
         for (let i = 0; i < numCells; i++) {
-            const row = startRow + (i * dRow * sign);
-            const col = startCol + (i * dCol * sign);
+            const row = startRow - (i * dRow * sign);
+            const col = startCol - (i * dCol * sign);
             if (row < 0 || row >= grid.length || col < 0 || col >= grid[0].length) break;
             cells.push({ row, col, letter: grid[row][col] });
         }


### PR DESCRIPTION
Fixed the axis lock feature to select cells in the correct direction. Previously, when players dragged in a direction (up, down, left, right, or diagonal), the selection would occur in the opposite direction.

Changed the getCellsAlongDirection function to subtract instead of add the directional offset, which inverts the selection to match the actual drag direction.

This enables proper word selection in all 8 directions: up, down, left, right, and all diagonal combinations.