### PR TITLE
Fix word selection marking direction issue

### DIFF
--- a/fe-next/components/GridComponent.jsx
+++ b/fe-next/components/GridComponent.jsx
@@ -201,8 +201,8 @@ const GridComponent = ({
         const cells = [];
         const sign = forward ? 1 : -1;
         for (let i = 0; i < numCells; i++) {
-            const row = startRow - (i * dRow * sign);
-            const col = startCol - (i * dCol * sign);
+            const row = startRow + (i * dRow * sign);
+            const col = startCol + (i * dCol * sign);
             if (row < 0 || row >= grid.length || col < 0 || col >= grid[0].length) break;
             cells.push({ row, col, letter: grid[row][col] });
         }


### PR DESCRIPTION
The getCellsAlongDirection function was using subtraction instead of addition, causing word selection to go in the opposite direction from the player's swipe gesture. Changed operators from - to + to align selection with actual swipe direction.

- Swipe DOWN now correctly selects cells downward (higher row indices)
- Swipe RIGHT now correctly selects cells rightward (higher col indices)
- All 8 directional selections now work as expected