### PR TITLE
Fix marking words direction logic

### DIFF
--- a/fe-next/components/GridComponent.jsx
+++ b/fe-next/components/GridComponent.jsx
@@ -199,7 +199,7 @@ const GridComponent = ({
     // Calculate cells along direction from start
     const getCellsAlongDirection = useCallback((startRow, startCol, dRow, dCol, numCells, forward) => {
         const cells = [];
-        const sign = forward ? 1 : -1;
+        const sign = forward ? -1 : 1;
         for (let i = 0; i < numCells; i++) {
             const row = startRow + (i * dRow * sign);
             const col = startCol + (i * dCol * sign);


### PR DESCRIPTION
Changed the sign logic in getCellsAlongDirection so that when the user swipes in a direction, cells are selected in that same direction relative to the visual display. Previously the selection was going opposite to the user's swipe gesture.

Inverted the forward/backward sign: forward now uses -1 and backward uses 1, which correctly aligns the cell selection with the player's input direction.