### PR TITLE
Fix word marking direction mechanism

### DIFF
--- a/fe-next/components/GridComponent.jsx
+++ b/fe-next/components/GridComponent.jsx
@@ -152,6 +152,17 @@ const GridComponent = ({
     };
 
     // Get direction vectors for a snapped angle
+    //
+    // dx, dy: Viewport coordinates (screen space)
+    //   - Positive dx = right, negative dx = left
+    //   - Positive dy = down, negative dy = up
+    //
+    // dRow, dCol: Grid coordinates (array indices)
+    //   - Positive dRow = down (increasing row index)
+    //   - Positive dCol = right (increasing column index)
+    //
+    // These are aligned so that moving in (dx, dy) direction in viewport
+    // corresponds to moving in (dRow, dCol) direction in the grid.
     const getDirectionFromAngle = (angle) => {
         const directions = {
             0:   { dx: 1,  dy: 0,  dRow: 0,  dCol: 1  },  // Right
@@ -174,6 +185,15 @@ const GridComponent = ({
     };
 
     // Project touch onto locked axis
+    //
+    // Returns the projection of the touch point onto the locked axis, plus the
+    // signed distance along the axis from the start point.
+    //
+    // distance > 0: Touch is on the "forward" side (in direction of dx, dy)
+    // distance < 0: Touch is on the "backward" side (opposite to dx, dy)
+    //
+    // This allows bi-directional selection: user can extend in either direction
+    // along the locked axis.
     const projectOntoAxis = (touchX, touchY, startX, startY, dirX, dirY) => {
         const vecX = touchX - startX;
         const vecY = touchY - startY;
@@ -197,9 +217,16 @@ const GridComponent = ({
     }, [grid]);
 
     // Calculate cells along direction from start
+    // The 'forward' flag indicates whether the user is swiping in the positive direction
+    // of the locked axis (projection.distance >= 0) or in the negative direction.
+    //
+    // When forward = true:  sign = 1  → select cells in direction of (dRow, dCol)
+    // When forward = false: sign = -1 → select cells opposite to (dRow, dCol)
+    //
+    // This ensures cells are selected in the same direction the user is swiping.
     const getCellsAlongDirection = useCallback((startRow, startCol, dRow, dCol, numCells, forward) => {
         const cells = [];
-        const sign = forward ? -1 : 1;
+        const sign = forward ? 1 : -1;
         for (let i = 0; i < numCells; i++) {
             const row = startRow + (i * dRow * sign);
             const col = startCol + (i * dCol * sign);


### PR DESCRIPTION
The sign calculation in getCellsAlongDirection was inverted, causing cells to be selected in the opposite direction of the user's swipe.

Changed from: sign = forward ? -1 : 1
Changed to:   sign = forward ? 1 : -1

When forward=true (user swiping in the direction of the locked axis), sign should be 1 to select cells in that same direction (dRow, dCol). When forward=false (user backtracking), sign should be -1 to select cells in the opposite direction.

Also added comprehensive documentation explaining:
- Viewport coordinates (dx, dy) vs grid coordinates (dRow, dCol)
- How projection distance indicates forward/backward movement
- How the sign affects cell selection direction