### PR TITLE
Fix reversed marking letters in game

### DIFF
--- a/fe-next/components/GridComponent.jsx
+++ b/fe-next/components/GridComponent.jsx
@@ -57,8 +57,11 @@ const GridComponent = ({
         const cellsToFade = [...selectedCells];
         setFadingCells(cellsToFade);
 
-        // Fade out each cell sequentially in the order they were marked
-        cellsToFade.forEach((cell, index) => {
+        // Fade out each cell sequentially from END to START (reverse order)
+        // This creates a "retracting trail" effect from where the finger lifted
+        // back to where the swipe began, which feels more natural
+        const reversedCells = [...cellsToFade].reverse();
+        reversedCells.forEach((cell, index) => {
             setTimeout(() => {
                 setFadingCells(prev => prev.filter(c => !(c.row === cell.row && c.col === cell.col)));
             }, index * 80); // 80ms delay between each cell fade


### PR DESCRIPTION
The sequential fade-out animation was fading cells from start-to-end (in the order they were selected), which created a visual effect that appeared "reversed" especially for vertical and diagonal swipes.

Changed the animation to fade from END to START, creating a natural "retracting trail" effect where the trail disappears from where the user's finger lifted back towards where they started swiping.

This addresses the root cause of the perceived reversed marking for vertical and diagonal swipes.