### PR TITLE
Fix inverted letter marking direction on drag

### DIFF
--- a/fe-next/components/GridComponent.jsx
+++ b/fe-next/components/GridComponent.jsx
@@ -223,13 +223,15 @@ const GridComponent = ({
     // The 'forward' flag indicates whether the user is swiping in the positive direction
     // of the locked axis (projection.distance >= 0) or in the negative direction.
     //
-    // When forward = true:  sign = 1  → select cells in direction of (dRow, dCol)
-    // When forward = false: sign = -1 → select cells opposite to (dRow, dCol)
+    // When forward = true:  sign = -1 → select cells opposite to (dRow, dCol)
+    // When forward = false: sign = 1  → select cells in direction of (dRow, dCol)
     //
-    // This ensures cells are selected in the same direction the user is swiping.
+    // The sign is inverted because the projection distance increases in the
+    // direction of the locked axis (dRow, dCol), but visually the user expects
+    // cells to be selected in the direction they are swiping.
     const getCellsAlongDirection = useCallback((startRow, startCol, dRow, dCol, numCells, forward) => {
         const cells = [];
-        const sign = forward ? 1 : -1;
+        const sign = forward ? -1 : 1;
         for (let i = 0; i < numCells; i++) {
             const row = startRow + (i * dRow * sign);
             const col = startCol + (i * dCol * sign);


### PR DESCRIPTION
The sign calculation in getCellsAlongDirection was causing cells to be selected in the opposite direction of the user's swipe. When dragging right, cells were being marked to the left, and vice versa.

Changed from: sign = forward ? 1 : -1
Changed to:   sign = forward ? -1 : 1

This inverts the selection direction to match the user's visual expectation - dragging right selects cells to the right, dragging left selects cells to the left, etc.