### PR TITLE
Fix Supabase config parsing error

### DIFF
--- a/fe-next/supabase/config.toml
+++ b/fe-next/supabase/config.toml
@@ -1,9 +1,6 @@
 # Supabase Configuration
 # https://supabase.com/docs/guides/cli/config
 
-[project]
-id = "hdtmpkicuxvtmvrmtybx"  # Your Supabase project ID
-
 [api]
 enabled = true
 port = 54321


### PR DESCRIPTION
The [project] section with id is not a valid configuration key in Supabase CLI config.toml. The project ID should be provided via --project-ref flag when linking, not in the config file.