### PR TITLE
Update baseline-browser-mapping dependency

### DIFF
--- a/fe-next/lib/ai-service.ts
+++ b/fe-next/lib/ai-service.ts
@@ -348,7 +348,7 @@ class GameAIService {
       return validated;
     } catch (error) {
       if (error instanceof z.ZodError) {
-        console.error('[GameAIService] AI response schema validation failed:', error.errors);
+        console.error('[GameAIService] AI response schema validation failed:', error.issues);
         return { isValid: false, reason: 'Invalid AI response format' };
       }
       console.error('[GameAIService] AI validation error:', error);

--- a/fe-next/package-lock.json
+++ b/fe-next/package-lock.json
@@ -63,6 +63,7 @@
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
+        "baseline-browser-mapping": "^2.8.32",
         "eslint": "^9",
         "eslint-config-next": "16.0.3",
         "typescript": "^5.9.3"
@@ -3890,9 +3891,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.30",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.30.tgz",
-      "integrity": "sha512-aTUKW4ptQhS64+v2d6IkPzymEzzhw+G0bA1g3uBRV3+ntkH+svttKseW5IOR4Ed6NUVKqnY7qT3dKvzQ7io4AA==",
+      "version": "2.8.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.32.tgz",
+      "integrity": "sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"

--- a/fe-next/package.json
+++ b/fe-next/package.json
@@ -68,6 +68,7 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "baseline-browser-mapping": "^2.8.32",
     "eslint": "^9",
     "eslint-config-next": "16.0.3",
     "typescript": "^5.9.3"


### PR DESCRIPTION
- Fix TypeScript error in ai-service.ts where error.errors was used instead of error.issues for ZodError instances
- Update baseline-browser-mapping to latest version