### PR TITLE
Fix game result recording RLS policy error

### DIFF
--- a/fe-next/lib/ai-service.ts
+++ b/fe-next/lib/ai-service.ts
@@ -505,7 +505,7 @@ class GameAIService {
       return filteredWords;
     } catch (error) {
       if (error instanceof z.ZodError) {
-        console.error('[GameAIService] Themed words schema validation failed:', error.errors);
+        console.error('[GameAIService] Themed words schema validation failed:', error.issues);
         return [];
       }
       console.error('[GameAIService] generateThemedBoard error:', error);

--- a/fe-next/supabase/migrations/007_fix_game_results_rls.sql
+++ b/fe-next/supabase/migrations/007_fix_game_results_rls.sql
@@ -1,0 +1,22 @@
+-- Migration: Fix game_results RLS policy for server inserts
+-- Issue: "new row violates row-level security policy for table game_results"
+-- The backend uses the anonymous key (no auth session), so auth.uid() is NULL
+-- This migration updates the INSERT policy to explicitly allow server inserts
+
+-- Drop existing INSERT policy
+DROP POLICY IF EXISTS "Server can insert game results" ON game_results;
+
+-- Create new INSERT policy that explicitly allows:
+-- 1. Server inserts via anon key (auth.uid() IS NULL)
+-- 2. Authenticated users inserting their own results (auth.uid() = player_id)
+CREATE POLICY "Server can insert game results"
+    ON game_results FOR INSERT
+    WITH CHECK (
+        -- Server inserting via anon key (no user session)
+        auth.uid() IS NULL
+        -- OR authenticated user inserting their own result
+        OR auth.uid() = player_id
+    );
+
+-- Ensure RLS is enabled on the table
+ALTER TABLE game_results ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
- Add migration 007 to fix RLS policy for game_results table The INSERT policy now explicitly allows server inserts (auth.uid() IS NULL) and authenticated users inserting their own results
- Fix ZodError property from 'errors' to 'issues' in ai-service.ts