### PR TITLE
Fix database migrations

### DIFF
--- a/fe-next/supabase/config.toml
+++ b/fe-next/supabase/config.toml
@@ -31,7 +31,7 @@ enabled = true
 site_url = "http://localhost:3001"
 
 [auth.external.google]
-enabled = true
+enabled = false
 
 [auth.external.discord]
 enabled = false


### PR DESCRIPTION
Google auth was enabled but missing required client_id field, causing the CI migration workflow to fail during 'supabase link'. Google auth configuration is managed in production dashboard.