### PR TITLE
Fix player disconnection during low signal

### DIFF
--- a/fe-next/hooks/usePresence.ts
+++ b/fe-next/hooks/usePresence.ts
@@ -19,12 +19,14 @@ interface UsePresenceReturn {
 
 /**
  * Configuration for presence tracking
+ * Tuned for better handling of poor network conditions
  */
 const PRESENCE_CONFIG = {
-  HEARTBEAT_INTERVAL: 10000,  // Send heartbeat every 10 seconds
+  HEARTBEAT_INTERVAL: 8000,   // Send heartbeat every 8 seconds (more frequent for poor connections)
   ACTIVITY_DEBOUNCE: 1000,    // Debounce activity events by 1 second
   IDLE_CHECK_INTERVAL: 5000,  // Check idle status every 5 seconds
   IDLE_THRESHOLD: 30000,      // 30 seconds = idle
+  RETRY_HEARTBEAT_INTERVAL: 3000, // Retry heartbeat faster when reconnecting
 };
 
 /**

--- a/fe-next/host/hooks/useHostSocketEvents.ts
+++ b/fe-next/host/hooks/useHostSocketEvents.ts
@@ -531,6 +531,23 @@ const useHostSocketEvents = ({
       });
     };
 
+    const handlePlayerConnectionStatusChanged = (data: { username: string; connectionStatus: 'weak' | 'stable'; message: string }) => {
+      logger.log('[HOST] Player connection status changed:', data);
+      if (data.connectionStatus === 'weak') {
+        // Show a subtle warning toast for weak connection
+        neoInfoToast(data.message || `${data.username} has weak connection`, {
+          icon: '📶',
+          duration: 4000
+        });
+      } else if (data.connectionStatus === 'stable') {
+        // Connection recovered
+        neoSuccessToast(data.message || `${data.username}'s connection recovered`, {
+          icon: '✅',
+          duration: 2000
+        });
+      }
+    };
+
     const handlePlayerLeft = (data: any) => {
       logger.log('[HOST] Player left:', data.username);
       neoInfoToast(data.message || `${data.username} left the room`, {
@@ -588,6 +605,7 @@ const useHostSocketEvents = ({
     socket.on('wordsForBoard', handleWordsForBoard);
     socket.on('playerDisconnected', handlePlayerDisconnected);
     socket.on('playerReconnected', handlePlayerReconnected);
+    socket.on('playerConnectionStatusChanged', handlePlayerConnectionStatusChanged);
     socket.on('playerLeft', handlePlayerLeft);
     socket.on('xpGained', handleXpGained);
     socket.on('levelUp', handleLevelUp);
@@ -616,6 +634,7 @@ const useHostSocketEvents = ({
       socket.off('wordsForBoard', handleWordsForBoard);
       socket.off('playerDisconnected', handlePlayerDisconnected);
       socket.off('playerReconnected', handlePlayerReconnected);
+      socket.off('playerConnectionStatusChanged', handlePlayerConnectionStatusChanged);
       socket.off('playerLeft', handlePlayerLeft);
       socket.off('xpGained', handleXpGained);
       socket.off('levelUp', handleLevelUp);

--- a/fe-next/player/hooks/usePlayerSocketEvents.ts
+++ b/fe-next/player/hooks/usePlayerSocketEvents.ts
@@ -600,6 +600,23 @@ const usePlayerSocketEvents = ({
       });
     };
 
+    const handlePlayerConnectionStatusChanged = (data: { username: string; connectionStatus: 'weak' | 'stable'; message: string }) => {
+      logger.log('[PLAYER] Player connection status changed:', data);
+      if (data.connectionStatus === 'weak') {
+        // Show a subtle warning toast for weak connection
+        neoInfoToast(data.message || `${data.username} has weak connection`, {
+          icon: '📶',
+          duration: 4000
+        });
+      } else if (data.connectionStatus === 'stable') {
+        // Connection recovered
+        neoSuccessToast(data.message || `${data.username}'s connection recovered`, {
+          icon: '✅',
+          duration: 2000
+        });
+      }
+    };
+
     const handlePlayerLeft = (data: any) => {
       logger.log('[PLAYER] Player left:', data.username);
       neoInfoToast(data.message || `${data.username} ${t('playerView.leftRoom') || 'left the room'}`, {
@@ -692,6 +709,7 @@ const usePlayerSocketEvents = ({
     socket.on('hostTransferred', handleHostTransferred);
     socket.on('playerDisconnected', handlePlayerDisconnected);
     socket.on('playerReconnected', handlePlayerReconnected);
+    socket.on('playerConnectionStatusChanged', handlePlayerConnectionStatusChanged);
     socket.on('playerLeft', handlePlayerLeft);
     socket.on('sessionTakenOver', handleSessionTakenOver);
     socket.on('sessionMigrated', handleSessionMigrated);
@@ -733,6 +751,7 @@ const usePlayerSocketEvents = ({
       socket.off('hostTransferred', handleHostTransferred);
       socket.off('playerDisconnected', handlePlayerDisconnected);
       socket.off('playerReconnected', handlePlayerReconnected);
+      socket.off('playerConnectionStatusChanged', handlePlayerConnectionStatusChanged);
       socket.off('playerLeft', handlePlayerLeft);
       socket.off('sessionTakenOver', handleSessionTakenOver);
       socket.off('sessionMigrated', handleSessionMigrated);

--- a/fe-next/utils/SocketContext.tsx
+++ b/fe-next/utils/SocketContext.tsx
@@ -15,12 +15,12 @@ export interface SocketContextValue {
 // Socket.IO Context
 export const SocketContext = createContext<SocketContextValue | null>(null);
 
-// Configuration
+// Configuration - increased for better handling of poor network conditions
 const SOCKET_CONFIG = {
-  reconnectionAttempts: 10,
+  reconnectionAttempts: 20,        // Increased from 10 for poor connections
   reconnectionDelay: 1000,
-  reconnectionDelayMax: 30000,
-  timeout: 20000,
+  reconnectionDelayMax: 45000,     // Increased from 30000 for longer grace period
+  timeout: 30000,                  // Increased from 20000 for slow connections
 };
 
 interface SocketProviderProps {


### PR DESCRIPTION
- Increased player reconnection grace period from 15s to 45s
- Increased host reconnection grace period from 30s to 60s
- Added 'weak connection' intermediate state before disconnect
- Implemented periodic connection health monitoring
- Added heartbeat recovery notifications when connection stabilizes
- Increased Socket.IO reconnection attempts from 10 to 20
- Reduced heartbeat interval from 10s to 8s for faster detection
- Frontend now displays weak connection and recovery notifications

This prevents players from being unexpectedly disconnected due to temporary network issues or poor signal conditions.