### PR TITLE
Fix game result RLS policy and add AI logging

### DIFF
--- a/fe-next/supabase/migrations/008_fix_game_results_rls_simple.sql
+++ b/fe-next/supabase/migrations/008_fix_game_results_rls_simple.sql
@@ -1,0 +1,21 @@
+-- Migration: 008_fix_game_results_rls_simple
+-- Fix: RLS policy for game_results was too restrictive
+-- Issue: "new row violates row-level security policy for table game_results"
+--
+-- The previous migration (007) used auth.uid() IS NULL check which may not
+-- work correctly in all cases. Reverting to simpler WITH CHECK (true)
+-- since the backend handles all validation.
+
+-- Drop existing INSERT policy
+DROP POLICY IF EXISTS "Server can insert game results" ON game_results;
+
+-- Create simple INSERT policy - server handles all validation
+CREATE POLICY "Server can insert game results"
+    ON game_results FOR INSERT
+    WITH CHECK (true);
+
+-- Ensure RLS is enabled on the table
+ALTER TABLE game_results ENABLE ROW LEVEL SECURITY;
+
+-- Add comment for documentation
+COMMENT ON POLICY "Server can insert game results" ON game_results IS 'Allow all inserts - backend server handles validation of game results';


### PR DESCRIPTION
…scores

1. RLS Fix: Create migration 008 to simplify game_results INSERT policy
   - Reverts to `WITH CHECK (true)` which allows backend server inserts
   - Previous migration 007 was too restrictive with auth.uid() check

2. AI Validation Integration:
   - Import validateWordsWithAI for batch validation
   - Collect non-dictionary words during final score calculation
   - Batch validate with AI service when available
   - Add comprehensive logging with AI_VALIDATION category
   - Logs now appear similar to FINAL_SCORES format: [timestamp] [AI_VALIDATION] Game XXXX: X unique words...
   - Update playerWordDetails to include AI validation results