### PR TITLE
Fix Gemini model not found error in GameAIService

### DIFF
--- a/fe-next/backend/modules/gameAIService.js
+++ b/fe-next/backend/modules/gameAIService.js
@@ -132,7 +132,7 @@ class GameAIService {
 
       // Get the Gemini 1.5 Flash model
       this.model = this.vertexAI.getGenerativeModel({
-        model: process.env.VERTEX_AI_MODEL || 'gemini-1.5-flash-001',
+        model: process.env.VERTEX_AI_MODEL || 'gemini-1.5-flash-002',
         generationConfig: {
           maxOutputTokens: 256,
           temperature: 0.1, // Low temperature for consistent validation

--- a/fe-next/lib/ai-service.ts
+++ b/fe-next/lib/ai-service.ts
@@ -183,7 +183,7 @@ class GameAIService {
 
       // Get the Gemini 1.5 Flash model
       this.model = this.vertexAI.getGenerativeModel({
-        model: process.env.VERTEX_AI_MODEL || 'gemini-1.5-flash-001',
+        model: process.env.VERTEX_AI_MODEL || 'gemini-1.5-flash-002',
         generationConfig: {
           maxOutputTokens: 256,
           temperature: 0.1, // Low temperature for consistent validation


### PR DESCRIPTION
The gemini-1.5-flash-001 model was deprecated and returning 404 errors. Updated to gemini-1.5-flash-002 which is the current stable version.