### PR TITLE
fix: reduce combo bonus for small words to discourage short word spam

### DIFF
--- a/fe-next/backend/modules/scoringEngine.js
+++ b/fe-next/backend/modules/scoringEngine.js
@@ -22,18 +22,23 @@ const getComboMultiplier = (comboLevel) => {
 // Get flat combo bonus based on combo level and word length
 // Combo bonus now scales with word length to reward longer words in combos
 // Formula: comboBonus = floor(comboLevel * wordLengthFactor)
-// wordLengthFactor: 3-4 letters = 0.5, 5-6 letters = 1.0, 7+ letters = 1.5
+// wordLengthFactor: 3 letters = 0.1, 4 letters = 0.3, 5 letters = 0.7, 6 letters = 1.0, 7+ letters = 1.5
 const getComboBonus = (comboLevel, wordLength = 4) => {
   if (comboLevel <= 2) return 0; // No bonus for combos 0-2
 
-  // Word length factor - longer words get better combo bonuses
+  // Word length factor - longer words get much better combo bonuses
+  // Short words get minimal combo benefit to discourage short word spam
   let wordLengthFactor;
-  if (wordLength <= 4) {
-    wordLengthFactor = 0.5;  // Short words
-  } else if (wordLength <= 6) {
-    wordLengthFactor = 1.0;  // Medium words
+  if (wordLength <= 3) {
+    wordLengthFactor = 0.1;  // Very short words - almost no combo bonus
+  } else if (wordLength === 4) {
+    wordLengthFactor = 0.3;  // Short words - small combo bonus
+  } else if (wordLength === 5) {
+    wordLengthFactor = 0.7;  // Medium words
+  } else if (wordLength === 6) {
+    wordLengthFactor = 1.0;  // Good words
   } else {
-    wordLengthFactor = 1.5;  // Long words (7+)
+    wordLengthFactor = 1.5;  // Long words (7+) - full combo bonus
   }
 
   // Base bonus scales with combo level

--- a/fe-next/utils/clientWordValidator.ts
+++ b/fe-next/utils/clientWordValidator.ts
@@ -117,19 +117,24 @@ export function validateWordLocally(
  * Get combo bonus based on combo level and word length
  * Combo bonus scales with word length to reward longer words in combos
  * Formula: comboBonus = floor(baseBonus * wordLengthFactor)
- * wordLengthFactor: 3-4 letters = 0.5, 5-6 letters = 1.0, 7+ letters = 1.5
+ * wordLengthFactor: 3 letters = 0.1, 4 letters = 0.3, 5 letters = 0.7, 6 letters = 1.0, 7+ letters = 1.5
  */
 function getComboBonus(comboLevel: number, wordLength: number): number {
   if (comboLevel <= 2) return 0; // No bonus for combos 0-2
 
-  // Word length factor - longer words get better combo bonuses
+  // Word length factor - longer words get much better combo bonuses
+  // Short words get minimal combo benefit to discourage short word spam
   let wordLengthFactor: number;
-  if (wordLength <= 4) {
-    wordLengthFactor = 0.5;  // Short words
-  } else if (wordLength <= 6) {
-    wordLengthFactor = 1.0;  // Medium words
+  if (wordLength <= 3) {
+    wordLengthFactor = 0.1;  // Very short words - almost no combo bonus
+  } else if (wordLength === 4) {
+    wordLengthFactor = 0.3;  // Short words - small combo bonus
+  } else if (wordLength === 5) {
+    wordLengthFactor = 0.7;  // Medium words
+  } else if (wordLength === 6) {
+    wordLengthFactor = 1.0;  // Good words
   } else {
-    wordLengthFactor = 1.5;  // Long words (7+)
+    wordLengthFactor = 1.5;  // Long words (7+) - full combo bonus
   }
 
   // Base bonus scales with combo level (caps at 8)


### PR DESCRIPTION
- 3-letter words: 0.1x factor (down from 0.5x)
- 4-letter words: 0.3x factor (down from 0.5x)
- 5-letter words: 0.7x factor (down from 1.0x)
- 6-letter words: 1.0x factor (unchanged)
- 7+ letter words: 1.5x factor (unchanged)

At max combo (level 10), a 3-letter word now gets 0 bonus points (was 4). A 4-letter word now gets 2 bonus points (was 4).