### PR TITLE
Improve word validation scoring system

### DIFF
--- a/fe-next/backend/socketHandlers.js
+++ b/fe-next/backend/socketHandlers.js
@@ -2345,6 +2345,7 @@ async function calculateAndBroadcastFinalScores(io, gameCode) {
         isDuplicate: isDuplicate,
         isPendingValidation: isPendingValidation, // New flag for pending community validation
         isAiVerified: aiResult?.isAiVerified || wordDetail?.isAiVerified || false,  // Track if AI verified
+        aiReason: aiResult?.reason || undefined,  // AI's reason for validating/invalidating (shown in tooltip)
         invalidReason: !isValid && aiResult?.reason ? aiResult.reason : undefined  // Reason for invalid words (in game language)
       });
     });

--- a/fe-next/components/results/ResultsPlayerCard.tsx
+++ b/fe-next/components/results/ResultsPlayerCard.tsx
@@ -25,6 +25,7 @@ interface WordObject {
   isPendingValidation?: boolean;
   potentialScore?: number;
   invalidReason?: string;
+  aiReason?: string; // AI's reason for validating/invalidating the word
 }
 
 interface Title {
@@ -90,6 +91,7 @@ const WordChip = memo<WordChipProps>(({ wordObj, playerCount }) => {
   const isAiVerified = wordObj.isAiVerified;
   const isPending = wordObj.isPendingValidation;
   const invalidReason = wordObj.invalidReason;
+  const aiReason = wordObj.aiReason;
   const displayWord = applyHebrewFinalLetters(wordObj.word);
   const comboBonus = wordObj.comboBonus || 0;
 
@@ -158,7 +160,7 @@ const WordChip = memo<WordChipProps>(({ wordObj, playerCount }) => {
           </Tooltip>
         </TooltipProvider>
       )}
-      {/* Show AI verification indicator */}
+      {/* Show AI verification indicator with reason tooltip */}
       {isAiVerified && isValid && !isDuplicate && (
         <TooltipProvider delayDuration={0}>
           <Tooltip>
@@ -169,9 +171,12 @@ const WordChip = memo<WordChipProps>(({ wordObj, playerCount }) => {
             </TooltipTrigger>
             <TooltipContent
               side="top"
-              className="bg-neo-purple border-2 border-neo-black shadow-hard rounded-neo p-2"
+              className="bg-neo-purple border-2 border-neo-black shadow-hard rounded-neo p-2 max-w-[250px]"
             >
               <p className="text-xs font-bold text-neo-cream">{t('results.aiVerified') || 'Verified by AI'}</p>
+              {aiReason && (
+                <p className="text-xs text-neo-yellow mt-1">{aiReason}</p>
+              )}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/fe-next/contexts/LanguageContext.tsx
+++ b/fe-next/contexts/LanguageContext.tsx
@@ -168,11 +168,17 @@ export const LanguageProvider = ({ children, initialLanguage }: LanguageProvider
             current = (current as Record<string, unknown>)[key];
         }
 
-        // Replace template variables like ${varName} with params
+        // Replace template variables like ${varName} or {varName} with params
         if (typeof current === 'string' && Object.keys(params).length > 0) {
-            return current.replace(/\$\{(\w+)\}/g, (match, key) => {
+            // First handle ${varName} format
+            let result = current.replace(/\$\{(\w+)\}/g, (match, key) => {
                 return params[key] !== undefined ? String(params[key]) : match;
             });
+            // Then handle {varName} format (for translations with curly braces only)
+            result = result.replace(/\{(\w+)\}/g, (match, key) => {
+                return params[key] !== undefined ? String(params[key]) : match;
+            });
+            return result;
         }
 
         return typeof current === 'string' ? current : path;

--- a/fe-next/translations/index.js
+++ b/fe-next/translations/index.js
@@ -1026,7 +1026,9 @@ export const translations = {
       realWord: 'Real word!',
       nextWord: 'Next word...',
       almostApproved: 'Almost approved!',
-      votesNeeded: '${count} more votes to approve',
+      votesNeeded: '{count} more votes to approve',
+      validForScoring: 'Counts as valid! Help add it to dictionary.',
+      moreForDictionary: 'more for dictionary',
     },
     support: {
       kofiWinner: 'Feeling Generous, Champ?',
@@ -2055,7 +2057,9 @@ export const translations = {
       realWord: 'מילה אמיתית!',
       nextWord: 'מילה הבאה...',
       almostApproved: 'כמעט מאושר!',
-      votesNeeded: 'עוד ${count} הצבעות לאישור',
+      votesNeeded: 'עוד {count} הצבעות לאישור',
+      validForScoring: 'נחשב כמילה! עזור להוסיף למילון.',
+      moreForDictionary: 'עוד להוספה למילון',
     },
     support: {
       kofiWinner: 'מרגיש נדיב, אלוף?',
@@ -3087,7 +3091,9 @@ export const translations = {
       realWord: 'Riktigt ord!',
       nextWord: 'Nästa ord...',
       almostApproved: 'Nästan godkänt!',
-      votesNeeded: '${count} röster till för att godkänna',
+      votesNeeded: '{count} röster till för att godkänna',
+      validForScoring: 'Räknas som giltigt! Hjälp till att lägga till i ordboken.',
+      moreForDictionary: 'mer till ordbok',
     },
     support: {
       kofiWinner: 'Känn dig generös, mästare?',
@@ -4053,7 +4059,9 @@ export const translations = {
       realWord: '本物の言葉！',
       nextWord: '次の言葉...',
       almostApproved: 'もう少しで承認！',
-      votesNeeded: 'あと${count}票で承認',
+      votesNeeded: 'あと{count}票で承認',
+      validForScoring: '有効とカウント！辞書に追加するお手伝いを。',
+      moreForDictionary: 'あと辞書に追加まで',
     },
     support: {
       kofiWinner: '勝者の余裕で応援してね！',


### PR DESCRIPTION
- AI validation now counts as 4 points toward validation threshold
- Words need 10 points (up from 6) for prominent dictionary addition
- Words with positive ratio (>0) count as valid for scoring but still show validation modal
- Fixed modal text interpolation to properly replace {player} and {word} placeholders
- Added AI reason tooltip on words in results to show why AI validated/invalidated
- Added new translations for valid for scoring status
- Updated VoteInfo interface to include isValidForScoring flag