### PR TITLE
Optimize combo score calculation and tuning

### DIFF
--- a/fe-next/backend/modules/scoringEngine.js
+++ b/fe-next/backend/modules/scoringEngine.js
@@ -22,27 +22,30 @@ const getComboMultiplier = (comboLevel) => {
 // Get flat combo bonus based on combo level and word length
 // Combo bonus now scales with word length to reward longer words in combos
 // Formula: comboBonus = floor(comboLevel * wordLengthFactor)
-// wordLengthFactor: 3 letters = 0.1, 4 letters = 0.3, 5 letters = 0.7, 6 letters = 1.0, 7+ letters = 1.5
+// Optimized to help slower/perfectionist players who find quality words
+// wordLengthFactor: 3 letters = 0.2, 4 letters = 0.5, 5 letters = 1.0, 6 letters = 1.5, 7+ letters = 2.0
 const getComboBonus = (comboLevel, wordLength = 4) => {
-  if (comboLevel <= 2) return 0; // No bonus for combos 0-2
+  if (comboLevel <= 0) return 0; // No bonus for combo 0
 
-  // Word length factor - longer words get much better combo bonuses
-  // Short words get minimal combo benefit to discourage short word spam
+  // Word length factor - longer words get significantly better combo bonuses
+  // This rewards perfectionist players who find quality words
+  // Short words still get minimal combo benefit to discourage short word spam
   let wordLengthFactor;
   if (wordLength <= 3) {
-    wordLengthFactor = 0.1;  // Very short words - almost no combo bonus
+    wordLengthFactor = 0.2;  // Very short words - minimal combo bonus
   } else if (wordLength === 4) {
-    wordLengthFactor = 0.3;  // Short words - small combo bonus
+    wordLengthFactor = 0.5;  // Short words - modest combo bonus
   } else if (wordLength === 5) {
-    wordLengthFactor = 0.7;  // Medium words
+    wordLengthFactor = 1.0;  // Medium words - full base bonus
   } else if (wordLength === 6) {
-    wordLengthFactor = 1.0;  // Good words
+    wordLengthFactor = 1.5;  // Good words - 1.5x bonus
   } else {
-    wordLengthFactor = 1.5;  // Long words (7+) - full combo bonus
+    wordLengthFactor = 2.0;  // Long words (7+) - 2x bonus (perfectionist reward)
   }
 
-  // Base bonus scales with combo level
-  const baseBonus = Math.min(comboLevel - 2, 8); // Caps at 8 bonus points base
+  // Base bonus scales with combo level, starting from combo 1
+  // This helps slower players who build combos more deliberately
+  const baseBonus = Math.min(comboLevel, 10); // Caps at 10 bonus points base
 
   return Math.floor(baseBonus * wordLengthFactor);
 };

--- a/fe-next/components/HowToPlay.jsx
+++ b/fe-next/components/HowToPlay.jsx
@@ -272,12 +272,12 @@ const ComboVisualizer = ({ t }) => {
   const [isAnimating, setIsAnimating] = useState(false);
 
   const comboTiers = [
-    { level: '0-2', multiplier: '1.0x', color: 'bg-gray-400', bonus: t('howToPlay.combo.noBonus') },
-    { level: '3-4', multiplier: '1.25x', color: 'bg-neo-cyan', bonus: '+25%' },
-    { level: '5-6', multiplier: '1.5x', color: 'bg-neo-lime', bonus: '+50%' },
-    { level: '7-8', multiplier: '1.75x', color: 'bg-neo-yellow', bonus: '+75%' },
-    { level: '9-10', multiplier: '2.0x', color: 'bg-neo-orange', bonus: '+100%' },
-    { level: '11+', multiplier: '2.25x', color: 'bg-neo-pink', bonus: '+125%' },
+    { level: '0', multiplier: '1.0x', color: 'bg-gray-400', bonus: t('howToPlay.combo.noBonus') },
+    { level: '1-2', multiplier: '+1-2', color: 'bg-neo-cyan', bonus: '+1-2' },
+    { level: '3-4', multiplier: '+3-4', color: 'bg-neo-lime', bonus: '+3-4' },
+    { level: '5-6', multiplier: '+5-6', color: 'bg-neo-yellow', bonus: '+5-6' },
+    { level: '7-8', multiplier: '+7-8', color: 'bg-neo-orange', bonus: '+7-8' },
+    { level: '9+', multiplier: '+10', color: 'bg-neo-pink', bonus: '+10 max' },
   ];
 
   const simulateCombo = () => {
@@ -300,11 +300,11 @@ const ComboVisualizer = ({ t }) => {
   };
 
   const getCurrentTier = () => {
-    if (comboLevel <= 2) return 0;
-    if (comboLevel <= 4) return 1;
-    if (comboLevel <= 6) return 2;
-    if (comboLevel <= 8) return 3;
-    if (comboLevel <= 10) return 4;
+    if (comboLevel <= 0) return 0;
+    if (comboLevel <= 2) return 1;
+    if (comboLevel <= 4) return 2;
+    if (comboLevel <= 6) return 3;
+    if (comboLevel <= 8) return 4;
     return 5;
   };
 


### PR DESCRIPTION
- Start giving combo bonuses from level 1 (was level 3)
- Increase word length factors to reward longer words more:
  * 3 letters: 0.2 (was 0.1)
  * 4 letters: 0.5 (was 0.3)
  * 5 letters: 1.0 (was 0.7)
  * 6 letters: 1.5 (was 1.0)
  * 7+ letters: 2.0 (was 1.5)
- Increase max base bonus cap from 8 to 10
- Update HowToPlay combo visualizer to reflect new tiers

This helps slower players who focus on quality words over quantity by significantly boosting combo rewards for longer words.