### PR TITLE
Fix leaderboard not displaying results

### DIFF
--- a/fe-next/app/[locale]/leaderboard/page.jsx
+++ b/fe-next/app/[locale]/leaderboard/page.jsx
@@ -281,7 +281,7 @@ export default function LeaderboardPage() {
                             ? isDarkMode ? 'text-cyan-400' : 'text-cyan-600'
                             : isDarkMode ? 'text-white' : 'text-gray-900'
                         )}>
-                          {entry.username}
+                          {entry.display_name || entry.username}
                         </span>
                       </div>
                       <div className={cn(

--- a/fe-next/backend/modules/supabaseServer.js
+++ b/fe-next/backend/modules/supabaseServer.js
@@ -238,7 +238,7 @@ async function updateLeaderboardEntry(playerId) {
   // Get updated profile stats
   const { data: profile, error: fetchError } = await client
     .from('profiles')
-    .select('username, avatar_emoji, avatar_color, total_score, total_games, ranked_wins, ranked_mmr')
+    .select('username, display_name, avatar_emoji, avatar_color, total_score, total_games, ranked_wins, ranked_mmr')
     .eq('id', playerId)
     .single();
 
@@ -250,6 +250,7 @@ async function updateLeaderboardEntry(playerId) {
     .upsert({
       player_id: playerId,
       username: profile.username,
+      display_name: profile.display_name,
       avatar_emoji: profile.avatar_emoji,
       avatar_color: profile.avatar_color,
       total_score: profile.total_score || 0,

--- a/fe-next/backend/socketHandlers.js
+++ b/fe-next/backend/socketHandlers.js
@@ -2545,7 +2545,11 @@ async function recordGameResultsToSupabase(gameCode, scoresArray, game) {
 
     logger.info('SUPABASE', `Recorded game results for ${gameCode} - ${scoresWithPlacement.length} players`);
   } catch (error) {
-    logger.error('SUPABASE', `Error recording game results for ${gameCode}`, error);
+    // Extract error details even if error object is not a standard Error
+    const errorDetails = error instanceof Error
+      ? { name: error.name, message: error.message, stack: error.stack }
+      : (error?.message || error?.code || error?.error || String(error) || 'Unknown error');
+    logger.error('SUPABASE', `Error recording game results for ${gameCode}`, errorDetails);
   }
 }
 

--- a/fe-next/supabase/migrations/009_add_display_name_to_leaderboard.sql
+++ b/fe-next/supabase/migrations/009_add_display_name_to_leaderboard.sql
@@ -1,0 +1,68 @@
+-- =============================================
+-- MIGRATION: Add display_name to leaderboard table
+-- This fixes the issue where leaderboard shows username instead of display_name
+-- =============================================
+
+-- Add display_name column to leaderboard table
+ALTER TABLE leaderboard ADD COLUMN IF NOT EXISTS display_name TEXT;
+
+-- Update existing leaderboard entries with display_name from profiles
+UPDATE leaderboard l
+SET display_name = p.display_name
+FROM profiles p
+WHERE l.player_id = p.id;
+
+-- Drop and recreate the sync trigger to include display_name
+DROP FUNCTION IF EXISTS sync_profile_to_leaderboard() CASCADE;
+
+CREATE FUNCTION sync_profile_to_leaderboard()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO leaderboard (
+        player_id,
+        username,
+        display_name,
+        avatar_emoji,
+        avatar_color,
+        total_score,
+        games_played,
+        games_won,
+        ranked_mmr,
+        last_updated
+    ) VALUES (
+        NEW.id,
+        NEW.username,
+        NEW.display_name,
+        NEW.avatar_emoji,
+        NEW.avatar_color,
+        COALESCE(NEW.total_score, 0),
+        COALESCE(NEW.total_games, 0),
+        COALESCE(NEW.ranked_wins, 0),
+        COALESCE(NEW.ranked_mmr, 1000),
+        NOW()
+    )
+    ON CONFLICT (player_id) DO UPDATE SET
+        username = EXCLUDED.username,
+        display_name = EXCLUDED.display_name,
+        avatar_emoji = EXCLUDED.avatar_emoji,
+        avatar_color = EXCLUDED.avatar_color,
+        total_score = EXCLUDED.total_score,
+        games_played = EXCLUDED.games_played,
+        games_won = EXCLUDED.games_won,
+        ranked_mmr = EXCLUDED.ranked_mmr,
+        last_updated = NOW();
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recreate trigger to include display_name in the trigger columns
+DROP TRIGGER IF EXISTS profile_to_leaderboard_sync ON profiles;
+CREATE TRIGGER profile_to_leaderboard_sync
+    AFTER INSERT OR UPDATE OF username, display_name, avatar_emoji, avatar_color, total_score, total_games, ranked_wins, ranked_mmr
+    ON profiles
+    FOR EACH ROW
+    EXECUTE FUNCTION sync_profile_to_leaderboard();
+
+-- Add index on display_name for search
+CREATE INDEX IF NOT EXISTS idx_leaderboard_display_name ON leaderboard(display_name);


### PR DESCRIPTION
- Add display_name column to leaderboard table with migration
- Update sync trigger to include display_name in profile-to-leaderboard sync
- Update leaderboard page to show display_name with fallback to username
- Fix empty error objects in logger by properly serializing Error instances
- Improve error details extraction in game results recording
- Reduce auth loading timeout from 10s to 3s for faster UI response
- Add 2s timeout to getSession call to prevent slow connections blocking UI
- Make fetchUserData non-blocking to improve initial page load