### PR TITLE
Add admin dashboard with player analytics

### DIFF
--- a/fe-next/app/[locale]/admin/page.tsx
+++ b/fe-next/app/[locale]/admin/page.tsx
@@ -1,0 +1,943 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import {
+  FaUsers, FaGamepad, FaClock, FaGlobe, FaChartLine,
+  FaArrowLeft, FaSync, FaUserPlus, FaLanguage, FaLink,
+  FaTrophy, FaCalendarDay, FaCalendarWeek, FaServer
+} from 'react-icons/fa';
+import { useRouter } from 'next/navigation';
+import Header from '@/components/Header';
+import { Button } from '@/components/ui/button';
+import { useTheme } from '@/utils/ThemeContext';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/lib/supabase';
+import { cn } from '@/lib/utils';
+import toast from 'react-hot-toast';
+
+// Country code to flag emoji and name mapping
+const COUNTRY_INFO: Record<string, { flag: string; name: string }> = {
+  'US': { flag: '🇺🇸', name: 'United States' },
+  'IL': { flag: '🇮🇱', name: 'Israel' },
+  'GB': { flag: '🇬🇧', name: 'United Kingdom' },
+  'DE': { flag: '🇩🇪', name: 'Germany' },
+  'FR': { flag: '🇫🇷', name: 'France' },
+  'CA': { flag: '🇨🇦', name: 'Canada' },
+  'AU': { flag: '🇦🇺', name: 'Australia' },
+  'SE': { flag: '🇸🇪', name: 'Sweden' },
+  'JP': { flag: '🇯🇵', name: 'Japan' },
+  'BR': { flag: '🇧🇷', name: 'Brazil' },
+  'IN': { flag: '🇮🇳', name: 'India' },
+  'NL': { flag: '🇳🇱', name: 'Netherlands' },
+  'ES': { flag: '🇪🇸', name: 'Spain' },
+  'IT': { flag: '🇮🇹', name: 'Italy' },
+  'RU': { flag: '🇷🇺', name: 'Russia' },
+  'PL': { flag: '🇵🇱', name: 'Poland' },
+  'MX': { flag: '🇲🇽', name: 'Mexico' },
+  'KR': { flag: '🇰🇷', name: 'South Korea' },
+  'Unknown': { flag: '🌍', name: 'Unknown' },
+};
+
+const LANGUAGE_NAMES: Record<string, string> = {
+  'en': 'English',
+  'he': 'Hebrew',
+  'sv': 'Swedish',
+  'ja': 'Japanese',
+};
+
+interface Stats {
+  overview: {
+    totalPlayers: number;
+    totalGames: number;
+    totalGameTimeHours: number;
+    totalWords: number;
+  };
+  activity: {
+    gamesToday: number;
+    uniquePlayersToday: number;
+    uniquePlayersWeek: number;
+    uniquePlayersMonth: number;
+    signupsToday: number;
+    signupsWeek: number;
+  };
+  languages: Record<string, number>;
+}
+
+interface RealtimeStats {
+  activeRooms: number;
+  playersOnline: number;
+  gamesInProgress: number;
+  socketConnections: number;
+  timestamp: number;
+}
+
+interface CountryData {
+  country: string;
+  count: number;
+}
+
+interface SourceData {
+  sources: { name: string; count: number }[];
+  mediums: { name: string; count: number }[];
+  campaigns: { name: string; count: number }[];
+  referrers: { name: string; count: number }[];
+}
+
+interface DailyActivity {
+  date: string;
+  games: number;
+  uniquePlayers: number;
+  signups: number;
+}
+
+interface TopPlayer {
+  id: string;
+  username: string;
+  display_name?: string;
+  avatar_emoji?: string;
+  avatar_color?: string;
+  total_score: number;
+  total_games: number;
+  total_words: number;
+  total_time_played: number;
+  current_level?: number;
+  created_at: string;
+}
+
+export default function AdminDashboard() {
+  const { theme } = useTheme();
+  const { language } = useLanguage();
+  const { user, profile, isAdmin, loading: authLoading } = useAuth();
+  const router = useRouter();
+  const isDarkMode = theme === 'dark';
+
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [realtimeStats, setRealtimeStats] = useState<RealtimeStats | null>(null);
+  const [countries, setCountries] = useState<CountryData[]>([]);
+  const [sources, setSources] = useState<SourceData | null>(null);
+  const [dailyActivity, setDailyActivity] = useState<DailyActivity[]>([]);
+  const [topPlayers, setTopPlayers] = useState<TopPlayer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [activeTab, setActiveTab] = useState<'overview' | 'players' | 'sources' | 'activity'>('overview');
+
+  // Get auth token for API calls
+  const getAuthToken = useCallback(async () => {
+    if (!supabase) return null;
+    const { data: { session } } = await supabase.auth.getSession();
+    return session?.access_token;
+  }, []);
+
+  // Fetch all admin data
+  const fetchAdminData = useCallback(async () => {
+    const token = await getAuthToken();
+    if (!token) {
+      toast.error('Authentication required');
+      return;
+    }
+
+    const headers = { 'Authorization': `Bearer ${token}` };
+
+    try {
+      // Fetch all data in parallel
+      const [statsRes, realtimeRes, countriesRes, sourcesRes, dailyRes, playersRes] = await Promise.all([
+        fetch('/api/admin/stats', { headers }),
+        fetch('/api/admin/realtime', { headers }),
+        fetch('/api/admin/players/countries', { headers }),
+        fetch('/api/admin/players/sources', { headers }),
+        fetch('/api/admin/activity/daily?days=30', { headers }),
+        fetch('/api/admin/players/top?limit=20', { headers }),
+      ]);
+
+      if (!statsRes.ok) {
+        const error = await statsRes.json();
+        throw new Error(error.error || 'Failed to fetch stats');
+      }
+
+      const [statsData, realtimeData, countriesData, sourcesData, dailyData, playersData] = await Promise.all([
+        statsRes.json(),
+        realtimeRes.json(),
+        countriesRes.json(),
+        sourcesRes.json(),
+        dailyRes.json(),
+        playersRes.json(),
+      ]);
+
+      setStats(statsData);
+      setRealtimeStats(realtimeData);
+      setCountries(countriesData.countries || []);
+      setSources(sourcesData);
+      setDailyActivity(dailyData.daily || []);
+      setTopPlayers(playersData.players || []);
+    } catch (error) {
+      console.error('Failed to fetch admin data:', error);
+      toast.error(error instanceof Error ? error.message : 'Failed to load dashboard data');
+    }
+  }, [getAuthToken]);
+
+  // Initial load and refresh
+  useEffect(() => {
+    if (!authLoading && isAdmin) {
+      setLoading(true);
+      fetchAdminData().finally(() => setLoading(false));
+    }
+  }, [authLoading, isAdmin, fetchAdminData]);
+
+  // Refresh realtime stats every 10 seconds
+  useEffect(() => {
+    if (!isAdmin) return;
+
+    const interval = setInterval(async () => {
+      const token = await getAuthToken();
+      if (!token) return;
+
+      try {
+        const res = await fetch('/api/admin/realtime', {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setRealtimeStats(data);
+        }
+      } catch (error) {
+        console.error('Failed to refresh realtime stats:', error);
+      }
+    }, 10000);
+
+    return () => clearInterval(interval);
+  }, [isAdmin, getAuthToken]);
+
+  // Handle manual refresh
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await fetchAdminData();
+    setRefreshing(false);
+    toast.success('Dashboard refreshed');
+  };
+
+  // Not authenticated or not admin
+  if (!authLoading && (!user || !isAdmin)) {
+    return (
+      <div className={cn(
+        'min-h-screen',
+        isDarkMode ? 'bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900' : 'bg-gradient-to-br from-blue-50 via-white to-purple-50'
+      )}>
+        <Header />
+        <div className="max-w-4xl mx-auto px-4 py-8">
+          <div className="text-center py-12">
+            <div className="text-6xl mb-4">🔒</div>
+            <h2 className={cn(
+              'text-2xl font-bold mb-2',
+              isDarkMode ? 'text-white' : 'text-gray-900'
+            )}>
+              Admin Access Required
+            </h2>
+            <p className={cn(
+              'text-lg mb-6',
+              isDarkMode ? 'text-gray-400' : 'text-gray-600'
+            )}>
+              You don't have permission to access this page.
+            </p>
+            <Button
+              onClick={() => router.push(`/${language}`)}
+              className={cn(
+                'rounded-full px-6',
+                isDarkMode
+                  ? 'bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-500 hover:to-blue-500'
+                  : 'bg-gradient-to-r from-cyan-500 to-blue-500 hover:from-cyan-400 hover:to-blue-400'
+              )}
+            >
+              <FaArrowLeft className="mr-2" />
+              Back to Game
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Loading state
+  if (authLoading || loading) {
+    return (
+      <div className={cn(
+        'min-h-screen',
+        isDarkMode ? 'bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900' : 'bg-gradient-to-br from-blue-50 via-white to-purple-50'
+      )}>
+        <Header />
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="flex justify-center py-12">
+            <div className="w-8 h-8 border-4 border-cyan-500 border-t-transparent rounded-full animate-spin" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn(
+      'min-h-screen pb-8',
+      isDarkMode ? 'bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900' : 'bg-gradient-to-br from-blue-50 via-white to-purple-50'
+    )}>
+      <Header />
+
+      <div className="max-w-7xl mx-auto px-4 py-6">
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
+          <div>
+            <h1 className={cn(
+              'text-2xl sm:text-3xl font-bold',
+              isDarkMode ? 'text-white' : 'text-gray-900'
+            )}>
+              Admin Dashboard
+            </h1>
+            <p className={cn(
+              'text-sm',
+              isDarkMode ? 'text-gray-400' : 'text-gray-600'
+            )}>
+              Welcome, {profile?.display_name || profile?.username}
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              onClick={handleRefresh}
+              disabled={refreshing}
+              variant="outline"
+              size="sm"
+              className={cn(
+                'rounded-lg',
+                isDarkMode ? 'border-slate-600 text-gray-300' : ''
+              )}
+            >
+              <FaSync className={cn('mr-2', refreshing && 'animate-spin')} />
+              Refresh
+            </Button>
+            <Button
+              onClick={() => router.push(`/${language}`)}
+              variant="outline"
+              size="sm"
+              className={cn(
+                'rounded-lg',
+                isDarkMode ? 'border-slate-600 text-gray-300' : ''
+              )}
+            >
+              <FaArrowLeft className="mr-2" />
+              Back
+            </Button>
+          </div>
+        </div>
+
+        {/* Realtime Stats Bar */}
+        {realtimeStats && (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className={cn(
+              'rounded-xl p-4 mb-6 border',
+              isDarkMode
+                ? 'bg-gradient-to-r from-green-900/30 to-emerald-900/30 border-green-500/30'
+                : 'bg-gradient-to-r from-green-50 to-emerald-50 border-green-200'
+            )}
+          >
+            <div className="flex items-center gap-2 mb-2">
+              <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+              <span className={cn(
+                'text-sm font-medium',
+                isDarkMode ? 'text-green-400' : 'text-green-700'
+              )}>
+                Live Stats
+              </span>
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+              <RealtimeStat icon={<FaServer />} label="Socket Connections" value={realtimeStats.socketConnections} isDarkMode={isDarkMode} />
+              <RealtimeStat icon={<FaGamepad />} label="Active Rooms" value={realtimeStats.activeRooms} isDarkMode={isDarkMode} />
+              <RealtimeStat icon={<FaUsers />} label="Players Online" value={realtimeStats.playersOnline} isDarkMode={isDarkMode} />
+              <RealtimeStat icon={<FaTrophy />} label="Games In Progress" value={realtimeStats.gamesInProgress} isDarkMode={isDarkMode} />
+            </div>
+          </motion.div>
+        )}
+
+        {/* Tab Navigation */}
+        <div className="flex gap-2 mb-6 overflow-x-auto pb-2">
+          {(['overview', 'players', 'sources', 'activity'] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={cn(
+                'px-4 py-2 rounded-lg font-medium text-sm whitespace-nowrap transition-colors',
+                activeTab === tab
+                  ? isDarkMode
+                    ? 'bg-cyan-600 text-white'
+                    : 'bg-cyan-500 text-white'
+                  : isDarkMode
+                    ? 'bg-slate-800 text-gray-400 hover:bg-slate-700'
+                    : 'bg-white text-gray-600 hover:bg-gray-100 border border-gray-200'
+              )}
+            >
+              {tab === 'overview' && 'Overview'}
+              {tab === 'players' && 'Players'}
+              {tab === 'sources' && 'Traffic Sources'}
+              {tab === 'activity' && 'Activity'}
+            </button>
+          ))}
+        </div>
+
+        {/* Overview Tab */}
+        {activeTab === 'overview' && stats && (
+          <div className="space-y-6">
+            {/* Main Stats Grid */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+              <StatCard
+                icon={<FaUsers />}
+                label="Total Players"
+                value={stats.overview.totalPlayers.toLocaleString()}
+                isDarkMode={isDarkMode}
+                color="cyan"
+              />
+              <StatCard
+                icon={<FaGamepad />}
+                label="Total Games"
+                value={stats.overview.totalGames.toLocaleString()}
+                isDarkMode={isDarkMode}
+                color="purple"
+              />
+              <StatCard
+                icon={<FaClock />}
+                label="Total Play Time"
+                value={`${stats.overview.totalGameTimeHours}h`}
+                isDarkMode={isDarkMode}
+                color="orange"
+              />
+              <StatCard
+                icon={<FaChartLine />}
+                label="Words Found"
+                value={stats.overview.totalWords.toLocaleString()}
+                isDarkMode={isDarkMode}
+                color="green"
+              />
+            </div>
+
+            {/* Activity Stats */}
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+              <SmallStatCard
+                icon={<FaCalendarDay />}
+                label="Games Today"
+                value={stats.activity.gamesToday}
+                isDarkMode={isDarkMode}
+              />
+              <SmallStatCard
+                icon={<FaUsers />}
+                label="Players Today"
+                value={stats.activity.uniquePlayersToday}
+                isDarkMode={isDarkMode}
+              />
+              <SmallStatCard
+                icon={<FaCalendarWeek />}
+                label="Players This Week"
+                value={stats.activity.uniquePlayersWeek}
+                isDarkMode={isDarkMode}
+              />
+              <SmallStatCard
+                icon={<FaUsers />}
+                label="Players This Month"
+                value={stats.activity.uniquePlayersMonth}
+                isDarkMode={isDarkMode}
+              />
+              <SmallStatCard
+                icon={<FaUserPlus />}
+                label="Signups Today"
+                value={stats.activity.signupsToday}
+                isDarkMode={isDarkMode}
+              />
+              <SmallStatCard
+                icon={<FaUserPlus />}
+                label="Signups This Week"
+                value={stats.activity.signupsWeek}
+                isDarkMode={isDarkMode}
+              />
+            </div>
+
+            {/* Languages & Countries Row */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              {/* Languages */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.1 }}
+                className={cn(
+                  'rounded-xl p-6 border',
+                  isDarkMode ? 'bg-slate-800/50 border-slate-700' : 'bg-white border-gray-200 shadow-md'
+                )}
+              >
+                <h3 className={cn(
+                  'text-lg font-bold mb-4 flex items-center gap-2',
+                  isDarkMode ? 'text-white' : 'text-gray-900'
+                )}>
+                  <FaLanguage className="text-cyan-500" />
+                  Games by Language
+                </h3>
+                <div className="space-y-3">
+                  {Object.entries(stats.languages)
+                    .sort((a, b) => b[1] - a[1])
+                    .map(([lang, count]) => {
+                      const total = Object.values(stats.languages).reduce((a, b) => a + b, 0);
+                      const percentage = Math.round((count / total) * 100);
+                      return (
+                        <div key={lang}>
+                          <div className="flex justify-between text-sm mb-1">
+                            <span className={isDarkMode ? 'text-gray-300' : 'text-gray-700'}>
+                              {LANGUAGE_NAMES[lang] || lang}
+                            </span>
+                            <span className={isDarkMode ? 'text-gray-400' : 'text-gray-500'}>
+                              {count.toLocaleString()} ({percentage}%)
+                            </span>
+                          </div>
+                          <div className={cn(
+                            'h-2 rounded-full overflow-hidden',
+                            isDarkMode ? 'bg-slate-700' : 'bg-gray-200'
+                          )}>
+                            <div
+                              className="h-full bg-gradient-to-r from-cyan-500 to-blue-500 transition-all"
+                              style={{ width: `${percentage}%` }}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })}
+                </div>
+              </motion.div>
+
+              {/* Countries */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.2 }}
+                className={cn(
+                  'rounded-xl p-6 border',
+                  isDarkMode ? 'bg-slate-800/50 border-slate-700' : 'bg-white border-gray-200 shadow-md'
+                )}
+              >
+                <h3 className={cn(
+                  'text-lg font-bold mb-4 flex items-center gap-2',
+                  isDarkMode ? 'text-white' : 'text-gray-900'
+                )}>
+                  <FaGlobe className="text-green-500" />
+                  Players by Country
+                </h3>
+                {countries.length > 0 ? (
+                  <div className="space-y-2 max-h-64 overflow-y-auto">
+                    {countries.slice(0, 10).map((item) => {
+                      const info = COUNTRY_INFO[item.country] || { flag: '🌍', name: item.country };
+                      const total = countries.reduce((a, b) => a + b.count, 0);
+                      const percentage = Math.round((item.count / total) * 100);
+                      return (
+                        <div
+                          key={item.country}
+                          className={cn(
+                            'flex items-center justify-between p-2 rounded-lg',
+                            isDarkMode ? 'bg-slate-700/50' : 'bg-gray-50'
+                          )}
+                        >
+                          <div className="flex items-center gap-2">
+                            <span className="text-xl">{info.flag}</span>
+                            <span className={isDarkMode ? 'text-gray-300' : 'text-gray-700'}>
+                              {info.name}
+                            </span>
+                          </div>
+                          <span className={cn(
+                            'font-medium',
+                            isDarkMode ? 'text-gray-400' : 'text-gray-600'
+                          )}>
+                            {item.count} ({percentage}%)
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className={cn(
+                    'text-center py-4',
+                    isDarkMode ? 'text-gray-500' : 'text-gray-400'
+                  )}>
+                    No country data available yet
+                  </p>
+                )}
+              </motion.div>
+            </div>
+          </div>
+        )}
+
+        {/* Players Tab */}
+        {activeTab === 'players' && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className={cn(
+              'rounded-xl p-6 border',
+              isDarkMode ? 'bg-slate-800/50 border-slate-700' : 'bg-white border-gray-200 shadow-md'
+            )}
+          >
+            <h3 className={cn(
+              'text-lg font-bold mb-4 flex items-center gap-2',
+              isDarkMode ? 'text-white' : 'text-gray-900'
+            )}>
+              <FaTrophy className="text-yellow-500" />
+              Top Players
+            </h3>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className={cn(
+                    'text-left border-b',
+                    isDarkMode ? 'border-slate-700' : 'border-gray-200'
+                  )}>
+                    <th className={cn('pb-2 pr-4', isDarkMode ? 'text-gray-400' : 'text-gray-600')}>#</th>
+                    <th className={cn('pb-2 pr-4', isDarkMode ? 'text-gray-400' : 'text-gray-600')}>Player</th>
+                    <th className={cn('pb-2 pr-4 text-right', isDarkMode ? 'text-gray-400' : 'text-gray-600')}>Score</th>
+                    <th className={cn('pb-2 pr-4 text-right hidden sm:table-cell', isDarkMode ? 'text-gray-400' : 'text-gray-600')}>Games</th>
+                    <th className={cn('pb-2 pr-4 text-right hidden md:table-cell', isDarkMode ? 'text-gray-400' : 'text-gray-600')}>Words</th>
+                    <th className={cn('pb-2 text-right hidden lg:table-cell', isDarkMode ? 'text-gray-400' : 'text-gray-600')}>Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topPlayers.map((player, index) => (
+                    <tr
+                      key={player.id}
+                      className={cn(
+                        'border-b last:border-0',
+                        isDarkMode ? 'border-slate-700' : 'border-gray-100'
+                      )}
+                    >
+                      <td className={cn('py-3 pr-4', isDarkMode ? 'text-gray-400' : 'text-gray-600')}>
+                        {index + 1}
+                      </td>
+                      <td className="py-3 pr-4">
+                        <div className="flex items-center gap-2">
+                          <div
+                            className="w-8 h-8 rounded-full flex items-center justify-center text-sm"
+                            style={{ backgroundColor: player.avatar_color || '#6366f1' }}
+                          >
+                            {player.avatar_emoji || '😀'}
+                          </div>
+                          <span className={isDarkMode ? 'text-white' : 'text-gray-900'}>
+                            {player.display_name || player.username}
+                          </span>
+                        </div>
+                      </td>
+                      <td className={cn('py-3 pr-4 text-right font-medium', isDarkMode ? 'text-cyan-400' : 'text-cyan-600')}>
+                        {player.total_score.toLocaleString()}
+                      </td>
+                      <td className={cn('py-3 pr-4 text-right hidden sm:table-cell', isDarkMode ? 'text-gray-400' : 'text-gray-600')}>
+                        {player.total_games}
+                      </td>
+                      <td className={cn('py-3 pr-4 text-right hidden md:table-cell', isDarkMode ? 'text-gray-400' : 'text-gray-600')}>
+                        {player.total_words?.toLocaleString() || 0}
+                      </td>
+                      <td className={cn('py-3 text-right hidden lg:table-cell', isDarkMode ? 'text-gray-400' : 'text-gray-600')}>
+                        {formatTime(player.total_time_played || 0)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </motion.div>
+        )}
+
+        {/* Traffic Sources Tab */}
+        {activeTab === 'sources' && sources && (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {/* UTM Sources */}
+            <SourceCard
+              title="UTM Sources"
+              icon={<FaLink />}
+              data={sources.sources}
+              isDarkMode={isDarkMode}
+            />
+            {/* UTM Mediums */}
+            <SourceCard
+              title="UTM Mediums"
+              icon={<FaLink />}
+              data={sources.mediums}
+              isDarkMode={isDarkMode}
+            />
+            {/* Campaigns */}
+            <SourceCard
+              title="Campaigns"
+              icon={<FaChartLine />}
+              data={sources.campaigns}
+              isDarkMode={isDarkMode}
+            />
+            {/* Referrers */}
+            <SourceCard
+              title="Referrer Domains"
+              icon={<FaGlobe />}
+              data={sources.referrers}
+              isDarkMode={isDarkMode}
+            />
+          </div>
+        )}
+
+        {/* Activity Tab */}
+        {activeTab === 'activity' && dailyActivity.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className={cn(
+              'rounded-xl p-6 border',
+              isDarkMode ? 'bg-slate-800/50 border-slate-700' : 'bg-white border-gray-200 shadow-md'
+            )}
+          >
+            <h3 className={cn(
+              'text-lg font-bold mb-4 flex items-center gap-2',
+              isDarkMode ? 'text-white' : 'text-gray-900'
+            )}>
+              <FaChartLine className="text-blue-500" />
+              Daily Activity (Last 30 Days)
+            </h3>
+
+            {/* Simple bar chart */}
+            <div className="space-y-2 max-h-96 overflow-y-auto">
+              {dailyActivity.slice().reverse().map((day) => {
+                const maxGames = Math.max(...dailyActivity.map(d => d.games), 1);
+                const gameWidth = (day.games / maxGames) * 100;
+
+                return (
+                  <div key={day.date} className="flex items-center gap-4">
+                    <div className={cn(
+                      'w-24 text-sm',
+                      isDarkMode ? 'text-gray-400' : 'text-gray-600'
+                    )}>
+                      {new Date(day.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                    </div>
+                    <div className="flex-1">
+                      <div className={cn(
+                        'h-6 rounded overflow-hidden',
+                        isDarkMode ? 'bg-slate-700' : 'bg-gray-200'
+                      )}>
+                        <div
+                          className="h-full bg-gradient-to-r from-cyan-500 to-blue-500 flex items-center justify-end pr-2 transition-all"
+                          style={{ width: `${Math.max(gameWidth, 5)}%` }}
+                        >
+                          {day.games > 0 && (
+                            <span className="text-xs text-white font-medium">{day.games}</span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    <div className={cn(
+                      'w-20 text-sm text-right',
+                      isDarkMode ? 'text-gray-500' : 'text-gray-500'
+                    )}>
+                      {day.uniquePlayers} players
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Legend */}
+            <div className={cn(
+              'mt-4 pt-4 border-t flex flex-wrap gap-4 text-sm',
+              isDarkMode ? 'border-slate-700' : 'border-gray-200'
+            )}>
+              <div className="flex items-center gap-2">
+                <div className="w-3 h-3 rounded bg-gradient-to-r from-cyan-500 to-blue-500" />
+                <span className={isDarkMode ? 'text-gray-400' : 'text-gray-600'}>Games played</span>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Helper Components
+function StatCard({ icon, label, value, isDarkMode, color }: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  isDarkMode: boolean;
+  color: 'cyan' | 'purple' | 'orange' | 'green';
+}) {
+  const colorClasses = {
+    cyan: isDarkMode
+      ? 'from-cyan-900/40 to-blue-900/40 border-cyan-500/30'
+      : 'from-cyan-50 to-blue-50 border-cyan-200',
+    purple: isDarkMode
+      ? 'from-purple-900/40 to-pink-900/40 border-purple-500/30'
+      : 'from-purple-50 to-pink-50 border-purple-200',
+    orange: isDarkMode
+      ? 'from-orange-900/40 to-amber-900/40 border-orange-500/30'
+      : 'from-orange-50 to-amber-50 border-orange-200',
+    green: isDarkMode
+      ? 'from-green-900/40 to-emerald-900/40 border-green-500/30'
+      : 'from-green-50 to-emerald-50 border-green-200',
+  };
+
+  const iconColorClasses = {
+    cyan: isDarkMode ? 'text-cyan-400' : 'text-cyan-600',
+    purple: isDarkMode ? 'text-purple-400' : 'text-purple-600',
+    orange: isDarkMode ? 'text-orange-400' : 'text-orange-600',
+    green: isDarkMode ? 'text-green-400' : 'text-green-600',
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={cn(
+        'rounded-xl p-4 sm:p-6 bg-gradient-to-br border',
+        colorClasses[color]
+      )}
+    >
+      <div className={cn('text-2xl sm:text-3xl mb-2', iconColorClasses[color])}>
+        {icon}
+      </div>
+      <p className={cn(
+        'text-2xl sm:text-3xl font-bold',
+        isDarkMode ? 'text-white' : 'text-gray-900'
+      )}>
+        {value}
+      </p>
+      <p className={cn(
+        'text-xs sm:text-sm',
+        isDarkMode ? 'text-gray-400' : 'text-gray-600'
+      )}>
+        {label}
+      </p>
+    </motion.div>
+  );
+}
+
+function SmallStatCard({ icon, label, value, isDarkMode }: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  isDarkMode: boolean;
+}) {
+  return (
+    <div className={cn(
+      'rounded-xl p-4 border',
+      isDarkMode ? 'bg-slate-800/50 border-slate-700' : 'bg-white border-gray-200 shadow-sm'
+    )}>
+      <div className={cn('text-lg mb-1', isDarkMode ? 'text-gray-400' : 'text-gray-500')}>
+        {icon}
+      </div>
+      <p className={cn(
+        'text-xl font-bold',
+        isDarkMode ? 'text-white' : 'text-gray-900'
+      )}>
+        {value.toLocaleString()}
+      </p>
+      <p className={cn(
+        'text-xs',
+        isDarkMode ? 'text-gray-500' : 'text-gray-500'
+      )}>
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function RealtimeStat({ icon, label, value, isDarkMode }: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  isDarkMode: boolean;
+}) {
+  return (
+    <div className="text-center">
+      <div className={cn('text-sm mb-1', isDarkMode ? 'text-green-400' : 'text-green-600')}>
+        {icon}
+      </div>
+      <p className={cn(
+        'text-xl font-bold',
+        isDarkMode ? 'text-white' : 'text-gray-900'
+      )}>
+        {value}
+      </p>
+      <p className={cn(
+        'text-xs',
+        isDarkMode ? 'text-gray-500' : 'text-gray-500'
+      )}>
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function SourceCard({ title, icon, data, isDarkMode }: {
+  title: string;
+  icon: React.ReactNode;
+  data: { name: string; count: number }[];
+  isDarkMode: boolean;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={cn(
+        'rounded-xl p-6 border',
+        isDarkMode ? 'bg-slate-800/50 border-slate-700' : 'bg-white border-gray-200 shadow-md'
+      )}
+    >
+      <h3 className={cn(
+        'text-lg font-bold mb-4 flex items-center gap-2',
+        isDarkMode ? 'text-white' : 'text-gray-900'
+      )}>
+        <span className={isDarkMode ? 'text-cyan-400' : 'text-cyan-600'}>{icon}</span>
+        {title}
+      </h3>
+      {data.length > 0 ? (
+        <div className="space-y-2 max-h-48 overflow-y-auto">
+          {data.slice(0, 10).map((item) => {
+            const total = data.reduce((a, b) => a + b.count, 0);
+            const percentage = Math.round((item.count / total) * 100);
+            return (
+              <div
+                key={item.name}
+                className={cn(
+                  'flex items-center justify-between p-2 rounded-lg',
+                  isDarkMode ? 'bg-slate-700/50' : 'bg-gray-50'
+                )}
+              >
+                <span className={cn(
+                  'truncate flex-1 mr-2',
+                  isDarkMode ? 'text-gray-300' : 'text-gray-700'
+                )}>
+                  {item.name}
+                </span>
+                <span className={cn(
+                  'font-medium whitespace-nowrap',
+                  isDarkMode ? 'text-gray-400' : 'text-gray-600'
+                )}>
+                  {item.count} ({percentage}%)
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className={cn(
+          'text-center py-4',
+          isDarkMode ? 'text-gray-500' : 'text-gray-400'
+        )}>
+          No data available yet
+        </p>
+      )}
+    </motion.div>
+  );
+}
+
+function formatTime(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+}

--- a/fe-next/components/Header.tsx
+++ b/fe-next/components/Header.tsx
@@ -1,5 +1,7 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import { motion } from 'framer-motion';
+import { FaChartBar } from 'react-icons/fa';
+import Link from 'next/link';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useAuth } from '../contexts/AuthContext';
 import { cn } from '../lib/utils';
@@ -20,7 +22,7 @@ interface HeaderProps {
  */
 const Header = memo<HeaderProps>(({ className = '' }) => {
     const { t, language } = useLanguage();
-    const { isAuthenticated, profile } = useAuth();
+    const { isAuthenticated, isAdmin, profile } = useAuth();
 
     // Get font family based on language (memoized)
     const fontFamily = useMemo(() => {
@@ -109,8 +111,28 @@ const Header = memo<HeaderProps>(({ className = '' }) => {
                     </h1>
                 </motion.button>
 
-                {/* Controls: Level + Music + Auth/Settings */}
+                {/* Controls: Admin + Level + Music + Auth/Settings */}
                 <div className="flex items-center gap-1.5 sm:gap-3 flex-shrink-0 min-w-0">
+                    {/* Admin Dashboard Link - only shown for admin users */}
+                    {isAdmin && (
+                        <Link
+                            href={`/${language}/admin`}
+                            className="
+                                flex items-center justify-center
+                                w-8 h-8 sm:w-10 sm:h-10
+                                bg-neo-purple text-white
+                                border-2 sm:border-3 border-neo-black
+                                rounded-neo
+                                shadow-hard
+                                hover:translate-x-[-2px] hover:translate-y-[-2px] hover:shadow-hard-lg
+                                active:translate-x-[2px] active:translate-y-[2px] active:shadow-none
+                                transition-all duration-100
+                            "
+                            title="Admin Dashboard"
+                        >
+                            <FaChartBar className="text-sm sm:text-base" />
+                        </Link>
+                    )}
                     {/* Show level badge for authenticated users - hidden on very small screens */}
                     {isAuthenticated && profile?.current_level && (
                         <div className="hidden xs:block">

--- a/fe-next/contexts/AuthContext.tsx
+++ b/fe-next/contexts/AuthContext.tsx
@@ -30,6 +30,7 @@ export interface ProfileData {
   longest_word_length?: number;
   achievement_counts?: Record<string, number>;
   current_level?: number;
+  is_admin?: boolean;
   created_at?: string;
   updated_at?: string;
 }
@@ -53,6 +54,7 @@ export interface AuthContextValue {
   // Computed
   isAuthenticated: boolean;
   isGuest: boolean;
+  isAdmin: boolean;
   canPlayRanked: boolean;
   gamesUntilRanked: number;
 
@@ -408,6 +410,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     // Computed
     isAuthenticated: !!user && !!profile,
     isGuest: !user,
+    isAdmin: !!profile?.is_admin,
     canPlayRanked: canPlayRanked(),
     gamesUntilRanked: gamesUntilRanked(),
 

--- a/fe-next/server.js
+++ b/fe-next/server.js
@@ -301,6 +301,400 @@ app.prepare().then(() => {
     }
   });
 
+  // =============================================
+  // ADMIN API ENDPOINTS
+  // =============================================
+
+  // Admin authentication middleware
+  const adminAuth = async (req, res, next) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'Missing authorization header' });
+    }
+
+    const token = authHeader.substring(7);
+    if (!isSupabaseConfigured()) {
+      return res.status(503).json({ error: 'Auth service not available' });
+    }
+
+    try {
+      const supabase = getSupabase();
+      // Verify the JWT and get user
+      const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+
+      if (authError || !user) {
+        return res.status(401).json({ error: 'Invalid token' });
+      }
+
+      // Check if user is admin
+      const { data: profile, error: profileError } = await supabase
+        .from('profiles')
+        .select('is_admin')
+        .eq('id', user.id)
+        .single();
+
+      if (profileError || !profile?.is_admin) {
+        return res.status(403).json({ error: 'Admin access required' });
+      }
+
+      req.adminUser = user;
+      next();
+    } catch (error) {
+      console.error('[ADMIN API] Auth error:', error);
+      return res.status(500).json({ error: 'Authentication failed' });
+    }
+  };
+
+  // GET /api/admin/stats - Get main dashboard stats
+  server.get('/api/admin/stats', adminAuth, async (_req, res) => {
+    try {
+      const supabase = getSupabase();
+      const now = new Date();
+      const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+      const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+      const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+      // Get total unique players
+      const { count: totalPlayers } = await supabase
+        .from('profiles')
+        .select('*', { count: 'exact', head: true });
+
+      // Get total games played
+      const { count: totalGames } = await supabase
+        .from('game_results')
+        .select('*', { count: 'exact', head: true });
+
+      // Get games today
+      const { count: gamesToday } = await supabase
+        .from('game_results')
+        .select('*', { count: 'exact', head: true })
+        .gte('created_at', todayStart);
+
+      // Get unique players today
+      const { data: todayPlayersData } = await supabase
+        .from('game_results')
+        .select('player_id')
+        .gte('created_at', todayStart);
+      const uniquePlayersToday = new Set(todayPlayersData?.map(r => r.player_id)).size;
+
+      // Get unique players this week
+      const { data: weekPlayersData } = await supabase
+        .from('game_results')
+        .select('player_id')
+        .gte('created_at', weekAgo);
+      const uniquePlayersWeek = new Set(weekPlayersData?.map(r => r.player_id)).size;
+
+      // Get unique players this month
+      const { data: monthPlayersData } = await supabase
+        .from('game_results')
+        .select('player_id')
+        .gte('created_at', monthAgo);
+      const uniquePlayersMonth = new Set(monthPlayersData?.map(r => r.player_id)).size;
+
+      // Get cumulative game time (in hours)
+      const { data: timeData } = await supabase
+        .from('profiles')
+        .select('total_time_played');
+      const totalGameTimeSeconds = timeData?.reduce((sum, p) => sum + (p.total_time_played || 0), 0) || 0;
+      const totalGameTimeHours = Math.round(totalGameTimeSeconds / 3600 * 10) / 10;
+
+      // Get new signups today
+      const { count: signupsToday } = await supabase
+        .from('profiles')
+        .select('*', { count: 'exact', head: true })
+        .gte('created_at', todayStart);
+
+      // Get new signups this week
+      const { count: signupsWeek } = await supabase
+        .from('profiles')
+        .select('*', { count: 'exact', head: true })
+        .gte('created_at', weekAgo);
+
+      // Get total words found
+      const { data: wordsData } = await supabase
+        .from('profiles')
+        .select('total_words');
+      const totalWords = wordsData?.reduce((sum, p) => sum + (p.total_words || 0), 0) || 0;
+
+      // Get games by language
+      const { data: langData } = await supabase
+        .from('game_results')
+        .select('language');
+      const languageCounts = {};
+      langData?.forEach(g => {
+        const lang = g.language || 'en';
+        languageCounts[lang] = (languageCounts[lang] || 0) + 1;
+      });
+
+      res.json({
+        overview: {
+          totalPlayers: totalPlayers || 0,
+          totalGames: totalGames || 0,
+          totalGameTimeHours,
+          totalWords,
+        },
+        activity: {
+          gamesToday: gamesToday || 0,
+          uniquePlayersToday,
+          uniquePlayersWeek,
+          uniquePlayersMonth,
+          signupsToday: signupsToday || 0,
+          signupsWeek: signupsWeek || 0,
+        },
+        languages: languageCounts,
+      });
+    } catch (error) {
+      console.error('[ADMIN API] Stats error:', error);
+      res.status(500).json({ error: 'Failed to fetch stats' });
+    }
+  });
+
+  // GET /api/admin/players/countries - Get player distribution by country
+  server.get('/api/admin/players/countries', adminAuth, async (_req, res) => {
+    try {
+      const supabase = getSupabase();
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('country_code')
+        .not('country_code', 'is', null);
+
+      if (error) throw error;
+
+      const countryCounts = {};
+      data?.forEach(p => {
+        const country = p.country_code || 'Unknown';
+        countryCounts[country] = (countryCounts[country] || 0) + 1;
+      });
+
+      // Sort by count descending
+      const sorted = Object.entries(countryCounts)
+        .sort((a, b) => b[1] - a[1])
+        .map(([country, count]) => ({ country, count }));
+
+      res.json({ countries: sorted });
+    } catch (error) {
+      console.error('[ADMIN API] Countries error:', error);
+      res.status(500).json({ error: 'Failed to fetch country data' });
+    }
+  });
+
+  // GET /api/admin/players/sources - Get player acquisition sources (UTM)
+  server.get('/api/admin/players/sources', adminAuth, async (_req, res) => {
+    try {
+      const supabase = getSupabase();
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('utm_source, utm_medium, utm_campaign, referrer');
+
+      if (error) throw error;
+
+      const sourceCounts = {};
+      const mediumCounts = {};
+      const campaignCounts = {};
+      const referrerCounts = {};
+
+      data?.forEach(p => {
+        if (p.utm_source) {
+          sourceCounts[p.utm_source] = (sourceCounts[p.utm_source] || 0) + 1;
+        }
+        if (p.utm_medium) {
+          mediumCounts[p.utm_medium] = (mediumCounts[p.utm_medium] || 0) + 1;
+        }
+        if (p.utm_campaign) {
+          campaignCounts[p.utm_campaign] = (campaignCounts[p.utm_campaign] || 0) + 1;
+        }
+        if (p.referrer) {
+          // Extract domain from referrer
+          try {
+            const domain = new URL(p.referrer).hostname;
+            referrerCounts[domain] = (referrerCounts[domain] || 0) + 1;
+          } catch {
+            referrerCounts[p.referrer] = (referrerCounts[p.referrer] || 0) + 1;
+          }
+        }
+      });
+
+      const sortByCount = (obj) => Object.entries(obj)
+        .sort((a, b) => b[1] - a[1])
+        .map(([name, count]) => ({ name, count }));
+
+      res.json({
+        sources: sortByCount(sourceCounts),
+        mediums: sortByCount(mediumCounts),
+        campaigns: sortByCount(campaignCounts),
+        referrers: sortByCount(referrerCounts),
+      });
+    } catch (error) {
+      console.error('[ADMIN API] Sources error:', error);
+      res.status(500).json({ error: 'Failed to fetch source data' });
+    }
+  });
+
+  // GET /api/admin/players/top - Get top players by score
+  server.get('/api/admin/players/top', adminAuth, async (req, res) => {
+    try {
+      const limit = Math.min(parseInt(req.query.limit) || 50, 100);
+      const supabase = getSupabase();
+
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('id, username, display_name, avatar_emoji, avatar_color, total_score, total_games, total_words, total_time_played, ranked_mmr, current_level, created_at')
+        .order('total_score', { ascending: false })
+        .limit(limit);
+
+      if (error) throw error;
+
+      res.json({ players: data || [] });
+    } catch (error) {
+      console.error('[ADMIN API] Top players error:', error);
+      res.status(500).json({ error: 'Failed to fetch top players' });
+    }
+  });
+
+  // GET /api/admin/players/recent - Get recently active players
+  server.get('/api/admin/players/recent', adminAuth, async (req, res) => {
+    try {
+      const limit = Math.min(parseInt(req.query.limit) || 50, 100);
+      const supabase = getSupabase();
+
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('id, username, display_name, avatar_emoji, avatar_color, total_score, total_games, last_game_at, created_at')
+        .order('last_game_at', { ascending: false, nullsFirst: false })
+        .limit(limit);
+
+      if (error) throw error;
+
+      res.json({ players: data || [] });
+    } catch (error) {
+      console.error('[ADMIN API] Recent players error:', error);
+      res.status(500).json({ error: 'Failed to fetch recent players' });
+    }
+  });
+
+  // GET /api/admin/games/history - Get recent games history
+  server.get('/api/admin/games/history', adminAuth, async (req, res) => {
+    try {
+      const limit = Math.min(parseInt(req.query.limit) || 100, 500);
+      const supabase = getSupabase();
+
+      const { data, error } = await supabase
+        .from('game_results')
+        .select(`
+          id,
+          game_code,
+          score,
+          word_count,
+          placement,
+          is_ranked,
+          language,
+          time_played,
+          created_at,
+          player_id,
+          profiles:player_id (username, display_name)
+        `)
+        .order('created_at', { ascending: false })
+        .limit(limit);
+
+      if (error) throw error;
+
+      res.json({ games: data || [] });
+    } catch (error) {
+      console.error('[ADMIN API] Games history error:', error);
+      res.status(500).json({ error: 'Failed to fetch games history' });
+    }
+  });
+
+  // GET /api/admin/activity/daily - Get daily activity for charts
+  server.get('/api/admin/activity/daily', adminAuth, async (req, res) => {
+    try {
+      const days = Math.min(parseInt(req.query.days) || 30, 90);
+      const supabase = getSupabase();
+
+      // Get all games in the date range
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() - days);
+
+      const { data: gamesData, error: gamesError } = await supabase
+        .from('game_results')
+        .select('created_at, player_id')
+        .gte('created_at', startDate.toISOString());
+
+      if (gamesError) throw gamesError;
+
+      // Get all signups in the date range
+      const { data: signupsData, error: signupsError } = await supabase
+        .from('profiles')
+        .select('created_at')
+        .gte('created_at', startDate.toISOString());
+
+      if (signupsError) throw signupsError;
+
+      // Aggregate by day
+      const dailyData = {};
+      for (let i = 0; i < days; i++) {
+        const date = new Date();
+        date.setDate(date.getDate() - i);
+        const dateStr = date.toISOString().split('T')[0];
+        dailyData[dateStr] = { games: 0, uniquePlayers: new Set(), signups: 0 };
+      }
+
+      gamesData?.forEach(game => {
+        const dateStr = game.created_at.split('T')[0];
+        if (dailyData[dateStr]) {
+          dailyData[dateStr].games++;
+          dailyData[dateStr].uniquePlayers.add(game.player_id);
+        }
+      });
+
+      signupsData?.forEach(profile => {
+        const dateStr = profile.created_at.split('T')[0];
+        if (dailyData[dateStr]) {
+          dailyData[dateStr].signups++;
+        }
+      });
+
+      // Convert to array and format
+      const result = Object.entries(dailyData)
+        .map(([date, data]) => ({
+          date,
+          games: data.games,
+          uniquePlayers: data.uniquePlayers.size,
+          signups: data.signups,
+        }))
+        .sort((a, b) => a.date.localeCompare(b.date));
+
+      res.json({ daily: result });
+    } catch (error) {
+      console.error('[ADMIN API] Daily activity error:', error);
+      res.status(500).json({ error: 'Failed to fetch daily activity' });
+    }
+  });
+
+  // GET /api/admin/realtime - Get current realtime stats
+  server.get('/api/admin/realtime', adminAuth, async (_req, res) => {
+    try {
+      const { getAllGames } = require('./backend/modules/gameStateManager');
+      const games = getAllGames();
+
+      const activeRooms = games.length;
+      const playersOnline = games.reduce((sum, g) => sum + g.playerCount, 0);
+      const gamesInProgress = games.filter(g => g.status === 'playing').length;
+      const socketConnections = io.sockets.sockets.size;
+
+      res.json({
+        activeRooms,
+        playersOnline,
+        gamesInProgress,
+        socketConnections,
+        timestamp: Date.now(),
+      });
+    } catch (error) {
+      console.error('[ADMIN API] Realtime error:', error);
+      res.status(500).json({ error: 'Failed to fetch realtime stats' });
+    }
+  });
+
   // Next.js handler for all other routes
   server.use(async (req, res) => {
     try {

--- a/fe-next/supabase/migrations/010_admin_and_analytics.sql
+++ b/fe-next/supabase/migrations/010_admin_and_analytics.sql
@@ -1,0 +1,136 @@
+-- =============================================
+-- ADMIN ROLE AND ANALYTICS TRACKING
+-- Migration: 010_admin_and_analytics
+-- =============================================
+
+-- Add admin flag to profiles
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT FALSE;
+
+-- Add UTM tracking fields to profiles (track how users found the game)
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS utm_source TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS utm_medium TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS utm_campaign TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS referrer TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS country_code TEXT; -- ISO 3166-1 alpha-2
+
+-- Create analytics_events table for tracking various events
+CREATE TABLE IF NOT EXISTS analytics_events (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    event_type TEXT NOT NULL, -- 'page_view', 'game_start', 'game_end', 'signup', etc.
+    player_id UUID REFERENCES profiles(id) ON DELETE SET NULL,
+    session_id TEXT, -- For anonymous tracking
+    country_code TEXT,
+    utm_source TEXT,
+    utm_medium TEXT,
+    utm_campaign TEXT,
+    referrer TEXT,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for analytics queries
+CREATE INDEX IF NOT EXISTS idx_analytics_events_type ON analytics_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_created_at ON analytics_events(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_player_id ON analytics_events(player_id);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_country ON analytics_events(country_code);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_utm_source ON analytics_events(utm_source);
+
+-- Index for admin lookup
+CREATE INDEX IF NOT EXISTS idx_profiles_is_admin ON profiles(is_admin) WHERE is_admin = TRUE;
+
+-- Index for country analytics
+CREATE INDEX IF NOT EXISTS idx_profiles_country ON profiles(country_code);
+
+-- RLS for analytics_events - only service role can write, admins can read
+ALTER TABLE analytics_events ENABLE ROW LEVEL SECURITY;
+
+-- Allow admins to read analytics
+CREATE POLICY "Admins can read analytics"
+    ON analytics_events FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM profiles
+            WHERE profiles.id = auth.uid()
+            AND profiles.is_admin = TRUE
+        )
+    );
+
+-- Service role bypass for inserts (handled by backend)
+-- No INSERT/UPDATE/DELETE policies for regular users
+
+-- Grant the specific admin user admin access
+-- User ID: 9a4bd525-6517-488d-a4fa-ee20f76e06c9
+UPDATE profiles
+SET is_admin = TRUE
+WHERE id = '9a4bd525-6517-488d-a4fa-ee20f76e06c9';
+
+-- =============================================
+-- ANALYTICS HELPER FUNCTIONS
+-- =============================================
+
+-- Function to get daily unique players
+CREATE OR REPLACE FUNCTION get_daily_unique_players(target_date DATE DEFAULT CURRENT_DATE)
+RETURNS INTEGER AS $$
+BEGIN
+    RETURN (
+        SELECT COUNT(DISTINCT player_id)
+        FROM game_results
+        WHERE DATE(created_at) = target_date
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to get player count by date range
+CREATE OR REPLACE FUNCTION get_unique_players_in_range(start_date DATE, end_date DATE)
+RETURNS INTEGER AS $$
+BEGIN
+    RETURN (
+        SELECT COUNT(DISTINCT player_id)
+        FROM game_results
+        WHERE DATE(created_at) BETWEEN start_date AND end_date
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to get cumulative game time in hours
+CREATE OR REPLACE FUNCTION get_total_game_time_hours()
+RETURNS NUMERIC AS $$
+BEGIN
+    RETURN (
+        SELECT COALESCE(SUM(total_time_played) / 3600.0, 0)
+        FROM profiles
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to get games by country
+CREATE OR REPLACE FUNCTION get_players_by_country()
+RETURNS TABLE(country_code TEXT, player_count BIGINT) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT p.country_code, COUNT(*) as player_count
+    FROM profiles p
+    WHERE p.country_code IS NOT NULL
+    GROUP BY p.country_code
+    ORDER BY player_count DESC;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to get players by UTM source
+CREATE OR REPLACE FUNCTION get_players_by_utm_source()
+RETURNS TABLE(utm_source TEXT, player_count BIGINT) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT p.utm_source, COUNT(*) as player_count
+    FROM profiles p
+    WHERE p.utm_source IS NOT NULL
+    GROUP BY p.utm_source
+    ORDER BY player_count DESC;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Comments
+COMMENT ON COLUMN profiles.is_admin IS 'Whether user has admin dashboard access';
+COMMENT ON COLUMN profiles.country_code IS 'ISO 3166-1 alpha-2 country code';
+COMMENT ON COLUMN profiles.utm_source IS 'UTM source parameter from signup';
+COMMENT ON TABLE analytics_events IS 'General analytics event tracking table';

--- a/fe-next/types/user.ts
+++ b/fe-next/types/user.ts
@@ -36,6 +36,7 @@ export interface UserProfile {
   stats: UserStats;
   achievements: Achievement[];
   isGuest: boolean;
+  isAdmin?: boolean;
 }
 
 export interface UserStats {


### PR DESCRIPTION
- Add database migration for admin role and analytics tracking
- Create admin API endpoints for stats, players, sources, and activity
- Add is_admin flag to profiles and AuthContext
- Create responsive admin dashboard page with:
  - Realtime stats (socket connections, active rooms, players online)
  - Overview metrics (total players, games, play time, words)
  - Daily/weekly/monthly activity breakdowns
  - Games by language distribution
  - Players by country distribution
  - Traffic sources (UTM parameters, referrers)
  - Top players leaderboard
  - Daily activity chart
- Add admin link in header for authorized users
- Grant admin access to user ID 9a4bd525-6517-488d-a4fa-ee20f76e06c9