### PR TITLE
Fix language and URL synchronization issue

### DIFF
--- a/fe-next/contexts/LanguageContext.tsx
+++ b/fe-next/contexts/LanguageContext.tsx
@@ -88,9 +88,22 @@ export const LanguageProvider = ({ children, initialLanguage }: LanguageProvider
         languageRef.current = language;
     }, [language]);
 
-    // After mount, check for client-side preferences
+    // After mount, sync localStorage with URL locale
+    // URL is the source of truth - don't override explicit URL locale with stored preferences
     useEffect(() => {
         mountedRef.current = true;
+
+        // Get the locale from the URL path
+        const urlLocale = pathname ? parseLocaleFromPath(pathname) : null;
+
+        // If URL has an explicit locale, that's the source of truth
+        // Don't change language state - the URL dictates the language
+        if (urlLocale) {
+            return;
+        }
+
+        // Only if there's NO locale in URL (shouldn't happen with middleware, but fallback)
+        // do we check stored preferences
         const currentLang = languageRef.current;
 
         // Check localStorage for user's explicit preference


### PR DESCRIPTION
The post-mount effect was checking localStorage/cookies and potentially overriding the language state without updating the URL. This caused a scenario where URL showed /en but content displayed in Hebrew.

Now when there's an explicit locale in the URL path, that locale is respected as the source of truth. Stored preferences are only used as fallback when there's no locale in the URL (shouldn't happen with middleware but provides robustness).