### PR TITLE
Fix admin login stuck on loading screen

### DIFF
--- a/fe-next/lib/supabase.ts
+++ b/fe-next/lib/supabase.ts
@@ -14,7 +14,10 @@ export const supabase: SupabaseClient | null = supabaseUrl && supabaseAnonKey
       auth: {
         autoRefreshToken: true,
         persistSession: true,
-        detectSessionInUrl: true
+        // Disable auto-detection - we manually handle auth callback at /auth/callback
+        // This prevents race conditions where Supabase tries to exchange the code
+        // before our callback component mounts
+        detectSessionInUrl: false
       }
     })
   : null;


### PR DESCRIPTION
- Check for existing session BEFORE attempting code exchange to handle cases where session was set before component mounted
- Disable detectSessionInUrl to prevent race conditions between Supabase's auto-detection and our manual code exchange
- Add retry logic if code exchange fails (code might already be used)
- Add final session check with small delay for async session setting
- All hash flow and error redirects now use the 'next' URL consistently