### PR TITLE
Collect stats for UTM, referral domains, and guests

### DIFF
--- a/fe-next/JoinView.jsx
+++ b/fe-next/JoinView.jsx
@@ -20,6 +20,8 @@ import LogRocket from 'logrocket';
 import { validateUsername, validateRoomName, validateGameCode, sanitizeInput } from './utils/validation';
 import { useValidation } from './hooks/useValidation';
 import { generateRoomCode as generateCode } from './utils/utils';
+import { setGuestName } from './utils/guestManager';
+import { trackGuestJoin } from './utils/growthTracking';
 
 // Dynamic imports for heavy animation components (reduces initial bundle by ~50KB)
 const HowToPlay = dynamic(() => import('./components/HowToPlay'), { ssr: false });
@@ -184,6 +186,11 @@ const JoinView = ({ handleJoin, gameCode, username, setGameCode, setUsername, er
         role: 'host',
         gameCode: gameCode,
       });
+      // Store guest name and track analytics for guest hosts (non-authenticated)
+      if (!isAuthenticated) {
+        setGuestName(rn.trim());
+        trackGuestJoin(rn.trim(), gameCode, roomLanguage);
+      }
     } else {
       // Player needs username
       const un = sanitizeInput(username, 20);
@@ -208,6 +215,11 @@ const JoinView = ({ handleJoin, gameCode, username, setGameCode, setUsername, er
         role: 'player',
         gameCode: gameCode,
       });
+      // Store guest name and track analytics for guest players (non-authenticated)
+      if (!isAuthenticated) {
+        setGuestName(un.trim());
+        trackGuestJoin(un.trim(), gameCode, language);
+      }
     }
 
     handleJoin(mode === 'host', roomLanguage);
@@ -250,6 +262,11 @@ const JoinView = ({ handleJoin, gameCode, username, setGameCode, setUsername, er
       role: 'player',
       gameCode: gameCode,
     });
+    // Store guest name and track analytics for guest players (non-authenticated)
+    if (!isAuthenticated) {
+      setGuestName(un.trim());
+      trackGuestJoin(un.trim(), gameCode, language);
+    }
     handleJoin(false); // Always join mode for quick join
   };
 

--- a/fe-next/app/providers.jsx
+++ b/fe-next/app/providers.jsx
@@ -9,6 +9,17 @@ import { SoundEffectsProvider } from '@/contexts/SoundEffectsContext';
 import { AchievementQueueProvider } from '@/components/achievements';
 import { Toaster } from 'react-hot-toast';
 import ErrorBoundary from './components/ErrorBoundary';
+import { initUtmCapture } from '@/utils/utmCapture';
+
+// Initialize UTM capture immediately
+let utmCaptureInitialized = false;
+const initUtm = () => {
+    if (utmCaptureInitialized) return;
+    if (typeof window === 'undefined') return;
+
+    utmCaptureInitialized = true;
+    initUtmCapture();
+};
 
 // Lazy load LogRocket after user interaction to save ~100KB on initial load
 let logRocketInitialized = false;
@@ -23,6 +34,12 @@ const initLogRocket = () => {
 };
 
 export function Providers({ children, lang }) {
+    // Initialize UTM capture immediately on mount
+    // This captures UTM params and referrer from the initial page load
+    useEffect(() => {
+        initUtm();
+    }, []);
+
     // Defer LogRocket initialization for slow connections
     // Load after 3 seconds or on first user interaction, whichever comes first
     useEffect(() => {

--- a/fe-next/components/results/ShareWinPrompt.tsx
+++ b/fe-next/components/results/ShareWinPrompt.tsx
@@ -372,22 +372,25 @@ const ShareWinPrompt: React.FC<ShareWinPromptProps> = ({
     return pickRandom(getViralPrompts());
   }, [language]);
 
-  // Handle WhatsApp share
+  // Handle WhatsApp share - use whatsapp utm_source for tracking
   const handleWhatsAppShare = () => {
     trackShare('whatsapp', gameCode);
 
+    // Generate message with whatsapp utm_source
     const referralCode = generateReferralCode();
-    const url = getShareUrlWithTracking(gameCode, referralCode);
-    const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(shareMessage)}`;
+    const url = getShareUrlWithTracking(gameCode, referralCode, 'whatsapp');
+    // Replace URL in share message with the whatsapp-tracked URL
+    const messageWithTracking = shareMessage.replace(/https?:\/\/[^\s]+/, url);
+    const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(messageWithTracking)}`;
     window.open(whatsappUrl, '_blank');
   };
 
-  // Handle copy link
+  // Handle copy link - use copy utm_source for tracking
   const handleCopyLink = async () => {
     trackShare('copy', gameCode);
 
     const referralCode = generateReferralCode();
-    const url = getShareUrlWithTracking(gameCode, referralCode);
+    const url = getShareUrlWithTracking(gameCode, referralCode, 'copy');
 
     try {
       await navigator.clipboard.writeText(url);
@@ -399,16 +402,18 @@ const ShareWinPrompt: React.FC<ShareWinPromptProps> = ({
     }
   };
 
-  // Handle native share (if available)
+  // Handle native share (if available) - use native_share utm_source
   const handleNativeShare = async () => {
     if (navigator.share) {
       trackShare('native', gameCode);
 
       try {
+        const referralCode = generateReferralCode();
+        const url = getShareUrlWithTracking(gameCode, referralCode, 'native_share');
         await navigator.share({
           title: 'LexiClash',
-          text: shareMessage,
-          url: getShareUrlWithTracking(gameCode, generateReferralCode()),
+          text: shareMessage.replace(/https?:\/\/[^\s]+/, url),
+          url: url,
         });
       } catch {
         // User cancelled or error

--- a/fe-next/contexts/AuthContext.tsx
+++ b/fe-next/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ import {
   isSupabaseConfigured
 } from '../lib/supabase';
 import { getGuestSessionId, getGuestStats, clearGuestData, hashToken } from '../utils/guestManager';
+import { getUtmDataForProfile } from '../utils/utmCapture';
 import logger from '@/utils/logger';
 import type { User } from '@supabase/supabase-js';
 
@@ -54,6 +55,10 @@ export interface ProfileData {
   current_level?: number;
   is_admin?: boolean;
   country_code?: string | null;
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+  referrer?: string | null;
   created_at?: string;
   updated_at?: string;
 }
@@ -369,6 +374,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     // Fetch geolocation data for analytics
     const geoData = await fetchGeolocation();
 
+    // Get UTM and referral data captured during user's first visit
+    const utmData = getUtmDataForProfile();
+
     const profileData: Partial<ProfileData> = {
       id: user.id,
       username,
@@ -377,7 +385,11 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       avatar_color: avatarColor || '#4ECDC4',
       profile_picture_url: profilePictureUrl,
       profile_picture_provider: profilePictureProvider,
-      country_code: geoData.countryCode
+      country_code: geoData.countryCode,
+      utm_source: utmData.utm_source,
+      utm_medium: utmData.utm_medium,
+      utm_campaign: utmData.utm_campaign,
+      referrer: utmData.referrer,
     };
 
     // Check if there's a guest session to merge

--- a/fe-next/utils/guestManager.ts
+++ b/fe-next/utils/guestManager.ts
@@ -7,6 +7,7 @@ import logger from '@/utils/logger';
 
 const GUEST_SESSION_KEY = 'boggle_guest_session_id';
 const GUEST_STATS_KEY = 'boggle_guest_stats';
+const GUEST_NAME_KEY = 'boggle_guest_name';
 
 export interface GuestStats {
   games: number;
@@ -16,6 +17,8 @@ export interface GuestStats {
   longestWord: string | null;
   achievementCounts: Record<string, number>;
   createdAt: number;
+  // Guest player name for tracking
+  guestName?: string | null;
 }
 
 export interface GameResult {
@@ -159,6 +162,7 @@ export function clearGuestData(): void {
 
   localStorage.removeItem(GUEST_SESSION_KEY);
   localStorage.removeItem(GUEST_STATS_KEY);
+  localStorage.removeItem(GUEST_NAME_KEY);
 }
 
 /**
@@ -216,3 +220,39 @@ export function getGuestCasualGamesCount(): number {
   const stats = getGuestStats();
   return stats.games || 0;
 }
+
+/**
+ * Store guest player name for analytics tracking
+ */
+export function setGuestName(name: string): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    localStorage.setItem(GUEST_NAME_KEY, name);
+    // Also update in stats
+    const stats = getGuestStats();
+    stats.guestName = name;
+    saveGuestStats(stats);
+  } catch (error) {
+    logger.error('Error saving guest name:', error);
+  }
+}
+
+/**
+ * Get stored guest player name
+ */
+export function getGuestName(): string | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    // First check dedicated key
+    const name = localStorage.getItem(GUEST_NAME_KEY);
+    if (name) return name;
+    // Fall back to stats
+    const stats = getGuestStats();
+    return stats.guestName || null;
+  } catch {
+    return null;
+  }
+}
+

--- a/fe-next/utils/utmCapture.ts
+++ b/fe-next/utils/utmCapture.ts
@@ -1,0 +1,219 @@
+/**
+ * UTM Parameter and Referral Capture Utility
+ * Captures UTM parameters and referrer data for analytics tracking
+ */
+
+import logger from '@/utils/logger';
+
+const UTM_STORAGE_KEY = 'lexiclash_utm_data';
+
+export interface UtmData {
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  utm_term: string | null;
+  utm_content: string | null;
+  referrer: string | null;
+  ref: string | null; // Custom referral code from share links
+  captured_at: number;
+}
+
+/**
+ * Extract UTM parameters from current URL
+ */
+export function extractUtmFromUrl(): Partial<UtmData> {
+  if (typeof window === 'undefined') return {};
+
+  const params = new URLSearchParams(window.location.search);
+
+  return {
+    utm_source: params.get('utm_source'),
+    utm_medium: params.get('utm_medium'),
+    utm_campaign: params.get('utm_campaign'),
+    utm_term: params.get('utm_term'),
+    utm_content: params.get('utm_content'),
+    ref: params.get('ref'),
+  };
+}
+
+/**
+ * Get HTTP referrer domain
+ */
+export function getReferrerDomain(): string | null {
+  if (typeof window === 'undefined') return null;
+
+  const referrer = document.referrer;
+  if (!referrer) return null;
+
+  try {
+    const url = new URL(referrer);
+    // Exclude self-referrals
+    if (url.hostname === window.location.hostname) return null;
+    return url.hostname;
+  } catch {
+    return referrer; // Return raw if URL parsing fails
+  }
+}
+
+/**
+ * Get full referrer URL
+ */
+export function getReferrerUrl(): string | null {
+  if (typeof window === 'undefined') return null;
+
+  const referrer = document.referrer;
+  if (!referrer) return null;
+
+  try {
+    const url = new URL(referrer);
+    // Exclude self-referrals
+    if (url.hostname === window.location.hostname) return null;
+    return referrer;
+  } catch {
+    return referrer;
+  }
+}
+
+/**
+ * Capture and store UTM data on page load
+ * Should be called once when the app initializes
+ */
+export function captureUtmData(): void {
+  if (typeof window === 'undefined') return;
+
+  // Check if we already have stored UTM data
+  const existing = getStoredUtmData();
+
+  const urlUtm = extractUtmFromUrl();
+  const referrer = getReferrerUrl();
+
+  // Only update if we have new UTM data or referrer
+  const hasNewData = urlUtm.utm_source || urlUtm.utm_medium || urlUtm.utm_campaign ||
+                     urlUtm.ref || referrer;
+
+  if (hasNewData) {
+    // Merge with existing, preferring new values
+    const utmData: UtmData = {
+      utm_source: urlUtm.utm_source || existing?.utm_source || null,
+      utm_medium: urlUtm.utm_medium || existing?.utm_medium || null,
+      utm_campaign: urlUtm.utm_campaign || existing?.utm_campaign || null,
+      utm_term: urlUtm.utm_term || existing?.utm_term || null,
+      utm_content: urlUtm.utm_content || existing?.utm_content || null,
+      referrer: referrer || existing?.referrer || null,
+      ref: urlUtm.ref || existing?.ref || null,
+      captured_at: Date.now(),
+    };
+
+    try {
+      localStorage.setItem(UTM_STORAGE_KEY, JSON.stringify(utmData));
+      logger.info('[UTM] Captured UTM data:', utmData);
+    } catch (error) {
+      logger.warn('[UTM] Failed to store UTM data:', error);
+    }
+  }
+}
+
+/**
+ * Get stored UTM data from localStorage
+ */
+export function getStoredUtmData(): UtmData | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const stored = localStorage.getItem(UTM_STORAGE_KEY);
+    if (!stored) return null;
+    return JSON.parse(stored) as UtmData;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get UTM data for profile creation (flattened for database)
+ */
+export function getUtmDataForProfile(): {
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  referrer: string | null;
+} {
+  const utmData = getStoredUtmData();
+
+  // If we have a ref code but no utm_source, use ref as the source
+  let utm_source = utmData?.utm_source || null;
+  if (!utm_source && utmData?.ref) {
+    utm_source = `ref:${utmData.ref}`;
+  }
+
+  return {
+    utm_source,
+    utm_medium: utmData?.utm_medium || null,
+    utm_campaign: utmData?.utm_campaign || null,
+    referrer: utmData?.referrer || null,
+  };
+}
+
+/**
+ * Clear stored UTM data (e.g., after successful profile creation)
+ * Note: We don't clear this to preserve attribution across sessions
+ */
+export function clearUtmData(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(UTM_STORAGE_KEY);
+}
+
+/**
+ * Get utm_source for event tracking (prioritizes current URL over stored)
+ */
+export function getUtmSourceForTracking(): string | null {
+  if (typeof window === 'undefined') return null;
+
+  const params = new URLSearchParams(window.location.search);
+
+  // First check current URL
+  const urlSource = params.get('utm_source') || params.get('ref');
+  if (urlSource) return urlSource;
+
+  // Fall back to stored
+  const stored = getStoredUtmData();
+  return stored?.utm_source || stored?.ref || null;
+}
+
+/**
+ * Check if user came from WhatsApp (detected via referrer)
+ */
+export function isWhatsAppReferral(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  const referrer = document.referrer.toLowerCase();
+  return referrer.includes('whatsapp') || referrer.includes('wa.me');
+}
+
+/**
+ * Initialize UTM capture on app load
+ * Call this in the root layout or app component
+ */
+export function initUtmCapture(): void {
+  if (typeof window === 'undefined') return;
+
+  // Capture immediately on load
+  captureUtmData();
+
+  // Also capture if user navigates back with UTM params
+  window.addEventListener('popstate', () => {
+    captureUtmData();
+  });
+}
+
+export default {
+  captureUtmData,
+  getStoredUtmData,
+  getUtmDataForProfile,
+  getUtmSourceForTracking,
+  isWhatsAppReferral,
+  initUtmCapture,
+  extractUtmFromUrl,
+  getReferrerDomain,
+  getReferrerUrl,
+  clearUtmData,
+};


### PR DESCRIPTION
- Add utmCapture utility to extract and store UTM params/referrer on page load
- Update AuthContext to save UTM data during profile creation
- Add guest name tracking in guestManager
- Update share.ts to include utm_source for WhatsApp, copy, and native shares
- Add /api/analytics/track endpoint for guest player event tracking
- Update /api/admin/players/sources to combine registered user and guest stats
- Add /api/admin/analytics/guest-players endpoint for guest analytics
- Initialize UTM capture in providers on app load
- Integrate guest tracking in JoinView when players join games

UTM sources now tracked: whatsapp, copy, native_share, referral, ref codes