### PR TITLE
Fix ES module export syntax error

### DIFF
--- a/fe-next/translations/index.js
+++ b/fe-next/translations/index.js
@@ -4082,3 +4082,8 @@ export const translations = {
     }
   }
 };
+
+// CommonJS export for backend compatibility
+if (typeof module \!== 'undefined' && module.exports) {
+  module.exports = { translations };
+}


### PR DESCRIPTION
The translations/index.js file was using ES module syntax (export const) but the backend modules use CommonJS (require). Added a conditional CommonJS export to support both module systems.