### PR TITLE
Debug build failure on Metal builder

### DIFF
--- a/fe-next/translations/index.js
+++ b/fe-next/translations/index.js
@@ -4084,6 +4084,6 @@ export const translations = {
 };
 
 // CommonJS export for backend compatibility
-if (typeof module \!== 'undefined' && module.exports) {
+if (typeof module !== 'undefined' && module.exports) {
   module.exports = { translations };
 }


### PR DESCRIPTION
The backslash before !== was causing a Turbopack parsing error during build.