### PR TITLE
Fix undefined io variable in game results

### DIFF
--- a/fe-next/backend/socketHandlers.js
+++ b/fe-next/backend/socketHandlers.js
@@ -2461,18 +2461,19 @@ async function calculateAndBroadcastFinalScores(io, gameCode) {
   }
 
   // Record game results to Supabase
-  await recordGameResultsToSupabase(gameCode, scoresArray, game);
+  await recordGameResultsToSupabase(io, gameCode, scoresArray, game);
 
   logger.info('FINAL_SCORES', `Final scores broadcast for game ${gameCode}`);
 }
 
 /**
  * Record game results to Supabase for leaderboard and stats
+ * @param {object} io - Socket.IO server instance
  * @param {string} gameCode - Game code
  * @param {array} scoresArray - Array of player scores with metadata
  * @param {object} game - Game object
  */
-async function recordGameResultsToSupabase(gameCode, scoresArray, game) {
+async function recordGameResultsToSupabase(io, gameCode, scoresArray, game) {
   if (!isSupabaseConfigured()) {
     logger.debug('SUPABASE', `Supabase not configured, skipping stats save for game ${gameCode}`);
     return;


### PR DESCRIPTION
The function was using io.sockets.sockets.get() to emit XP events to players but io was not being passed to the function. Added io as the first parameter and updated the call from calculateAndBroadcastFinalScores to pass it through.

Fixes ReferenceError: io is not defined at line 2542