### PR TITLE
Fix authentication callback stuck on language path

### DIFF
--- a/fe-next/app/[locale]/auth/callback/page.jsx
+++ b/fe-next/app/[locale]/auth/callback/page.jsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, Suspense } from 'react';
 import { useRouter, useSearchParams, useParams } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
 import logger from '@/utils/logger';
-import { defaultLocale } from '@/lib/i18n';
+import { defaultLocale, locales } from '@/lib/i18n';
 
 // Loading UI component
 function LoadingUI() {
@@ -41,10 +41,14 @@ function AuthCallbackContent() {
           return;
         }
 
-        // Ensure next URL has locale prefix
+        // Ensure next URL has the correct locale prefix
         let next = searchParams.get('next') || `/${locale}`;
         if (next === '/') {
           next = `/${locale}`;
+        } else if (!next.startsWith(`/${locale}`)) {
+          // If next URL has a different locale or no locale, update it to use current locale
+          const pathWithoutLocale = next.replace(/^\/(he|en|sv|ja)/, '');
+          next = `/${locale}${pathWithoutLocale || ''}`;
         }
 
         // IMPORTANT: Check for existing session FIRST

--- a/fe-next/app/auth/callback/route.js
+++ b/fe-next/app/auth/callback/route.js
@@ -61,8 +61,17 @@ export async function GET(request) {
   const errorParam = requestUrl.searchParams.get('error');
   const errorDescription = requestUrl.searchParams.get('error_description');
 
-  // Detect the user's preferred locale
-  const locale = getPreferredLocale(request);
+  // Priority 1: Use locale from query param (passed from OAuth redirect)
+  // This preserves the user's locale from before they started the OAuth flow
+  const localeParam = requestUrl.searchParams.get('locale');
+
+  // Detect the user's preferred locale (fallback if not in query param)
+  let locale;
+  if (localeParam && locales.includes(localeParam)) {
+    locale = localeParam;
+  } else {
+    locale = getPreferredLocale(request);
+  }
 
   // Get the correct origin (handles proxy scenarios)
   const origin = getOrigin(request);

--- a/fe-next/lib/supabase.ts
+++ b/fe-next/lib/supabase.ts
@@ -14,20 +14,47 @@ export const supabase: SupabaseClient | null = supabaseUrl && supabaseAnonKey
   ? createBrowserClient(supabaseUrl, supabaseAnonKey)
   : null;
 
+// Helper to get the current locale from the URL path
+function getCurrentLocale(): string | null {
+  if (typeof window === 'undefined') return null;
+  const pathSegments = window.location.pathname.split('/').filter(Boolean);
+  const locales = ['he', 'en', 'sv', 'ja'];
+  if (pathSegments.length > 0 && locales.includes(pathSegments[0])) {
+    return pathSegments[0];
+  }
+  return null;
+}
+
 // Auth helper functions
 export async function signInWithGoogle() {
   if (!supabase) return { error: { message: 'Supabase not configured' } };
+
+  // Include current locale in the callback URL so we can redirect back correctly
+  const currentLocale = getCurrentLocale();
+  const redirectUrl = new URL('/auth/callback', window.location.origin);
+  if (currentLocale) {
+    redirectUrl.searchParams.set('locale', currentLocale);
+  }
+
   return supabase.auth.signInWithOAuth({
     provider: 'google',
-    options: { redirectTo: `${window.location.origin}/auth/callback` }
+    options: { redirectTo: redirectUrl.toString() }
   });
 }
 
 export async function signInWithDiscord() {
   if (!supabase) return { error: { message: 'Supabase not configured' } };
+
+  // Include current locale in the callback URL so we can redirect back correctly
+  const currentLocale = getCurrentLocale();
+  const redirectUrl = new URL('/auth/callback', window.location.origin);
+  if (currentLocale) {
+    redirectUrl.searchParams.set('locale', currentLocale);
+  }
+
   return supabase.auth.signInWithOAuth({
     provider: 'discord',
-    options: { redirectTo: `${window.location.origin}/auth/callback` }
+    options: { redirectTo: redirectUrl.toString() }
   });
 }
 


### PR DESCRIPTION
The auth callback was getting stuck when the user's browsing locale didn't match their browser language or cookie preference. This fix:

- Passes the current locale from the OAuth initiation to the callback URL
- Server callback route prioritizes the locale query param over detection
- Client callback ensures next URL uses the correct locale prefix

This prevents users from being redirected to the wrong locale after authentication and fixes the callback getting stuck issue.