### PR TITLE
Fix bot finding non-existent words

### DIFF
--- a/fe-next/backend/modules/boggleSolver.js
+++ b/fe-next/backend/modules/boggleSolver.js
@@ -179,6 +179,13 @@ function findWordsForBots(grid, language, options = {}) {
     maxWords: 300
   });
 
+  // Filter to only solid words (no excessive duplicate letters)
+  // Allow max 2 of same letter for short words, 3 for longer words
+  const solidWords = allWords.filter(word => {
+    const maxDupes = word.length >= 6 ? 3 : 2;
+    return isSolidWord(word, maxDupes);
+  });
+
   // Categorize by difficulty based on word length
   const result = {
     easy: [],    // 3-4 letter words
@@ -186,7 +193,7 @@ function findWordsForBots(grid, language, options = {}) {
     hard: []     // 6+ letter words
   };
 
-  for (const word of allWords) {
+  for (const word of solidWords) {
     const len = word.length;
     if (len <= 4) {
       result.easy.push(word);
@@ -217,6 +224,29 @@ function shuffleArray(array) {
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
   return shuffled;
+}
+
+/**
+ * Check if a word is "solid" - doesn't have too many duplicate letters
+ * Words with excessive duplicates (like "aaaa", "mississippi") are often obscure
+ * @param {string} word - Word to check
+ * @param {number} maxDuplicates - Maximum allowed occurrences of any single letter (default: 2)
+ * @returns {boolean} - True if word is solid (acceptable)
+ */
+function isSolidWord(word, maxDuplicates = 2) {
+  if (!word || word.length < 3) return false;
+
+  // Count letter occurrences
+  const letterCounts = {};
+  for (const char of word.toLowerCase()) {
+    letterCounts[char] = (letterCounts[char] || 0) + 1;
+    // Quick exit if any letter exceeds max
+    if (letterCounts[char] > maxDuplicates) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /**
@@ -281,5 +311,6 @@ module.exports = {
   getWordPath,
   buildTrie,
   getTrieNode,
-  shuffleArray
+  shuffleArray,
+  isSolidWord
 };

--- a/fe-next/backend/modules/botManager.js
+++ b/fe-next/backend/modules/botManager.js
@@ -434,10 +434,8 @@ function calculateNextDelay(bot) {
  * @param {number} gameDuration - Game duration in seconds
  */
 function startBot(bot, grid, language, onWordSubmit, gameDuration) {
-  // Prepare words if not already done
-  if (bot.wordsToFind.length === 0) {
-    prepareBotWords(bot, grid, language);
-  }
+  // Always prepare fresh words for the new grid (fixes bots not finding words after first game)
+  prepareBotWords(bot, grid, language);
 
   bot.isActive = true;
   const timing = BOT_CONFIG.TIMING[bot.difficulty] || BOT_CONFIG.TIMING.medium;


### PR DESCRIPTION
- Always reset bot words for each new game (fixes bots not finding words after first game)
- Add isSolidWord filter to reject words with too many duplicate letters
- Short words allow max 2 duplicate letters, longer words allow max 3
- This makes bots find more common, recognizable words