### PR TITLE
Fix authentication callback stuck issue

### DIFF
--- a/fe-next/app/[locale]/auth/callback/page.jsx
+++ b/fe-next/app/[locale]/auth/callback/page.jsx
@@ -139,7 +139,8 @@ function AuthCallbackContent() {
         }
 
         // Final check for session - might have been set asynchronously
-        await new Promise(resolve => setTimeout(resolve, 300));
+        // Use longer timeout for slow connections/mobile networks
+        await new Promise(resolve => setTimeout(resolve, 1000));
         const { data: finalCheck } = await supabase.auth.getSession();
         if (finalCheck?.session) {
           logger.log('Auth callback: Session found in final check');

--- a/fe-next/lib/supabase.ts
+++ b/fe-next/lib/supabase.ts
@@ -10,8 +10,16 @@ if (!supabaseUrl || !supabaseAnonKey) {
 }
 
 // Browser client using @supabase/ssr for proper cookie-based session handling
+// CRITICAL: detectSessionInUrl must be false to prevent race condition in auth callback
+// When true (default), Supabase auto-detects and exchanges the auth code in background,
+// which races with our manual exchangeCodeForSession() call in the callback page.
 export const supabase: SupabaseClient | null = supabaseUrl && supabaseAnonKey
-  ? createBrowserClient(supabaseUrl, supabaseAnonKey)
+  ? createBrowserClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        detectSessionInUrl: false,
+        flowType: 'pkce'
+      }
+    })
   : null;
 
 // Helper to get the current locale from the URL path


### PR DESCRIPTION
…nUrl

The migration to @supabase/ssr removed the critical detectSessionInUrl: false configuration, causing a race condition where:
- Supabase auto-detection exchanges the auth code in background
- The callback page also tries to exchange the same code
- The second exchange fails with "code already used"
- User gets stuck on the loading screen

This fix:
- Adds detectSessionInUrl: false to prevent auto-detection racing with manual exchange
- Sets flowType: 'pkce' explicitly for clearer auth flow
- Increases session check timeout from 300ms to 1000ms for slow connections