### PR TITLE
Fix game timer updating every 10 seconds

### DIFF
--- a/fe-next/host/HostView.jsx
+++ b/fe-next/host/HostView.jsx
@@ -161,6 +161,26 @@ const HostView = ({ gameCode, roomLanguage: roomLanguageProp, initialPlayers = [
     }
   }, [remainingTime, gameStarted, playCountdownBeep]);
 
+  // Client-side countdown timer - decrements remainingTime every second
+  // Server broadcasts time updates every ~10 seconds, so we interpolate locally
+  useEffect(() => {
+    if (!gameStarted || remainingTime === null || remainingTime <= 0) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      setRemainingTime(prev => {
+        if (prev === null || prev <= 0) {
+          clearInterval(intervalId);
+          return prev;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, [gameStarted, remainingTime === null, remainingTime <= 0]);
+
   // Update players list from props
   useEffect(() => {
     setPlayersReady(initialPlayers);

--- a/fe-next/player/PlayerView.jsx
+++ b/fe-next/player/PlayerView.jsx
@@ -144,6 +144,26 @@ const PlayerView = ({ onShowResults, initialPlayers = [], username, gameCode, pe
     }
   }, [remainingTime, gameActive, playCountdownBeep]);
 
+  // Client-side countdown timer - decrements remainingTime every second
+  // Server broadcasts time updates every ~10 seconds, so we interpolate locally
+  useEffect(() => {
+    if (!gameActive || remainingTime === null || remainingTime <= 0) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      setRemainingTime(prev => {
+        if (prev === null || prev <= 0) {
+          clearInterval(intervalId);
+          return prev;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, [gameActive, remainingTime === null, remainingTime <= 0]);
+
   // Keep refs in sync
   useEffect(() => {
     comboLevelRef.current = comboLevel;


### PR DESCRIPTION
The server optimizes network traffic by broadcasting timer updates every 10 seconds. This adds local countdown logic to interpolate between server broadcasts, ensuring the timer UI updates every second for both players and hosts.