### PR TITLE
Fix leaderboard flickering on results screen

### DIFF
--- a/fe-next/components/SlotMachineText.jsx
+++ b/fe-next/components/SlotMachineText.jsx
@@ -1,20 +1,43 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 const SlotMachineText = ({ text, duration = 1000 }) => {
-    const [displayedText, setDisplayedText] = useState('');
-    const [isAnimating, setIsAnimating] = useState(true);
-    const [glowIntensity, setGlowIntensity] = useState(0);
+    const [displayedText, setDisplayedText] = useState(text);
+    const [isAnimating, setIsAnimating] = useState(false);
+    const [glowIntensity, setGlowIntensity] = useState(1);
+
+    // Track if we've already animated this text to prevent re-animation on parent re-renders
+    const hasAnimatedRef = useRef(new Set());
+    const lastTextRef = useRef(text);
 
     // Include Hebrew characters for better support
     const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789אבגדהוזחטיכלמנסעפצקרשת!@#$%^&*()';
 
     useEffect(() => {
+        // Only animate if this is a new text we haven't animated before
+        if (hasAnimatedRef.current.has(text)) {
+            // Already animated this text, just display it without animation
+            setDisplayedText(text);
+            setIsAnimating(false);
+            setGlowIntensity(1);
+            return;
+        }
+
+        // If text actually changed to something new, animate it
+        const isNewText = lastTextRef.current !== text;
+        lastTextRef.current = text;
+
+        // Mark this text as animated
+        hasAnimatedRef.current.add(text);
+
+        // Only run animation for new, unseen text
+        if (!isNewText && hasAnimatedRef.current.size > 1) {
+            setDisplayedText(text);
+            return;
+        }
+
         let startTime = Date.now();
         let animationFrame;
-        // Defer state update to avoid synchronous setState
-        Promise.resolve().then(() => {
-            setIsAnimating(true);
-        });
+        setIsAnimating(true);
 
         const animate = () => {
             const now = Date.now();

--- a/fe-next/player/components/PlayerWaitingResultsView.jsx
+++ b/fe-next/player/components/PlayerWaitingResultsView.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { FaTrophy } from 'react-icons/fa';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '../../components/ui/alert-dialog';
@@ -26,6 +26,8 @@ const PlayerWaitingResultsView = ({
   const [currentWordIndex, setCurrentWordIndex] = useState(0);
   // Simulated progress percentage
   const [progress, setProgress] = useState(0);
+  // Track which players have already been animated to prevent re-animations
+  const animatedPlayersRef = useRef(new Set());
 
   // Validation stages with messages
   const validationStages = useMemo(() => [
@@ -204,6 +206,11 @@ const PlayerWaitingResultsView = ({
                 <div className="p-3 space-y-2 max-h-[300px] overflow-y-auto">
                   {leaderboard.map((player, index) => {
                     const isMe = player.username === username;
+                    // Track if this player has already been animated
+                    const isNewPlayer = !animatedPlayersRef.current.has(player.username);
+                    if (isNewPlayer) {
+                      animatedPlayersRef.current.add(player.username);
+                    }
                     const getRankStyle = () => {
                       if (index === 0) return 'bg-neo-yellow text-neo-black';
                       if (index === 1) return 'bg-slate-300 text-neo-black';
@@ -213,10 +220,14 @@ const PlayerWaitingResultsView = ({
                     return (
                       <motion.div
                         key={player.username}
-                        initial={{ opacity: 0 }}
+                        layout
+                        initial={isNewPlayer ? { opacity: 0 } : false}
                         animate={{ opacity: 1 }}
-                        transition={{ duration: 0.2, delay: index * 0.05 }}
-                        className={`flex items-center gap-3 p-3 rounded-neo border-3 border-neo-black shadow-hard-sm transition-all
+                        transition={{
+                          layout: { type: 'spring', stiffness: 300, damping: 30 },
+                          opacity: isNewPlayer ? { duration: 0.2, delay: index * 0.05 } : { duration: 0 }
+                        }}
+                        className={`flex items-center gap-3 p-3 rounded-neo border-3 border-neo-black shadow-hard-sm transition-colors
                           hover:translate-x-[-1px] hover:translate-y-[-1px] hover:shadow-hard
                           ${getRankStyle()} ${dir === 'rtl' ? 'flex-row-reverse' : ''}`}
                       >


### PR DESCRIPTION
- Fix SlotMachineText to track already-animated text and prevent re-animation on parent re-renders
- Memoize leaderboard calculation in HostWaitingResultsView to prevent unnecessary recalculations
- Use Framer Motion layout animations instead of initial/animate for smooth position changes when rankings update
- Track animated players with refs to prevent entrance animations from replaying when list re-renders