### PR TITLE
Fix verify word modal not appearing for bots

### DIFF
--- a/fe-next/backend/modules/gameStateManager.js
+++ b/fe-next/backend/modules/gameStateManager.js
@@ -714,6 +714,7 @@ function addPlayerWord(gameCode, username, word, options = {}) {
       validated: validatedStatus,
       autoValidated: options.autoValidated || false,
       onBoard: true,
+      isBot: options.isBot || false,
     });
   }
 }


### PR DESCRIPTION
The isBot flag was passed to addPlayerWord() but never stored in playerWordDetails. This caused collectNonDictionaryWords() to never find bot words since detail.isBot was always undefined, preventing the word verification modal from showing bot words to players.