### PR TITLE
Add difficulty levels and word rejection tooltips

### DIFF
--- a/fe-next/backend/socketHandlers.js
+++ b/fe-next/backend/socketHandlers.js
@@ -2599,6 +2599,22 @@ async function calculateAndBroadcastFinalScores(io, gameCode) {
         score += wordScore;
       }
 
+      // Determine invalid reason for rejected words
+      // Priority: AI reason > default "Not found in dictionary"
+      let invalidReasonText = undefined;
+      if (!isValid && !isPendingValidation) {
+        if (aiResult?.reason) {
+          // AI provided a specific reason for rejection
+          invalidReasonText = aiResult.reason;
+        } else if (aiResult && !aiResult.isValid) {
+          // AI checked and rejected but no specific reason
+          invalidReasonText = 'Invalid word';
+        } else {
+          // Not in dictionary and AI didn't check
+          invalidReasonText = 'Not found in dictionary';
+        }
+      }
+
       wordObjects.push({
         word: word,
         score: isDuplicate ? 0 : wordScore,
@@ -2609,7 +2625,7 @@ async function calculateAndBroadcastFinalScores(io, gameCode) {
         isPendingValidation: isPendingValidation, // New flag for pending community validation
         isAiVerified: aiResult?.isAiVerified || wordDetail?.isAiVerified || false,  // Track if AI verified
         aiReason: aiResult?.reason || undefined,  // AI's reason for validating/invalidating (shown in tooltip)
-        invalidReason: !isValid && aiResult?.reason ? aiResult.reason : undefined  // Reason for invalid words (in game language)
+        invalidReason: invalidReasonText  // Reason for invalid words (shown in tooltip)
       });
     });
 

--- a/fe-next/player/components/PlayerWaitingResultsView.jsx
+++ b/fe-next/player/components/PlayerWaitingResultsView.jsx
@@ -167,19 +167,18 @@ const PlayerWaitingResultsView = ({
                 </div>
               )}
 
-              {/* Processing indicators - More subtle animation */}
+              {/* Processing indicators - Opacity-only animation to prevent layout shift */}
               <div className="flex gap-3 mt-4 justify-center">
                 {[0, 1, 2].map((i) => (
                   <motion.div
                     key={i}
                     animate={{
-                      scale: [1, 1.15, 1],
-                      opacity: [0.5, 1, 0.5],
+                      opacity: [0.3, 1, 0.3],
                     }}
                     transition={{
                       duration: 1.5,
                       repeat: Infinity,
-                      delay: i * 0.2,
+                      delay: i * 0.3,
                       ease: 'easeInOut',
                     }}
                     className="w-3 h-3 bg-neo-black rounded-full"
@@ -220,15 +219,13 @@ const PlayerWaitingResultsView = ({
                     return (
                       <motion.div
                         key={player.username}
-                        layout
                         initial={isNewPlayer ? { opacity: 0 } : false}
                         animate={{ opacity: 1 }}
                         transition={{
-                          layout: { type: 'spring', stiffness: 300, damping: 30 },
-                          opacity: isNewPlayer ? { duration: 0.2, delay: index * 0.05 } : { duration: 0 }
+                          opacity: isNewPlayer ? { duration: 0.3, delay: index * 0.05 } : { duration: 0 }
                         }}
                         className={`flex items-center gap-3 p-3 rounded-neo border-3 border-neo-black shadow-hard-sm transition-colors
-                          hover:translate-x-[-1px] hover:translate-y-[-1px] hover:shadow-hard
+                          hover:brightness-110
                           ${getRankStyle()} ${dir === 'rtl' ? 'flex-row-reverse' : ''}`}
                       >
                         <div className="w-10 h-10 rounded-neo flex items-center justify-center font-black text-lg bg-neo-black text-neo-white border-2 border-neo-black">

--- a/fe-next/types/game.ts
+++ b/fe-next/types/game.ts
@@ -7,7 +7,7 @@ export type Language = 'he' | 'en' | 'sv' | 'ja' | 'es' | 'fr' | 'de';
 
 export type GameState = 'waiting' | 'in-progress' | 'finished' | 'validating';
 
-export type DifficultyLevel = 'EASY' | 'MEDIUM' | 'HARD' | 'EXPERT' | 'MASTER';
+export type DifficultyLevel = 'EASY' | 'MEDIUM' | 'HARD';
 
 export interface Difficulty {
   nameKey: string;
@@ -19,8 +19,6 @@ export interface DifficultySettings {
   EASY: Difficulty;
   MEDIUM: Difficulty;
   HARD: Difficulty;
-  EXPERT: Difficulty;
-  MASTER: Difficulty;
 }
 
 export type LetterGrid = string[][];

--- a/fe-next/utils/consts.ts
+++ b/fe-next/utils/consts.ts
@@ -104,11 +104,9 @@ export const kanjiCompounds: string[] = [
 ];
 
 export const DIFFICULTIES: DifficultySettings = {
-  EASY: { nameKey: 'difficulty.easy', rows: 4, cols: 4 },
-  MEDIUM: { nameKey: 'difficulty.medium', rows: 5, cols: 5 },
-  HARD: { nameKey: 'difficulty.hard', rows: 7, cols: 7 },
-  EXPERT: { nameKey: 'difficulty.expert', rows: 9, cols: 9 },
-  MASTER: { nameKey: 'difficulty.master', rows: 11, cols: 11 },
+  EASY: { nameKey: 'difficulty.easy', rows: 5, cols: 5 },
+  MEDIUM: { nameKey: 'difficulty.medium', rows: 7, cols: 7 },
+  HARD: { nameKey: 'difficulty.hard', rows: 11, cols: 11 },
 };
 
 export const DEFAULT_DIFFICULTY = 'MEDIUM' as const;
@@ -120,8 +118,6 @@ export const DIFFICULTY_TIMERS: Record<string, number> = {
   EASY: 60,     // 1 minute - small board, quick games
   MEDIUM: 60,   // 1 minute - default, fast-paced
   HARD: 120,    // 2 minutes - larger board
-  EXPERT: 180,  // 3 minutes - large board, more searching
-  MASTER: 240,  // 4 minutes - massive board, extensive exploration
 };
 
 export const DEFAULT_TIMER = 60; // 1 minute


### PR DESCRIPTION
- Simplify difficulty levels to 3 options:
  - Easy: 5x5 board, 1 minute
  - Medium: 7x7 board, 1 minute (default)
  - Hard: 11x11 board, 2 minutes

- Fix AI reasoning tooltips for rejected words:
  - Now shows "Not found in dictionary" for words not in dictionary
  - Shows AI's specific reason when AI rejects a word
  - Shows "Invalid word" when AI rejects without specific reason

- Fix shaking issue on waiting results screen:
  - Remove layout animations that caused position shifting
  - Replace scale animations with opacity-only transitions
  - Change hover effect to brightness instead of transforms

- Fix room creation getting stuck:
  - Add rateLimited event handler on frontend
  - Show user-friendly message when rate limited
  - Clear loading state properly on rate limit