### PR TITLE
Fix page shaking and improve achievement difficulty

### DIFF
--- a/fe-next/ResultsPage.jsx
+++ b/fe-next/ResultsPage.jsx
@@ -83,9 +83,9 @@ const LetterGrid = ({ letterGrid, heatMapData, showHeatmap, onToggleHeatmap }) =
       {/* Heatmap Toggle Button - Always visible */}
       {heatMapData && heatMapData.maxCount > 0 && (
         <motion.button
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.3 }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.3, duration: 0.3 }}
           onClick={onToggleHeatmap}
           className={`mb-3 mx-auto flex items-center gap-2 px-4 py-2 rounded-neo border-3 border-neo-black font-bold text-sm uppercase transition-all shadow-hard-sm hover:shadow-hard hover:translate-x-[-1px] hover:translate-y-[-1px] active:translate-x-[1px] active:translate-y-[1px] active:shadow-hard-pressed ${
             showHeatmap
@@ -452,9 +452,9 @@ const ResultsPage = ({ finalScores, letterGrid, gameCode, onReturnToRoom, userna
           {/* Letter Grid */}
           {letterGrid && (
             <motion.div
-              initial={{ y: 20, opacity: 0 }}
-              animate={{ y: 0, opacity: 1 }}
-              transition={{ delay: 0.1 }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.1, duration: 0.3 }}
               className="mb-6 px-0 sm:px-4"
             >
               <LetterGrid
@@ -468,9 +468,9 @@ const ResultsPage = ({ finalScores, letterGrid, gameCode, onReturnToRoom, userna
 
           {/* Final Scores Title */}
           <motion.div
-            initial={{ y: 20, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ delay: 0.2 }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.2, duration: 0.3 }}
             className="flex items-center justify-center gap-3 mb-6"
           >
             <motion.div
@@ -554,10 +554,11 @@ const ResultsPage = ({ finalScores, letterGrid, gameCode, onReturnToRoom, userna
         {/* Play Again Section - Neo-Brutalist */}
         {gameCode && onReturnToRoom && (
           <motion.div
-            initial={{ y: 30, opacity: 0, rotate: -2 }}
-            animate={{ y: 0, opacity: 1, rotate: 1 }}
-            transition={{ delay: 0.5 + sortedScores.length * 0.1 }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.5 + sortedScores.length * 0.1, duration: 0.3 }}
             className="mt-8 max-w-4xl mx-auto"
+            style={{ transform: 'rotate(1deg)' }}
           >
             <div className="p-5 sm:p-6 bg-neo-cyan border-4 border-neo-black rounded-neo-lg shadow-hard-xl relative overflow-hidden">
               {/* Halftone texture pattern */}

--- a/fe-next/components/results/ResultsWinnerBanner.jsx
+++ b/fe-next/components/results/ResultsWinnerBanner.jsx
@@ -43,9 +43,9 @@ const ResultsWinnerBanner = ({ winner, isCurrentUserWinner }) => {
 
   return (
     <motion.div
-      initial={{ scale: 0.9, opacity: 0, rotate: -3 }}
-      animate={{ scale: 1, opacity: 1, rotate: 0 }}
-      transition={{ duration: 0.4, ease: [0.68, -0.55, 0.265, 1.55] }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
       className="mb-4 sm:mb-6 md:mb-8 relative w-full"
     >
       {/* Neo-Brutalist Main Container */}

--- a/fe-next/translations/index.js
+++ b/fe-next/translations/index.js
@@ -395,6 +395,8 @@ const translations = {
       needsVerification: 'Needs Verification',
       autoVerified: 'Auto-Verified',
       aiVerified: 'Verified by AI',
+      aiRejected: 'Rejected by AI',
+      tapToClose: 'Tap anywhere to close',
       showHeatmap: 'Show Heatmap',
       hideHeatmap: 'Hide Heatmap',
       startNewGame: 'Start New Game',
@@ -667,6 +669,47 @@ const translations = {
       CLUTCH_PLAYER: {
         name: 'Clutch Player',
         description: 'Found 3+ words in the last 10 seconds'
+      },
+      // Lifetime/Career Achievements
+      VETERAN: {
+        name: 'Veteran',
+        description: 'Played 50 games total'
+      },
+      CENTURION: {
+        name: 'Centurion',
+        description: 'Played 100 games total'
+      },
+      WORD_COLLECTOR: {
+        name: 'Word Collector',
+        description: 'Found 1000 total valid words'
+      },
+      WORD_HOARDER: {
+        name: 'Word Hoarder',
+        description: 'Found 5000 total valid words'
+      },
+      CHAMPION: {
+        name: 'Champion',
+        description: 'Won 25 games total'
+      },
+      LEGEND: {
+        name: 'Legend',
+        description: 'Won 100 games total'
+      },
+      POINT_MASTER: {
+        name: 'Point Master',
+        description: 'Accumulated 10,000 total points'
+      },
+      POINT_KING: {
+        name: 'Point King',
+        description: 'Accumulated 50,000 total points'
+      },
+      DEDICATION: {
+        name: 'Dedication',
+        description: 'Played on 7 different days'
+      },
+      LOYAL_PLAYER: {
+        name: 'Loyal Player',
+        description: 'Played on 30 different days'
       }
     },
     achievementTiers: {
@@ -1488,6 +1531,8 @@ const translations = {
       needsVerification: 'דורש אימות',
       autoVerified: 'אומת אוטומטית',
       aiVerified: 'אומת על ידי AI',
+      aiRejected: 'נדחה על ידי AI',
+      tapToClose: 'לחץ בכל מקום לסגירה',
       showHeatmap: 'הצג מפת חום',
       hideHeatmap: 'הסתר מפת חום',
       startNewGame: 'התחל משחק חדש',
@@ -1755,6 +1800,47 @@ const translations = {
       CLUTCH_PLAYER: {
         name: 'שחקן קלאץ\'',
         description: 'מצא 3+ מילים ב-10 השניות האחרונות'
+      },
+      // הישגי קריירה
+      VETERAN: {
+        name: 'ותיק',
+        description: 'שיחק 50 משחקים'
+      },
+      CENTURION: {
+        name: 'סנטוריון',
+        description: 'שיחק 100 משחקים'
+      },
+      WORD_COLLECTOR: {
+        name: 'אספן מילים',
+        description: 'מצא 1000 מילים תקינות סה"כ'
+      },
+      WORD_HOARDER: {
+        name: 'אוגר מילים',
+        description: 'מצא 5000 מילים תקינות סה"כ'
+      },
+      CHAMPION: {
+        name: 'אלוף',
+        description: 'ניצח 25 משחקים'
+      },
+      LEGEND: {
+        name: 'אגדה',
+        description: 'ניצח 100 משחקים'
+      },
+      POINT_MASTER: {
+        name: 'אדון הנקודות',
+        description: 'צבר 10,000 נקודות סה"כ'
+      },
+      POINT_KING: {
+        name: 'מלך הנקודות',
+        description: 'צבר 50,000 נקודות סה"כ'
+      },
+      DEDICATION: {
+        name: 'מסירות',
+        description: 'שיחק ב-7 ימים שונים'
+      },
+      LOYAL_PLAYER: {
+        name: 'שחקן נאמן',
+        description: 'שיחק ב-30 ימים שונים'
       }
     },
     achievementTiers: {
@@ -2575,6 +2661,8 @@ const translations = {
       needsVerification: 'Behöver Verifiering',
       autoVerified: 'Automatiskt Verifierad',
       aiVerified: 'Verifierad av AI',
+      aiRejected: 'Avvisad av AI',
+      tapToClose: 'Tryck var som helst för att stänga',
       showHeatmap: 'Visa värmekarta',
       hideHeatmap: 'Dölj värmekarta',
       startNewGame: 'Starta nytt spel',
@@ -2847,6 +2935,47 @@ const translations = {
       CLUTCH_PLAYER: {
         name: 'Clutch-spelare',
         description: 'Hittade 3+ ord under sista 10 sekunderna'
+      },
+      // Livstidsprestationer
+      VETERAN: {
+        name: 'Veteran',
+        description: 'Spelade 50 spel totalt'
+      },
+      CENTURION: {
+        name: 'Centurion',
+        description: 'Spelade 100 spel totalt'
+      },
+      WORD_COLLECTOR: {
+        name: 'Ordsamlare',
+        description: 'Hittade 1000 giltiga ord totalt'
+      },
+      WORD_HOARDER: {
+        name: 'Ordhoarder',
+        description: 'Hittade 5000 giltiga ord totalt'
+      },
+      CHAMPION: {
+        name: 'Mästare',
+        description: 'Vann 25 spel totalt'
+      },
+      LEGEND: {
+        name: 'Legend',
+        description: 'Vann 100 spel totalt'
+      },
+      POINT_MASTER: {
+        name: 'Poängmästare',
+        description: 'Samlade 10 000 poäng totalt'
+      },
+      POINT_KING: {
+        name: 'Poängkung',
+        description: 'Samlade 50 000 poäng totalt'
+      },
+      DEDICATION: {
+        name: 'Hängivenhet',
+        description: 'Spelade på 7 olika dagar'
+      },
+      LOYAL_PLAYER: {
+        name: 'Lojal spelare',
+        description: 'Spelade på 30 olika dagar'
       }
     },
     achievementTiers: {
@@ -3664,6 +3793,8 @@ const translations = {
       needsVerification: '検証が必要',
       autoVerified: '自動検証済み',
       aiVerified: 'AIで検証済み',
+      aiRejected: 'AIにより却下',
+      tapToClose: 'どこかをタップして閉じる',
       showHeatmap: 'ヒートマップを表示',
       hideHeatmap: 'ヒートマップを非表示',
       startNewGame: '新しいゲームを開始',
@@ -3871,6 +4002,47 @@ const translations = {
       CLUTCH_PLAYER: {
         name: 'クラッチプレイヤー',
         description: '最後の10秒で3つ以上の単語を発見'
+      },
+      // 生涯実績
+      VETERAN: {
+        name: 'ベテラン',
+        description: '合計50ゲームをプレイ'
+      },
+      CENTURION: {
+        name: 'センチュリオン',
+        description: '合計100ゲームをプレイ'
+      },
+      WORD_COLLECTOR: {
+        name: '言葉コレクター',
+        description: '合計1000の有効な単語を発見'
+      },
+      WORD_HOARDER: {
+        name: '言葉ハンター',
+        description: '合計5000の有効な単語を発見'
+      },
+      CHAMPION: {
+        name: 'チャンピオン',
+        description: '合計25ゲームに勝利'
+      },
+      LEGEND: {
+        name: 'レジェンド',
+        description: '合計100ゲームに勝利'
+      },
+      POINT_MASTER: {
+        name: 'ポイントマスター',
+        description: '合計10,000ポイントを獲得'
+      },
+      POINT_KING: {
+        name: 'ポイントキング',
+        description: '合計50,000ポイントを獲得'
+      },
+      DEDICATION: {
+        name: '献身',
+        description: '7日間にわたってプレイ'
+      },
+      LOYAL_PLAYER: {
+        name: '忠実なプレイヤー',
+        description: '30日間にわたってプレイ'
       }
     },
     achievementTiers: {


### PR DESCRIPTION
…d tooltips

- Fixed CLS on results page by using opacity-only animations instead of transform/position animations that cause layout shifts
- Made achievements harder to get:
  - FIRST_BLOOD: now requires 4+ letter word (not just any word)
  - SPEED_DEMON: increased from 25 to 28 words in 50% of game time
  - WORDSMITH: increased from 30 to 35 words
  - LEXICON: increased from 40 to 45 words
  - LIGHTNING_ROUND: increased from 12 to 15 words in first 17% of game
  - PERFECTIONIST: increased from 20 to 25 words
  - COMBO_KING: increased from 15 to 18 combo streak
  - DIVERSE_VOCABULARY: increased from 6 to 7 different lengths
  - EXPLORER: increased from 7 to 8 different lengths
  - All time-based achievements now scale with game duration
- Added lifetime/career achievements (VETERAN, CENTURION, WORD_COLLECTOR, WORD_HOARDER, CHAMPION, LEGEND, POINT_MASTER, POINT_KING, DEDICATION, LOYAL_PLAYER) that track stats across all games
- Added mobile-friendly tooltips for invalid words:
  - Invalid words now show info icon (ℹ️) indicating they're tappable
  - Tap/click on invalid words opens a popup showing AI rejection reason
  - Popup has close button and backdrop for dismissal
  - Works on both mobile (tap) and desktop (hover)
- Added translations for new features in all 4 languages (EN, HE, SV, JA)