### PR TITLE
Fix word selection passing to result page

### DIFF
--- a/fe-next/backend/modules/scoringEngine.js
+++ b/fe-next/backend/modules/scoringEngine.js
@@ -122,6 +122,7 @@ const calculateGameScores = (game, wordCountMap = {}, dictionaryValidatedWords =
         inDictionary,
         validationSource,
         isUnique,
+        isDuplicate: !isUnique, // Frontend expects isDuplicate (inverse of isUnique)
         comboBonus: existingDetails?.comboBonus || 0
       });
     }
@@ -131,8 +132,10 @@ const calculateGameScores = (game, wordCountMap = {}, dictionaryValidatedWords =
 
     results.push({
       username,
-      totalScore,
-      wordDetails,
+      score: totalScore, // Frontend expects 'score' not 'totalScore'
+      totalScore, // Keep for backwards compatibility with other usages
+      allWords: wordDetails, // Frontend expects 'allWords' not 'wordDetails'
+      wordDetails, // Keep for backwards compatibility with other usages
       wordCount: uniqueWords.length,
       avatar: userData.avatar || null,
       isBot: userData.isBot || false,


### PR DESCRIPTION
The recent refactor in d051b1c changed the return structure of calculateGameScores to use 'totalScore' and 'wordDetails', but the frontend expects 'score' and 'allWords'. This fix adds the frontend-expected field names while keeping the backend fields for backwards compatibility:

- Add 'score' alias for 'totalScore'
- Add 'allWords' alias for 'wordDetails'
- Add 'isDuplicate' field (inverse of 'isUnique') to word objects