### PR TITLE
Fix result page and achievement issues

### DIFF
--- a/fe-next/backend/modules/scoreManager.js
+++ b/fe-next/backend/modules/scoreManager.js
@@ -24,6 +24,12 @@ const leaderboardPendingUpdate = {};
 function addPlayerWord(game, username, word, options = {}) {
   if (!game) return;
 
+  // Defensive check: ensure word is a valid string
+  if (!word || typeof word !== 'string') {
+    console.warn(`[SCORE] addPlayerWord called with invalid word: ${word} for user ${username}`);
+    return;
+  }
+
   const normalizedWord = word.toLowerCase();
 
   // Initialize playerWords if needed
@@ -85,6 +91,7 @@ function addPlayerWord(game, username, word, options = {}) {
  */
 function playerHasWord(game, username, word) {
   if (!game) return false;
+  if (!word || typeof word !== 'string') return false;
   return game.playerWords[username]?.includes(word.toLowerCase()) || false;
 }
 


### PR DESCRIPTION
… null checks

The TypeError 'Cannot read properties of undefined (reading toLowerCase)' was caused by incorrect callback signature in startBotsForGame. The botManager passes a single object with { botId, username, word, score, comboLevel } but shared.js was expecting separate parameters (botId, word, score).

Changes:
- Fix callback signature in shared.js to properly destructure bot submission object
- Add defensive null/type checks in scoreManager.addPlayerWord to prevent crashes
- Add validation before bot word submission to catch invalid words early

This fixes:
- Bots showing 0 words in results page
- Players not getting achievements (since words weren't being recorded properly)
- TypeError crashes that killed the server