### PR TITLE
Investigate and fix build failure

### DIFF
--- a/fe-next/components/NeoToast.tsx
+++ b/fe-next/components/NeoToast.tsx
@@ -116,7 +116,7 @@ export const wordAcceptedToast = (word: string, options: WordAcceptedOptions = {
               </motion.span>
             )}
             {/* Show combo bonus if present */}
-            {comboBonus > 0 && (
+            {typeof comboBonus === 'number' && comboBonus > 0 && (
               <motion.span
                 initial={{ scale: 0, rotate: -10 }}
                 animate={{ scale: 1, rotate: 0 }}


### PR DESCRIPTION
The TypeScript build was failing because comboBonus could be undefined when compared with > 0. Added typeof check consistent with how score is handled in the same component.