### PR TITLE
Fix duplicate loaders and achievement count bugs

### DIFF
--- a/fe-next/backend/modules/achievementManager.js
+++ b/fe-next/backend/modules/achievementManager.js
@@ -87,6 +87,13 @@ const ACHIEVEMENTS = getLocalizedAchievements('he');
 
 // Check and award LIVE achievements during gameplay (selective achievements only)
 const checkLiveAchievements = (game, username, word, timeSinceStart) => {
+  // Ensure playerAchievements is initialized (defensive check for bots and edge cases)
+  if (!game.playerAchievements) {
+    game.playerAchievements = {};
+  }
+  if (!game.playerAchievements[username]) {
+    game.playerAchievements[username] = [];
+  }
   const achievements = game.playerAchievements[username];
   const newAchievements = [];
 
@@ -95,15 +102,19 @@ const checkLiveAchievements = (game, username, word, timeSinceStart) => {
   // Get all word details for this player
   const allWordDetails = game.playerWordDetails?.[username] || [];
 
-  // Filter to only count validated words (validated !== false)
-  // Words with validated=null are pending (not yet rejected), so we count them for live achievements
-  // Words with validated=false are explicitly rejected (wrong words)
-  const validatedWordDetails = allWordDetails.filter(w => w.validated !== false);
+  // Filter to only count ACTUALLY validated words (validated === true OR autoValidated === true)
+  // This prevents awarding achievements for pending words that may later be rejected
+  // Words with validated=null are pending and should NOT count for word-count achievements
+  const validatedWordDetails = allWordDetails.filter(w => w.validated === true || w.autoValidated === true);
   const validatedWordCount = validatedWordDetails.length;
 
-  // Check if the current word being submitted is validated (not rejected)
+  // Check if the current word being submitted is auto-validated (in dictionary)
+  // or has been validated. For current word, we check if it's auto-validated since
+  // manual validation happens asynchronously
   const currentWordDetails = allWordDetails.find(w => w.word.toLowerCase() === word.toLowerCase());
-  const isCurrentWordValid = currentWordDetails ? currentWordDetails.validated !== false : true;
+  const isCurrentWordValid = currentWordDetails
+    ? (currentWordDetails.validated === true || currentWordDetails.autoValidated === true)
+    : false;
 
   // Helper to add achievement - returns unlocalized object with key and icon
   const addAchievementAndReturn = (key) => {
@@ -314,11 +325,22 @@ const getPlayerAchievements = (gameCode, username) => {
 // Award final achievements after validation (post-game)
 const awardFinalAchievements = (game, users) => {
   logger.debug('ACHIEVEMENT', `Awarding final achievements for ${users.length} players`);
+
+  // Ensure playerAchievements is initialized (defensive check)
+  if (!game.playerAchievements) {
+    game.playerAchievements = {};
+  }
+
   users.forEach(username => {
     // Safety check: ensure player data exists
     if (!game.playerWordDetails[username]) {
       logger.warn('ACHIEVEMENT', `Player ${username} missing word details during achievement calculation`);
       return;
+    }
+
+    // Initialize playerAchievements for this user if needed (bots and edge cases)
+    if (!game.playerAchievements[username]) {
+      game.playerAchievements[username] = [];
     }
 
     // Bots can also earn achievements - this makes the game more competitive

--- a/fe-next/backend/modules/scoreManager.js
+++ b/fe-next/backend/modules/scoreManager.js
@@ -45,6 +45,14 @@ function addPlayerWord(game, username, word, options = {}) {
     game.playerWordDetails[username] = [];
   }
 
+  // Initialize playerAchievements if needed (important for bots and late joiners)
+  if (!game.playerAchievements) {
+    game.playerAchievements = {};
+  }
+  if (!game.playerAchievements[username]) {
+    game.playerAchievements[username] = [];
+  }
+
   // Only add if not already present
   if (!game.playerWords[username].includes(normalizedWord)) {
     game.playerWords[username].push(normalizedWord);

--- a/fe-next/host/hooks/useHostSocketEvents.ts
+++ b/fe-next/host/hooks/useHostSocketEvents.ts
@@ -413,6 +413,7 @@ const useHostSocketEvents = ({
       setRemainingTime(data.remainingTime);
       if (data.remainingTime === 0 && gameStarted) {
         setGameStarted(false);
+        setShowStartAnimation(false); // Clear any lingering animation to prevent double loaders
         // Track when we entered waiting state for minimum display time
         if (!waitingStartTimeRef.current) {
           waitingStartTimeRef.current = Date.now();

--- a/fe-next/player/hooks/usePlayerSocketEvents.ts
+++ b/fe-next/player/hooks/usePlayerSocketEvents.ts
@@ -276,6 +276,7 @@ const usePlayerSocketEvents = ({
       logger.log('[PLAYER] Received endGame event, wasInActiveGame:', wasInActiveGame);
       setGameActive(false);
       setRemainingTime(0);
+      setShowStartAnimation(false); // Clear any lingering animation to prevent double loaders
       if (wasInActiveGame) {
         logger.log('[PLAYER] Setting waitingForResults to true');
         // Track when we entered waiting state for minimum display time
@@ -435,6 +436,7 @@ const usePlayerSocketEvents = ({
 
       if (data.remainingTime <= 0) {
         setGameActive(false);
+        setShowStartAnimation(false); // Clear any lingering animation to prevent double loaders
         // Track when we entered waiting state for minimum display time
         if (!waitingStartTimeRef.current) {
           waitingStartTimeRef.current = Date.now();


### PR DESCRIPTION
1. Fix double loaders issue by clearing showStartAnimation when waitingForResults is set to prevent both animations showing simultaneously

2. Fix achievement counting bug - only count actually validated words (validated===true or autoValidated===true) for word-count achievements. Previously pending words (validated=null) were incorrectly counted.

3. Ensure bots get achievements by adding defensive initialization of playerAchievements array in scoreManager and achievementManager