### PR TITLE
Fix multiplayer game bugs with bot

### DIFF
--- a/fe-next/backend/handlers/gameLifecycleHandler.js
+++ b/fe-next/backend/handlers/gameLifecycleHandler.js
@@ -42,6 +42,7 @@ const { getRandomLongWords } = require('../dictionary');
 const logger = require('../utils/logger');
 const { startGameTimer, endGame } = require('./shared');
 const { validatePayload, createGameSchema, startGameSchema } = require('../utils/socketValidation');
+const botManager = require('../modules/botManager');
 
 /**
  * Register game lifecycle socket event handlers
@@ -310,6 +311,10 @@ function registerGameLifecycleHandlers(io, socket) {
     }
 
     timerManager.clearGameTimer(gameCode);
+
+    // Clean up bots from previous game to prevent stale state
+    botManager.cleanupGameBots(gameCode);
+
     resetGameForNewRound(gameCode);
 
     broadcastToRoom(io, getGameRoom(gameCode), 'resetGame', {

--- a/fe-next/backend/handlers/roomManagementHandler.js
+++ b/fe-next/backend/handlers/roomManagementHandler.js
@@ -17,6 +17,7 @@ const {
 
 const { checkRateLimit } = require('../utils/rateLimiter');
 const timerManager = require('../utils/timerManager');
+const botManager = require('../modules/botManager');
 const logger = require('../utils/logger');
 
 /**
@@ -40,6 +41,7 @@ function registerRoomManagementHandlers(io, socket) {
     if (!game || game.hostSocketId !== socket.id) return;
 
     timerManager.clearGameTimer(gameCode);
+    botManager.cleanupGameBots(gameCode);
 
     broadcastToRoom(io, getGameRoom(gameCode), 'roomClosed', {});
     deleteGame(gameCode);

--- a/fe-next/player/PlayerView.tsx
+++ b/fe-next/player/PlayerView.tsx
@@ -422,27 +422,32 @@ const PlayerView: React.FC<PlayerViewProps> = memo(({
   const showGameView = gameActive || (showStartAnimation && hasGameData);
 
   if (!showGameView && !waitingForResults) {
-    return (
-      <>
-        {showStartAnimation && (
+    // When countdown animation is active, only show the countdown overlay
+    // Don't render PlayerWaitingView underneath to avoid double loaders
+    if (showStartAnimation) {
+      return (
+        <div className="min-h-screen bg-gradient-to-b from-slate-50 via-slate-100 to-slate-200 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 flex items-center justify-center">
           <GoRipplesAnimation onComplete={() => setShowStartAnimation(false)} />
-        )}
-        <PlayerWaitingView
-          gameCode={gameCode}
-          gameLanguage={gameLanguage}
-          username={username}
-          t={t}
-          playersReady={playersReady}
-          shufflingGrid={shufflingGrid}
-          highlightedCells={highlightedCells}
-          showQR={showQR}
-          setShowQR={setShowQR}
-          showExitConfirm={showExitConfirm}
-          setShowExitConfirm={setShowExitConfirm}
-          onExitRoom={handleExitRoom}
-          onConfirmExit={confirmExitRoom}
-        />
-      </>
+        </div>
+      );
+    }
+
+    return (
+      <PlayerWaitingView
+        gameCode={gameCode}
+        gameLanguage={gameLanguage}
+        username={username}
+        t={t}
+        playersReady={playersReady}
+        shufflingGrid={shufflingGrid}
+        highlightedCells={highlightedCells}
+        showQR={showQR}
+        setShowQR={setShowQR}
+        showExitConfirm={showExitConfirm}
+        setShowExitConfirm={setShowExitConfirm}
+        onExitRoom={handleExitRoom}
+        onConfirmExit={confirmExitRoom}
+      />
     );
   }
 


### PR DESCRIPTION
Root causes fixed:
1. Bot cleanup was never called between games - bots were stopped but not fully cleaned up, causing stale state that interfered with subsequent games (timer stuck at zero, notifications not working)
2. Double loaders appeared because GoRipplesAnimation countdown and PlayerWaitingView (with its pulsing grid skeleton) were both rendered simultaneously when game data hadn't arrived yet

Changes:
- Add botManager.cleanupGameBots() call in resetGame handler
- Add botManager.cleanupGameBots() call in closeRoom handler
- Isolate countdown animation in PlayerView to prevent double loaders