### PR TITLE
Fix new game start in same room

### DIFF
--- a/fe-next/host/HostView.tsx
+++ b/fe-next/host/HostView.tsx
@@ -417,19 +417,15 @@ const HostView: React.FC<HostViewProps> = memo(({
   }, []);
 
   const handleStartNewGame = useCallback(() => {
+    // Emit reset to server - the socket handler (handleResetGame in useHostSocketEvents)
+    // will handle resetting game state when server confirms
     socket?.emit('resetGame');
-    setFinalScores(null);
-    setGameStarted(false);
-    setWaitingForResults(false);
-    setRemainingTime(null);
-    setTournamentData(null);
+
+    // Reset UI settings that aren't passed to the socket events hook
     setGameType('regular');
-    setPlayerWordCounts({});
-    setPlayerScores({});
-    setHostFoundWords([]);
-    setHostAchievements([]);
     setTimerValue(1);
 
+    // Show immediate feedback to host
     neoSuccessToast(`${t('common.newGameReady')}`, {
       icon: '🔄',
       duration: 2000,

--- a/fe-next/host/hooks/useHostSocketEvents.ts
+++ b/fe-next/host/hooks/useHostSocketEvents.ts
@@ -689,7 +689,14 @@ const useHostSocketEvents = ({
       if (comboTimeoutRef.current) {
         clearTimeout(comboTimeoutRef.current);
       }
-      neoSuccessToast(data?.message || t('common.newGameReady') || 'New game ready!', { icon: '🔄', duration: 3000 });
+      // Reset tournament state
+      setTournamentData(null);
+      setTournamentCreating(false);
+      // Reset XP/Level state for new game
+      setXpGainedData(null);
+      setLevelUpData(null);
+      // Note: Toast is shown in handleStartNewGame for immediate feedback to host
+      // Players will receive their toast from their own handleResetGame handler
     };
 
     // Register all event listeners

--- a/fe-next/player/hooks/usePlayerSocketEvents.ts
+++ b/fe-next/player/hooks/usePlayerSocketEvents.ts
@@ -584,6 +584,10 @@ const usePlayerSocketEvents = ({
       }
       comboShieldsUsedRef.current = 0;
 
+      // Reset word feedback state (close modal if open)
+      setShowWordFeedback(false);
+      setWordToVote(null);
+
       // Reset tournament state
       setTournamentData(null);
       setTournamentStandings([]);


### PR DESCRIPTION
- Remove double toast when host starts new game (toast was showing twice)
- Add missing tournament/XP state reset in host socket handler
- Add word feedback modal reset in player socket handler
- Simplify handleStartNewGame to only reset UI settings, let socket handler reset game state