### PR TITLE
Disable duplicate word rule for large rooms

### DIFF
--- a/fe-next/app/[locale]/page.tsx
+++ b/fe-next/app/[locale]/page.tsx
@@ -33,6 +33,10 @@ interface ResultsData {
     words: string[];
   }>;
   letterGrid: string[][];
+  /** Whether duplicate word rule is disabled (for rooms with >7 players) */
+  duplicateRuleDisabled?: boolean;
+  /** Number of players in the game */
+  playerCount?: number;
 }
 
 interface GameStartData {
@@ -966,6 +970,8 @@ export default function GamePage(): React.JSX.Element {
             onReturnToRoom={handleReturnToRoom}
             username={username}
             socket={socket}
+            duplicateRuleDisabled={resultsData?.duplicateRuleDisabled}
+            playerCount={resultsData?.playerCount}
           />
         </FeatureErrorBoundary>
       );

--- a/fe-next/backend/handlers/shared.js
+++ b/fe-next/backend/handlers/shared.js
@@ -324,13 +324,20 @@ async function calculateAndBroadcastFinalScores(io, gameCode) {
     }
   }
 
+  // Get player count for duplicate rule logic
+  const playerCount = Object.keys(game.users || {}).length;
+
+  // Disable duplicate rule for large rooms (more than 7 players)
+  const duplicateRuleDisabled = playerCount > 7;
+
   // Calculate final scores
   const finalScores = calculateGameScores(
     game,
     wordCountMap,
     dictionaryValidatedWords,
     communityValidatedWords,
-    aiValidatedWords
+    aiValidatedWords,
+    { playerCount }
   );
 
   // Update game state with final scores
@@ -359,13 +366,18 @@ async function calculateAndBroadcastFinalScores(io, gameCode) {
 
   // Broadcast results to all clients
   // Host expects 'validationComplete', players expect 'validatedScores'
+  // Include duplicateRuleDisabled flag so frontend can display a notice
   broadcastToRoom(io, getGameRoom(gameCode), 'validatedScores', {
     scores: finalScores,
-    letterGrid: game.letterGrid
+    letterGrid: game.letterGrid,
+    duplicateRuleDisabled,
+    playerCount
   });
   broadcastToRoom(io, getGameRoom(gameCode), 'validationComplete', {
     scores: finalScores,
-    letterGrid: game.letterGrid
+    letterGrid: game.letterGrid,
+    duplicateRuleDisabled,
+    playerCount
   });
 
   // Record to database

--- a/fe-next/backend/modules/scoringEngine.js
+++ b/fe-next/backend/modules/scoringEngine.js
@@ -66,9 +66,15 @@ const calculateWordScore = (word, comboLevel = 0) => {
  * @param {Set} dictionaryValidatedWords - Words validated by dictionary
  * @param {Set} communityValidatedWords - Words validated by community
  * @param {Map} aiValidatedWords - Words validated by AI with isValid status and reason
+ * @param {object} options - Additional options
+ * @param {number} options.playerCount - Number of players in the game (used to disable duplicate rule for large rooms)
  * @returns {array} - Array of player score objects
  */
-const calculateGameScores = (game, wordCountMap = {}, dictionaryValidatedWords = new Set(), communityValidatedWords = new Set(), aiValidatedWords = new Map()) => {
+const calculateGameScores = (game, wordCountMap = {}, dictionaryValidatedWords = new Set(), communityValidatedWords = new Set(), aiValidatedWords = new Map(), options = {}) => {
+  const { playerCount = 0 } = options;
+
+  // Disable duplicate rule for large rooms (more than 7 players)
+  const duplicateRuleDisabled = playerCount > 7;
   if (!game) return [];
 
   const results = [];
@@ -104,7 +110,8 @@ const calculateGameScores = (game, wordCountMap = {}, dictionaryValidatedWords =
       }
 
       // Check if word is unique (only one player submitted it)
-      const isUnique = (wordCountMap[word] || 0) === 1;
+      // When duplicate rule is disabled (large rooms with >7 players), treat all words as unique
+      const isUnique = duplicateRuleDisabled || (wordCountMap[word] || 0) === 1;
 
       // Get pre-calculated score from word details if available
       const existingDetails = (playerWordDetails[username] || []).find(d => d.word === word);

--- a/fe-next/components/results/ResultsPlayerCard.tsx
+++ b/fe-next/components/results/ResultsPlayerCard.tsx
@@ -144,6 +144,8 @@ interface ResultsPlayerCardProps {
   isWinner: boolean;
   xpGainedData?: XpGainedData | null;
   levelUpData?: LevelUpData | null;
+  /** Whether duplicate word rule is disabled (for rooms with >7 players) */
+  duplicateRuleDisabled?: boolean;
 }
 
 interface WordChipProps {
@@ -386,7 +388,7 @@ const WordChip = memo<WordChipProps>(({ wordObj, playerCount }) => {
 
 WordChip.displayName = 'WordChip';
 
-const ResultsPlayerCard: React.FC<ResultsPlayerCardProps> = ({ player, index, allPlayerWords, currentUsername, isWinner, xpGainedData, levelUpData }) => {
+const ResultsPlayerCard: React.FC<ResultsPlayerCardProps> = ({ player, index, allPlayerWords, currentUsername, isWinner, xpGainedData, levelUpData, duplicateRuleDisabled }) => {
   const { t, dir } = useLanguage();
   // Arrow direction for level up indicator - flip for RTL
   const levelArrow = dir === 'rtl' ? '←' : '→';

--- a/fe-next/components/views/ResultsPage.tsx
+++ b/fe-next/components/views/ResultsPage.tsx
@@ -157,7 +157,7 @@ const LetterGrid: React.FC<LetterGridProps> = ({ letterGrid, heatMapData, showHe
   );
 };
 
-const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, letterGrid, gameCode, onReturnToRoom, username, socket, achievements }) => {
+const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, letterGrid, gameCode, onReturnToRoom, username, socket, achievements, duplicateRuleDisabled, playerCount }) => {
   const { t } = useLanguage();
   const { isAuthenticated } = useAuth();
   const [showExitConfirm, setShowExitConfirm] = useState<boolean>(false);
@@ -563,6 +563,29 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, letterGrid, game
             </motion.div>
           </motion.div>
 
+          {/* Large Room Notice - Duplicate rule disabled */}
+          {duplicateRuleDisabled && (
+            <motion.div
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3, duration: 0.3 }}
+              className="mb-4 mx-auto max-w-md"
+            >
+              <div className="bg-neo-cyan border-3 border-neo-black rounded-neo p-3 shadow-hard text-center">
+                <div className="flex items-center justify-center gap-2">
+                  <span className="text-lg">👥</span>
+                  <span className="font-black text-neo-black text-sm uppercase">
+                    {t('results.largeRoomMode') || 'Large Room Mode'}
+                  </span>
+                  <span className="text-lg">👥</span>
+                </div>
+                <p className="text-xs text-neo-black mt-1 font-bold">
+                  {t('results.duplicateRuleDisabled') || `With ${playerCount || '8+'} players, duplicate words still count!`}
+                </p>
+              </div>
+            </motion.div>
+          )}
+
         </div>
 
         {/* Player Results Cards */}
@@ -577,6 +600,7 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, letterGrid, game
               isWinner={index === 0}
               xpGainedData={player.username === username ? xpGainedData : null}
               levelUpData={player.username === username ? levelUpData : null}
+              duplicateRuleDisabled={duplicateRuleDisabled}
             />
           ))}
         </div>

--- a/fe-next/host/hooks/useHostSocketEvents.ts
+++ b/fe-next/host/hooks/useHostSocketEvents.ts
@@ -379,7 +379,9 @@ const useHostSocketEvents = ({
           logger.log('[HOST] Calling onShowResults with scores');
           currentOnShowResults({
             scores: data.scores,
-            letterGrid: currentTableData
+            letterGrid: currentTableData,
+            duplicateRuleDisabled: data.duplicateRuleDisabled,
+            playerCount: data.playerCount,
           });
         } else {
           logger.log('[HOST] onShowResults not defined, setting finalScores in modal');

--- a/fe-next/player/hooks/usePlayerSocketEvents.ts
+++ b/fe-next/player/hooks/usePlayerSocketEvents.ts
@@ -501,6 +501,8 @@ const usePlayerSocketEvents = ({
           currentOnShowResults({
             scores: data.scores,
             letterGrid: data.letterGrid,
+            duplicateRuleDisabled: data.duplicateRuleDisabled,
+            playerCount: data.playerCount,
           });
         } else {
           logger.warn('[PLAYER] onShowResults is not defined!');

--- a/fe-next/translations/index.js
+++ b/fe-next/translations/index.js
@@ -423,6 +423,8 @@ const translations = {
       wordValidated: 'Word validated! You earned ${score} points!',
       autoRejoinIn: 'Auto-rejoin in',
       rejoinNow: 'Rejoin Now',
+      largeRoomMode: 'Large Room Mode',
+      duplicateRuleDisabled: 'With 8+ players, duplicate words still count!',
     },
     playerTitles: {
       champion: { name: 'Champion', icon: '👑', description: 'Winner of the game' },
@@ -1581,6 +1583,8 @@ const translations = {
       wordValidated: 'המילה אושרה! קיבלת ${score} נקודות!',
       autoRejoinIn: 'חזרה אוטומטית בעוד',
       rejoinNow: 'חזור עכשיו',
+      largeRoomMode: 'מצב חדר גדול',
+      duplicateRuleDisabled: 'עם 8+ שחקנים, מילים כפולות עדיין נספרות!',
     },
     playerTitles: {
       champion: { name: 'אלוף', icon: '👑', description: 'מנצח המשחק' },
@@ -2733,6 +2737,8 @@ const translations = {
       wordValidated: 'Ordet validerat! Du fick ${score} poäng!',
       autoRejoinIn: 'Automatiskt återansluter om',
       rejoinNow: 'Återanslut nu',
+      largeRoomMode: 'Stort rumsläge',
+      duplicateRuleDisabled: 'Med 8+ spelare räknas dubblettord fortfarande!',
     },
     playerTitles: {
       champion: { name: 'Mästare', icon: '👑', description: 'Spelets vinnare' },
@@ -3887,6 +3893,8 @@ const translations = {
       wordValidated: '単語が承認されました！${score}ポイント獲得！',
       autoRejoinIn: '自動再参加まで',
       rejoinNow: '今すぐ再参加',
+      largeRoomMode: '大規模ルームモード',
+      duplicateRuleDisabled: '8人以上のプレイヤーでは、重複単語もカウントされます！',
     },
     playerTitles: {
       champion: { name: 'チャンピオン', icon: '👑', description: 'ゲームの勝者' },

--- a/fe-next/types/components.ts
+++ b/fe-next/types/components.ts
@@ -90,6 +90,10 @@ export interface ResultsPageProps {
   socket: Socket | null;
   /** Player achievements from the game */
   achievements?: GameAchievement[];
+  /** Whether duplicate word rule is disabled (for rooms with >7 players) */
+  duplicateRuleDisabled?: boolean;
+  /** Number of players in the game */
+  playerCount?: number;
 }
 
 export interface HeatMapData {


### PR DESCRIPTION
- Modified scoringEngine.js to accept playerCount option and skip marking words as duplicates when playerCount > 7
- Updated shared.js to pass playerCount to calculateGameScores and include duplicateRuleDisabled flag in the broadcast
- Added duplicateRuleDisabled and playerCount props to ResultsPageProps
- Updated usePlayerSocketEvents and useHostSocketEvents hooks to pass the new fields to onShowResults
- Added "Large Room Mode" notice banner on results page when duplicate rule is disabled
- Added translations for largeRoomMode and duplicateRuleDisabled in all 4 languages (English, Hebrew, Swedish, Japanese)

This change improves gameplay in large rooms where the duplicate word penalty would significantly reduce scoring opportunities for all players.