### PR TITLE
Fix second game start in same room

### DIFF
--- a/fe-next/host/hooks/useHostSocketEvents.ts
+++ b/fe-next/host/hooks/useHostSocketEvents.ts
@@ -53,7 +53,7 @@ interface UseHostSocketEventsProps {
   username: string;
   queueAchievement: (achievement: any) => void;
   playComboSound: (level: number) => void;
-  onShowResults?: (data: { scores: any; letterGrid: any }) => void;
+  onShowResults?: (data: { scores: any; letterGrid: any; duplicateRuleDisabled?: boolean; playerCount?: number }) => void;
 
   // State setters
   setPlayersReady: React.Dispatch<React.SetStateAction<Player[]>>;
@@ -675,6 +675,7 @@ const useHostSocketEvents = ({
       setGameStarted(false);
       setRemainingTime(null);
       setWaitingForResults(false);
+      setShowStartAnimation(false); // Reset animation state for new game
       setTableData(null);
       setHostFoundWords([]);
       setHostAchievements([]);

--- a/fe-next/player/hooks/usePlayerSocketEvents.ts
+++ b/fe-next/player/hooks/usePlayerSocketEvents.ts
@@ -69,7 +69,7 @@ interface UsePlayerSocketEventsProps {
   username: string;
   queueAchievement: (achievement: any) => void;
   playComboSound: (level: number) => void;
-  onShowResults?: (data: { scores: any; letterGrid: any }) => void;
+  onShowResults?: (data: { scores: any; letterGrid: any; duplicateRuleDisabled?: boolean; playerCount?: number }) => void;
 
   // State setters
   setPlayersReady: React.Dispatch<React.SetStateAction<Player[]>>;
@@ -573,6 +573,7 @@ const usePlayerSocketEvents = ({
       setRemainingTime(null);
       setWaitingForResults(false);
       setLetterGrid(null);
+      setShowStartAnimation(false); // Reset animation state for new game
       waitingStartTimeRef.current = null; // Reset waiting state tracking
 
       // Reset combo state for new game


### PR DESCRIPTION
The animation state was not being reset in handleResetGame for both host and player components, causing issues when starting a second game in the same room. Also updated onShowResults type to include duplicateRuleDisabled and playerCount properties.