### PR TITLE
Improve SEO structure for main and child pages

### DIFF
--- a/fe-next/app/[locale]/layout.tsx
+++ b/fe-next/app/[locale]/layout.tsx
@@ -226,6 +226,29 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
             },
             inLanguage: [languageCode, 'he', 'en', 'sv', 'ja'],
         },
+        // WebPage schema - marks the main page as the primary entry point
+        {
+            '@context': 'https://schema.org',
+            '@type': 'WebPage',
+            '@id': `https://www.lexiclash.live${localePath}#webpage`,
+            url: `https://www.lexiclash.live${localePath}`,
+            name: seo.title,
+            description: seo.description,
+            isPartOf: {
+                '@id': 'https://www.lexiclash.live/#website',
+            },
+            about: {
+                '@id': 'https://www.lexiclash.live/#webapp',
+            },
+            primaryImageOfPage: {
+                '@type': 'ImageObject',
+                url: 'https://www.lexiclash.live/og-image-en.jpg',
+            },
+            mainContentOfPage: {
+                '@type': 'WebPageElement',
+                cssSelector: 'main',
+            },
+        },
         // FAQ schema - common questions users ask AI assistants and search engines
         {
             '@context': 'https://schema.org',

--- a/fe-next/app/[locale]/leaderboard/layout.tsx
+++ b/fe-next/app/[locale]/leaderboard/layout.tsx
@@ -51,13 +51,69 @@ export async function generateMetadata({ params }: LayoutParams): Promise<Metada
         ja: 'https://www.lexiclash.live/ja/leaderboard',
       },
     },
+    robots: {
+      index: true,
+      follow: true,
+    },
   };
 }
 
 interface LeaderboardLayoutProps {
   children: ReactNode;
+  params: Promise<{ locale: string }>;
 }
 
-export default function LeaderboardLayout({ children }: LeaderboardLayoutProps): ReactNode {
-  return children;
+export default async function LeaderboardLayout({ children, params }: LeaderboardLayoutProps): Promise<ReactNode> {
+  const { locale } = await params;
+  const localePath = locale === 'he' ? '' : `/${locale}`;
+
+  // Breadcrumb structured data - shows page hierarchy for search engines
+  const breadcrumbSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    '@id': `https://www.lexiclash.live${localePath}/leaderboard#breadcrumb`,
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'LexiClash',
+        item: `https://www.lexiclash.live${localePath}`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Leaderboard',
+        item: `https://www.lexiclash.live${localePath}/leaderboard`,
+      },
+    ],
+  };
+
+  // WebPage schema - identifies this page as subordinate to the main site
+  const webPageSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    '@id': `https://www.lexiclash.live${localePath}/leaderboard#webpage`,
+    url: `https://www.lexiclash.live${localePath}/leaderboard`,
+    name: 'Leaderboard - LexiClash',
+    description: 'View the top LexiClash players and their scores. See where you rank among word game champions.',
+    isPartOf: {
+      '@id': 'https://www.lexiclash.live/#website',
+    },
+    breadcrumb: {
+      '@id': `https://www.lexiclash.live${localePath}/leaderboard#breadcrumb`,
+    },
+    about: {
+      '@id': 'https://www.lexiclash.live/#webapp',
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbSchema, webPageSchema]) }}
+      />
+      {children}
+    </>
+  );
 }

--- a/fe-next/app/[locale]/profile/layout.tsx
+++ b/fe-next/app/[locale]/profile/layout.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: LayoutParams): Promise<Metada
     title: seo.title,
     description: seo.description,
     openGraph: {
-      type: 'website',
+      type: 'profile',
       locale: baseSeo.locale,
       url: `https://www.lexiclash.live${localePath}/profile`,
       title: seo.ogTitle,
@@ -51,13 +51,66 @@ export async function generateMetadata({ params }: LayoutParams): Promise<Metada
         ja: 'https://www.lexiclash.live/ja/profile',
       },
     },
+    robots: {
+      index: true,
+      follow: true,
+    },
   };
 }
 
 interface ProfileLayoutProps {
   children: ReactNode;
+  params: Promise<{ locale: string }>;
 }
 
-export default function ProfileLayout({ children }: ProfileLayoutProps): ReactNode {
-  return children;
+export default async function ProfileLayout({ children, params }: ProfileLayoutProps): Promise<ReactNode> {
+  const { locale } = await params;
+  const localePath = locale === 'he' ? '' : `/${locale}`;
+
+  // Breadcrumb structured data - shows page hierarchy for search engines
+  const breadcrumbSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    '@id': `https://www.lexiclash.live${localePath}/profile#breadcrumb`,
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'LexiClash',
+        item: `https://www.lexiclash.live${localePath}`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Profile',
+        item: `https://www.lexiclash.live${localePath}/profile`,
+      },
+    ],
+  };
+
+  // ProfilePage schema - identifies this as a profile page subordinate to the main site
+  const profilePageSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    '@id': `https://www.lexiclash.live${localePath}/profile#webpage`,
+    url: `https://www.lexiclash.live${localePath}/profile`,
+    name: 'Player Profile - LexiClash',
+    description: 'View and manage your LexiClash player profile, stats, achievements, and game history.',
+    isPartOf: {
+      '@id': 'https://www.lexiclash.live/#website',
+    },
+    breadcrumb: {
+      '@id': `https://www.lexiclash.live${localePath}/profile#breadcrumb`,
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbSchema, profilePageSchema]) }}
+      />
+      {children}
+    </>
+  );
 }

--- a/fe-next/app/[locale]/rules/layout.tsx
+++ b/fe-next/app/[locale]/rules/layout.tsx
@@ -1,25 +1,137 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
-export const metadata: Metadata = {
-    title: 'How to Play LexiClash - Game Rules & Strategy Guide',
-    description: 'Learn how to play LexiClash, the real-time multiplayer word game. Complete guide covering game rules, scoring system, winning strategies, and tips for beginners.',
-    openGraph: {
+interface LayoutParams {
+    params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({ params }: LayoutParams): Promise<Metadata> {
+    const { locale } = await params;
+    const localePath = locale === 'he' ? '' : `/${locale}`;
+
+    return {
         title: 'How to Play LexiClash - Game Rules & Strategy Guide',
-        description: 'Learn how to play LexiClash, the real-time multiplayer word game. Complete guide covering game rules, scoring system, and winning strategies.',
-        type: 'article',
-    },
-    twitter: {
-        card: 'summary_large_image',
-        title: 'How to Play LexiClash - Game Rules & Strategy Guide',
-        description: 'Learn how to play LexiClash, the real-time multiplayer word game. Complete guide covering game rules, scoring system, and winning strategies.',
-    },
-};
+        description: 'Learn how to play LexiClash, the real-time multiplayer word game. Complete guide covering game rules, scoring system, winning strategies, and tips for beginners.',
+        openGraph: {
+            title: 'How to Play LexiClash - Game Rules & Strategy Guide',
+            description: 'Learn how to play LexiClash, the real-time multiplayer word game. Complete guide covering game rules, scoring system, and winning strategies.',
+            type: 'article',
+            url: `https://www.lexiclash.live${localePath}/rules`,
+            siteName: 'LexiClash',
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title: 'How to Play LexiClash - Game Rules & Strategy Guide',
+            description: 'Learn how to play LexiClash, the real-time multiplayer word game. Complete guide covering game rules, scoring system, and winning strategies.',
+        },
+        alternates: {
+            canonical: `https://www.lexiclash.live${localePath}/rules`,
+            languages: {
+                'x-default': 'https://www.lexiclash.live/rules',
+                he: 'https://www.lexiclash.live/he/rules',
+                en: 'https://www.lexiclash.live/en/rules',
+                sv: 'https://www.lexiclash.live/sv/rules',
+                ja: 'https://www.lexiclash.live/ja/rules',
+            },
+        },
+        robots: {
+            index: true,
+            follow: true,
+        },
+    };
+}
 
 interface RulesLayoutProps {
     children: ReactNode;
+    params: Promise<{ locale: string }>;
 }
 
-export default function RulesLayout({ children }: RulesLayoutProps): ReactNode {
-    return children;
+export default async function RulesLayout({ children, params }: RulesLayoutProps): Promise<ReactNode> {
+    const { locale } = await params;
+    const localePath = locale === 'he' ? '' : `/${locale}`;
+
+    // Breadcrumb structured data - shows page hierarchy for search engines
+    const breadcrumbSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        '@id': `https://www.lexiclash.live${localePath}/rules#breadcrumb`,
+        itemListElement: [
+            {
+                '@type': 'ListItem',
+                position: 1,
+                name: 'LexiClash',
+                item: `https://www.lexiclash.live${localePath}`,
+            },
+            {
+                '@type': 'ListItem',
+                position: 2,
+                name: 'How to Play',
+                item: `https://www.lexiclash.live${localePath}/rules`,
+            },
+        ],
+    };
+
+    // HowTo schema - structured data for game instructions
+    const howToSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'HowTo',
+        '@id': `https://www.lexiclash.live${localePath}/rules#howto`,
+        name: 'How to Play LexiClash',
+        description: 'Learn how to play LexiClash, the real-time multiplayer word game.',
+        step: [
+            {
+                '@type': 'HowToStep',
+                name: 'Create or Join a Room',
+                text: 'Start by creating a new game room or joining an existing one with a room code.',
+            },
+            {
+                '@type': 'HowToStep',
+                name: 'Find Words on the Grid',
+                text: 'When the game starts, find words by connecting adjacent letters on the grid.',
+            },
+            {
+                '@type': 'HowToStep',
+                name: 'Score Points',
+                text: 'Earn points based on word length. Longer words score more points.',
+            },
+            {
+                '@type': 'HowToStep',
+                name: 'Win the Round',
+                text: 'The player with the most points at the end of the timer wins the round.',
+            },
+        ],
+        totalTime: 'PT5M',
+        isPartOf: {
+            '@id': 'https://www.lexiclash.live/#website',
+        },
+    };
+
+    // WebPage schema - identifies this page as subordinate to the main site
+    const webPageSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        '@id': `https://www.lexiclash.live${localePath}/rules#webpage`,
+        url: `https://www.lexiclash.live${localePath}/rules`,
+        name: 'How to Play LexiClash - Game Rules & Strategy Guide',
+        description: 'Learn how to play LexiClash with our comprehensive rules guide.',
+        isPartOf: {
+            '@id': 'https://www.lexiclash.live/#website',
+        },
+        breadcrumb: {
+            '@id': `https://www.lexiclash.live${localePath}/rules#breadcrumb`,
+        },
+        mainEntity: {
+            '@id': `https://www.lexiclash.live${localePath}/rules#howto`,
+        },
+    };
+
+    return (
+        <>
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbSchema, howToSchema, webPageSchema]) }}
+            />
+            {children}
+        </>
+    );
 }


### PR DESCRIPTION
Add structured data to clarify page hierarchy for search engines:
- Add BreadcrumbList schema to profile, leaderboard, and rules pages
- Add WebPage/ProfilePage schemas linking child pages to main site
- Add WebPage schema to main layout marking it as primary entry point
- Add HowTo schema to rules page for better rich results
- Add canonical URLs and language alternates to rules page