### PR TITLE
Fix second game stuck in same room

### DIFF
--- a/fe-next/backend/handlers/botHandler.js
+++ b/fe-next/backend/handlers/botHandler.js
@@ -171,8 +171,8 @@ function registerBotHandlers(io, socket) {
 
     const removedUsername = botToRemove.username;
 
-    // Remove bot from manager
-    botManager.removeBot(botToRemove.id);
+    // Remove bot from manager - pass both gameCode and botId
+    botManager.removeBot(gameCode, botToRemove.id);
 
     // Remove from game users
     removeUserFromGame(gameCode, removedUsername);

--- a/fe-next/backend/handlers/shared.js
+++ b/fe-next/backend/handlers/shared.js
@@ -85,10 +85,9 @@ function startGameTimer(io, gameCode, timerSeconds) {
   // Start bots if any are in the game
   startBotsForGame(io, gameCode, game.letterGrid, game.language, timerSeconds);
 
-  // Broadcast that game has officially started
-  broadcastToRoom(io, getGameRoom(gameCode), 'startGame', {
-    timerSeconds: remainingTime
-  });
+  // NOTE: We do NOT broadcast 'startGame' here anymore.
+  // The game start has already been broadcast from gameLifecycleHandler with all necessary data.
+  // A second broadcast was causing issues with the second game in the same room getting stuck.
 }
 
 /**

--- a/fe-next/player/PlayerView.tsx
+++ b/fe-next/player/PlayerView.tsx
@@ -132,16 +132,6 @@ const PlayerView: React.FC<PlayerViewProps> = memo(({
   // Enable presence tracking
   usePresence({ enabled: !!gameCode });
 
-  // Calculate human player count (exclude bots)
-  const humanPlayerCount = playersReady.filter(p => !p.isBot && !p.disconnected).length;
-
-  // Enable hints for single-player mode
-  const hints = useHints({
-    socket,
-    playerCount: humanPlayerCount,
-    gameActive,
-  });
-
   // Game state
   const [word, setWord] = useState<string>('');
   const [foundWords, setFoundWords] = useState<FoundWord[]>([]);
@@ -156,6 +146,16 @@ const PlayerView: React.FC<PlayerViewProps> = memo(({
 
   // Player state
   const [playersReady, setPlayersReady] = useState<Player[]>(initialPlayers);
+
+  // Calculate human player count (exclude bots)
+  const humanPlayerCount = playersReady.filter(p => !p.isBot && !p.disconnected).length;
+
+  // Enable hints for single-player mode
+  const hints = useHints({
+    socket,
+    playerCount: humanPlayerCount,
+    gameActive,
+  });
   const [shufflingGrid, setShufflingGrid] = useState<LetterGrid | null>(null);
   const [highlightedCells, setHighlightedCells] = useState<GridPosition[]>([]);
   const [gameLanguage, setGameLanguage] = useState<Language | null>(null);


### PR DESCRIPTION
- Remove duplicate startGame broadcast in shared.js that was causing second game in same room to get stuck due to overwriting client state
- Fix botHandler.js to pass gameCode parameter to botManager.removeBot() which was causing state inconsistency and player auto-exits
- Fix variable declaration order in PlayerView.tsx where playersReady was used before declaration