### PR TITLE
Fix Docker build caching for npm dependencies

### DIFF
--- a/fe-next/shared/types/index.ts
+++ b/fe-next/shared/types/index.ts
@@ -6,8 +6,26 @@
 // Game types
 export * from './game';
 
-// Socket event types
+// Socket event types (includes engagement payload types)
 export * from './socket';
 
-// Engagement system types
-export * from './engagement';
+// Engagement system types - export only unique types not already in socket.ts
+// The socket.ts file contains simplified versions of engagement types for socket payloads
+// For full engagement types, import directly from './engagement'
+export type {
+  ChallengeType,
+  ChallengeTier,
+  ChallengeRewardClaim,
+  StreakBonus,
+  StreakStatus,
+  CalendarRewardType,
+  MysteryBoxRarity,
+  CalendarClaimResult,
+  AppliedReward,
+  ComebackTier,
+  MysteryRewardTrigger,
+  MysteryRewardType,
+  RewardRarity,
+  GameStatsForEngagement,
+  EngagementSocketEvents,
+} from './engagement';


### PR DESCRIPTION
The socket.ts and engagement.ts files both export types with the same names (DailyChallenge, ChallengeProgress, CalendarStatus, etc.) causing TS2308 errors during build. Changed index.ts to use explicit exports for the engagement module, exporting only unique types that don't conflict with socket.ts payload types.