### PR TITLE
Fix bot word submission after first round

### DIFF
--- a/fe-next/backend/handlers/gameLifecycleHandler.js
+++ b/fe-next/backend/handlers/gameLifecycleHandler.js
@@ -208,7 +208,7 @@ function registerGameLifecycleHandlers(io, socket) {
       // Clear any lingering timers/state from previous game
       timerManager.clearGameTimer(gameCode);
       gameStartCoordinator.cleanupSequence(gameCode);
-      botManager.cleanupGameBots(gameCode);
+      botManager.stopAllBots(gameCode);
 
       // Force reset to 'waiting' state - try proper reset first, fallback to direct state change
       const resetSuccess = resetGameForNewRound(gameCode);


### PR DESCRIPTION
Root cause: When starting a new game while in an unexpected state (e.g., 'finished' instead of 'waiting'), the self-healing code called cleanupGameBots() which deleted all bots. This caused bots to disappear after the first round.

Fix: Changed cleanupGameBots() to stopAllBots() in the self-healing code. This stops bots (clears timers, sets inactive) but keeps them in the game so they can be restarted when the new game begins.

Location: fe-next/backend/handlers/gameLifecycleHandler.js:211