### PR TITLE
fix: resolve avatar, room entry, and user tracking issues

### DIFF
--- a/fe-next/backend/modules/supabaseServer.js
+++ b/fe-next/backend/modules/supabaseServer.js
@@ -154,10 +154,14 @@ async function updatePlayerStats(playerId, gameStats) {
     updates.casual_games = (profile.casual_games || 0) + 1;
   }
 
-  // Count wins - only for ranked games
+  // Count wins - both casual and ranked
   // Only count as win if placement === 1 AND more than 1 player (no solo wins)
-  if (gameStats.placement === 1 && (gameStats.totalPlayers || 0) > 1 && gameStats.isRanked) {
-    updates.ranked_wins = (profile.ranked_wins || 0) + 1;
+  if (gameStats.placement === 1 && (gameStats.totalPlayers || 0) > 1) {
+    if (gameStats.isRanked) {
+      updates.ranked_wins = (profile.ranked_wins || 0) + 1;
+    } else {
+      updates.casual_wins = (profile.casual_wins || 0) + 1;
+    }
   }
 
   // Update longest word if this game had a longer one
@@ -252,7 +256,7 @@ async function updateLeaderboardEntry(playerId) {
   // Get updated profile stats
   const { data: profile, error: fetchError } = await client
     .from('profiles')
-    .select('username, display_name, avatar_emoji, avatar_color, total_score, total_games, ranked_wins, ranked_mmr')
+    .select('username, display_name, avatar_emoji, avatar_color, total_score, total_games, ranked_wins, casual_wins, ranked_mmr')
     .eq('id', playerId)
     .single();
 
@@ -269,7 +273,7 @@ async function updateLeaderboardEntry(playerId) {
       avatar_color: profile.avatar_color,
       total_score: profile.total_score || 0,
       games_played: profile.total_games || 0,
-      games_won: profile.ranked_wins || 0,
+      games_won: (profile.casual_wins || 0) + (profile.ranked_wins || 0),
       ranked_mmr: profile.ranked_mmr || 1000,
       last_updated: new Date().toISOString()
     }, {

--- a/fe-next/components/EmojiAvatarPicker.tsx
+++ b/fe-next/components/EmojiAvatarPicker.tsx
@@ -130,6 +130,7 @@ const EmojiAvatarPicker: React.FC<EmojiAvatarPickerProps> = ({
           {/* Buttons */}
           <div className="flex gap-3">
             <button
+              type="button"
               onClick={onClose}
               className="flex-1 py-3 font-bold uppercase tracking-wide transition-all duration-100 flex items-center justify-center gap-2 bg-neo-cream text-neo-black border-3 border-neo-black shadow-hard-sm hover:shadow-hard hover:translate-x-[-2px] hover:translate-y-[-2px] active:shadow-none active:translate-x-[2px] active:translate-y-[2px]"
             >
@@ -137,6 +138,7 @@ const EmojiAvatarPicker: React.FC<EmojiAvatarPickerProps> = ({
               Cancel
             </button>
             <button
+              type="button"
               onClick={handleSave}
               className="flex-1 py-3 font-bold uppercase tracking-wide transition-all duration-100 flex items-center justify-center gap-2 bg-neo-cyan text-neo-black border-3 border-neo-black shadow-hard-sm hover:shadow-hard hover:translate-x-[-2px] hover:translate-y-[-2px] active:shadow-none active:translate-x-[2px] active:translate-y-[2px]"
             >

--- a/fe-next/components/join/HostModeFields.tsx
+++ b/fe-next/components/join/HostModeFields.tsx
@@ -92,8 +92,9 @@ const HostModeFields: React.FC<HostModeFieldsProps> = ({
       if (typeof window !== 'undefined') {
         localStorage.setItem('boggle_avatar_id', avatar.id);
       }
-      // Pre-fill host username with avatar name if username is empty or is a default avatar name
-      if (!hostUsername || hostUsername.trim() === '' || isAvatarDefaultName(hostUsername)) {
+      // Pre-fill host username with avatar name ONLY if username is empty
+      // Don't override if user has already entered a name (even if it matches an avatar name)
+      if (!hostUsername || hostUsername.trim() === '') {
         setHostUsername(avatar.name);
       }
     }

--- a/fe-next/components/join/JoinModeFields.tsx
+++ b/fe-next/components/join/JoinModeFields.tsx
@@ -83,8 +83,9 @@ const JoinModeFields: React.FC<JoinModeFieldsProps> = ({
       if (typeof window !== 'undefined') {
         localStorage.setItem('boggle_avatar_id', avatar.id);
       }
-      // Pre-fill username with avatar name if username is empty or is a default avatar name
-      if (!username || username.trim() === '' || isAvatarDefaultName(username)) {
+      // Pre-fill username with avatar name ONLY if username is empty
+      // Don't override if user has already entered a name (even if it matches an avatar name)
+      if (!username || username.trim() === '') {
         setUsername(avatar.name);
       }
     }

--- a/fe-next/supabase/migrations/018_add_casual_wins.sql
+++ b/fe-next/supabase/migrations/018_add_casual_wins.sql
@@ -1,0 +1,65 @@
+-- =============================================
+-- Add casual_wins column to profiles table
+-- Migration: 018_add_casual_wins
+-- =============================================
+
+-- Add casual_wins column to profiles table
+ALTER TABLE profiles
+ADD COLUMN IF NOT EXISTS casual_wins INTEGER DEFAULT 0;
+
+-- Add index for casual_wins (for potential leaderboards)
+CREATE INDEX IF NOT EXISTS idx_profiles_casual_wins ON profiles(casual_wins DESC);
+
+-- Update sync function to include casual_wins
+-- Drop existing function if return type changed
+DROP FUNCTION IF EXISTS sync_profile_to_leaderboard() CASCADE;
+
+CREATE FUNCTION sync_profile_to_leaderboard()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO leaderboard (
+        player_id,
+        username,
+        avatar_emoji,
+        avatar_color,
+        total_score,
+        games_played,
+        games_won,
+        ranked_mmr,
+        last_updated
+    ) VALUES (
+        NEW.id,
+        NEW.username,
+        NEW.avatar_emoji,
+        NEW.avatar_color,
+        COALESCE(NEW.total_score, 0),
+        COALESCE(NEW.total_games, 0),
+        -- Use sum of casual_wins + ranked_wins for total games_won
+        COALESCE(NEW.casual_wins, 0) + COALESCE(NEW.ranked_wins, 0),
+        COALESCE(NEW.ranked_mmr, 1000),
+        NOW()
+    )
+    ON CONFLICT (player_id) DO UPDATE SET
+        username = EXCLUDED.username,
+        avatar_emoji = EXCLUDED.avatar_emoji,
+        avatar_color = EXCLUDED.avatar_color,
+        total_score = EXCLUDED.total_score,
+        games_played = EXCLUDED.games_played,
+        games_won = EXCLUDED.games_won,
+        ranked_mmr = EXCLUDED.ranked_mmr,
+        last_updated = NOW();
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Re-create trigger with updated column list
+DROP TRIGGER IF EXISTS profile_to_leaderboard_sync ON profiles;
+CREATE TRIGGER profile_to_leaderboard_sync
+    AFTER INSERT OR UPDATE OF username, avatar_emoji, avatar_color, total_score, total_games, ranked_wins, casual_wins, ranked_mmr
+    ON profiles
+    FOR EACH ROW
+    EXECUTE FUNCTION sync_profile_to_leaderboard();
+
+-- Add comment for documentation
+COMMENT ON COLUMN profiles.casual_wins IS 'Number of casual game wins (placement=1 with >1 player)';


### PR DESCRIPTION
## Issues Fixed

### 1. Avatar name override after entering room
- **Problem**: When guest users selected an avatar, their custom username was
  overridden if it matched any avatar default name
- **Fix**: Updated JoinModeFields.tsx and HostModeFields.tsx to only auto-fill
  username when it's empty, not when it matches an avatar name
- **Files**: fe-next/components/join/{JoinModeFields,HostModeFields}.tsx

### 2. Avatar selection auto-entering room
- **Problem**: Clicking "Save" in the avatar picker triggered form submission,
  causing users to auto-enter rooms when they were just selecting an avatar
- **Fix**: Added type="button" to Save and Cancel buttons in EmojiAvatarPicker
  to prevent default form submission behavior
- **File**: fe-next/components/EmojiAvatarPicker.tsx

### 3. User tracking not working for casual games
- **Problem**: Only ranked game wins were being tracked (ranked_wins field),
  but most multiplayer games are casual (isRanked defaults to false), so
  most wins weren't being counted
- **Fix**:
  - Added casual_wins column to profiles table via migration
  - Updated supabaseServer.js to track both casual_wins and ranked_wins
  - Updated leaderboard sync to sum casual_wins + ranked_wins for total wins
- **Files**:
  - fe-next/supabase/migrations/018_add_casual_wins.sql (new)
  - fe-next/backend/modules/supabaseServer.js

### 4. Achievement translations
- **Status**: Verified all achievements are fully translated across all
  supported languages (en, he, sv, ja)

## Testing Notes
- Avatar selection no longer overrides user-entered names
- Avatar picker Save button no longer triggers form submission
- Casual game wins are now tracked in profiles.casual_wins
- Leaderboard games_won now reflects total wins (casual + ranked)