### PR TITLE
fix: remove 'use client' directive from [locale]/page to resolve revalidate error

### DIFF
--- a/fe-next/app/[locale]/page.tsx
+++ b/fe-next/app/[locale]/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 import { LandingView } from '@/components/landing';
 


### PR DESCRIPTION
The page component had both 'use client' and 'export const revalidate = 60',
which is invalid in Next.js. The revalidate export is server-side only for ISR.
Since LandingView is already a client component, the page doesn't need the
'use client' directive and can remain a server component.

Fixes: Invalid revalidate value error on /[locale] route