### PR TITLE
fix: enable word selection during tutorial by fixing pointer events

### DIFF
--- a/fe-next/components/GridComponent.tsx
+++ b/fe-next/components/GridComponent.tsx
@@ -385,6 +385,7 @@ const GridComponent = memo<GridComponentProps>(({
         <div
           ref={gridRef}
           dir="ltr"
+          data-tutorial="grid"
           className={cn(
             "grid touch-none select-none absolute rounded-neo",
             gridDimensions.gap,

--- a/fe-next/components/game/InGameScreen.tsx
+++ b/fe-next/components/game/InGameScreen.tsx
@@ -876,6 +876,7 @@ const InGameScreen = memo<InGameScreenProps>(({
 
             {/* Timer (center - always visible and prominent) */}
             <motion.div
+              data-tutorial="timer"
               initial={{ scale: 0, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               className="relative z-20"

--- a/fe-next/components/grid/ComboIndicator.tsx
+++ b/fe-next/components/grid/ComboIndicator.tsx
@@ -207,6 +207,7 @@ const ComboIndicator: React.FC<ComboIndicatorProps> = ({
       <motion.div
         key={`combo-${animationKey}`}
         className="fixed top-28 left-1/2 -translate-x-1/2 z-[80] pointer-events-none combo-indicator-container flex items-center justify-center"
+        data-tutorial="combo"
         data-extreme={isExtremeCombo}
         initial={{ opacity: 1 }}
         animate={controls}

--- a/fe-next/components/tutorial/TutorialOverlay.tsx
+++ b/fe-next/components/tutorial/TutorialOverlay.tsx
@@ -148,17 +148,10 @@ const TutorialOverlay: React.FC = () => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isActive, nextStep, prevStep, skipTutorial]);
 
-  // Handle click on overlay to advance
-  const handleOverlayClick = useCallback(
-    (e: React.MouseEvent) => {
-      // Don't advance if clicking on the tooltip itself
-      if ((e.target as HTMLElement).closest('[data-tutorial-tooltip]')) {
-        return;
-      }
-      nextStep();
-    },
-    [nextStep]
-  );
+  // Handle click on dark overlay to advance (not used on spotlight area)
+  const handleDarkOverlayClick = useCallback(() => {
+    nextStep();
+  }, [nextStep]);
 
   if (!isActive || !currentStep) {
     return null;
@@ -174,8 +167,7 @@ const TutorialOverlay: React.FC = () => {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.3 }}
-          className="fixed inset-0 z-[9999] cursor-pointer touch-pan-y"
-          onClick={handleOverlayClick}
+          className="fixed inset-0 z-[9999] pointer-events-none"
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
           role="dialog"
@@ -184,8 +176,9 @@ const TutorialOverlay: React.FC = () => {
         >
           {/* Dark overlay with spotlight cutout */}
           <svg
-            className="absolute inset-0 w-full h-full"
-            style={{ pointerEvents: 'none' }}
+            className="absolute inset-0 w-full h-full cursor-pointer"
+            style={{ pointerEvents: 'auto' }}
+            onClick={handleDarkOverlayClick}
           >
             <defs>
               <mask id="spotlight-mask">
@@ -252,7 +245,7 @@ const TutorialOverlay: React.FC = () => {
           />
 
           {/* Progress dots */}
-          <div className="fixed bottom-6 left-1/2 -translate-x-1/2 flex gap-2 z-[10000]">
+          <div className="fixed bottom-6 left-1/2 -translate-x-1/2 flex gap-2 z-[10000] pointer-events-auto">
             {Array.from({ length: totalSteps }).map((_, index) => (
               <motion.div
                 key={index}

--- a/fe-next/components/tutorial/TutorialTooltip.tsx
+++ b/fe-next/components/tutorial/TutorialTooltip.tsx
@@ -126,7 +126,7 @@ const TutorialTooltip: React.FC<TutorialTooltipProps> = ({
       animate={{ opacity: 1, scale: 1, y: 0 }}
       exit={{ opacity: 0, scale: 0.9, y: 20 }}
       transition={{ type: 'spring', stiffness: 300, damping: 25 }}
-      className="fixed z-[10001] w-[320px] max-w-[90vw]"
+      className="fixed z-[10001] w-[320px] max-w-[90vw] pointer-events-auto"
       style={tooltipStyle}
       onClick={(e) => e.stopPropagation()}
     >


### PR DESCRIPTION
The tutorial overlay was blocking all touch/click events to the grid,
making it impossible to select words during the tutorial. This commit
fixes the issue by:

1. Changed tutorial overlay to use pointer-events-none on main container
2. Added pointer-events-auto to specific interactive elements:
   - SVG dark overlay (to advance tutorial when clicking dark areas)
   - Tooltip component (to interact with tutorial buttons)
   - Progress dots (to show tutorial progress)
3. Added missing data-tutorial attributes:
   - data-tutorial="grid" on GridComponent
   - data-tutorial="combo" on ComboIndicator
   - data-tutorial="timer" on timer in InGameScreen

Now users can swipe and select words on the grid during the tutorial
while the spotlight highlights the relevant UI elements. Clicking on
the dark overlay areas still advances the tutorial as expected.