### PR TITLE
fix(auth): move WinnerOnboardingWrapper inside AuthProvider context

### DIFF
--- a/fe-next/app/providers.tsx
+++ b/fe-next/app/providers.tsx
@@ -119,6 +119,7 @@ export function Providers({ children, lang }: ProvidersProps) {
                                     <AudioProviders>
                                         <GameProviders>
                                             {children}
+                                            <WinnerOnboardingWrapper />
                                         </GameProviders>
                                     </AudioProviders>
                                 </SocketEventBusProvider>
@@ -140,7 +141,6 @@ export function Providers({ children, lang }: ProvidersProps) {
                         },
                     }}
                 />
-                <WinnerOnboardingWrapper />
             </>
         </ErrorBoundary>
     );


### PR DESCRIPTION
The WinnerOnboardingWrapper component uses the useAuth hook (via
useWinnerOnboarding), but it was rendered outside of the GameProviders
wrapper which contains the AuthProvider. This caused the error:
"useAuth must be used within an AuthProvider" when accessing routes
like /he.

Fixed by moving WinnerOnboardingWrapper inside the GameProviders
wrapper to ensure it has access to the AuthProvider context.

Fixes #useAuth error on /he route