### PR TITLE
fix(daily-challenge): sync winner profile with leaderboard and auto-navigate

### DIFF
--- a/fe-next/components/daily/DailyChallenge.tsx
+++ b/fe-next/components/daily/DailyChallenge.tsx
@@ -497,8 +497,23 @@ const DailyReadyScreen: React.FC<DailyReadyScreenProps> = ({
   onShowTutorial,
   t,
 }) => {
+  const searchParams = useSearchParams();
   const [showLangDropdown, setShowLangDropdown] = useState(false);
   const [showLeaderboard, setShowLeaderboard] = useState(false);
+
+  // Auto-open leaderboard if showLeaderboard query param is present
+  useEffect(() => {
+    const shouldShowLeaderboard = searchParams.get('showLeaderboard');
+    if (shouldShowLeaderboard === 'true') {
+      setShowLeaderboard(true);
+      // Clean up URL by removing the query parameter after opening
+      if (typeof window !== 'undefined') {
+        const url = new URL(window.location.href);
+        url.searchParams.delete('showLeaderboard');
+        window.history.replaceState({}, '', url.toString());
+      }
+    }
+  }, [searchParams]);
 
   // Check if this is a valid challenge (same puzzle number)
   const isValidChallenge = challengeData && challengeData.puzzleNumber === puzzleNumber;

--- a/fe-next/hooks/useWinnerOnboarding.ts
+++ b/fe-next/hooks/useWinnerOnboarding.ts
@@ -14,6 +14,7 @@ import {
   type WinnerOnboardingData,
 } from '@/utils/dailyChallenge';
 import { updateProfile } from '@/lib/supabase';
+import { getAvatarEmojiAndColor } from '@/utils/avatarConfig';
 
 /**
  * Hook to manage winner onboarding flow after daily challenge signup
@@ -71,10 +72,15 @@ export function useWinnerOnboarding() {
     try {
       logger.info('Completing winner onboarding with:', { displayName, avatarId });
 
+      // Get emoji and color representation for the avatar
+      const { emoji, color } = getAvatarEmojiAndColor(avatarId);
+
       // 1. Update the user's profile with chosen avatar and name
       const { data: updatedProfile, error: updateError } = await updateProfile(user.id, {
         display_name: displayName,
         avatar_image: avatarId,
+        avatar_emoji: emoji,
+        avatar_color: color,
         has_customized_profile: true, // Mark as customized
       });
 
@@ -82,13 +88,11 @@ export function useWinnerOnboarding() {
         throw new Error(updateError.message);
       }
 
-      logger.info('Profile updated successfully');
+      logger.info('Profile updated successfully with avatar:', { avatarId, emoji, color });
 
       // 2. Submit the pending daily challenge result with the NEW avatar/name
       const pending = getPendingDailyResult();
       if (pending) {
-        const guestPlayer = await getGuestDailyPlayer();
-
         const bodyData: Record<string, unknown> = {
           puzzleDate: pending.puzzleDate,
           puzzleNumber: pending.puzzleNumber,
@@ -96,8 +100,8 @@ export function useWinnerOnboarding() {
           playerId: user.id,
           guestFingerprint: null, // Now authenticated
           displayName: displayName, // Use the chosen name
-          avatarEmoji: updatedProfile?.avatar_emoji || guestPlayer?.avatarEmoji || '🎯',
-          avatarColor: updatedProfile?.avatar_color || guestPlayer?.avatarColor || '#6366f1',
+          avatarEmoji: emoji, // Use the emoji from avatar mapping
+          avatarColor: color, // Use the color from avatar mapping
           solved: pending.result.solved,
           attemptsUsed: pending.result.attemptsUsed,
           targetWord: pending.result.targetWord,

--- a/fe-next/utils/avatarConfig.ts
+++ b/fe-next/utils/avatarConfig.ts
@@ -60,6 +60,34 @@ export function getAvatarPath(avatar: AvatarConfig | string): string {
 }
 
 /**
+ * Map avatar ID to emoji representation (for Word Hunt leaderboard compatibility)
+ * Returns an emoji and color that represents the avatar
+ */
+export function getAvatarEmojiAndColor(avatarId: string): { emoji: string; color: string } {
+  const avatarToEmojiMap: Record<string, { emoji: string; color: string }> = {
+    'broccoli-bob': { emoji: '🥦', color: '#10b981' },
+    'drippy-drop': { emoji: '💧', color: '#06b6d4' },
+    'sunny-steve': { emoji: '☀️', color: '#f59e0b' },
+    'cloudy-carl': { emoji: '☁️', color: '#94a3b8' },
+    'octo-otto': { emoji: '🐙', color: '#8b5cf6' },
+    'pizza-pete': { emoji: '🍕', color: '#ef4444' },
+    'prickly-pat': { emoji: '🌵', color: '#84cc16' },
+    'melon-molly': { emoji: '🍉', color: '#ec4899' },
+    'avo-alex': { emoji: '🥑', color: '#22c55e' },
+    'frosty-frank': { emoji: '❄️', color: '#60a5fa' },
+    'flaky-fred': { emoji: '❄️', color: '#e0f2fe' },
+    'eggy-ed': { emoji: '🥚', color: '#fef3c7' },
+    'slimy-sam': { emoji: '💚', color: '#4ade80' },
+    'starry-stella': { emoji: '⭐', color: '#fbbf24' },
+    'shroom-shelly': { emoji: '🍄', color: '#f87171' },
+    'donut-danny': { emoji: '🍩', color: '#fb923c' },
+    'jelly-jen': { emoji: '🍇', color: '#c084fc' },
+  };
+
+  return avatarToEmojiMap[avatarId] || { emoji: '🎯', color: '#6366f1' };
+}
+
+/**
  * Map emoji to avatar (for migration from emoji-based avatars)
  * Maps the most commonly used emojis to similar avatar images
  */


### PR DESCRIPTION
After winner signup from daily challenge:
- Auto-navigate to daily challenge leaderboard with showLeaderboard query param
- Add avatar ID to emoji/color mapping for Word Hunt compatibility
- Update profile with both avatar_image and avatar_emoji/avatar_color
- Properly sync display name, avatar emoji, and color to leaderboard
- DailyReadyScreen now reads and respects showLeaderboard query parameter

Fixes:
- Winner not appearing on leaderboard after signup
- Avatar/name not syncing correctly
- No auto-navigation to leaderboard after signup