### PR TITLE
fix(signup): use OAuth profile picture and display name as defaults

### DIFF
--- a/fe-next/app/components/WinnerOnboardingWrapper.tsx
+++ b/fe-next/app/components/WinnerOnboardingWrapper.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useWinnerOnboarding } from '@/hooks/useWinnerOnboarding';
+import { useAuth } from '@/contexts/AuthContext';
 import WinnerOnboarding from '@/components/auth/WinnerOnboarding';
 
 /**
@@ -10,6 +11,7 @@ import WinnerOnboarding from '@/components/auth/WinnerOnboarding';
  */
 export default function WinnerOnboardingWrapper() {
   const { isOpen, onboardingData, isProcessing, completeOnboarding } = useWinnerOnboarding();
+  const { profile } = useAuth();
 
   if (!onboardingData) {
     return null;
@@ -21,6 +23,7 @@ export default function WinnerOnboardingWrapper() {
       onComplete={completeOnboarding}
       initialName={onboardingData.initialName}
       initialAvatarId={onboardingData.initialAvatarId}
+      profilePictureUrl={profile?.profile_picture_url ?? undefined}
       trigger={onboardingData.trigger}
     />
   );

--- a/fe-next/components/ProfileCustomizationModal.tsx
+++ b/fe-next/components/ProfileCustomizationModal.tsx
@@ -10,11 +10,13 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { useTheme } from '@/utils/ThemeContext';
 import { AVATARS, getAvatarPath, getAvatarById, getRandomAvatar } from '@/utils/avatarConfig';
 import { cn } from '@/lib/utils';
+import { PROFILE_AVATAR_ID } from '@/components/EmojiAvatarPicker';
 
 interface ProfileCustomizationModalProps {
   isOpen: boolean;
   onClose: () => void;
   defaultName: string;
+  profilePictureUrl?: string;
   onSave: (name: string, avatarId: string) => Promise<void>;
 }
 
@@ -26,14 +28,17 @@ const ProfileCustomizationModal: React.FC<ProfileCustomizationModalProps> = ({
   isOpen,
   onClose,
   defaultName,
+  profilePictureUrl,
   onSave,
 }) => {
   const { t, dir } = useLanguage();
   const { theme } = useTheme();
   const isDarkMode = theme === 'dark';
 
-  // Pre-select a random avatar
-  const [selectedAvatarId, setSelectedAvatarId] = useState<string>(() => getRandomAvatar().id);
+  // Pre-select profile picture if available, otherwise random avatar
+  const [selectedAvatarId, setSelectedAvatarId] = useState<string>(() =>
+    profilePictureUrl ? PROFILE_AVATAR_ID : getRandomAvatar().id
+  );
   const [displayName, setDisplayName] = useState(defaultName);
   const [isSaving, setIsSaving] = useState(false);
   const [nameTouched, setNameTouched] = useState(false);
@@ -42,10 +47,10 @@ const ProfileCustomizationModal: React.FC<ProfileCustomizationModalProps> = ({
   useEffect(() => {
     if (isOpen) {
       setDisplayName(defaultName);
-      setSelectedAvatarId(getRandomAvatar().id);
+      setSelectedAvatarId(profilePictureUrl ? PROFILE_AVATAR_ID : getRandomAvatar().id);
       setNameTouched(false);
     }
-  }, [isOpen, defaultName]);
+  }, [isOpen, defaultName, profilePictureUrl]);
 
   // Name validation
   const minLength = 2;
@@ -90,6 +95,7 @@ const ProfileCustomizationModal: React.FC<ProfileCustomizationModalProps> = ({
   };
 
   const selectedAvatar = getAvatarById(selectedAvatarId) || AVATARS[0];
+  const isUsingProfilePicture = selectedAvatarId === PROFILE_AVATAR_ID;
 
   return (
     <Dialog open={isOpen} onOpenChange={() => {}}>
@@ -116,8 +122,55 @@ const ProfileCustomizationModal: React.FC<ProfileCustomizationModalProps> = ({
               {t('profileCustomization.avatarLabel') || 'Pick your character'}
             </label>
             <div className="grid grid-cols-6 gap-1.5 sm:gap-2">
+              {/* Profile Picture Option (if available) */}
+              {profilePictureUrl && (
+                <motion.button
+                  onClick={() => setSelectedAvatarId(PROFILE_AVATAR_ID)}
+                  className={cn(
+                    'relative aspect-square rounded-neo border-2 overflow-hidden',
+                    'transition-all hover:scale-105 active:scale-95',
+                    'min-h-[40px] min-w-[40px]',
+                    isUsingProfilePicture
+                      ? 'border-neo-cyan shadow-hard-sm scale-105 ring-2 ring-neo-pink'
+                      : 'border-neo-black shadow-hard-sm hover:shadow-hard-md'
+                  )}
+                  initial={{ scale: 0, rotate: -180 }}
+                  animate={{ scale: 1, rotate: 0 }}
+                  transition={{ delay: 0.05 }}
+                  whileHover={{ scale: isUsingProfilePicture ? 1.05 : 1.1 }}
+                  whileTap={{ scale: 0.95 }}
+                >
+                  <Image
+                    src={profilePictureUrl}
+                    alt="Your Profile"
+                    fill
+                    className="object-cover"
+                    referrerPolicy="no-referrer"
+                  />
+
+                  {/* Selected indicator */}
+                  {isUsingProfilePicture && (
+                    <motion.div
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      className="absolute inset-0 bg-neo-cyan/20 flex items-center justify-center"
+                    >
+                      <div className="bg-neo-pink text-white border-2 border-neo-black rounded-full w-5 h-5 flex items-center justify-center font-black text-[10px] shadow-hard-sm">
+                        ✓
+                      </div>
+                    </motion.div>
+                  )}
+
+                  {/* Label */}
+                  <div className="absolute bottom-0 left-0 right-0 bg-neo-black/80 text-white text-[8px] font-bold text-center py-0.5">
+                    YOU
+                  </div>
+                </motion.button>
+              )}
+
+              {/* Regular Character Avatars */}
               {AVATARS.map((avatar, index) => {
-                const isSelected = avatar.id === selectedAvatarId;
+                const isSelected = !isUsingProfilePicture && avatar.id === selectedAvatarId;
 
                 return (
                   <motion.button
@@ -168,15 +221,25 @@ const ProfileCustomizationModal: React.FC<ProfileCustomizationModalProps> = ({
               {/* Avatar preview */}
               <div className="flex flex-col items-center gap-1 shrink-0">
                 <div className="relative w-14 h-14 rounded-full overflow-hidden border-3 border-neo-black dark:border-slate-500 shadow-hard-sm">
-                  <Image
-                    src={getAvatarPath(selectedAvatar)}
-                    alt={selectedAvatar.name}
-                    fill
-                    className="object-cover"
-                  />
+                  {isUsingProfilePicture && profilePictureUrl ? (
+                    <Image
+                      src={profilePictureUrl}
+                      alt="Your Profile"
+                      fill
+                      className="object-cover"
+                      referrerPolicy="no-referrer"
+                    />
+                  ) : (
+                    <Image
+                      src={getAvatarPath(selectedAvatar)}
+                      alt={selectedAvatar.name}
+                      fill
+                      className="object-cover"
+                    />
+                  )}
                 </div>
                 <div className="text-[10px] text-neo-black/60 dark:text-gray-400 text-center max-w-[60px] truncate">
-                  {selectedAvatar.name}
+                  {isUsingProfilePicture ? 'Your Profile' : selectedAvatar.name}
                 </div>
               </div>
 

--- a/fe-next/components/auth/WinnerOnboarding.tsx
+++ b/fe-next/components/auth/WinnerOnboarding.tsx
@@ -11,12 +11,14 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import { cn } from '../../lib/utils';
 import { AVATARS, getAvatarPath, type AvatarConfig } from '@/utils/avatarConfig';
 import { fireConfetti } from '@/utils/confettiUtils';
+import { PROFILE_AVATAR_ID } from '@/components/EmojiAvatarPicker';
 
 interface WinnerOnboardingProps {
   isOpen: boolean;
   onComplete: (displayName: string, avatarId: string) => void | Promise<void>;
   initialName?: string;
   initialAvatarId?: string;
+  profilePictureUrl?: string;
   trigger?: 'firstCompletion' | 'streakAtRisk' | 'topPercentile' | 'quickSolve';
 }
 
@@ -25,6 +27,7 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
   onComplete,
   initialName = '',
   initialAvatarId,
+  profilePictureUrl,
   trigger = 'firstCompletion'
 }) => {
   const { theme } = useTheme();
@@ -32,9 +35,17 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
   const isDarkMode = theme === 'dark';
 
   const [displayName, setDisplayName] = useState(initialName);
-  const [selectedAvatar, setSelectedAvatar] = useState<AvatarConfig>(
-    AVATARS.find(a => a.id === initialAvatarId) || AVATARS[0]
-  );
+
+  // Determine if we should use profile picture by default
+  const shouldUseProfilePicture = profilePictureUrl && initialAvatarId === PROFILE_AVATAR_ID;
+  const [useProfilePicture, setUseProfilePicture] = useState(shouldUseProfilePicture);
+
+  const [selectedAvatar, setSelectedAvatar] = useState<AvatarConfig>(() => {
+    if (shouldUseProfilePicture) {
+      return AVATARS[0]; // Default fallback, won't be shown if using profile picture
+    }
+    return AVATARS.find(a => a.id === initialAvatarId) || AVATARS[0];
+  });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -65,12 +76,13 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
     setError(null);
 
     try {
-      await onComplete(trimmedName, selectedAvatar.id);
+      const avatarId = useProfilePicture ? PROFILE_AVATAR_ID : selectedAvatar.id;
+      await onComplete(trimmedName, avatarId);
     } catch (err) {
       setError((err as Error).message || 'Failed to save profile');
       setIsSubmitting(false);
     }
-  }, [displayName, selectedAvatar, onComplete]);
+  }, [displayName, selectedAvatar, useProfilePicture, onComplete]);
 
   const handleKeyPress = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !isSubmitting) {
@@ -195,7 +207,7 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
               {/* Preview */}
               <div className="flex justify-center mb-4">
                 <motion.div
-                  key={selectedAvatar.id}
+                  key={useProfilePicture ? 'profile' : selectedAvatar.id}
                   initial={{ scale: 0.8, opacity: 0 }}
                   animate={{ scale: 1, opacity: 1 }}
                   className="relative"
@@ -204,14 +216,26 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
                     'w-32 h-32 rounded-2xl overflow-hidden border-4 shadow-hard',
                     isDarkMode ? 'border-amber-400' : 'border-amber-500'
                   )}>
-                    <Image
-                      src={getAvatarPath(selectedAvatar)}
-                      alt={selectedAvatar.name}
-                      width={128}
-                      height={128}
-                      className="object-cover"
-                      priority
-                    />
+                    {useProfilePicture && profilePictureUrl ? (
+                      <Image
+                        src={profilePictureUrl}
+                        alt="Your Profile"
+                        width={128}
+                        height={128}
+                        className="object-cover"
+                        priority
+                        referrerPolicy="no-referrer"
+                      />
+                    ) : (
+                      <Image
+                        src={getAvatarPath(selectedAvatar)}
+                        alt={selectedAvatar.name}
+                        width={128}
+                        height={128}
+                        className="object-cover"
+                        priority
+                      />
+                    )}
                   </div>
                   <div className={cn(
                     'absolute -bottom-2 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full border-2 text-xs font-bold whitespace-nowrap',
@@ -219,7 +243,7 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
                       ? 'bg-slate-800 border-amber-400 text-amber-300'
                       : 'bg-white border-amber-500 text-amber-700'
                   )}>
-                    {selectedAvatar.name}
+                    {useProfilePicture ? 'Your Profile' : selectedAvatar.name}
                   </div>
                 </motion.div>
               </div>
@@ -229,16 +253,55 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
                 'grid grid-cols-6 gap-3 p-4 rounded-xl border-2 max-h-64 overflow-y-auto',
                 isDarkMode ? 'bg-slate-700/50 border-slate-600' : 'bg-white/50 border-gray-300'
               )}>
-                {AVATARS.map((avatar) => (
+                {/* Profile Picture Option (if available) */}
+                {profilePictureUrl && (
                   <motion.button
-                    key={avatar.id}
+                    key="profile-picture"
                     type="button"
-                    onClick={() => setSelectedAvatar(avatar)}
+                    onClick={() => setUseProfilePicture(true)}
                     whileHover={{ scale: 1.1 }}
                     whileTap={{ scale: 0.95 }}
                     className={cn(
                       'relative w-full aspect-square rounded-xl overflow-hidden border-3 transition-all',
-                      selectedAvatar.id === avatar.id
+                      useProfilePicture
+                        ? 'border-amber-400 ring-4 ring-amber-400/50'
+                        : 'border-neo-black hover:border-gray-500'
+                    )}
+                  >
+                    <Image
+                      src={profilePictureUrl}
+                      alt="Your Profile"
+                      fill
+                      sizes="80px"
+                      className="object-cover"
+                      referrerPolicy="no-referrer"
+                    />
+                    {useProfilePicture && (
+                      <div className="absolute inset-0 bg-amber-400/20 flex items-center justify-center">
+                        <Check className="w-6 h-6 text-amber-600 drop-shadow" />
+                      </div>
+                    )}
+                    {/* Label */}
+                    <div className="absolute bottom-0 left-0 right-0 bg-neo-black/80 text-white text-[9px] font-bold text-center py-0.5">
+                      YOU
+                    </div>
+                  </motion.button>
+                )}
+
+                {/* Regular Character Avatars */}
+                {AVATARS.map((avatar) => (
+                  <motion.button
+                    key={avatar.id}
+                    type="button"
+                    onClick={() => {
+                      setSelectedAvatar(avatar);
+                      setUseProfilePicture(false);
+                    }}
+                    whileHover={{ scale: 1.1 }}
+                    whileTap={{ scale: 0.95 }}
+                    className={cn(
+                      'relative w-full aspect-square rounded-xl overflow-hidden border-3 transition-all',
+                      !useProfilePicture && selectedAvatar.id === avatar.id
                         ? 'border-amber-400 ring-4 ring-amber-400/50'
                         : 'border-neo-black hover:border-gray-500'
                     )}
@@ -250,7 +313,7 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
                       sizes="80px"
                       className="object-cover"
                     />
-                    {selectedAvatar.id === avatar.id && (
+                    {!useProfilePicture && selectedAvatar.id === avatar.id && (
                       <div className="absolute inset-0 bg-amber-400/20 flex items-center justify-center">
                         <Check className="w-6 h-6 text-amber-600 drop-shadow" />
                       </div>

--- a/fe-next/components/landing/LandingView.tsx
+++ b/fe-next/components/landing/LandingView.tsx
@@ -183,6 +183,7 @@ const LandingView: React.FC = () => {
         isOpen={showProfileCustomization}
         onClose={() => setShowProfileCustomization(false)}
         defaultName={profile?.display_name || profile?.username || ''}
+        profilePictureUrl={profile?.profile_picture_url ?? undefined}
         onSave={handleProfileCustomizationSave}
       />
 

--- a/fe-next/contexts/AuthContext.tsx
+++ b/fe-next/contexts/AuthContext.tsx
@@ -207,13 +207,17 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         avatarColor = randomData.avatar.color;
       }
 
+      // Determine the avatar_image: use PROFILE_AVATAR_ID if we have a profile picture,
+      // otherwise use the random character avatar
+      const finalAvatarImage = profilePictureUrl ? '__profile_avatar__' : avatarImage;
+
       const { data: newProfile, error: createError } = await createProfile({
         id: userId,
         username,
         display_name: displayName,
         avatar_emoji: avatarEmoji,
         avatar_color: avatarColor,
-        avatar_image: avatarImage, // Character avatar from our avatar options
+        avatar_image: finalAvatarImage, // Use profile picture if available, otherwise character avatar
         profile_picture_url: profilePictureUrl,
         profile_picture_provider: profilePictureProvider,
         has_customized_profile: false, // Will prompt user to customize after sign-in


### PR DESCRIPTION
- Set default avatar to OAuth profile picture instead of random avatar
- Show profile picture as first option in avatar selection modals
- Display name from OAuth is already set correctly
- Leaderboard syncs automatically via existing database triggers

Changes:
- WinnerOnboarding: Added profile picture option and support for PROFILE_AVATAR_ID
- ProfileCustomizationModal: Pre-select profile picture if available
- AuthContext: Set avatar_image to PROFILE_AVATAR_ID when profile picture exists
- Leaderboard: Already syncs via triggers on avatar_image and profile_picture_url updates