### PR TITLE
fix(new-year): correct celebration year display

### DIFF
--- a/fe-next/components/celebration/NewYearCountdown.tsx
+++ b/fe-next/components/celebration/NewYearCountdown.tsx
@@ -219,7 +219,7 @@ export default function NewYearCountdown({ enabled = true }: NewYearCountdownPro
                   animate={{ scale: 1, rotate: 0 }}
                   transition={{ delay: 0.3, type: 'spring', damping: 12 }}
                 >
-                  <span className="text-5xl font-black">{newYearState.nextYear}</span>
+                  <span className="text-5xl font-black">{newYearState.celebrationYear}</span>
                 </motion.div>
               </div>
 

--- a/fe-next/hooks/useNewYearDetection.ts
+++ b/fe-next/hooks/useNewYearDetection.ts
@@ -8,6 +8,8 @@ export interface NewYearState {
   secondsUntilMidnight: number;
   currentYear: number;
   nextYear: number;
+  /** The year to display in celebrations (current year on Jan 1, next year on Dec 31) */
+  celebrationYear: number;
 }
 
 interface UseNewYearDetectionOptions {
@@ -42,14 +44,16 @@ export function useNewYearDetection(options: UseNewYearDetectionOptions = {}): N
 
   const updateState = useCallback(() => {
     if (!enabled) {
+      const year = new Date().getFullYear();
       setState({
         isNewYearsEve: false,
         isNewYearsDay: false,
         isCountdownTime: false,
         isCelebrationTime: false,
         secondsUntilMidnight: 0,
-        currentYear: new Date().getFullYear(),
-        nextYear: new Date().getFullYear() + 1,
+        currentYear: year,
+        nextYear: year + 1,
+        celebrationYear: year + 1,
       });
       return;
     }
@@ -111,6 +115,9 @@ function calculateNewYearState(
   const secondsSinceMidnight = (now.getHours() * 3600) + (now.getMinutes() * 60) + now.getSeconds();
   const isCelebrationTime = isInCelebrationWindow && secondsSinceMidnight <= celebrationDurationSeconds;
 
+  // Celebration year: if we're on New Year's Day, show current year; if on New Year's Eve, show next year
+  const celebrationYear = isNewYearsDay ? currentYear : nextYear;
+
   return {
     isNewYearsEve,
     isNewYearsDay,
@@ -119,6 +126,7 @@ function calculateNewYearState(
     secondsUntilMidnight,
     currentYear,
     nextYear,
+    celebrationYear,
   };
 }
 


### PR DESCRIPTION
Fixed the New Year celebration to show the correct year. Previously,
when the celebration appeared after midnight on January 1st, it would
display the "next year" (e.g., 2027) instead of the year we just
entered (e.g., 2026).

Changes:
- Added celebrationYear to NewYearState interface
- celebrationYear shows current year on Jan 1, next year on Dec 31
- Updated NewYearCountdown to use celebrationYear instead of nextYear

Now correctly displays:
- Dec 31, 2025 at 11:59 PM: "Happy New Year 2026!"
- Jan 1, 2026 at 12:00 AM: "Happy New Year 2026!" (not 2027)