### PR TITLE
fix(daily-challenge): add avatarImage property to DailyShareImageOptions type

### DIFF
--- a/fe-next/utils/dailyShareImage.ts
+++ b/fe-next/utils/dailyShareImage.ts
@@ -36,6 +36,7 @@ export interface DailyShareImageOptions {
   // Player info (optional)
   displayName?: string;
   avatarEmoji?: string;
+  avatarImage?: string | null;
 }
 
 export interface ShareImageResult {


### PR DESCRIPTION
- Added missing avatarImage?: string | null to DailyShareImageOptions interface
- Fixes TypeScript error in DailyChallengeResults.tsx:336
- Aligns with usage where avatar_image from profile is passed to generateDailyShareImage