### PR TITLE
fix(education): remove referrer block on education landing

### DIFF
--- a/fe-next/app/[locale]/education/PageClient.tsx
+++ b/fe-next/app/[locale]/education/PageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
@@ -204,23 +204,6 @@ export default function EducationPageClient() {
   const { isAuthenticated, loading: authLoading, profile } = useAuth();
   const [showAuthModal, setShowAuthModal] = useState(false);
   const router = useRouter();
-
-  // Only allow access via direct URL (typed/bookmarked/external link).
-  // Any in-app navigation (referrer from same origin) redirects home,
-  // even from other education pages — this is the landing/hub, not a sub-route.
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const ref = document.referrer;
-    if (ref) {
-      try {
-        if (new URL(ref).origin === window.location.origin) {
-          router.replace(`/${language}`);
-        }
-      } catch {
-        // Malformed referrer — treat as direct access
-      }
-    }
-  }, [router, language]);
 
   // Determine the user's role for dashboard shortcut
   const userRole = profile?.user_role;


### PR DESCRIPTION
## Summary
- Removed the `useEffect` in `PageClient.tsx` that checked `document.referrer` and redirected to home if the referrer was from the same origin
- This blocked all in-app navigation to `/education`, which is terrible UX
- Cleaned up unused `useEffect` import

## Test plan
- [ ] Navigate to `/education` from another page in the app — should work without redirect
- [ ] Navigate to `/education` via direct URL — should still work
- [ ] Verify teacher/student click handlers still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)