### PR TITLE
feat(blast): unique lightning tile effects

### DIFF
--- a/fe-next/app/globals.css
+++ b/fe-next/app/globals.css
@@ -1196,6 +1196,12 @@ body {
     100% { opacity: 1; transform: scale(1); }
   }
 
+  @keyframes blastLightningFlash {
+    0% { opacity: 1; transform: scale(1.15); background: white; }
+    30% { opacity: 1; transform: scaleY(1.8) scaleX(0.5); }
+    100% { opacity: 0; transform: scaleY(2.5) scaleX(0.3); }
+  }
+
   /* Accessibility: disable all blast tile idle animations for users who prefer reduced motion */
   @media (prefers-reduced-motion: reduce) {
     .blast-tile-gold,

--- a/fe-next/components/blast/BlastEffectsCanvas.tsx
+++ b/fe-next/components/blast/BlastEffectsCanvas.tsx
@@ -117,6 +117,8 @@ interface DebrisFragment {
 const DEBRIS_LIFETIME = 2; // seconds
 const DEBRIS_PER_TILE = 3;
 const MAX_DEBRIS = 60;
+const LIGHTNING_DEBRIS_PER_CELL = 2;
+const LIGHTNING_FLASH_DURATION = 200; // ms
 
 function EffectsWorker({
   width,
@@ -154,6 +156,112 @@ function EffectsWorker({
       container.destroy();
     };
   }, [camera, physics]);
+
+  // Draw jagged lightning bolt down a column with rapid flash
+  const spawnLightningBolt = useCallback((col: number, gridRows: number) => {
+    const container = debrisContainerRef.current;
+    if (!container) return;
+
+    const x = col * cellSize + cellSize / 2;
+    const colHeight = gridRows * cellSize;
+
+    // Column flash overlay — white rectangle fading out
+    const flash = new Graphics();
+    flash.rect(col * cellSize, 0, cellSize, colHeight).fill({ color: 0xffffff });
+    flash.alpha = 0.8;
+    container.addChild(flash);
+
+    const flashStart = performance.now();
+    const fadeFlash = () => {
+      const elapsed = performance.now() - flashStart;
+      if (elapsed >= LIGHTNING_FLASH_DURATION) {
+        flash.destroy();
+        return;
+      }
+      flash.alpha = 0.8 * (1 - elapsed / LIGHTNING_FLASH_DURATION);
+      requestAnimationFrame(fadeFlash);
+    };
+    requestAnimationFrame(fadeFlash);
+
+    // Jagged bolt — zigzag line segments down the column
+    const drawBolt = (offsetX: number) => {
+      const bolt = new Graphics();
+      bolt.setStrokeStyle({ width: 2 + Math.random() * 2, color: 0x00ffff });
+      bolt.moveTo(x + offsetX, 0);
+      const segments = gridRows * 3;
+      const segHeight = colHeight / segments;
+      for (let i = 1; i <= segments; i++) {
+        const jitter = (Math.random() - 0.5) * cellSize * 0.6;
+        bolt.lineTo(x + offsetX + jitter, i * segHeight);
+      }
+      bolt.stroke();
+      bolt.alpha = 1;
+      container.addChild(bolt);
+      return bolt;
+    };
+
+    // Flash bolt 3 times rapidly
+    let flashCount = 0;
+    const boltA = drawBolt(0);
+    const boltB = drawBolt(3);
+    const boltFlashInterval = setInterval(() => {
+      flashCount++;
+      if (flashCount >= 6) {
+        clearInterval(boltFlashInterval);
+        boltA.destroy();
+        boltB.destroy();
+        return;
+      }
+      boltA.visible = flashCount % 2 === 0;
+      boltB.visible = flashCount % 2 === 1;
+    }, 50);
+  }, [cellSize]);
+
+  // Spawn thin elongated debris flung horizontally from lightning-cleared cells
+  const spawnLightningDebris = useCallback((tiles: ClearedTileEvent[]) => {
+    const container = debrisContainerRef.current;
+    if (!container) return;
+
+    const budget = MAX_DEBRIS - debrisRef.current.length;
+    const perTile = Math.min(LIGHTNING_DEBRIS_PER_CELL, Math.floor(budget / Math.max(tiles.length, 1)));
+    if (perTile <= 0) return;
+
+    const now = performance.now() / 1000;
+    const sparkColors = [0x00ffff, 0xffffff, 0x88eeff, 0xccffff];
+
+    for (const tile of tiles) {
+      const cx = tile.col * cellSize + cellSize / 2;
+      const cy = tile.row * cellSize + cellSize / 2;
+
+      for (let i = 0; i < perTile; i++) {
+        // Thin elongated spark: wider than tall
+        const w = 6 + Math.random() * 8;
+        const h = 1.5 + Math.random() * 2;
+        const color = sparkColors[Math.floor(Math.random() * sparkColors.length)];
+
+        const g = new Graphics();
+        g.rect(-w / 2, -h / 2, w, h).fill({ color });
+        g.x = cx;
+        g.y = cy;
+        container.addChild(g);
+
+        const bodyId = physics.createRect(cx, cy, w, h, {
+          restitution: 0.3,
+          frictionAir: 0.02,
+          density: 0.001,
+        });
+
+        // Fling horizontally
+        const dir = Math.random() > 0.5 ? 1 : -1;
+        physics.applyForce(bodyId, {
+          x: dir * (0.001 + Math.random() * 0.002),
+          y: (Math.random() - 0.5) * 0.0005,
+        });
+
+        debrisRef.current.push({ bodyId, graphic: g, color, size: w, createdAt: now });
+      }
+    }
+  }, [cellSize, physics]);
 
   // Spawn debris fragments for cleared tiles
   const spawnDebris = useCallback((tiles: ClearedTileEvent[]) => {
@@ -267,22 +375,41 @@ function EffectsWorker({
     if (key === prevClearedKeyRef.current) return;
     prevClearedKeyRef.current = key;
 
+    const lightningTiles: ClearedTileEvent[] = [];
+    const lightningCols = new Set<number>();
+
     for (const tile of clearedTiles) {
       const x = tile.col * cellSize + cellSize / 2;
       const y = tile.row * cellSize + cellSize / 2;
       const preset = CLEAR_PRESET_MAP[tile.type] ?? TILE_EXPLOSION;
       particles.burst(preset, x, y);
+
+      if (tile.type === 'lightning') {
+        lightningTiles.push(tile);
+        lightningCols.add(tile.col);
+      }
+    }
+
+    // Lightning-specific effects: bolt trail, column flash, elongated debris
+    if (lightningCols.size > 0) {
+      for (const col of lightningCols) {
+        spawnLightningBolt(col, gridSize);
+      }
+      spawnLightningDebris(lightningTiles);
+      shake.shake({ intensity: 6, duration: 0.3, decay: 'exponential' });
     }
 
     // Spawn physics debris fragments
     spawnDebris(clearedTiles);
 
-    // Screen shake scaled to clear count
-    const count = clearedTiles.length;
-    if (count >= 6) shake.heavy();
-    else if (count >= 3) shake.medium();
-    else shake.light();
-  }, [clearedTiles, particles, shake, cellSize, spawnDebris]);
+    // Screen shake scaled to clear count (lightning already shook above)
+    if (lightningCols.size === 0) {
+      const count = clearedTiles.length;
+      if (count >= 6) shake.heavy();
+      else if (count >= 3) shake.medium();
+      else shake.light();
+    }
+  }, [clearedTiles, particles, shake, cellSize, gridSize, spawnDebris, spawnLightningBolt, spawnLightningDebris]);
 
   // Chain cascade sparkle
   useEffect(() => {

--- a/fe-next/components/blast/BlastTile.tsx
+++ b/fe-next/components/blast/BlastTile.tsx
@@ -180,7 +180,10 @@ const CLEARING_COLORS: Partial<Record<BlastTileType, { background: string; borde
 /** Type-specific clearing transform overrides — gives each tile a unique death animation */
 const CLEARING_ANIMS: Partial<Record<BlastTileType, { transform: string; transition: string }>> = {
   bomb:      { transform: 'scale(1.8)', transition: 'all 220ms cubic-bezier(0.17, 0.67, 0.83, 0.67)' },
-  lightning: { transform: 'scaleY(2.5) scaleX(0.3)', transition: 'all 160ms ease-in' },
+  lightning: {
+    transform: 'scaleY(2.5) scaleX(0.3)',
+    transition: 'all 160ms ease-in',
+  },
   prism:     { transform: 'scale(1.6) rotate(180deg)', transition: 'all 250ms ease-out' },
   ice:       { transform: 'scale(0.6) rotate(8deg)', transition: 'all 200ms ease-in' },
   frozen:    { transform: 'scale(0.5) rotate(-12deg)', transition: 'all 220ms cubic-bezier(0.55, 0.06, 0.68, 0.19)' },
@@ -203,11 +206,18 @@ function getPhaseStyles(phase: TilePhase, type: BlastTileType, fallOffset?: numb
       return { filter: 'brightness(1.4)', transform: 'scale(1.1)', transition: 'all 120ms ease-out' };
     case 'clearing': {
       const clearingAnim = CLEARING_ANIMS[type];
+      const isLightning = type === 'lightning';
       return {
         transform: clearingAnim?.transform ?? `scale(1.3) rotate(${clearRotate ?? 0}deg)`,
         opacity: 0,
         transition: clearingAnim?.transition ?? 'all 180ms ease-in',
         ...(clearing && { background: clearing.background, border: clearing.border }),
+        // Lightning: bright white flash before stretch animation
+        ...(isLightning && {
+          background: 'white',
+          boxShadow: '0 0 24px 8px rgba(0,255,255,0.7), 0 0 48px 16px rgba(255,255,255,0.4)',
+          animation: 'blastLightningFlash 160ms ease-in forwards',
+        }),
       };
     }
     case 'falling':

--- a/fe-next/lib/gameEngine/presets/particles.ts
+++ b/fe-next/lib/gameEngine/presets/particles.ts
@@ -143,18 +143,19 @@ export const BOMB_EXPLOSION: ParticleConfig = {
 // Vertical column of electric sparks for lightning tile.
 
 export const LIGHTNING_SPARK: ParticleConfig = {
-  maxParticles: 30,
+  maxParticles: 45,
   frequency: 0.001,
-  emitterLifetime: 0.1,
-  particlesPerWave: 30,
-  lifetime: { min: 0.1, max: 0.4 },
-  speed: { min: 50, max: 200 },
+  emitterLifetime: 0.15,
+  particlesPerWave: 45,
+  lifetime: { min: 0.15, max: 0.5 },
+  speed: { min: 80, max: 350 },
   gravity: { x: 0, y: 0 },
-  scale: { start: 0.8, end: 0 },
+  scale: { start: 1.2, end: 0 },
   alpha: { start: 1, end: 0 },
-  colors: ['88ccff', 'ffffff', 'aaddff'],
+  rotationSpeed: { min: -400, max: 400 },
+  colors: ['00ffff', 'ffffff', '88eeff', 'aaddff', 'ccffff'],
   spawnShape: 'rect',
-  spawnConfig: { width: 10, height: 300 },
+  spawnConfig: { width: 14, height: 400 },
   blendMode: 'add',
 };
 


### PR DESCRIPTION
## Summary
- **PixiJS bolt trail**: Jagged zigzag line segments animate down the cleared column with rapid 3-flash strobe effect
- **Column flash overlay**: Full-column white PixiJS rectangle fades from 80% to 0 opacity over 200ms
- **Enhanced spark debris**: Thin elongated fragments flung horizontally via Matter.js physics from each cleared cell
- **Screen shake**: Medium exponential-decay shake (intensity 6, 300ms) on lightning activation
- **CSS white flash**: Lightning tiles get bright white background + cyan glow box-shadow during clearing animation via `blastLightningFlash` keyframes
- **Improved particle preset**: LIGHTNING_SPARK bumped to 45 particles with rotation, brighter cyan/white palette, larger spawn area

## Test plan
- [x] All 539 blast test suites pass
- [ ] Visual verification: trigger lightning tile in Blast mode, observe bolt + flash + debris
- [ ] Reduced motion: verify effects respect `prefers-reduced-motion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)