### PR TITLE
feat(blast): unique gem/frozen/ice tile clearing effects

### DIFF
--- a/fe-next/components/blast/BlastEffectsCanvas.tsx
+++ b/fe-next/components/blast/BlastEffectsCanvas.tsx
@@ -20,6 +20,11 @@ import {
   LIGHTNING_SPARK,
   PRISM_CROSS,
   GEM_SHATTER,
+  GEM_SHARD_BURST,
+  GEM_GOLDEN_EXPLOSION,
+  FROST_MIST,
+  ICE_SHATTER,
+  FROST_CRACK,
   VORTEX_PULL,
   COMBO_FLASH,
   CASCADE_SPARKLE,
@@ -35,6 +40,8 @@ export interface ClearedTileEvent {
   row: number;
   col: number;
   type: BlastTileType;
+  /** Hits remaining before this clear (0 = final hit, >0 = intermediate hit) */
+  hitsRemaining?: number;
 }
 
 interface BlastEffectsCanvasProps {
@@ -270,8 +277,33 @@ function EffectsWorker({
     for (const tile of clearedTiles) {
       const x = tile.col * cellSize + cellSize / 2;
       const y = tile.row * cellSize + cellSize / 2;
-      const preset = CLEAR_PRESET_MAP[tile.type] ?? TILE_EXPLOSION;
-      particles.burst(preset, x, y);
+      const isFinalHit = !tile.hitsRemaining || tile.hitsRemaining <= 0;
+
+      // Gem: shard burst on intermediate hits, golden explosion on final
+      if (tile.type === 'gem') {
+        if (isFinalHit) {
+          particles.burst(GEM_GOLDEN_EXPLOSION, x, y);
+          particles.burst(GEM_SHATTER, x, y);
+        } else {
+          particles.burst(GEM_SHARD_BURST, x, y);
+        }
+      // Frozen: crack lines on intermediate hit, ice shatter on final
+      } else if (tile.type === 'frozen') {
+        if (isFinalHit) {
+          particles.burst(ICE_SHATTER, x, y);
+        } else {
+          particles.burst(FROST_CRACK, x, y);
+        }
+      // Ice: frost mist on hit, crystalline shatter on final
+      } else if (tile.type === 'ice') {
+        if (isFinalHit) {
+          particles.burst(ICE_SHATTER, x, y);
+        }
+        particles.burst(FROST_MIST, x, y);
+      } else {
+        const preset = CLEAR_PRESET_MAP[tile.type] ?? TILE_EXPLOSION;
+        particles.burst(preset, x, y);
+      }
     }
 
     // Spawn physics debris fragments

--- a/fe-next/components/blast/BlastTile.tsx
+++ b/fe-next/components/blast/BlastTile.tsx
@@ -61,6 +61,23 @@ function getCrackClass(type: BlastTileType, hitsRemaining?: number): string {
   return '';
 }
 
+/** Type-specific visual effect classes for gem/frozen/ice tiles */
+function getSpecialEffectClasses(type: BlastTileType, phase: TilePhase, hitsRemaining?: number): string {
+  const classes: string[] = [];
+
+  if (type === 'gem') {
+    if (hitsRemaining != null && hitsRemaining > 0) classes.push(`blast-tile-gem-glow-${hitsRemaining}`);
+    if (phase === 'clearing') classes.push('blast-tile-gem-golden-flash');
+  } else if (type === 'frozen') {
+    if (hitsRemaining != null && hitsRemaining < (MULTI_HIT_MAX.frozen ?? 2)) classes.push('blast-tile-frozen-cracked');
+    if (phase === 'clearing') classes.push('blast-tile-frozen-emerge');
+  } else if (type === 'ice') {
+    classes.push('blast-tile-ice-shimmer');
+  }
+
+  return classes.join(' ');
+}
+
 /**
  * AAA Royal Blast tile visuals — 3D candy-button treatment.
  * Each tile gets a top-to-bottom gradient for depth, specular inset highlight,
@@ -277,6 +294,7 @@ export const BlastTile = memo(function BlastTile({
         visual.text ?? 'text-neo-navy',
         type !== 'standard' ? `blast-tile-${type}` : '',
         getCrackClass(type, hitsRemaining),
+        getSpecialEffectClasses(type, phase, hitsRemaining),
         activationEffect === 'frost-free' ? 'blast-tile-frost-shatter' : '',
         activationEffect === 'tile-earned' ? 'blast-tile-earned' : '',
         RARE_LETTERS.has(letter.toUpperCase()) ? 'blast-rare-letter' : '',

--- a/fe-next/components/blast/__tests__/BlastTile.effects.test.tsx
+++ b/fe-next/components/blast/__tests__/BlastTile.effects.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * BlastTile unique visual effects tests — gem glow, frozen crack, ice shimmer.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BlastTile } from '../BlastTile';
+
+vi.mock('@/hooks/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => false,
+}));
+
+const baseProps = {
+  letter: 'A',
+  phase: 'idle' as const,
+  isSelected: false,
+  isCleared: false,
+  onClick: vi.fn(),
+};
+
+describe('BlastTile unique effects', () => {
+  describe('gem glow intensification', () => {
+    it('adds blast-tile-gem-glow-3 class at full health (3 hits)', () => {
+      render(<BlastTile {...baseProps} type="gem" hitsRemaining={3} />);
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('blast-tile-gem-glow-3');
+    });
+
+    it('adds blast-tile-gem-glow-2 class at 2 hits remaining', () => {
+      render(<BlastTile {...baseProps} type="gem" hitsRemaining={2} />);
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('blast-tile-gem-glow-2');
+    });
+
+    it('adds blast-tile-gem-glow-1 class at 1 hit remaining (brightest)', () => {
+      render(<BlastTile {...baseProps} type="gem" hitsRemaining={1} />);
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('blast-tile-gem-glow-1');
+    });
+
+    it('does not add gem glow classes to non-gem tiles', () => {
+      render(<BlastTile {...baseProps} type="ice" hitsRemaining={2} />);
+      const button = screen.getByRole('button');
+      expect(button.className).not.toMatch(/blast-tile-gem-glow/);
+    });
+  });
+
+  describe('frozen crack overlay', () => {
+    it('adds blast-tile-frozen-cracked class on first hit (hitsRemaining=1)', () => {
+      render(<BlastTile {...baseProps} type="frozen" hitsRemaining={1} />);
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('blast-tile-frozen-cracked');
+    });
+
+    it('does not add frozen-cracked at full health', () => {
+      render(<BlastTile {...baseProps} type="frozen" hitsRemaining={2} />);
+      const button = screen.getByRole('button');
+      expect(button.className).not.toContain('blast-tile-frozen-cracked');
+    });
+
+    it('does not add frozen-cracked to non-frozen tiles', () => {
+      render(<BlastTile {...baseProps} type="ice" hitsRemaining={1} />);
+      const button = screen.getByRole('button');
+      expect(button.className).not.toContain('blast-tile-frozen-cracked');
+    });
+  });
+
+  describe('ice frost shimmer', () => {
+    it('adds blast-tile-ice-shimmer class to ice tiles', () => {
+      render(<BlastTile {...baseProps} type="ice" hitsRemaining={2} />);
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('blast-tile-ice-shimmer');
+    });
+
+    it('does not add ice-shimmer to non-ice tiles', () => {
+      render(<BlastTile {...baseProps} type="gem" hitsRemaining={3} />);
+      const button = screen.getByRole('button');
+      expect(button.className).not.toContain('blast-tile-ice-shimmer');
+    });
+  });
+
+  describe('gem golden flash on clearing', () => {
+    it('adds blast-tile-gem-golden-flash class during clearing phase', () => {
+      const { container } = render(
+        <BlastTile {...baseProps} type="gem" phase="clearing" />
+      );
+      const button = container.querySelector('button');
+      expect(button?.className).toContain('blast-tile-gem-golden-flash');
+    });
+
+    it('does not add golden-flash on non-gem clearing', () => {
+      const { container } = render(
+        <BlastTile {...baseProps} type="bomb" phase="clearing" />
+      );
+      const button = container.querySelector('button');
+      expect(button?.className).not.toContain('blast-tile-gem-golden-flash');
+    });
+  });
+
+  describe('frozen emergence glow on clearing', () => {
+    it('adds blast-tile-frozen-emerge class during clearing phase', () => {
+      const { container } = render(
+        <BlastTile {...baseProps} type="frozen" phase="clearing" />
+      );
+      const button = container.querySelector('button');
+      expect(button?.className).toContain('blast-tile-frozen-emerge');
+    });
+  });
+});

--- a/fe-next/lib/gameEngine/presets/__tests__/particles.special.test.ts
+++ b/fe-next/lib/gameEngine/presets/__tests__/particles.special.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for gem/frozen/ice-specific particle presets.
+ */
+import { describe, it, expect } from 'vitest';
+import type { ParticleConfig } from '../../types';
+import {
+  GEM_SHARD_BURST,
+  GEM_GOLDEN_EXPLOSION,
+  FROST_MIST,
+  ICE_SHATTER,
+  FROST_CRACK,
+} from '../particles';
+
+describe('special tile particle presets', () => {
+  const assertValidPreset = (preset: ParticleConfig) => {
+    expect(preset.maxParticles).toBeGreaterThan(0);
+    expect(preset.colors.length).toBeGreaterThan(0);
+    expect(preset.lifetime.min).toBeLessThanOrEqual(preset.lifetime.max);
+    expect(preset.speed.min).toBeLessThanOrEqual(preset.speed.max);
+  };
+
+  describe('GEM_SHARD_BURST', () => {
+    it('is a valid particle config with emerald colors', () => {
+      assertValidPreset(GEM_SHARD_BURST);
+      // Should have green/emerald tones
+      expect(GEM_SHARD_BURST.colors.some(c => c.includes('ff') || c.includes('88'))).toBe(true);
+    });
+
+    it('is a small burst (few particles for per-hit feedback)', () => {
+      expect(GEM_SHARD_BURST.maxParticles).toBeLessThanOrEqual(10);
+    });
+  });
+
+  describe('GEM_GOLDEN_EXPLOSION', () => {
+    it('is a valid particle config with golden colors', () => {
+      assertValidPreset(GEM_GOLDEN_EXPLOSION);
+      // Should contain gold/yellow tones
+      expect(GEM_GOLDEN_EXPLOSION.colors.some(c => c.toLowerCase().includes('ff'))).toBe(true);
+    });
+
+    it('is a larger burst than shard burst (dramatic final hit)', () => {
+      expect(GEM_GOLDEN_EXPLOSION.maxParticles).toBeGreaterThan(GEM_SHARD_BURST.maxParticles);
+    });
+
+    it('uses additive blending for sparkle', () => {
+      expect(GEM_GOLDEN_EXPLOSION.blendMode).toBe('add');
+    });
+  });
+
+  describe('FROST_MIST', () => {
+    it('is a valid particle config with white/blue colors', () => {
+      assertValidPreset(FROST_MIST);
+    });
+
+    it('has slow-moving particles (mist effect)', () => {
+      expect(FROST_MIST.speed.max).toBeLessThanOrEqual(60);
+    });
+
+    it('has low alpha for subtle effect', () => {
+      expect(FROST_MIST.alpha.start).toBeLessThanOrEqual(0.6);
+    });
+  });
+
+  describe('ICE_SHATTER', () => {
+    it('is a valid particle config', () => {
+      assertValidPreset(ICE_SHATTER);
+    });
+
+    it('uses diamond shape for crystalline fragments', () => {
+      expect(ICE_SHATTER.shape).toBe('diamond');
+    });
+
+    it('has light blue/cyan colors', () => {
+      expect(ICE_SHATTER.colors.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('FROST_CRACK', () => {
+    it('is a valid particle config', () => {
+      assertValidPreset(FROST_CRACK);
+    });
+
+    it('is a burst spawn shape', () => {
+      expect(FROST_CRACK.spawnShape).toBe('burst');
+    });
+
+    it('has white/ice colors for crack lines', () => {
+      expect(FROST_CRACK.colors.some(c => c === 'ffffff' || c === 'FFFFFF')).toBe(true);
+    });
+  });
+});

--- a/fe-next/lib/gameEngine/presets/particles.ts
+++ b/fe-next/lib/gameEngine/presets/particles.ts
@@ -339,6 +339,104 @@ export const GOLD_STARS: ParticleConfig = {
   shape: 'star',
 };
 
+// ─── Gem Shard Burst ─────────────────────────────────────────────────
+// Small emerald shard burst on each gem hit (not final). Few particles.
+
+export const GEM_SHARD_BURST: ParticleConfig = {
+  maxParticles: 8,
+  frequency: 0.001,
+  emitterLifetime: 0.08,
+  particlesPerWave: 8,
+  lifetime: { min: 0.2, max: 0.5 },
+  speed: { min: 80, max: 200 },
+  gravity: { x: 0, y: 180 },
+  scale: { start: 0.8, end: 0 },
+  alpha: { start: 1, end: 0.2 },
+  rotationSpeed: { min: -200, max: 200 },
+  colors: ['50c878', '34d399', '7dffb3', 'a7f3d0'],
+  spawnShape: 'burst',
+  spawnConfig: { directions: 8 },
+  shape: 'diamond',
+};
+
+// ─── Gem Golden Explosion ────────────────────────────────────────────
+// Dramatic golden sparkle explosion on gem final hit.
+
+export const GEM_GOLDEN_EXPLOSION: ParticleConfig = {
+  maxParticles: 35,
+  frequency: 0.001,
+  emitterLifetime: 0.12,
+  particlesPerWave: 35,
+  lifetime: { min: 0.4, max: 1.0 },
+  speed: { min: 120, max: 400 },
+  gravity: { x: 0, y: 200 },
+  scale: { start: 1.8, end: 0.2 },
+  alpha: { start: 1, end: 0 },
+  rotationSpeed: { min: -300, max: 300 },
+  colors: ['ffd700', 'ffee44', 'ffffff', 'ffe088', 'ffcc00'],
+  spawnShape: 'burst',
+  spawnConfig: { directions: 16 },
+  blendMode: 'add',
+  shape: 'star',
+};
+
+// ─── Frost Mist ──────────────────────────────────────────────────────
+// Subtle slow-drifting white particles for ice tile hit feedback.
+
+export const FROST_MIST: ParticleConfig = {
+  maxParticles: 12,
+  frequency: 0.04,
+  emitterLifetime: 0.6,
+  particlesPerWave: 2,
+  lifetime: { min: 0.5, max: 1.2 },
+  speed: { min: 10, max: 40 },
+  gravity: { x: 0, y: -25 },
+  scale: { start: 0.6, end: 1.2 },
+  alpha: { start: 0.4, end: 0 },
+  colors: ['ffffff', 'e0ffff', 'ccf0ff'],
+  spawnShape: 'circle',
+  spawnConfig: { radius: 15 },
+};
+
+// ─── Ice Shatter ─────────────────────────────────────────────────────
+// Sharp angular crystalline fragments for ice tile clear.
+
+export const ICE_SHATTER: ParticleConfig = {
+  maxParticles: 25,
+  frequency: 0.001,
+  emitterLifetime: 0.1,
+  particlesPerWave: 25,
+  lifetime: { min: 0.3, max: 0.8 },
+  speed: { min: 100, max: 350 },
+  gravity: { x: 0, y: 220 },
+  scale: { start: 1.3, end: 0.2 },
+  alpha: { start: 0.9, end: 0 },
+  rotationSpeed: { min: -400, max: 400 },
+  colors: ['b4e6ff', 'ffffff', '88eeff', 'ccf0ff', 'e0ffff'],
+  spawnShape: 'burst',
+  spawnConfig: { directions: 14 },
+  shape: 'diamond',
+};
+
+// ─── Frost Crack ─────────────────────────────────────────────────────
+// White crack lines radiating from center on frozen tile first hit.
+
+export const FROST_CRACK: ParticleConfig = {
+  maxParticles: 12,
+  frequency: 0.001,
+  emitterLifetime: 0.08,
+  particlesPerWave: 12,
+  lifetime: { min: 0.3, max: 0.6 },
+  speed: { min: 60, max: 180 },
+  gravity: { x: 0, y: 0 },
+  scale: { start: 0.6, end: 0.1 },
+  alpha: { start: 0.9, end: 0 },
+  colors: ['ffffff', 'e8f4ff', 'ccddff'],
+  spawnShape: 'burst',
+  spawnConfig: { directions: 8 },
+  blendMode: 'add',
+};
+
 // ─── Diamond Shards ──────────────────────────────────────────────────
 // Prismatic diamond shards for diamond tile shatter.
 


### PR DESCRIPTION
## Summary
- **Gem tiles**: Emerald shard burst on intermediate hits, golden sparkle explosion on final hit, glow intensification CSS classes per hit level
- **Frozen tiles**: Frost crack particles on first hit, ice shatter on reveal, crack overlay and emergence glow CSS
- **Ice tiles**: Frost mist particles on hit, crystalline diamond-shaped shatter on clear, shimmer CSS

## Test plan
- [x] 14 particle preset tests (particles.special.test.ts) — all pass
- [x] 12 BlastTile CSS effect tests (BlastTile.effects.test.tsx) — all pass
- [x] 47 existing BlastTile tests — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)