### PR TITLE
style(education): replace neo-yellow with neo-lime, fix dark theme

### DIFF
--- a/fe-next/app/[locale]/education/PageClient.tsx
+++ b/fe-next/app/[locale]/education/PageClient.tsx
@@ -275,7 +275,7 @@ export default function EducationPageClient() {
             )}
           >
             {/* Decorative corner elements */}
-            <Star className="absolute top-4 start-4 w-5 h-5 text-neo-yellow/20" />
+            <Star className="absolute top-4 start-4 w-5 h-5 text-neo-lime/20" />
             <Puzzle className="absolute bottom-4 end-4 w-6 h-6 text-neo-cyan/15 rotate-12" />
 
             <div className="flex items-center justify-between gap-4">
@@ -318,7 +318,7 @@ export default function EducationPageClient() {
             )}
           >
             <p className="text-sm sm:text-base font-bold text-neo-white flex items-center justify-center gap-2 flex-wrap">
-              <Globe className="w-4 h-4 text-neo-yellow flex-shrink-0" />
+              <Globe className="w-4 h-4 text-neo-lime flex-shrink-0" />
               {t('education.landing.socialProof')}
             </p>
           </motion.div>
@@ -332,16 +332,16 @@ export default function EducationPageClient() {
               transition={{ type: 'spring', stiffness: 300, damping: 25, delay: 0.2 }}
               className={cn(
                 'rounded-neo border-neo-thick border-neo-black overflow-hidden mb-8',
-                'bg-neo-yellow shadow-hard',
+                'bg-neo-lime shadow-hard',
               )}
             >
               <div className="px-5 py-4 flex items-center justify-between gap-4">
                 <div className="flex items-center gap-3 min-w-0">
                   <div className="w-10 h-10 rounded-neo border-2 border-neo-black bg-neo-black flex items-center justify-center flex-shrink-0">
                     {isTeacherRole ? (
-                      <GraduationCap className="w-5 h-5 text-neo-yellow" />
+                      <GraduationCap className="w-5 h-5 text-neo-lime" />
                     ) : (
-                      <BookOpen className="w-5 h-5 text-neo-yellow" />
+                      <BookOpen className="w-5 h-5 text-neo-lime" />
                     )}
                   </div>
                   <div className="min-w-0">
@@ -362,7 +362,7 @@ export default function EducationPageClient() {
                   data-testid="go-to-dashboard-link"
                   className={cn(
                     'flex items-center gap-2 px-4 py-2 rounded-neo border-2 border-neo-black',
-                    'bg-neo-black text-neo-yellow font-bold uppercase text-sm flex-shrink-0',
+                    'bg-neo-black text-neo-lime font-bold uppercase text-sm flex-shrink-0',
                     'shadow-hard-sm hover:shadow-hard transition-shadow',
                   )}
                 >

--- a/fe-next/app/[locale]/education/duels/PageClient.tsx
+++ b/fe-next/app/[locale]/education/duels/PageClient.tsx
@@ -85,7 +85,7 @@ export default function DuelsPageClient() {
               className={cn(
                 'flex items-center gap-2 px-6 py-3 font-bold transition-all',
                 activeTab === tab.id
-                  ? 'text-neo-yellow border-b-4 border-neo-yellow -mb-[2px]'
+                  ? 'text-neo-lime border-b-4 border-neo-lime -mb-[2px]'
                   : 'text-neo-white/50 hover:text-neo-white/80'
               )}
             >

--- a/fe-next/app/[locale]/education/duels/[duelId]/PageClient.tsx
+++ b/fe-next/app/[locale]/education/duels/[duelId]/PageClient.tsx
@@ -101,7 +101,7 @@ export default function DuelGamePageClient({ duelId }: { duelId: string }) {
               onClick={handleBackToLobby}
               className={cn(
                 'px-6 py-3 font-bold rounded-neo',
-                'bg-neo-yellow text-neo-black',
+                'bg-neo-lime text-neo-black',
                 'border-3 border-neo-black shadow-hard-sm',
                 'hover:shadow-hard transition-all'
               )}

--- a/fe-next/app/[locale]/student/PageClient.tsx
+++ b/fe-next/app/[locale]/student/PageClient.tsx
@@ -133,7 +133,7 @@ function StudentProgress({ classroomId, userId }: { classroomId: string; userId:
   // Skeleton loader
   if (leaderboardLoading || !streakLoaded) {
     return (
-      <div className="p-6 rounded-neo border-3 border-black bg-white shadow-hard animate-pulse">
+      <div className="p-6 rounded-neo border-neo border-neo-black bg-neo-navy shadow-hard animate-pulse">
         <div className="flex items-center gap-4 mb-4">
           <div className="w-14 h-14 rounded-neo bg-black/10" />
           <div className="flex-1">
@@ -165,7 +165,7 @@ function StudentProgress({ classroomId, userId }: { classroomId: string; userId:
         className="relative rounded-neo border-3 border-black shadow-hard overflow-hidden"
       >
       {/* Colorful header band */}
-      <div className="bg-neo-yellow px-6 pt-5 pb-4">
+      <div className="bg-neo-lime px-6 pt-5 pb-4">
         {/* Mascot - floating in top-right corner */}
         <motion.div
           className="absolute top-2 end-2 z-10"
@@ -194,7 +194,7 @@ function StudentProgress({ classroomId, userId }: { classroomId: string; userId:
               whileTap={{ scale: 0.9 }}
               transition={{ type: 'spring', stiffness: 400, damping: 17 }}
             >
-              <span className="text-2xl font-neo-display font-black text-neo-yellow tabular-nums">
+              <span className="text-2xl font-neo-display font-black text-neo-lime tabular-nums">
                 {xpProgress.currentLevel}
               </span>
             </motion.div>
@@ -219,30 +219,30 @@ function StudentProgress({ classroomId, userId }: { classroomId: string; userId:
         </motion.div>
       </div>
 
-      {/* White body with stats */}
-      <div className="bg-white px-6 py-4">
+      {/* Dark body with stats */}
+      <div className="bg-neo-navy-light px-6 py-4">
         {/* 3-column stats with stagger */}
         <motion.div
           variants={statsContainer}
           className="grid grid-cols-3 gap-3"
         >
           {/* Rank */}
-          <motion.div variants={statItem} className="flex flex-col items-center gap-1 p-3 rounded-neo border-2 border-black bg-neo-yellow/20 shadow-hard-sm text-center">
+          <motion.div variants={statItem} className="flex flex-col items-center gap-1 p-3 rounded-neo border-neo border-neo-black bg-neo-navy border-l-4 border-l-neo-lime shadow-hard-sm text-center">
             <motion.div
-              className="w-9 h-9 rounded-neo bg-neo-yellow border-2 border-black flex items-center justify-center shadow-hard-sm"
+              className="w-9 h-9 rounded-neo bg-neo-lime border-2 border-black flex items-center justify-center shadow-hard-sm"
               whileHover={{ scale: 1.2, rotate: -8 }}
               transition={{ type: 'spring', stiffness: 400, damping: 17 }}
             >
               <Trophy className="w-5 h-5 text-black" />
             </motion.div>
-            <p className="text-xs text-black/60 font-bold">{t('education.leaderboard.rank')}</p>
-            <p className="text-xl font-black text-black tabular-nums">
+            <p className="text-xs text-neo-cream/60 font-bold">{t('education.leaderboard.rank')}</p>
+            <p className="text-xl font-black text-neo-white tabular-nums">
               {typeof rank === 'number' ? `#${rank}` : rank}
             </p>
           </motion.div>
 
           {/* Total XP */}
-          <motion.div variants={statItem} className="flex flex-col items-center gap-1 p-3 rounded-neo border-2 border-black bg-neo-cyan/20 shadow-hard-sm text-center">
+          <motion.div variants={statItem} className="flex flex-col items-center gap-1 p-3 rounded-neo border-neo border-neo-black bg-neo-navy border-l-4 border-l-neo-cyan shadow-hard-sm text-center">
             <motion.div
               className="w-9 h-9 rounded-neo bg-neo-cyan border-2 border-black flex items-center justify-center shadow-hard-sm"
               whileHover={{ scale: 1.2, rotate: 8 }}
@@ -250,12 +250,12 @@ function StudentProgress({ classroomId, userId }: { classroomId: string; userId:
             >
               <Zap className="w-5 h-5 text-black" />
             </motion.div>
-            <p className="text-xs text-black/60 font-bold">{t('education.leaderboard.totalXP')}</p>
-            <p className="text-xl font-black text-black tabular-nums">{totalXP.toLocaleString()}</p>
+            <p className="text-xs text-neo-cream/60 font-bold">{t('education.leaderboard.totalXP')}</p>
+            <p className="text-xl font-black text-neo-white tabular-nums">{totalXP.toLocaleString()}</p>
           </motion.div>
 
           {/* Streak */}
-          <motion.div variants={statItem} className="flex flex-col items-center gap-1 p-3 rounded-neo border-2 border-black bg-neo-pink/20 shadow-hard-sm text-center">
+          <motion.div variants={statItem} className="flex flex-col items-center gap-1 p-3 rounded-neo border-neo border-neo-black bg-neo-navy border-l-4 border-l-neo-pink shadow-hard-sm text-center">
             <motion.div
               className="w-9 h-9 rounded-neo bg-neo-pink border-2 border-black flex items-center justify-center shadow-hard-sm"
               whileHover={{ scale: 1.2, rotate: -8 }}
@@ -263,8 +263,8 @@ function StudentProgress({ classroomId, userId }: { classroomId: string; userId:
             >
               <Flame className="w-5 h-5 text-white" />
             </motion.div>
-            <p className="text-xs text-black/60 font-bold">{t('education.leaderboard.streak')}</p>
-            <p className="text-xl font-black text-black tabular-nums">
+            <p className="text-xs text-neo-cream/60 font-bold">{t('education.leaderboard.streak')}</p>
+            <p className="text-xl font-black text-neo-white tabular-nums">
               {currentStreak} {t('common.days')}
             </p>
           </motion.div>
@@ -404,7 +404,7 @@ export default function StudentPageClient() {
         {/* Join Classroom CTA (when no classroom) */}
         {!classroomId && (
           <motion.div
-            className="mb-6 bg-neo-yellow text-neo-black border-3 border-black rounded-neo shadow-hard p-6"
+            className="mb-6 bg-neo-lime text-neo-black border-3 border-black rounded-neo shadow-hard p-6"
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ type: 'spring', stiffness: 260, damping: 24 }}
@@ -420,7 +420,7 @@ export default function StudentPageClient() {
             </p>
             <Link
               href={`/${language}/student/join`}
-              className="inline-block px-6 py-3 bg-neo-black text-neo-yellow font-neo-display font-bold rounded-neo border-3 border-black shadow-hard-sm hover:shadow-hard-pressed active:translate-x-[2px] active:translate-y-[2px] transition-all"
+              className="inline-block px-6 py-3 bg-neo-black text-neo-lime font-neo-display font-bold rounded-neo border-3 border-black shadow-hard-sm hover:shadow-hard-pressed active:translate-x-[2px] active:translate-y-[2px] transition-all"
             >
               {t('student.joinClassroom')}
             </Link>

--- a/fe-next/app/[locale]/student/profile/PageClient.tsx
+++ b/fe-next/app/[locale]/student/profile/PageClient.tsx
@@ -237,7 +237,7 @@ export default function StudentProfilePageClient() {
                 {profile?.display_name || profile?.username || t('common.guest')}
               </h1>
               <div className="flex items-center gap-3 mt-2">
-                <div className="px-3 py-1 bg-neo-yellow text-neo-black font-neo-display font-bold text-lg rounded-neo border-2 border-neo-black">
+                <div className="px-3 py-1 bg-neo-lime text-neo-black font-neo-display font-bold text-lg rounded-neo border-2 border-neo-black">
                   {t('education.xp.level')} {currentLevel}
                 </div>
                 <div className="px-3 py-1 bg-neo-orange text-neo-white font-neo-display font-bold text-lg rounded-neo border-2 border-neo-black">
@@ -310,7 +310,7 @@ export default function StudentProfilePageClient() {
                 <div className="text-neo-white/60 font-neo-body text-sm mb-1">
                   {t('education.practice.wordsFound')}
                 </div>
-                <div className="text-3xl font-neo-display font-black text-neo-yellow">
+                <div className="text-3xl font-neo-display font-black text-neo-lime">
                   {studentProgress?.words_mastered?.length || 0}
                 </div>
               </div>

--- a/fe-next/app/[locale]/teacher/PageClient.tsx
+++ b/fe-next/app/[locale]/teacher/PageClient.tsx
@@ -44,8 +44,8 @@ export default function TeacherPageClient() {
   if (!user || !isTeacher) {
     return (
       <div className="flex-1 bg-neo-navy text-neo-white flex items-center justify-center min-h-screen">
-        <div className="text-center p-8 bg-white border-3 border-black rounded-neo shadow-hard max-w-sm w-full mx-4">
-          <div className="w-16 h-16 rounded-neo bg-neo-yellow border-3 border-black flex items-center justify-center mx-auto mb-4 shadow-hard-sm">
+        <div className="text-center p-8 bg-neo-cream border-3 border-black rounded-neo shadow-hard max-w-sm w-full mx-4">
+          <div className="w-16 h-16 rounded-neo bg-neo-lime border-3 border-black flex items-center justify-center mx-auto mb-4 shadow-hard-sm">
             <Shield className="w-9 h-9 text-black" />
           </div>
           <h1 className="text-2xl font-neo-display font-black text-black mb-2">

--- a/fe-next/app/[locale]/teacher/classroom/[id]/analytics/PageClient.tsx
+++ b/fe-next/app/[locale]/teacher/classroom/[id]/analytics/PageClient.tsx
@@ -120,7 +120,7 @@ export function AnalyticsPageClient({ classroomId, locale }: AnalyticsPageClient
               onClick={handleBackToClassroom}
               className={cn(
                 'inline-flex items-center gap-2 mb-3',
-                'text-neo-cyan hover:text-neo-yellow',
+                'text-neo-cyan hover:text-neo-lime',
                 'transition-colors duration-200'
               )}
             >
@@ -195,7 +195,7 @@ export function AnalyticsPageClient({ classroomId, locale }: AnalyticsPageClient
               value="vocabulary"
               className={cn(
                 'font-neo-body font-bold rounded-neo',
-                'data-[state=active]:bg-neo-yellow data-[state=active]:text-neo-black',
+                'data-[state=active]:bg-neo-lime data-[state=active]:text-neo-black',
                 'data-[state=inactive]:text-neo-white/70',
                 'transition-all duration-200'
               )}
@@ -206,7 +206,7 @@ export function AnalyticsPageClient({ classroomId, locale }: AnalyticsPageClient
               value="assignments"
               className={cn(
                 'font-neo-body font-bold rounded-neo',
-                'data-[state=active]:bg-neo-yellow data-[state=active]:text-neo-black',
+                'data-[state=active]:bg-neo-lime data-[state=active]:text-neo-black',
                 'data-[state=inactive]:text-neo-white/70',
                 'transition-all duration-200'
               )}

--- a/fe-next/app/[locale]/teacher/profile/PageClient.tsx
+++ b/fe-next/app/[locale]/teacher/profile/PageClient.tsx
@@ -149,11 +149,11 @@ export default function TeacherProfilePageClient() {
         {/* Contact Admin Section */}
         <div
           data-testid="contact-admin-section"
-          className="p-6 bg-neo-yellow border-3 border-neo-black rounded-neo shadow-hard mb-8"
+          className="p-6 bg-neo-lime border-3 border-neo-black rounded-neo shadow-hard mb-8"
         >
           <div className="flex items-start gap-4">
             <div className="w-12 h-12 rounded-neo bg-neo-black border-2 border-neo-black flex items-center justify-center flex-shrink-0 shadow-hard-sm">
-              <Mail className="w-6 h-6 text-neo-yellow" />
+              <Mail className="w-6 h-6 text-neo-lime" />
             </div>
             <div>
               <h2 className="text-xl font-neo-display font-black text-neo-black mb-1">

--- a/fe-next/components/education/AchievementProgressCard.tsx
+++ b/fe-next/components/education/AchievementProgressCard.tsx
@@ -157,7 +157,7 @@ export default function AchievementProgressCard({
                 className={`
                   w-8 h-8 rounded flex items-center justify-center
                   border-neo border-neo-black transition-all
-                  ${isPinned ? 'bg-neo-yellow shadow-hard-sm' : 'bg-neo-white/30'}
+                  ${isPinned ? 'bg-neo-lime shadow-hard-sm' : 'bg-neo-white/30'}
                   ${!isPinned && !canPin ? 'opacity-40 cursor-not-allowed' : 'hover:scale-110 active:scale-95'}
                 `}
               >
@@ -199,7 +199,7 @@ export default function AchievementProgressCard({
           {/* Max Tier Badge */}
           {isEarned && achievement.isMaxTier && (
             <div className="mt-3">
-              <span className="inline-block px-3 py-1 bg-neo-yellow text-neo-black font-neo-display font-bold text-sm border-neo border-neo-black rounded-neo shadow-hard-sm">
+              <span className="inline-block px-3 py-1 bg-neo-lime text-neo-black font-neo-display font-bold text-sm border-neo border-neo-black rounded-neo shadow-hard-sm">
                 {t('education.achievements.maxTier')}
               </span>
             </div>

--- a/fe-next/components/education/AchievementUnlockModal.tsx
+++ b/fe-next/components/education/AchievementUnlockModal.tsx
@@ -38,7 +38,7 @@ export interface AchievementUnlockModalProps {
 const TIER_COLORS = {
   bronze: '#CD7F32',
   silver: '#C0C0C0',
-  gold: '#FFE135', // neo-yellow
+  gold: '#BFFF00', // neo-lime
   platinum: '#E5E4E2',
 } as const;
 
@@ -259,7 +259,7 @@ const AchievementUnlockModal = memo<AchievementUnlockModalProps>(({ unlock, onCl
               onClick={onClose}
               className={cn(
                 'w-full py-3 px-6',
-                'bg-neo-yellow hover:bg-neo-orange',
+                'bg-neo-lime hover:bg-neo-orange',
                 'text-neo-black font-black text-lg',
                 'border-3 border-neo-black rounded-neo',
                 'shadow-hard hover:shadow-hard-lg hover:-translate-y-0.5',

--- a/fe-next/components/education/ClassroomLeaderboard.tsx
+++ b/fe-next/components/education/ClassroomLeaderboard.tsx
@@ -100,7 +100,7 @@ const TimeScopeTabs = memo<TimeScopeTabsProps>(({ timeScope, onScopeChange }) =>
           className={cn(
             'px-4 py-2 rounded-neo border-neo font-neo-body font-bold text-sm transition-all',
             timeScope === tab.key
-              ? 'bg-neo-yellow text-neo-black border-neo-black shadow-hard-sm'
+              ? 'bg-neo-lime text-neo-black border-neo-black shadow-hard-sm'
               : 'bg-neo-navy text-neo-white/60 border-neo-black/30 hover:text-neo-white/80'
           )}
         >
@@ -196,7 +196,7 @@ const TierBadge = memo<TierBadgeProps>(({ rank, totalStudents }) => {
   if (!tier) return null;
 
   const tierConfig = {
-    top10: { bg: 'bg-neo-yellow', label: t('education.leaderboard.top10') },
+    top10: { bg: 'bg-neo-lime', label: t('education.leaderboard.top10') },
     top25: { bg: 'bg-neo-white/60', label: t('education.leaderboard.top25') },
     top50: { bg: 'bg-neo-orange', label: t('education.leaderboard.top50') },
   };
@@ -298,7 +298,7 @@ const LeaderboardEntryRow = memo<LeaderboardEntryRowProps>(
 
           <div className="flex items-center gap-3">
             {/* XP */}
-            <span className="font-neo-body font-bold text-neo-yellow text-sm tabular-nums">
+            <span className="font-neo-body font-bold text-neo-lime text-sm tabular-nums">
               {t('education.leaderboard.xp', { xp: animatedXp })}
             </span>
 

--- a/fe-next/components/education/ClassroomReviewStep.tsx
+++ b/fe-next/components/education/ClassroomReviewStep.tsx
@@ -39,7 +39,7 @@ function getBoardSizeLabel(size: string) {
 
 const GAME_MODES: { key: GameMode; icon: typeof LayoutGrid; color: string }[] = [
   { key: 'classic', icon: LayoutGrid, color: 'neo-cyan' },
-  { key: 'wordHunt', icon: Search, color: 'neo-yellow' },
+  { key: 'wordHunt', icon: Search, color: 'neo-lime' },
   { key: 'blast', icon: Zap, color: 'neo-pink' },
 ];
 
@@ -132,7 +132,7 @@ export function ClassroomReviewStep({
               <p className="text-xs text-neo-white/60 font-neo-body">
                 {t('education.classroomGame.scanToJoin')}
               </p>
-              <div className="p-2 bg-white rounded-neo border-neo border-neo-black shadow-hard-sm">
+              <div className="p-2 bg-neo-cream rounded-neo border-neo border-neo-black shadow-hard-sm">
                 <QRCodeCanvas value={joinUrl} size={180} bgColor="#ffffff" fgColor="#000000" level="M" />
               </div>
             </div>

--- a/fe-next/components/education/EducationBadgeGrid.tsx
+++ b/fe-next/components/education/EducationBadgeGrid.tsx
@@ -160,7 +160,7 @@ export default function EducationBadgeGrid({
             aria-valuemax={100}
           >
             <div
-              className="h-full bg-neo-yellow transition-all duration-500"
+              className="h-full bg-neo-lime transition-all duration-500"
               style={{ width: `${completionPercent}%` }}
             />
           </div>
@@ -309,7 +309,7 @@ export default function EducationBadgeGrid({
       <div className="text-center">
         <p className={cn(
           'text-sm font-neo-body',
-          canPinMore ? 'text-neo-white/60' : 'text-neo-yellow'
+          canPinMore ? 'text-neo-white/60' : 'text-neo-lime'
         )}>
           {t('education.achievements.pinLimit', {
             current: pinCount,

--- a/fe-next/components/education/LevelUpCelebration.tsx
+++ b/fe-next/components/education/LevelUpCelebration.tsx
@@ -115,7 +115,7 @@ const LevelUpCelebration = memo<LevelUpCelebrationProps>(
               id={titleId}
               className={cn(
                 'text-3xl md:text-4xl font-black',
-                'text-neo-yellow',
+                'text-neo-lime',
                 'drop-shadow-[0_0_15px_rgb(255_225_53/0.6)]',
                 'mb-4'
               )}
@@ -189,7 +189,7 @@ const LevelUpCelebration = memo<LevelUpCelebrationProps>(
               onClick={onClose}
               className={cn(
                 'w-full py-3 px-6',
-                'bg-neo-yellow hover:bg-neo-orange',
+                'bg-neo-lime hover:bg-neo-orange',
                 'text-neo-black font-black text-lg',
                 'border-3 border-neo-black rounded-neo',
                 'shadow-hard hover:shadow-hard-lg hover:-translate-y-0.5',

--- a/fe-next/components/education/TeacherOnboarding.tsx
+++ b/fe-next/components/education/TeacherOnboarding.tsx
@@ -58,8 +58,8 @@ const ONBOARDING_STEPS: OnboardingStep[] = [
     icon: <Send className="w-12 h-12" />,
     titleKey: 'education.onboarding.invite.title',
     descriptionKey: 'education.onboarding.invite.description',
-    color: 'text-neo-yellow',
-    bgColor: 'bg-neo-yellow/20',
+    color: 'text-neo-lime',
+    bgColor: 'bg-neo-lime/20',
   },
 ];
 
@@ -281,7 +281,7 @@ export const TeacherOnboarding = memo<TeacherOnboardingProps>(({
           </div>
 
           {/* Decorative sparkles */}
-          <div className="absolute top-8 start-8 text-neo-yellow/30">
+          <div className="absolute top-8 start-8 text-neo-lime/30">
             <Sparkles className="w-6 h-6" />
           </div>
           <div className="absolute bottom-12 end-12 text-neo-pink/30">

--- a/fe-next/components/education/XpProgressBar.test.tsx
+++ b/fe-next/components/education/XpProgressBar.test.tsx
@@ -207,11 +207,11 @@ describe('XpProgressBar', () => {
       expect(container).toHaveClass('shadow-hard');
     });
 
-    it('uses neo-yellow for progress fill', () => {
+    it('uses neo-lime for progress fill', () => {
       render(<XpProgressBar totalXp={150} />);
 
       const progressFill = screen.getByTestId('xp-progress-fill');
-      expect(progressFill).toHaveClass('bg-neo-yellow');
+      expect(progressFill).toHaveClass('bg-neo-lime');
     });
   });
 });

--- a/fe-next/components/education/XpProgressBar.tsx
+++ b/fe-next/components/education/XpProgressBar.tsx
@@ -113,7 +113,7 @@ const XpProgressBar = memo<XpProgressBarProps>(({
               {t('education.xp.level')}
             </span>
             <span className={cn(
-              'font-neo-display font-black text-neo-yellow',
+              'font-neo-display font-black text-neo-lime',
               sizeConfig.levelText
             )}>
               {progress.currentLevel}
@@ -186,7 +186,7 @@ const XpProgressBar = memo<XpProgressBarProps>(({
           transition={progressTransition}
           className={cn(
             'absolute inset-y-0 w-full',
-            'bg-neo-yellow',
+            'bg-neo-lime',
             // RTL: transform origin on right side
             isRTL ? 'origin-right' : 'origin-left'
           )}

--- a/fe-next/components/education/achievements/AchievementGrid.test.tsx
+++ b/fe-next/components/education/achievements/AchievementGrid.test.tsx
@@ -296,6 +296,6 @@ describe('AchievementGrid', () => {
 
     // All tab should be active (different styling)
     const allTab = screen.getByText('education.achievements.all');
-    expect(allTab).toHaveClass('bg-neo-yellow');
+    expect(allTab).toHaveClass('bg-neo-lime');
   });
 });

--- a/fe-next/components/education/achievements/AchievementGrid.tsx
+++ b/fe-next/components/education/achievements/AchievementGrid.tsx
@@ -71,7 +71,7 @@ export const AchievementGrid = memo<AchievementGridProps>(
                 'px-4 py-2 rounded-neo border-neo border-neo-black',
                 'font-bold text-sm transition-all duration-200',
                 activeCategory === key
-                  ? 'bg-neo-yellow text-neo-black shadow-hard'
+                  ? 'bg-neo-lime text-neo-black shadow-hard'
                   : 'bg-neo-navy/50 text-neo-white/60 hover:bg-neo-navy/70'
               )}
             >

--- a/fe-next/components/education/challenges/ChallengePanel.tsx
+++ b/fe-next/components/education/challenges/ChallengePanel.tsx
@@ -125,7 +125,7 @@ export function ChallengePanel({ playerId, className = '' }: ChallengePanelProps
           )}
         >
           <motion.div
-            className="w-14 h-14 rounded-neo bg-neo-yellow border-3 border-black flex items-center justify-center shadow-hard-sm"
+            className="w-14 h-14 rounded-neo bg-neo-lime border-3 border-black flex items-center justify-center shadow-hard-sm"
             animate={{ rotate: [0, -5, 5, 0] }}
             transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
           >
@@ -141,7 +141,7 @@ export function ChallengePanel({ playerId, className = '' }: ChallengePanelProps
         <motion.div variants={sectionReveal}>
           <div className="flex items-center gap-3 mb-4">
             <motion.div
-              className="w-8 h-8 rounded-neo bg-neo-yellow border-3 border-black flex items-center justify-center shadow-hard-sm"
+              className="w-8 h-8 rounded-neo bg-neo-lime border-3 border-black flex items-center justify-center shadow-hard-sm"
               whileHover={{ scale: 1.15, rotate: -8 }}
               transition={{ type: 'spring', stiffness: 400, damping: 17 }}
             >
@@ -154,7 +154,7 @@ export function ChallengePanel({ playerId, className = '' }: ChallengePanelProps
               initial={{ scale: 0 }}
               animate={{ scale: 1 }}
               transition={{ type: 'spring', stiffness: 500, damping: 14, delay: 0.3 }}
-              className="px-2 py-0.5 border-3 border-black text-[10px] font-black rounded-neo shadow-hard-sm uppercase tracking-widest bg-neo-yellow text-black"
+              className="px-2 py-0.5 border-3 border-black text-[10px] font-black rounded-neo shadow-hard-sm uppercase tracking-widest bg-neo-lime text-black"
             >
               {dailyChallenges.length}
             </motion.span>

--- a/fe-next/components/education/challenges/DailyChallengeCard.tsx
+++ b/fe-next/components/education/challenges/DailyChallengeCard.tsx
@@ -65,7 +65,7 @@ export function DailyChallengeCard({ challenge, onClaim }: DailyChallengeCardPro
 
       {/* Rewards */}
       <div className="flex items-center gap-3 mb-3 text-sm">
-        <span className="text-neo-yellow">+{challenge.xp_reward} XP</span>
+        <span className="text-neo-lime">+{challenge.xp_reward} XP</span>
         {challenge.bonus_reward?.coins && (
           <span className="text-neo-orange">+{challenge.bonus_reward.coins} coins</span>
         )}
@@ -75,7 +75,7 @@ export function DailyChallengeCard({ challenge, onClaim }: DailyChallengeCardPro
       {canClaim && (
         <button
           onClick={() => onClaim(challenge.id)}
-          className="w-full bg-neo-yellow text-black font-bold py-2 px-4 rounded-neo border-neo border-3 shadow-hard hover:shadow-hard-pressed active:translate-y-0.5 transition-transform"
+          className="w-full bg-neo-lime text-black font-bold py-2 px-4 rounded-neo border-neo border-3 shadow-hard hover:shadow-hard-pressed active:translate-y-0.5 transition-transform"
           data-testid="claim-button"
         >
           {t('challenges.claim')}

--- a/fe-next/components/education/challenges/WeeklyChallengeCard.tsx
+++ b/fe-next/components/education/challenges/WeeklyChallengeCard.tsx
@@ -51,7 +51,7 @@ export function WeeklyChallengeCard({ quest, onClaim }: WeeklyChallengeCardProps
       </div>
 
       <div className="flex items-center gap-3 mb-3 text-sm">
-        <span className="text-neo-yellow">+{quest.xp_reward} XP</span>
+        <span className="text-neo-lime">+{quest.xp_reward} XP</span>
         {quest.bonus_rewards?.coins && (
           <span className="text-neo-orange">+{quest.bonus_rewards.coins} coins</span>
         )}
@@ -60,7 +60,7 @@ export function WeeklyChallengeCard({ quest, onClaim }: WeeklyChallengeCardProps
       {canClaim && (
         <button
           onClick={() => onClaim(quest.id)}
-          className="w-full bg-neo-yellow text-black font-bold py-2 px-4 rounded-neo border-neo border-3 shadow-hard hover:shadow-hard-pressed active:translate-y-0.5 transition-transform"
+          className="w-full bg-neo-lime text-black font-bold py-2 px-4 rounded-neo border-neo border-3 shadow-hard hover:shadow-hard-pressed active:translate-y-0.5 transition-transform"
           data-testid="claim-button"
         >
           {t('challenges.claim')}

--- a/fe-next/components/education/duels/ChallengeButton.tsx
+++ b/fe-next/components/education/duels/ChallengeButton.tsx
@@ -99,7 +99,7 @@ export function ChallengeButton({
           onClick={handleClick}
           className={cn(
             'p-2 rounded-neo transition-all',
-            'text-neo-orange hover:text-neo-yellow',
+            'text-neo-orange hover:text-neo-lime',
             'hover:bg-neo-navy/30',
             className
           )}

--- a/fe-next/components/education/duels/DuelChallengeModal.tsx
+++ b/fe-next/components/education/duels/DuelChallengeModal.tsx
@@ -99,7 +99,7 @@ export default function DuelChallengeModal({
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-3">
-            <Swords className="w-6 h-6 text-neo-yellow" />
+            <Swords className="w-6 h-6 text-neo-lime" />
             <h3 id={titleId} className="text-xl font-neo-display font-black text-neo-white">
               {t('challengePlayer', { name: opponent.displayName ?? '?' })}
             </h3>
@@ -146,7 +146,7 @@ export default function DuelChallengeModal({
                 'shadow-hard-sm transition-all',
                 'text-start',
                 duelType === 'async'
-                  ? 'bg-neo-yellow text-neo-black shadow-hard'
+                  ? 'bg-neo-lime text-neo-black shadow-hard'
                   : 'bg-neo-navy text-neo-white hover:shadow-hard'
               )}
             >
@@ -165,7 +165,7 @@ export default function DuelChallengeModal({
                 'shadow-hard-sm transition-all',
                 'text-start',
                 duelType === 'realtime'
-                  ? 'bg-neo-yellow text-neo-black shadow-hard'
+                  ? 'bg-neo-lime text-neo-black shadow-hard'
                   : 'bg-neo-navy text-neo-white hover:shadow-hard'
               )}
             >
@@ -221,7 +221,7 @@ export default function DuelChallengeModal({
             disabled={!selectedLessonId || isCreating}
             className={cn(
               'flex-1 px-6 py-3 font-bold rounded-neo',
-              'bg-neo-yellow text-neo-black',
+              'bg-neo-lime text-neo-black',
               'border-neo border-neo-black shadow-hard',
               'hover:shadow-hard-lg transition-all',
               'disabled:opacity-50 disabled:cursor-not-allowed'

--- a/fe-next/components/education/duels/DuelDisconnectOverlay.tsx
+++ b/fe-next/components/education/duels/DuelDisconnectOverlay.tsx
@@ -65,7 +65,7 @@ export function DuelDisconnectOverlay({
 
         {/* Countdown */}
         <div className="mb-6">
-          <div className="text-6xl font-neo-display font-bold text-neo-yellow mb-2">
+          <div className="text-6xl font-neo-display font-bold text-neo-lime mb-2">
             {secondsRemaining}
           </div>
           <p className="text-neo-white/70 text-sm">

--- a/fe-next/components/education/duels/DuelGameView.tsx
+++ b/fe-next/components/education/duels/DuelGameView.tsx
@@ -258,7 +258,7 @@ export function DuelGameView({ duelId, studentId, onBackToLobby }: DuelGameViewP
           transition={{ delay: 0.2, type: 'spring', stiffness: 200 }}
           className={cn(
             'mb-6 p-6 rounded-neo border-neo-thick shadow-hard',
-            isDraw ? 'bg-yellow-500 border-neo-black' : isWinner ? 'bg-neo-yellow border-neo-black' : 'bg-red-500 border-neo-black'
+            isDraw ? 'bg-yellow-500 border-neo-black' : isWinner ? 'bg-neo-lime border-neo-black' : 'bg-red-500 border-neo-black'
           )}
         >
           {isWinner ? (
@@ -294,7 +294,7 @@ export function DuelGameView({ duelId, studentId, onBackToLobby }: DuelGameViewP
         <div className="flex items-center gap-2 mb-8 p-4 bg-neo-navy border-neo rounded-neo shadow-hard">
           <Flame className="w-6 h-6 text-neo-orange" />
           <span className="text-neo-white font-neo-body">
-            {t('duels.xpEarned')}: <span className="font-bold text-neo-yellow">{xp}</span>
+            {t('duels.xpEarned')}: <span className="font-bold text-neo-lime">{xp}</span>
           </span>
         </div>
 
@@ -345,7 +345,7 @@ export function DuelGameView({ duelId, studentId, onBackToLobby }: DuelGameViewP
               <Check className="w-5 h-5 text-green-500" />
               <span className="text-neo-white">{t('duels.wordsAccepted')}</span>
             </div>
-            <span className="text-neo-yellow font-bold">{validatedScore.wordsValidated}</span>
+            <span className="text-neo-lime font-bold">{validatedScore.wordsValidated}</span>
           </div>
 
           <div className="flex items-center justify-between">
@@ -386,7 +386,7 @@ export function DuelGameView({ duelId, studentId, onBackToLobby }: DuelGameViewP
             'flex items-center gap-1 px-3 py-1 rounded-neo border-neo font-neo-display font-bold',
             timeRemaining <= 30 ? 'bg-red-500 text-neo-white animate-pulse' :
             timeRemaining <= 60 ? 'bg-neo-orange text-neo-black' :
-            'bg-neo-yellow text-neo-black'
+            'bg-neo-lime text-neo-black'
           )}>
             <Clock className="w-4 h-4" />
             <span>{Math.floor(timeRemaining / 60)}:{(timeRemaining % 60).toString().padStart(2, '0')}</span>
@@ -412,7 +412,7 @@ export function DuelGameView({ duelId, studentId, onBackToLobby }: DuelGameViewP
             {duelData.boardState.flat().map((letter, idx) => (
               <div
                 key={idx}
-                className="aspect-square flex items-center justify-center bg-neo-yellow text-neo-black font-neo-display font-bold text-2xl rounded-neo border-neo shadow-hard-sm"
+                className="aspect-square flex items-center justify-center bg-neo-lime text-neo-black font-neo-display font-bold text-2xl rounded-neo border-neo shadow-hard-sm"
                 data-testid={`board-letter-${idx}`}
               >
                 {letter}
@@ -440,7 +440,7 @@ export function DuelGameView({ duelId, studentId, onBackToLobby }: DuelGameViewP
             <button
               onClick={handleAddWord}
               disabled={!currentWord.trim()}
-              className="px-4 py-2 bg-neo-yellow text-neo-black font-neo-body font-bold rounded-neo border-neo shadow-hard hover:shadow-hard-pressed active:translate-x-[2px] active:translate-y-[2px] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-4 py-2 bg-neo-lime text-neo-black font-neo-body font-bold rounded-neo border-neo shadow-hard hover:shadow-hard-pressed active:translate-x-[2px] active:translate-y-[2px] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {t('duels.addWord')}
             </button>

--- a/fe-next/components/education/duels/DuelHistory.tsx
+++ b/fe-next/components/education/duels/DuelHistory.tsx
@@ -118,7 +118,7 @@ export function DuelHistory({ studentId, className }: DuelHistoryProps) {
     <div className={cn('max-w-4xl mx-auto p-6', className)}>
       {/* Header */}
       <div className="flex items-center gap-3 mb-6">
-        <Trophy className="w-6 h-6 text-neo-yellow" />
+        <Trophy className="w-6 h-6 text-neo-lime" />
         <h1 className="text-2xl font-neo-display font-bold text-neo-white">
           {t('duels.duelHistory')}
         </h1>

--- a/fe-next/components/education/duels/DuelLobby.tsx
+++ b/fe-next/components/education/duels/DuelLobby.tsx
@@ -167,7 +167,7 @@ export default function DuelLobby({ classroomId, studentId, lessons }: DuelLobby
 
       {/* Pending Challenges Section */}
       <section className="mb-8">
-        <h3 className="text-lg font-neo-display font-black text-neo-yellow uppercase tracking-wide mb-4">
+        <h3 className="text-lg font-neo-display font-black text-neo-lime uppercase tracking-wide mb-4">
           {t('pendingChallenges')}
         </h3>
 
@@ -184,7 +184,7 @@ export default function DuelLobby({ classroomId, studentId, lessons }: DuelLobby
                 key={challenge.id}
                 className={cn(
                   'p-4 rounded-neo border-3 border-black',
-                  'bg-white shadow-hard-sm',
+                  'bg-neo-cream shadow-hard-sm',
                   'flex items-center justify-between gap-4'
                 )}
               >
@@ -206,7 +206,7 @@ export default function DuelLobby({ classroomId, studentId, lessons }: DuelLobby
                       'border-3 border-black shadow-hard-sm',
                       'hover:-translate-y-0.5 hover:shadow-hard active:translate-y-0.5 active:shadow-hard-pressed',
                       'transition-all duration-100',
-                      'focus:outline-none focus-visible:ring-2 focus-visible:ring-neo-yellow'
+                      'focus:outline-none focus-visible:ring-2 focus-visible:ring-neo-lime'
                     )}
                   >
                     {t('accept')}
@@ -219,7 +219,7 @@ export default function DuelLobby({ classroomId, studentId, lessons }: DuelLobby
                       'border-3 border-black shadow-hard-sm',
                       'hover:-translate-y-0.5 hover:shadow-hard active:translate-y-0.5 active:shadow-hard-pressed',
                       'transition-all duration-100',
-                      'focus:outline-none focus-visible:ring-2 focus-visible:ring-neo-yellow'
+                      'focus:outline-none focus-visible:ring-2 focus-visible:ring-neo-lime'
                     )}
                   >
                     {t('decline')}
@@ -238,7 +238,7 @@ export default function DuelLobby({ classroomId, studentId, lessons }: DuelLobby
           disabled={opponents.length === 0}
           className={cn(
             'w-full px-6 py-4 font-black text-lg rounded-neo font-neo-display uppercase tracking-tight',
-            'bg-neo-yellow text-black',
+            'bg-neo-lime text-black',
             'border-3 border-black shadow-hard',
             'hover:-translate-y-1 hover:shadow-hard-lg active:translate-y-0.5 active:shadow-hard-pressed',
             'animate-neo-press transition-all duration-100',
@@ -267,7 +267,7 @@ export default function DuelLobby({ classroomId, studentId, lessons }: DuelLobby
                 onClick={() => handleSelectOpponent(opponent)}
                 className={cn(
                   'p-4 rounded-neo border-3 border-black',
-                  'bg-white shadow-hard-sm',
+                  'bg-neo-cream shadow-hard-sm',
                   'hover:-translate-y-1 hover:shadow-hard',
                   'active:translate-y-0.5 active:shadow-hard-pressed',
                   'transition-all duration-100 cursor-pointer',

--- a/fe-next/components/education/duels/DuelNotification.tsx
+++ b/fe-next/components/education/duels/DuelNotification.tsx
@@ -99,7 +99,7 @@ export default function DuelNotification({ classroomId }: DuelNotificationProps)
           >
             {/* Icon */}
             <div className="flex-shrink-0">
-              <Swords className="w-8 h-8 text-neo-yellow" />
+              <Swords className="w-8 h-8 text-neo-lime" />
             </div>
 
             {/* Content */}

--- a/fe-next/components/education/duels/RealTimeDuelGame.tsx
+++ b/fe-next/components/education/duels/RealTimeDuelGame.tsx
@@ -266,7 +266,7 @@ export function RealTimeDuelGame({
             isDraw
               ? 'bg-yellow-500 border-neo-black'
               : isWinner
-                ? 'bg-neo-yellow border-neo-black'
+                ? 'bg-neo-lime border-neo-black'
                 : 'bg-red-500 border-neo-black'
           )}
         >
@@ -299,7 +299,7 @@ export function RealTimeDuelGame({
         <div className="flex items-center gap-2 mb-8 p-4 bg-neo-navy border-neo rounded-neo shadow-hard">
           <Flame className="w-6 h-6 text-neo-orange" />
           <span className="text-neo-white font-neo-body">
-            {t('duels.xpEarned')}: <span className="font-bold text-neo-yellow">{xp}</span>
+            {t('duels.xpEarned')}: <span className="font-bold text-neo-lime">{xp}</span>
           </span>
         </div>
 
@@ -374,7 +374,7 @@ export function RealTimeDuelGame({
             {boardState.flat().map((letter, idx) => (
               <div
                 key={idx}
-                className="aspect-square flex items-center justify-center bg-neo-yellow text-neo-black font-neo-display font-bold text-2xl rounded-neo border-neo shadow-hard-sm"
+                className="aspect-square flex items-center justify-center bg-neo-lime text-neo-black font-neo-display font-bold text-2xl rounded-neo border-neo shadow-hard-sm"
               >
                 {letter}
               </div>
@@ -403,7 +403,7 @@ export function RealTimeDuelGame({
               onClick={handleSubmitWord}
               disabled={!currentWord.trim()}
               data-testid="submit-word-btn"
-              className="px-4 py-2 bg-neo-yellow text-neo-black font-neo-body font-bold rounded-neo border-neo shadow-hard hover:shadow-hard-pressed active:translate-x-[2px] active:translate-y-[2px] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-4 py-2 bg-neo-lime text-neo-black font-neo-body font-bold rounded-neo border-neo shadow-hard hover:shadow-hard-pressed active:translate-x-[2px] active:translate-y-[2px] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {t('duels.addWord')}
             </button>

--- a/fe-next/components/education/duels/__tests__/ChallengeButton.test.tsx
+++ b/fe-next/components/education/duels/__tests__/ChallengeButton.test.tsx
@@ -161,7 +161,7 @@ describe('ChallengeButton', () => {
 
       const button = screen.getByTestId('challenge-button-icon');
       expect(button).toHaveClass('text-neo-orange');
-      expect(button).toHaveClass('hover:text-neo-yellow');
+      expect(button).toHaveClass('hover:text-neo-lime');
     });
   });
 

--- a/fe-next/components/education/milestones/MilestoneCelebration.tsx
+++ b/fe-next/components/education/milestones/MilestoneCelebration.tsx
@@ -113,7 +113,7 @@ export const MilestoneCelebration = memo<MilestoneCelebrationProps>(
               id={titleId}
               className={cn(
                 'text-3xl md:text-4xl font-black',
-                'text-neo-yellow',
+                'text-neo-lime',
                 'drop-shadow-[0_0_15px_rgb(255_225_53/0.6)]',
                 'mb-4'
               )}
@@ -173,13 +173,13 @@ export const MilestoneCelebration = memo<MilestoneCelebrationProps>(
               <motion.div
                 className={cn(
                   'p-3 rounded-neo',
-                  'bg-neo-yellow/10 border-neo border-neo-yellow'
+                  'bg-neo-lime/10 border-neo border-neo-lime'
                 )}
                 initial={{ opacity: 0, x: 10 }}
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ delay: 0.6 }}
               >
-                <p className="text-neo-yellow font-bold text-sm">
+                <p className="text-neo-lime font-bold text-sm">
                   {t('education.milestones.coinBonus')}
                 </p>
                 <p className="text-2xl font-black text-neo-white">
@@ -213,7 +213,7 @@ export const MilestoneCelebration = memo<MilestoneCelebrationProps>(
               onClick={onClose}
               className={cn(
                 'w-full py-3 px-6',
-                'bg-neo-yellow hover:bg-neo-orange',
+                'bg-neo-lime hover:bg-neo-orange',
                 'text-neo-black font-black text-lg',
                 'border-3 border-neo-black rounded-neo',
                 'shadow-hard hover:shadow-hard-lg hover:-translate-y-0.5',

--- a/fe-next/components/education/milestones/MilestoneTracker.tsx
+++ b/fe-next/components/education/milestones/MilestoneTracker.tsx
@@ -48,7 +48,7 @@ export const MilestoneTracker = memo<MilestoneTrackerProps>(
         {/* Header: Current Level -> Next Milestone */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="text-neo-yellow font-black text-lg">
+            <span className="text-neo-lime font-black text-lg">
               {currentLevel}
             </span>
             <span className="text-neo-white/50">→</span>
@@ -61,7 +61,7 @@ export const MilestoneTracker = memo<MilestoneTrackerProps>(
           </div>
           {nextMilestone && (
             <div className="text-sm text-neo-white/70">
-              {t('education.milestones.xpRemaining')}: <span className="font-bold text-neo-yellow">{xpToNextMilestone}</span>
+              {t('education.milestones.xpRemaining')}: <span className="font-bold text-neo-lime">{xpToNextMilestone}</span>
             </div>
           )}
         </div>
@@ -85,7 +85,7 @@ export const MilestoneTracker = memo<MilestoneTrackerProps>(
             <div
               className={cn(
                 'h-full rounded-full',
-                'bg-gradient-to-r from-neo-yellow to-neo-orange',
+                'bg-gradient-to-r from-neo-lime to-neo-orange',
                 'transition-all duration-500 ease-out'
               )}
               style={{ width: `${progressPercent}%` }}
@@ -117,7 +117,7 @@ export const MilestoneTracker = memo<MilestoneTrackerProps>(
                       // Size: major = larger
                       milestone.isMajor ? 'w-4 h-8' : 'w-2 h-6',
                       // Color: major = yellow, minor = gray
-                      milestone.isMajor ? 'bg-neo-yellow' : 'bg-neo-white/60',
+                      milestone.isMajor ? 'bg-neo-lime' : 'bg-neo-white/60',
                       // Dim upcoming milestones
                       !isPassed && 'opacity-30'
                     )}

--- a/fe-next/components/student/ActivityFeed.tsx
+++ b/fe-next/components/student/ActivityFeed.tsx
@@ -31,7 +31,7 @@ export default function ActivityFeed({ classroomId, userId }: ActivityFeedProps)
     return (
       <div
         className={cn(
-          'p-6 rounded-neo border-3 border-black bg-white shadow-hard-sm',
+          'p-6 rounded-neo border-3 border-black bg-neo-cream shadow-hard-sm',
           isRTL && 'rtl'
         )}
       >
@@ -64,7 +64,7 @@ export default function ActivityFeed({ classroomId, userId }: ActivityFeedProps)
     return (
       <div
         className={cn(
-          'p-6 rounded-neo border-3 border-black bg-white shadow-hard-sm',
+          'p-6 rounded-neo border-3 border-black bg-neo-cream shadow-hard-sm',
           isRTL && 'rtl'
         )}
       >
@@ -84,7 +84,7 @@ export default function ActivityFeed({ classroomId, userId }: ActivityFeedProps)
     return (
       <div
         className={cn(
-          'p-6 rounded-neo border-3 border-black bg-white shadow-hard-sm',
+          'p-6 rounded-neo border-3 border-black bg-neo-cream shadow-hard-sm',
           isRTL && 'rtl'
         )}
       >
@@ -103,7 +103,7 @@ export default function ActivityFeed({ classroomId, userId }: ActivityFeedProps)
   return (
     <motion.div
       className={cn(
-        'p-6 rounded-neo border-3 border-black bg-white shadow-hard-sm',
+        'p-6 rounded-neo border-3 border-black bg-neo-cream shadow-hard-sm',
         isRTL && 'rtl'
       )}
       initial="hidden"
@@ -169,7 +169,7 @@ export default function ActivityFeed({ classroomId, userId }: ActivityFeedProps)
               <motion.div
                 className={cn(
                   'flex-shrink-0 w-10 h-10 rounded-full border-2 border-black flex items-center justify-center text-lg shadow-hard-sm',
-                  isCurrentUser ? 'bg-neo-cyan' : 'bg-neo-yellow'
+                  isCurrentUser ? 'bg-neo-cyan' : 'bg-neo-lime'
                 )}
                 whileHover={{ scale: 1.15, rotate: -8 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 17 }}
@@ -195,7 +195,7 @@ export default function ActivityFeed({ classroomId, userId }: ActivityFeedProps)
                 data-testid={`activity-icon-${activity.type}`}
                 className={cn(
                   'flex-shrink-0 w-9 h-9 rounded-neo border-2 border-black flex items-center justify-center shadow-hard-sm',
-                  isDuel ? 'bg-neo-yellow' : 'bg-neo-cyan'
+                  isDuel ? 'bg-neo-lime' : 'bg-neo-cyan'
                 )}
                 whileHover={{ scale: 1.2, rotate: 8 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 17 }}

--- a/fe-next/components/student/ClassroomGameBanner.tsx
+++ b/fe-next/components/student/ClassroomGameBanner.tsx
@@ -154,7 +154,7 @@ export function ClassroomGameBanner({
         'flex items-center gap-3 px-4 py-3 rounded-neo border-2 border-black shadow-hard-sm',
         isConnected
           ? 'bg-neo-cyan/20'
-          : 'bg-neo-yellow/20'
+          : 'bg-neo-lime/20'
       )}>
         <Radio className={cn(
           'w-4 h-4 flex-shrink-0',
@@ -203,9 +203,9 @@ export function ClassroomGameBanner({
           </div>
         </div>
 
-        {/* White body */}
-        <div className="bg-white px-6 py-4">
-          <p className="text-black/80 font-neo-body font-bold mb-3">
+        {/* Dark body */}
+        <div className="bg-neo-navy-light px-6 py-4">
+          <p className="text-neo-cream/80 font-neo-body font-bold mb-3">
             {t('student.activeGame.teacherStarted', { teacher: activeGame.teacherName })}
           </p>
 
@@ -233,7 +233,7 @@ export function ClassroomGameBanner({
             disabled={isJoining}
             className={cn(
               'w-full px-6 py-4 font-black text-lg rounded-neo',
-              'bg-neo-yellow text-black',
+              'bg-neo-lime text-black',
               'border-3 border-black shadow-hard',
               'hover:shadow-hard-lg hover:-translate-y-0.5',
               'active:shadow-hard-sm active:translate-y-0.5',

--- a/fe-next/components/student/JoinClassroomForm.tsx
+++ b/fe-next/components/student/JoinClassroomForm.tsx
@@ -160,7 +160,7 @@ const JoinClassroomForm: React.FC<JoinClassroomFormProps> = ({ initialCode = '' 
                           size="icon"
                           variant="outline"
                           onClick={handlePaste}
-                          className="absolute end-2 top-1/2 -translate-y-1/2 h-10 w-10 bg-neo-yellow hover:bg-neo-yellow/90 text-neo-black border-neo border-neo-black shadow-hard-sm hover:shadow-hard hover:translate-x-[-1px] hover:translate-y-[-1px] active:shadow-hard-pressed transition-all"
+                          className="absolute end-2 top-1/2 -translate-y-1/2 h-10 w-10 bg-neo-lime hover:bg-neo-lime/90 text-neo-black border-neo border-neo-black shadow-hard-sm hover:shadow-hard hover:translate-x-[-1px] hover:translate-y-[-1px] active:shadow-hard-pressed transition-all"
                           aria-label={t('education.student.join.pasteButton')}
                         >
                           <ClipboardPaste className="w-4 h-4" />

--- a/fe-next/components/student/StreakCalendar.tsx
+++ b/fe-next/components/student/StreakCalendar.tsx
@@ -109,7 +109,7 @@ export default function StreakCalendar({ currentStreak, lastWinDate }: StreakCal
       {/* Header: Streak count */}
       <div className="flex items-center gap-3 mb-5">
         <motion.div
-          className="w-10 h-10 rounded-neo bg-neo-yellow border-3 border-black shadow-hard-sm flex items-center justify-center flex-shrink-0"
+          className="w-10 h-10 rounded-neo bg-neo-lime border-3 border-black shadow-hard-sm flex items-center justify-center flex-shrink-0"
           whileHover={{ scale: 1.15, rotate: -8 }}
           transition={{ type: 'spring', stiffness: 400, damping: 17 }}
         >
@@ -120,7 +120,7 @@ export default function StreakCalendar({ currentStreak, lastWinDate }: StreakCal
         </p>
         <motion.div
           variants={streakBadgePop}
-          className="ms-auto flex items-center gap-2 bg-neo-yellow border-3 border-black rounded-neo px-3 py-1 shadow-hard-sm"
+          className="ms-auto flex items-center gap-2 bg-neo-lime border-3 border-black rounded-neo px-3 py-1 shadow-hard-sm"
         >
           <span className="text-xl font-neo-display font-black text-black tabular-nums">
             {currentStreak}
@@ -144,7 +144,7 @@ export default function StreakCalendar({ currentStreak, lastWinDate }: StreakCal
             className={cn(
               'flex flex-col items-center gap-1.5 p-2 rounded-neo border-3 cursor-default',
               day.isActive
-                ? 'bg-neo-yellow border-black shadow-hard-sm text-black'
+                ? 'bg-neo-lime border-black shadow-hard-sm text-black'
                 : 'bg-neo-navy border-black/40 text-neo-white/40',
               day.isToday && !day.isActive && 'border-neo-cyan bg-neo-cyan/10 text-neo-white',
               day.isToday && 'ring-2 ring-neo-cyan ring-offset-1 ring-offset-neo-navy'

--- a/fe-next/components/student/StudentLessonView.tsx
+++ b/fe-next/components/student/StudentLessonView.tsx
@@ -169,10 +169,10 @@ export default function StudentLessonView() {
 
         // Card colors per status
         const cardBg =
-          status === 'assigned' ? 'bg-white' : status === 'completed' ? 'bg-neo-yellow/10' : 'bg-white';
+          status === 'assigned' ? 'bg-neo-navy' : status === 'completed' ? 'bg-neo-lime/10' : 'bg-neo-navy';
         const accentBar =
-          status === 'assigned' ? 'bg-neo-cyan' : status === 'completed' ? 'bg-neo-yellow' : 'bg-black/20';
-        const fillColor = status === 'completed' ? 'bg-neo-yellow' : 'bg-neo-cyan';
+          status === 'assigned' ? 'bg-neo-cyan' : status === 'completed' ? 'bg-neo-lime' : 'bg-black/20';
+        const fillColor = status === 'completed' ? 'bg-neo-lime' : 'bg-neo-cyan';
 
         // Alternating slight tilt for visual rhythm
         const cardTilt = index % 2 === 0 ? -0.4 : 0.4;
@@ -237,7 +237,7 @@ export default function StudentLessonView() {
                         variants={doneBadge}
                         initial="hidden"
                         animate="visible"
-                        className="flex-shrink-0 px-2 py-0.5 bg-neo-yellow border-2 border-black text-black text-xs font-black rounded-neo shadow-hard-sm"
+                        className="flex-shrink-0 px-2 py-0.5 bg-neo-lime border-2 border-black text-black text-xs font-black rounded-neo shadow-hard-sm"
                       >
                         ✓ DONE
                       </AdaptiveMotion.span>
@@ -262,7 +262,7 @@ export default function StudentLessonView() {
                           animate={masteryPercent === 100 ? { scale: [1, 1.15, 1] } : {}}
                           transition={{ duration: 0.6, delay: 0.8 }}
                         >
-                          <Activity className="w-4 h-4 text-neo-yellow" />
+                          <Activity className="w-4 h-4 text-neo-lime" />
                           {masteryPercent}%
                         </AdaptiveMotion.span>
                       </>

--- a/fe-next/components/teacher/BulkWordImporter.tsx
+++ b/fe-next/components/teacher/BulkWordImporter.tsx
@@ -177,7 +177,7 @@ export default function BulkWordImporter({
                           'flex items-center gap-1 px-2 py-1 rounded text-sm font-neo-body',
                           word.canIntegrate
                             ? 'bg-neo-cyan/20 text-neo-cyan border border-neo-cyan/30'
-                            : 'bg-neo-yellow/20 text-neo-yellow border border-neo-yellow/30'
+                            : 'bg-neo-lime/20 text-neo-lime border border-neo-lime/30'
                         )}
                       >
                         {word.canIntegrate ? (

--- a/fe-next/components/teacher/ClassroomManager.tsx
+++ b/fe-next/components/teacher/ClassroomManager.tsx
@@ -130,7 +130,7 @@ export default function ClassroomManager() {
 
       {/* Classroom Grid */}
       {classrooms.length === 0 ? (
-        <div className="border-3 border-black rounded-neo bg-white shadow-hard py-12 text-center">
+        <div className="border-3 border-black rounded-neo bg-neo-cream shadow-hard py-12 text-center">
           <div className="w-16 h-16 rounded-neo bg-neo-cyan border-2 border-black flex items-center justify-center mx-auto mb-4 shadow-hard-sm">
             <Users className="w-9 h-9 text-black" />
           </div>
@@ -153,13 +153,13 @@ export default function ClassroomManager() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {classrooms.map((classroom, idx) => {
             // Alternate card accent colors
-            const headerColors = ['bg-neo-cyan', 'bg-neo-yellow', 'bg-neo-pink'];
+            const headerColors = ['bg-neo-cyan', 'bg-neo-lime', 'bg-neo-pink'];
             const headerBg = headerColors[idx % headerColors.length];
 
             return (
               <div
                 key={classroom.id}
-                className="border-3 border-black rounded-neo shadow-hard bg-white overflow-hidden hover:-translate-y-0.5 hover:shadow-hard-lg transition-all"
+                className="border-3 border-black rounded-neo shadow-hard bg-neo-cream overflow-hidden hover:-translate-y-0.5 hover:shadow-hard-lg transition-all"
               >
                 {/* Colored header */}
                 <div className={cn('px-5 py-4', headerBg)}>
@@ -181,7 +181,7 @@ export default function ClassroomManager() {
                 {/* Card body */}
                 <div className="p-4 space-y-3">
                   {/* Join Code */}
-                  <div className="bg-neo-yellow/20 border-2 border-black p-3 rounded-neo">
+                  <div className="bg-neo-lime/20 border-2 border-black p-3 rounded-neo">
                     <p className="text-xs text-black/60 font-bold mb-1">{t('teacher.classroom.joinCode')}</p>
                     <div className="flex items-center justify-between">
                       <code className="text-2xl font-neo-display font-black text-black tracking-wider">
@@ -217,7 +217,7 @@ export default function ClassroomManager() {
                       'w-full flex items-center justify-between px-3 py-2 rounded-neo border-2 border-black font-bold text-sm transition-all shadow-hard-sm',
                       expandedClassroomId === classroom.id
                         ? 'bg-black text-white'
-                        : 'bg-white text-black hover:bg-black/5'
+                        : 'bg-neo-cream text-black hover:bg-black/5'
                     )}
                   >
                     <span className="flex items-center gap-2">
@@ -284,7 +284,7 @@ export default function ClassroomManager() {
           <Dialog.Content
             className={cn(
               'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
-              'w-full max-w-md bg-white border-3 border-black shadow-hard-lg z-50',
+              'w-full max-w-md bg-neo-cream border-3 border-black shadow-hard-lg z-50',
               'rounded-neo overflow-hidden'
             )}
           >
@@ -320,7 +320,7 @@ export default function ClassroomManager() {
                   value={formData.language}
                   onChange={(e) => setFormData({ ...formData, language: e.target.value as Language })}
                   className={cn(
-                    'w-full px-4 py-2 bg-white border-2 border-black',
+                    'w-full px-4 py-2 bg-neo-cream border-2 border-black',
                     'text-black font-neo-body font-bold shadow-hard-sm rounded-neo',
                     'focus:outline-none focus:ring-2 focus:ring-neo-cyan'
                   )}
@@ -346,7 +346,7 @@ export default function ClassroomManager() {
                     setIsEditDialogOpen(false);
                     setSelectedClassroomId(null);
                   }}
-                  className="bg-white text-black font-black border-2 border-black shadow-hard-sm hover:bg-black/5 transition-all"
+                  className="bg-neo-cream text-black font-black border-2 border-black shadow-hard-sm hover:bg-black/5 transition-all"
                 >
                   {t('common.cancel')}
                 </Button>
@@ -355,7 +355,7 @@ export default function ClassroomManager() {
 
             <Dialog.Close asChild>
               <button
-                className="absolute top-4 end-4 w-8 h-8 flex items-center justify-center rounded-neo border-2 border-black bg-white text-black hover:bg-black hover:text-white transition-all shadow-hard-sm"
+                className="absolute top-4 end-4 w-8 h-8 flex items-center justify-center rounded-neo border-2 border-black bg-neo-cream text-black hover:bg-black hover:text-white transition-all shadow-hard-sm"
                 aria-label={t('common.close')}
               >
                 <X className="w-4 h-4" />
@@ -372,7 +372,7 @@ export default function ClassroomManager() {
           <AlertDialog.Content
             className={cn(
               'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
-              'w-full max-w-md bg-white border-3 border-black shadow-hard-lg z-50',
+              'w-full max-w-md bg-neo-cream border-3 border-black shadow-hard-lg z-50',
               'rounded-neo overflow-hidden'
             )}
           >
@@ -397,7 +397,7 @@ export default function ClassroomManager() {
                   </Button>
                 </AlertDialog.Action>
                 <AlertDialog.Cancel asChild>
-                  <Button className="bg-white text-black font-black border-2 border-black shadow-hard-sm hover:bg-black/5 transition-all">
+                  <Button className="bg-neo-cream text-black font-black border-2 border-black shadow-hard-sm hover:bg-black/5 transition-all">
                     {t('common.cancel')}
                   </Button>
                 </AlertDialog.Cancel>

--- a/fe-next/components/teacher/ClassroomStudentList.tsx
+++ b/fe-next/components/teacher/ClassroomStudentList.tsx
@@ -58,7 +58,7 @@ export default function ClassroomStudentList({ classroomId, joinCode }: Classroo
 
   if (students.length === 0) {
     return (
-      <div className="border-3 border-black rounded-neo p-8 text-center bg-white shadow-hard-sm">
+      <div className="border-3 border-black rounded-neo p-8 text-center bg-neo-cream shadow-hard-sm">
         <div className="w-14 h-14 rounded-neo bg-neo-cyan border-2 border-black flex items-center justify-center mx-auto mb-3 shadow-hard-sm">
           <Users className="w-8 h-8 text-black" />
         </div>
@@ -73,7 +73,7 @@ export default function ClassroomStudentList({ classroomId, joinCode }: Classroo
   }
 
   // Cycle through bold accent colors for visual interest
-  const accentColors = ['bg-neo-cyan', 'bg-neo-yellow', 'bg-neo-pink', 'bg-neo-orange'];
+  const accentColors = ['bg-neo-cyan', 'bg-neo-lime', 'bg-neo-pink', 'bg-neo-orange'];
 
   return (
     <div className="space-y-2">
@@ -89,7 +89,7 @@ export default function ClassroomStudentList({ classroomId, joinCode }: Classroo
         return (
           <div
             key={student.id}
-            className="flex items-center gap-3 p-3 border-2 border-black rounded-neo bg-white shadow-hard-sm hover:-translate-y-0.5 hover:shadow-hard transition-all"
+            className="flex items-center gap-3 p-3 border-2 border-black rounded-neo bg-neo-cream shadow-hard-sm hover:-translate-y-0.5 hover:shadow-hard transition-all"
           >
             {/* Avatar */}
             <div className="flex-shrink-0">

--- a/fe-next/components/teacher/GameCodeDisplay.tsx
+++ b/fe-next/components/teacher/GameCodeDisplay.tsx
@@ -110,7 +110,7 @@ export default function GameCodeDisplay({
 
       {/* QR Code Section */}
       {showQR && (
-        <div className="flex flex-col items-center mb-4 p-4 bg-white rounded-neo">
+        <div className="flex flex-col items-center mb-4 p-4 bg-neo-cream rounded-neo">
           <QRCodeSVG
             value={joinUrl}
             size={180}

--- a/fe-next/components/teacher/LessonAssignmentDialog.tsx
+++ b/fe-next/components/teacher/LessonAssignmentDialog.tsx
@@ -87,9 +87,9 @@ export default function LessonAssignmentDialog({
                   <Loader size="sm" />
                 </div>
               ) : classrooms.length === 0 ? (
-                <div className="bg-neo-black/30 border-neo border-neo-yellow p-4 rounded-neo">
+                <div className="bg-neo-black/30 border-neo border-neo-lime p-4 rounded-neo">
                   <div className="flex items-start gap-3">
-                    <AlertCircle className="w-5 h-5 text-neo-yellow shrink-0 mt-0.5" />
+                    <AlertCircle className="w-5 h-5 text-neo-lime shrink-0 mt-0.5" />
                     <p className="text-sm text-neo-white">
                       {t('teacher.lessons.assign.noClassrooms')}
                     </p>

--- a/fe-next/components/teacher/LessonBuilder.tsx
+++ b/fe-next/components/teacher/LessonBuilder.tsx
@@ -233,7 +233,7 @@ export default function LessonBuilder() {
                         defCount === totalWords && totalWords > 0
                           ? 'text-neo-cyan bg-neo-cyan/10'
                           : defCount > 0
-                            ? 'text-neo-yellow bg-neo-yellow/10'
+                            ? 'text-neo-lime bg-neo-lime/10'
                             : 'text-neo-white/40 bg-neo-navy/10'
                       )}
                     >
@@ -259,7 +259,7 @@ export default function LessonBuilder() {
                         {word.canIntegrate ? (
                           <CheckCircle className="w-4 h-4 text-neo-cyan shrink-0" />
                         ) : (
-                          <AlertCircle className="w-4 h-4 text-neo-yellow shrink-0" />
+                          <AlertCircle className="w-4 h-4 text-neo-lime shrink-0" />
                         )}
                         <span className="text-neo-white font-neo-body">{word.word}</span>
                         {word.definition && (

--- a/fe-next/components/teacher/LessonBuilderCreateDialog.tsx
+++ b/fe-next/components/teacher/LessonBuilderCreateDialog.tsx
@@ -88,7 +88,7 @@ export default function LessonBuilderCreateDialog({
                 type="button"
               >
                 <div className="flex items-center gap-2">
-                  <BookTemplate className="w-5 h-5 text-neo-yellow" />
+                  <BookTemplate className="w-5 h-5 text-neo-lime" />
                   <span className="font-neo-body font-bold text-neo-white">
                     {t('teacher.lesson.startFromTemplate')}
                   </span>

--- a/fe-next/components/teacher/LessonTemplateEditor.tsx
+++ b/fe-next/components/teacher/LessonTemplateEditor.tsx
@@ -153,7 +153,7 @@ export default function LessonTemplateEditor({
             {/* Timer */}
             <div className="space-y-3">
               <Label className="text-sm font-neo-body text-neo-white flex items-center gap-2">
-                <Clock className="w-4 h-4 text-neo-yellow" />
+                <Clock className="w-4 h-4 text-neo-lime" />
                 {t('education.template.timer')}
               </Label>
               <div className="flex gap-2 flex-wrap">
@@ -166,7 +166,7 @@ export default function LessonTemplateEditor({
                     className={cn(
                       'border-neo border-neo-black transition-all',
                       timerSeconds === option.value
-                        ? 'bg-neo-yellow text-neo-black shadow-hard-pressed'
+                        ? 'bg-neo-lime text-neo-black shadow-hard-pressed'
                         : 'bg-neo-navy/50 text-neo-white shadow-hard hover:shadow-hard-pressed'
                     )}
                   >

--- a/fe-next/components/teacher/QuickStartButton.tsx
+++ b/fe-next/components/teacher/QuickStartButton.tsx
@@ -66,7 +66,7 @@ export default function QuickStartButton({
         'bg-neo-lime/90 hover:bg-neo-lime',
         'shadow-hard hover:shadow-hard-lg transition-all',
         'text-left hover:translate-x-[-2px] hover:translate-y-[-2px]',
-        'focus:outline-none focus:ring-2 focus:ring-neo-yellow',
+        'focus:outline-none focus:ring-2 focus:ring-neo-lime',
         isRTL && 'rtl text-right',
         className
       )}

--- a/fe-next/components/teacher/StarterPacksSection.tsx
+++ b/fe-next/components/teacher/StarterPacksSection.tsx
@@ -20,7 +20,7 @@ const categoryIcons = {
 const categoryColors = {
   general: { bg: 'bg-neo-cyan', border: 'border-l-neo-cyan' },
   academic: { bg: 'bg-neo-pink', border: 'border-l-neo-pink' },
-  language: { bg: 'bg-neo-yellow', border: 'border-l-neo-yellow' },
+  language: { bg: 'bg-neo-lime', border: 'border-l-neo-lime' },
 };
 
 function PackCard({
@@ -71,7 +71,7 @@ function PackCard({
           onClick={onSelect}
           className={cn(
             'w-full flex items-center justify-center gap-2 px-4 py-3',
-            'bg-neo-yellow text-black border-3 border-black',
+            'bg-neo-lime text-black border-3 border-black',
             'font-black font-neo-body text-sm rounded-neo shadow-hard-sm',
             'hover:-translate-y-0.5 hover:shadow-hard active:translate-y-0.5',
             'transition-all duration-100'

--- a/fe-next/components/teacher/TeacherDashboard.tsx
+++ b/fe-next/components/teacher/TeacherDashboard.tsx
@@ -74,15 +74,15 @@ const accordionBody = {
 function SectionDivider() {
   return (
     <div className="flex items-center gap-4 mb-10" aria-hidden="true">
-      <div className="flex-1 h-1 bg-neo-yellow/20 rounded-neo" />
-      <div className="flex items-center gap-2 px-4 py-1.5 bg-black border-3 border-neo-yellow/40 rounded-neo shadow-hard-sm">
-        <Hammer className="w-4 h-4 text-neo-yellow" />
-        <span className="font-neo-body font-black text-[10px] uppercase tracking-widest text-neo-yellow whitespace-nowrap">
+      <div className="flex-1 h-1 bg-neo-lime/20 rounded-neo" />
+      <div className="flex items-center gap-2 px-4 py-1.5 bg-black border-3 border-neo-lime/40 rounded-neo shadow-hard-sm">
+        <Hammer className="w-4 h-4 text-neo-lime" />
+        <span className="font-neo-body font-black text-[10px] uppercase tracking-widest text-neo-lime whitespace-nowrap">
           {/* No hardcoded text — purely decorative divider */}
           ▸ ▸ ▸
         </span>
       </div>
-      <div className="flex-1 h-1 bg-neo-yellow/20 rounded-neo" />
+      <div className="flex-1 h-1 bg-neo-lime/20 rounded-neo" />
     </div>
   );
 }
@@ -101,19 +101,19 @@ interface HudSectionProps {
 }
 
 const badgePalette = {
-  yellow: 'bg-neo-yellow text-black border-black',
+  yellow: 'bg-neo-lime text-black border-black',
   pink: 'bg-neo-pink text-white border-black',
   cyan: 'bg-neo-cyan text-black border-black',
 };
 
 const headerActiveBg = {
-  yellow: 'bg-neo-yellow text-black border-b-black',
+  yellow: 'bg-neo-lime text-black border-b-black',
   pink: 'bg-neo-pink text-black',
   cyan: 'bg-neo-cyan text-black',
 };
 
 const headerCollapsedHover = {
-  yellow: 'hover:bg-neo-yellow',
+  yellow: 'hover:bg-neo-lime',
   pink: 'hover:bg-neo-pink',
   cyan: 'hover:bg-neo-cyan',
 };
@@ -125,7 +125,7 @@ function HudSection({ label, badge, badgeColor, emoji, icon, isOpen, onToggle, c
         'rounded-neo-xl border-4 border-black bg-neo-navy overflow-hidden shadow-hard-lg',
         // Party mode: thick left accent when collapsed
         !isOpen && cn('border-s-[10px]', {
-          yellow: 'border-s-neo-yellow',
+          yellow: 'border-s-neo-lime',
           pink: 'border-s-neo-pink',
           cyan: 'border-s-neo-cyan',
         }[badgeColor])
@@ -136,10 +136,10 @@ function HudSection({ label, badge, badgeColor, emoji, icon, isOpen, onToggle, c
         aria-expanded={isOpen}
         className={cn(
           'w-full flex items-center justify-between p-6 border-b-4 border-black transition-colors',
-          'focus:outline-none focus-visible:ring-2 focus-visible:ring-neo-yellow focus-visible:ring-offset-2 focus-visible:ring-offset-neo-navy',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-neo-lime focus-visible:ring-offset-2 focus-visible:ring-offset-neo-navy',
           isOpen
             ? headerActiveBg[badgeColor]
-            : cn('bg-white text-black', headerCollapsedHover[badgeColor])
+            : cn('bg-neo-cream text-black', headerCollapsedHover[badgeColor])
         )}
       >
         <div className="flex items-center gap-4">
@@ -158,7 +158,7 @@ function HudSection({ label, badge, badgeColor, emoji, icon, isOpen, onToggle, c
               isOpen ? 'bg-black rotate-[-2deg]' : 'bg-black rotate-[2deg]'
             )}
           >
-            <span className={isOpen ? 'text-neo-yellow' : 'text-white'}>{icon}</span>
+            <span className={isOpen ? 'text-neo-lime' : 'text-white'}>{icon}</span>
           </div>
           <h2 className="text-3xl font-neo-display font-black uppercase tracking-tighter italic text-black">
             {label}
@@ -167,7 +167,7 @@ function HudSection({ label, badge, badgeColor, emoji, icon, isOpen, onToggle, c
           <span
             className={cn(
               'px-3 py-1 border-3 border-black text-[10px] font-black rounded-neo shadow-hard-sm uppercase tracking-widest',
-              isOpen ? 'bg-black text-neo-yellow' : badgePalette[badgeColor],
+              isOpen ? 'bg-black text-neo-lime' : badgePalette[badgeColor],
               isOpen ? '' : 'rotate-2'
             )}
           >
@@ -232,7 +232,7 @@ export default function TeacherDashboard() {
     <select
       value={selectedClassroomId}
       onChange={(e) => setSelectedClassroomId(e.target.value)}
-      className="px-4 py-2 bg-white border-2 border-black text-black font-neo-body font-bold shadow-hard-sm rounded-neo focus:outline-none focus:ring-2 focus:ring-neo-cyan"
+      className="px-4 py-2 bg-neo-cream border-2 border-black text-black font-neo-body font-bold shadow-hard-sm rounded-neo focus:outline-none focus:ring-2 focus:ring-neo-cyan"
     >
       {classrooms.map((c) => (
         <option key={c.id} value={c.id}>{c.name}</option>
@@ -293,7 +293,7 @@ export default function TeacherDashboard() {
             className={cn(
               'group relative overflow-hidden p-10 rounded-neo-xl border-4 border-black',
               'bg-neo-cyan shadow-hard-xl text-left',
-              'focus:outline-none focus:ring-2 focus:ring-neo-yellow'
+              'focus:outline-none focus:ring-2 focus:ring-neo-lime'
             )}
           >
             {/* Ghost background icon */}
@@ -324,7 +324,7 @@ export default function TeacherDashboard() {
             className={cn(
               'group relative overflow-hidden p-10 rounded-neo-xl border-4 border-black',
               'bg-neo-pink shadow-hard-xl text-left',
-              'focus:outline-none focus:ring-2 focus:ring-neo-yellow'
+              'focus:outline-none focus:ring-2 focus:ring-neo-lime'
             )}
           >
             {/* Ghost background icon */}
@@ -494,7 +494,7 @@ export default function TeacherDashboard() {
               href={`/${language}/teacher/reports`}
               className={cn(
                 'flex items-center gap-4 p-5 rounded-neo-xl border-4 border-black',
-                'bg-white shadow-hard-lg hover:shadow-hard-xl transition-shadow',
+                'bg-neo-cream shadow-hard-lg hover:shadow-hard-xl transition-shadow',
                 'text-black font-neo-body font-bold'
               )}
             >
@@ -513,7 +513,7 @@ export default function TeacherDashboard() {
         <motion.div
           variants={slideInUp}
           whileHover={{ y: -3, boxShadow: '8px 8px 0px black' }}
-          className="mt-12 p-6 rounded-neo-xl border-4 border-black bg-neo-yellow shadow-hard text-black relative overflow-hidden"
+          className="mt-12 p-6 rounded-neo-xl border-4 border-black bg-neo-lime shadow-hard text-black relative overflow-hidden"
         >
           {/* Decorative circle */}
           <div className="absolute top-0 right-0 w-32 h-32 bg-black/5 rotate-12 -me-16 -mt-16 rounded-full pointer-events-none" />
@@ -530,7 +530,7 @@ export default function TeacherDashboard() {
                 <h3 className="text-xl font-neo-display font-black uppercase tracking-tight italic">
                   {t('teacher.dashboard.quickTip')}
                 </h3>
-                <span className="text-[10px] font-black bg-black text-neo-yellow px-2 py-0.5 rounded uppercase tracking-widest">
+                <span className="text-[10px] font-black bg-black text-neo-lime px-2 py-0.5 rounded uppercase tracking-widest">
                   PRO
                 </span>
               </div>

--- a/fe-next/components/teacher/WordListEditor.tsx
+++ b/fe-next/components/teacher/WordListEditor.tsx
@@ -114,7 +114,7 @@ export default function WordListEditor({
                         <span className="text-xs">{t('teacher.lesson.canIntegrate')}</span>
                       </div>
                     ) : (
-                      <div className="flex items-center gap-1 text-neo-yellow">
+                      <div className="flex items-center gap-1 text-neo-lime">
                         <AlertCircle className="w-4 h-4" />
                         <span className="text-xs">{t('teacher.lesson.cannotIntegrate')}</span>
                       </div>

--- a/fe-next/components/teacher/analytics/AnalyticsDashboard.tsx
+++ b/fe-next/components/teacher/analytics/AnalyticsDashboard.tsx
@@ -84,7 +84,7 @@ export function AnalyticsDashboard({
     return (
       <div
         className={cn(
-          'bg-white border-3 border-black shadow-hard rounded-neo p-6',
+          'bg-neo-cream border-3 border-black shadow-hard rounded-neo p-6',
           'flex flex-col items-center gap-4 text-center'
         )}
       >
@@ -118,7 +118,7 @@ export function AnalyticsDashboard({
     return (
       <div
         className={cn(
-          'bg-white border-3 border-black shadow-hard rounded-neo p-6',
+          'bg-neo-cream border-3 border-black shadow-hard rounded-neo p-6',
           'flex flex-col items-center gap-4 text-center'
         )}
       >

--- a/fe-next/components/teacher/analytics/LiveActivityIndicator.tsx
+++ b/fe-next/components/teacher/analytics/LiveActivityIndicator.tsx
@@ -69,8 +69,8 @@ export function LiveActivityIndicator({
 
     case 'connecting':
       statusText = t('education.analytics.connecting');
-      statusColor = 'text-neo-yellow';
-      dotColor = 'bg-neo-yellow';
+      statusColor = 'text-neo-lime';
+      dotColor = 'bg-neo-lime';
       shouldPulse = false;
       break;
 

--- a/fe-next/components/teacher/analytics/MetricCard.tsx
+++ b/fe-next/components/teacher/analytics/MetricCard.tsx
@@ -69,7 +69,7 @@ export function MetricCard({
   // Card bg + icon bg based on severity
   const cardBg = {
     info: 'bg-neo-cyan',
-    warning: 'bg-neo-yellow',
+    warning: 'bg-neo-lime',
     urgent: 'bg-neo-pink',
   }[severity || 'info'] || 'bg-neo-cyan';
 
@@ -81,7 +81,7 @@ export function MetricCard({
 
   const iconFg = {
     info: 'text-neo-cyan',
-    warning: 'text-neo-yellow',
+    warning: 'text-neo-lime',
     urgent: 'text-neo-pink',
   }[severity || 'info'] || 'text-neo-cyan';
 
@@ -123,7 +123,7 @@ export function MetricCard({
       </div>
 
       {/* White body */}
-      <div className="bg-white px-4 py-3 flex flex-col gap-2 flex-1 border-t-3 border-black">
+      <div className="bg-neo-cream px-4 py-3 flex flex-col gap-2 flex-1 border-t-3 border-black">
         {/* Title */}
         <div className="text-sm font-neo-body font-bold text-black">{title}</div>
 
@@ -147,11 +147,11 @@ export function MetricCard({
           <button
             onClick={actionable.onClick}
             className={cn(
-              'mt-1 px-3 py-2 bg-black text-neo-yellow',
+              'mt-1 px-3 py-2 bg-black text-neo-lime',
               'font-black font-neo-body text-sm rounded-neo border-3 border-black shadow-hard-sm',
               'hover:-translate-y-0.5 hover:shadow-hard active:translate-y-0.5 active:shadow-hard-pressed',
               'transition-all duration-100',
-              'focus:outline-none focus-visible:ring-2 focus-visible:ring-neo-yellow'
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-neo-lime'
             )}
           >
             {actionable.label}

--- a/fe-next/components/teacher/analytics/StudentProgressTable.tsx
+++ b/fe-next/components/teacher/analytics/StudentProgressTable.tsx
@@ -219,7 +219,7 @@ export function StudentProgressTable({ classroomId, onStudentClick }: StudentPro
                   <div className="flex items-center gap-2">
                     <div className="flex-1 h-2 bg-neo-black/20 rounded-full overflow-hidden">
                       <div
-                        className="h-full bg-neo-yellow transition-all"
+                        className="h-full bg-neo-lime transition-all"
                         style={{ width: `${student.vocabularyMastery}%` }}
                       />
                     </div>

--- a/fe-next/components/teacher/analytics/VocabularyHeatmap.tsx
+++ b/fe-next/components/teacher/analytics/VocabularyHeatmap.tsx
@@ -71,7 +71,7 @@ export function VocabularyHeatmap({
       case 'mastered':
         return 'bg-neo-cyan';
       case 'practicing':
-        return 'bg-neo-yellow';
+        return 'bg-neo-lime';
       case 'struggling':
         return 'bg-neo-orange';
       case 'not-started':
@@ -98,7 +98,7 @@ export function VocabularyHeatmap({
         <div className="flex gap-3">
           {[
             { key: 'mastered', color: 'bg-neo-cyan' },
-            { key: 'practicing', color: 'bg-neo-yellow' },
+            { key: 'practicing', color: 'bg-neo-lime' },
             { key: 'struggling', color: 'bg-neo-orange' },
             { key: 'notStarted', color: 'bg-neo-navy/50' },
           ].map(level => (

--- a/fe-next/components/teacher/analytics/__tests__/MetricCard.test.tsx
+++ b/fe-next/components/teacher/analytics/__tests__/MetricCard.test.tsx
@@ -164,7 +164,7 @@ describe('MetricCard - Severity Styling', () => {
 
     const card = screen.getByTestId('metric-card');
     const header = card.firstElementChild;
-    expect(header).toHaveClass('bg-neo-yellow');
+    expect(header).toHaveClass('bg-neo-lime');
   });
 
   it('applies urgent severity styling', () => {

--- a/fe-next/components/teacher/analytics/__tests__/VocabularyHeatmap.test.tsx
+++ b/fe-next/components/teacher/analytics/__tests__/VocabularyHeatmap.test.tsx
@@ -213,7 +213,7 @@ describe('VocabularyHeatmap', () => {
     const notStartedCell = container.querySelector('[data-mastery="not-started"]');
 
     expect(masteredCell).toHaveClass('bg-neo-cyan');
-    expect(practicingCell).toHaveClass('bg-neo-yellow');
+    expect(practicingCell).toHaveClass('bg-neo-lime');
     expect(strugglingCell).toHaveClass('bg-neo-orange');
     expect(notStartedCell).toHaveClass('bg-neo-navy/50');
   });

--- a/fe-next/components/teacher/assignments/CompletionTracker.tsx
+++ b/fe-next/components/teacher/assignments/CompletionTracker.tsx
@@ -226,7 +226,7 @@ export default function CompletionTracker({
                             'h-full transition-all',
                             item.errorRate > 66 ? 'bg-red-500' :
                             item.errorRate > 33 ? 'bg-neo-orange' :
-                            'bg-neo-yellow'
+                            'bg-neo-lime'
                           )}
                           style={{ width: `${item.errorRate}%` }}
                         />

--- a/fe-next/components/teacher/curriculum/CurriculumWordListBrowser.tsx
+++ b/fe-next/components/teacher/curriculum/CurriculumWordListBrowser.tsx
@@ -157,7 +157,7 @@ export function CurriculumWordListBrowser({
       {/* Filters */}
       <div className="bg-neo-navy/50 border-neo border-black rounded-neo p-4">
         <div className="flex items-center gap-2 mb-4">
-          <Filter className="w-5 h-5 text-neo-yellow" />
+          <Filter className="w-5 h-5 text-neo-lime" />
           <h2 className="text-lg font-semibold text-neo-white">
             {t('teacher.curriculum.filters.title')}
           </h2>
@@ -177,7 +177,7 @@ export function CurriculumWordListBrowser({
               aria-label={t('teacher.curriculum.filters.grade')}
               value={filters.gradeLevel || ''}
               onChange={handleGradeChange}
-              className="w-full bg-neo-navy border-neo border-black rounded-neo p-2 text-neo-white focus:ring-2 focus:ring-neo-yellow focus:outline-none"
+              className="w-full bg-neo-navy border-neo border-black rounded-neo p-2 text-neo-white focus:ring-2 focus:ring-neo-lime focus:outline-none"
             >
               <option value="">{t('teacher.curriculum.allGrades')}</option>
               {GRADE_LEVELS.map((grade) => (
@@ -201,7 +201,7 @@ export function CurriculumWordListBrowser({
               aria-label={t('teacher.curriculum.filters.subject')}
               value={filters.subject || ''}
               onChange={handleSubjectChange}
-              className="w-full bg-neo-navy border-neo border-black rounded-neo p-2 text-neo-white focus:ring-2 focus:ring-neo-yellow focus:outline-none"
+              className="w-full bg-neo-navy border-neo border-black rounded-neo p-2 text-neo-white focus:ring-2 focus:ring-neo-lime focus:outline-none"
             >
               <option value="">{t('teacher.curriculum.allSubjects')}</option>
               {SUBJECTS.map((subject) => (
@@ -267,7 +267,7 @@ export function CurriculumWordListBrowser({
                       <p className="text-sm text-neo-gray mt-1">{list.description}</p>
                     )}
                     <div className="flex flex-wrap gap-2 mt-2">
-                      <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-neo-yellow/20 text-neo-yellow rounded">
+                      <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-neo-lime/20 text-neo-lime rounded">
                         {getGradeGroup(list.grade_level)} - {t(`teacher.curriculum.grades.${list.grade_level}`)}
                       </span>
                       <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-neo-cyan/20 text-neo-cyan rounded">
@@ -306,7 +306,7 @@ export function CurriculumWordListBrowser({
                     <button
                       onClick={() => handleImport(list)}
                       disabled={!teacherId || importingListId === list.id}
-                      className="flex items-center gap-2 px-3 py-2 bg-neo-yellow text-black border-neo border-black rounded-neo shadow-hard hover:shadow-hard-pressed hover:translate-x-[2px] hover:translate-y-[2px] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="flex items-center gap-2 px-3 py-2 bg-neo-lime text-black border-neo border-black rounded-neo shadow-hard hover:shadow-hard-pressed hover:translate-x-[2px] hover:translate-y-[2px] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                       aria-label={t('teacher.curriculum.import')}
                     >
                       <Download className="w-4 h-4" />

--- a/fe-next/components/teacher/lesson-creation/BulkImportEnhanced.tsx
+++ b/fe-next/components/teacher/lesson-creation/BulkImportEnhanced.tsx
@@ -241,7 +241,7 @@ export default function BulkImportEnhanced({
                       </div>
                     )}
                     {stats.errors > 0 && (
-                      <div className="flex items-center gap-1 text-neo-yellow">
+                      <div className="flex items-center gap-1 text-neo-lime">
                         <AlertCircle className="w-4 h-4" />
                         <span className="tabular-nums">{stats.errors} errors</span>
                       </div>
@@ -251,8 +251,8 @@ export default function BulkImportEnhanced({
 
                 {/* Niqqud warning */}
                 {stats.niqqudWarnings > 0 && (
-                  <div className="p-3 bg-neo-yellow/20 border-neo border-neo-yellow/50 rounded-neo">
-                    <div className="flex items-center gap-2 text-sm font-neo-body text-neo-yellow">
+                  <div className="p-3 bg-neo-lime/20 border-neo border-neo-lime/50 rounded-neo">
+                    <div className="flex items-center gap-2 text-sm font-neo-body text-neo-lime">
                       <AlertCircle className="w-4 h-4" />
                       <span>
                         {stats.niqqudWarnings} words contain niqqud (vowel points will be removed)
@@ -271,7 +271,7 @@ export default function BulkImportEnhanced({
                           'flex items-center gap-1 px-2 py-1 rounded text-sm font-neo-body',
                           result.canIntegrate
                             ? 'bg-neo-cyan/20 text-neo-cyan border border-neo-cyan/30'
-                            : 'bg-neo-yellow/20 text-neo-yellow border border-neo-yellow/30'
+                            : 'bg-neo-lime/20 text-neo-lime border border-neo-lime/30'
                         )}
                       >
                         {result.canIntegrate ? (

--- a/fe-next/components/teacher/reports/ClassProgressReport.tsx
+++ b/fe-next/components/teacher/reports/ClassProgressReport.tsx
@@ -174,7 +174,7 @@ export function ClassProgressReport({
         <button
           onClick={handleExportPDF}
           disabled={exporting}
-          className="px-4 py-2 bg-neo-yellow text-black font-bold rounded-neo border-neo border-black shadow-hard hover:shadow-hard-pressed transition-shadow disabled:opacity-50"
+          className="px-4 py-2 bg-neo-lime text-black font-bold rounded-neo border-neo border-black shadow-hard hover:shadow-hard-pressed transition-shadow disabled:opacity-50"
         >
           {exporting
             ? t('teacher.reports.export.downloading')
@@ -240,15 +240,15 @@ export function ClassProgressReport({
             {data.topPerformers.map((performer, index) => (
               <div
                 key={performer.studentId}
-                className="flex items-center gap-4 p-3 bg-neo-yellow/10 border-neo border-black rounded-neo"
+                className="flex items-center gap-4 p-3 bg-neo-lime/10 border-neo border-black rounded-neo"
               >
-                <span className="text-xl font-bold text-neo-yellow w-8">
+                <span className="text-xl font-bold text-neo-lime w-8">
                   #{index + 1}
                 </span>
                 {handleStudentClick ? (
                   <button
                     onClick={() => handleStudentClick(performer.studentId)}
-                    className="flex-1 text-left text-neo-white font-medium hover:text-neo-yellow transition-colors"
+                    className="flex-1 text-left text-neo-white font-medium hover:text-neo-lime transition-colors"
                     aria-label={`View ${performer.studentName}'s profile`}
                   >
                     {performer.studentName}
@@ -282,7 +282,7 @@ export function ClassProgressReport({
                 {handleStudentClick ? (
                   <button
                     onClick={() => handleStudentClick(student.studentId)}
-                    className="flex-1 text-left text-neo-white font-medium hover:text-neo-yellow transition-colors"
+                    className="flex-1 text-left text-neo-white font-medium hover:text-neo-lime transition-colors"
                     aria-label={`View ${student.studentName}'s profile`}
                   >
                     {student.studentName}
@@ -333,7 +333,7 @@ export function ClassProgressReport({
                     {handleStudentClick ? (
                       <button
                         onClick={() => handleStudentClick(student.studentId)}
-                        className="text-neo-white font-medium hover:text-neo-yellow transition-colors"
+                        className="text-neo-white font-medium hover:text-neo-lime transition-colors"
                         aria-label={`View ${student.studentName}'s profile`}
                       >
                         {student.studentName}

--- a/fe-next/components/teacher/reports/StudentProgressReport.tsx
+++ b/fe-next/components/teacher/reports/StudentProgressReport.tsx
@@ -204,7 +204,7 @@ export function StudentProgressReport({
         <button
           onClick={handleExportPDF}
           disabled={exporting}
-          className="px-4 py-2 bg-neo-yellow text-black font-bold rounded-neo border-neo border-black shadow-hard hover:shadow-hard-pressed transition-shadow disabled:opacity-50"
+          className="px-4 py-2 bg-neo-lime text-black font-bold rounded-neo border-neo border-black shadow-hard hover:shadow-hard-pressed transition-shadow disabled:opacity-50"
         >
           {exporting
             ? t('teacher.reports.export.downloading')
@@ -314,7 +314,7 @@ export function StudentProgressReport({
                 key={index}
                 className="flex items-start gap-2 p-3 bg-neo-navy/50 border-neo border-black rounded-neo"
               >
-                <span className="text-neo-yellow font-bold">-</span>
+                <span className="text-neo-lime font-bold">-</span>
                 <span className="text-neo-white">{recommendation}</span>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- Replace all `neo-yellow` color usage with `neo-lime` across 62 education/student/teacher files
- Fix `bg-white` sections that break the dark theme (student progress card, classroom game banner, teacher dashboard, activity feed, classroom manager, etc.)
- Update gold hex color in AchievementUnlockModal from `#FFE135` to `#BFFF00` to match neo-lime
- Student progress stats cards now use `bg-neo-navy` with colored accent borders instead of colored backgrounds

## Test plan
- [x] All 13,325 tests pass (1,175 test files)
- [x] Education tests: 351 passed
- [x] Teacher tests: 227 passed
- [x] Student tests: 35 passed
- [ ] Visual check: student dashboard, teacher dashboard, education pages in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)