### PR TITLE
feat(education): add PulseGlow and WordOfTheDay animations

### DIFF
--- a/fe-next/components/education/animations/PulseGlow.tsx
+++ b/fe-next/components/education/animations/PulseGlow.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+/**
+ * PulseGlow — pulsing glow ring around children
+ *
+ * Draws attention to active game buttons with a box-shadow pulse.
+ * Uses framer-motion for animation. Respects reduced motion.
+ */
+
+import { motion, useReducedMotion } from 'framer-motion';
+import type { ReactNode } from 'react';
+
+interface PulseGlowProps {
+  active: boolean;
+  /** Glow colour — default neo-pink */
+  color?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+const PULSE_TRANSITION = {
+  duration: 1.2,
+  repeat: Infinity,
+  repeatType: 'reverse' as const,
+  ease: 'easeInOut' as const,
+};
+
+export function PulseGlow({
+  active,
+  color = '#FF1493',
+  children,
+  className = '',
+}: PulseGlowProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  if (!active) {
+    return <>{children}</>;
+  }
+
+  return (
+    <motion.div
+      className={`relative inline-block ${className}`}
+      animate={{
+        boxShadow: shouldReduceMotion
+          ? `0 0 0 2px ${color}`
+          : [
+              `0 0 4px 1px ${color}`,
+              `0 0 12px 4px ${color}`,
+            ],
+      }}
+      transition={shouldReduceMotion ? { duration: 0 } : PULSE_TRANSITION}
+      style={{ borderRadius: 'inherit' }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/fe-next/components/education/animations/WordOfTheDay.tsx
+++ b/fe-next/components/education/animations/WordOfTheDay.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+/**
+ * WordOfTheDay — decorative vocab card with staggered character entrance
+ *
+ * Neo-brutalist card showing a vocabulary word with definition.
+ * Characters animate in one-by-one via framer-motion stagger.
+ */
+
+import { motion, useReducedMotion } from 'framer-motion';
+import { Star } from 'lucide-react';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+interface WordOfTheDayProps {
+  word: string;
+  definition?: string;
+  className?: string;
+}
+
+const CHAR_VARIANTS = {
+  hidden: { opacity: 0, y: 12 },
+  visible: { opacity: 1, y: 0 },
+};
+
+const CONTAINER_VARIANTS = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: 0.05 },
+  },
+};
+
+export function WordOfTheDay({ word, definition, className = '' }: WordOfTheDayProps) {
+  const { t } = useLanguage();
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <div
+      data-testid="wotd-card"
+      className={`border-neo shadow-hard-sm rounded-neo bg-neo-navy p-4 ${className}`}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <Star className="w-4 h-4 text-neo-lime" />
+        <span className="text-xs font-neo-body text-neo-lime uppercase tracking-wide">
+          {t('education.wordOfTheDay.title')}
+        </span>
+      </div>
+
+      <motion.div
+        data-testid="wotd-word"
+        className="text-xl font-neo-display text-neo-cream mb-1"
+        variants={shouldReduceMotion ? undefined : CONTAINER_VARIANTS}
+        initial={shouldReduceMotion ? undefined : 'hidden'}
+        animate={shouldReduceMotion ? undefined : 'visible'}
+      >
+        {word.split('').map((char, i) => (
+          <motion.span
+            key={`${char}-${i}`}
+            variants={shouldReduceMotion ? undefined : CHAR_VARIANTS}
+            transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+          >
+            {char}
+          </motion.span>
+        ))}
+      </motion.div>
+
+      {definition && (
+        <p data-testid="wotd-definition" className="text-sm text-neo-cream/70 font-neo-body">
+          {definition}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/fe-next/components/education/animations/__tests__/PulseGlow.test.tsx
+++ b/fe-next/components/education/animations/__tests__/PulseGlow.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * PulseGlow tests
+ * Tests: renders children, animates when active, no animation when inactive
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PulseGlow } from '../PulseGlow';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, className, style, ...rest }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode; animate?: unknown }) => (
+      <div className={className} style={style as React.CSSProperties} data-testid="pulse-glow-wrapper" data-animate={JSON.stringify((rest as Record<string, unknown>).animate)} {...rest}>{children}</div>
+    ),
+  },
+  useReducedMotion: vi.fn().mockReturnValue(false),
+}));
+
+describe('PulseGlow', () => {
+  it('renders children', () => {
+    render(
+      <PulseGlow active={false}>
+        <span data-testid="child">Hello</span>
+      </PulseGlow>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('applies glow animation wrapper when active', () => {
+    render(
+      <PulseGlow active={true}>
+        <span>Content</span>
+      </PulseGlow>
+    );
+    const wrapper = screen.getByTestId('pulse-glow-wrapper');
+    expect(wrapper).toBeInTheDocument();
+    // When active, animate prop should have boxShadow
+    const animate = JSON.parse(wrapper.getAttribute('data-animate') || '{}');
+    expect(animate).toHaveProperty('boxShadow');
+  });
+
+  it('does not animate when inactive', () => {
+    render(
+      <PulseGlow active={false}>
+        <span>Content</span>
+      </PulseGlow>
+    );
+    expect(screen.getByText('Content')).toBeInTheDocument();
+    // Should not have pulse-glow-wrapper when inactive
+    expect(screen.queryByTestId('pulse-glow-wrapper')).not.toBeInTheDocument();
+  });
+
+  it('forwards className', () => {
+    render(
+      <PulseGlow active={true} className="extra-class">
+        <span>Content</span>
+      </PulseGlow>
+    );
+    expect(screen.getByTestId('pulse-glow-wrapper')).toHaveClass('extra-class');
+  });
+});

--- a/fe-next/components/education/animations/__tests__/WordOfTheDay.test.tsx
+++ b/fe-next/components/education/animations/__tests__/WordOfTheDay.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * WordOfTheDay tests
+ * Tests: renders word, renders definition, correct test IDs, uses translations
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { WordOfTheDay } from '../WordOfTheDay';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, className, ...rest }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => (
+      <div className={className} data-testid="motion-div" {...rest}>{children}</div>
+    ),
+    span: ({ children, className, ...rest }: React.HTMLAttributes<HTMLSpanElement> & { children?: React.ReactNode }) => (
+      <span className={className} data-testid="motion-span" {...rest}>{children}</span>
+    ),
+  },
+  useReducedMotion: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'education.wordOfTheDay.title': 'Word of the Day',
+        'education.wordOfTheDay.learnMore': 'Learn More',
+      };
+      return map[key] || key;
+    },
+  }),
+}));
+
+vi.mock('lucide-react', () => ({
+  Star: (props: React.SVGAttributes<SVGElement>) => <svg data-testid="star-icon" {...props} />,
+}));
+
+describe('WordOfTheDay', () => {
+  it('renders the word text', () => {
+    render(<WordOfTheDay word="ephemeral" />);
+    const wordEl = screen.getByTestId('wotd-word');
+    expect(wordEl.textContent).toBe('ephemeral');
+  });
+
+  it('renders definition when provided', () => {
+    render(<WordOfTheDay word="ephemeral" definition="lasting a very short time" />);
+    expect(screen.getByText('lasting a very short time')).toBeInTheDocument();
+  });
+
+  it('does not render definition when not provided', () => {
+    render(<WordOfTheDay word="ephemeral" />);
+    expect(screen.queryByTestId('wotd-definition')).not.toBeInTheDocument();
+  });
+
+  it('has correct test IDs', () => {
+    render(<WordOfTheDay word="test" definition="a test" />);
+    expect(screen.getByTestId('wotd-card')).toBeInTheDocument();
+    expect(screen.getByTestId('wotd-word')).toBeInTheDocument();
+    expect(screen.getByTestId('wotd-definition')).toBeInTheDocument();
+  });
+
+  it('renders translated title', () => {
+    render(<WordOfTheDay word="test" />);
+    expect(screen.getByText('Word of the Day')).toBeInTheDocument();
+  });
+
+  it('renders star icon', () => {
+    render(<WordOfTheDay word="test" />);
+    expect(screen.getByTestId('star-icon')).toBeInTheDocument();
+  });
+
+  it('forwards className', () => {
+    render(<WordOfTheDay word="test" className="my-class" />);
+    expect(screen.getByTestId('wotd-card')).toHaveClass('my-class');
+  });
+});

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -8170,6 +8170,10 @@ const en = {
     }
   },
   "education": {
+    "wordOfTheDay": {
+      "title": "Word of the Day",
+      "learnMore": "Learn More"
+    },
     "landing": {
       "title": "Education Mode",
       "teacher": "I'm a Teacher",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -8027,6 +8027,10 @@ const es = {
     }
   },
   "education": {
+    "wordOfTheDay": {
+      "title": "Palabra del Dia",
+      "learnMore": "Saber Mas"
+    },
     "landing": {
       "title": "Modo Educativo",
       "teacher": "Soy Profesor",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -7996,6 +7996,10 @@ const he = {
     }
   },
   "education": {
+    "wordOfTheDay": {
+      "title": "המילה היומית",
+      "learnMore": "למד עוד"
+    },
     "landing": {
       "title": "מצב חינוכי",
       "teacher": "אני מורה",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -8013,6 +8013,10 @@ const ja = {
     }
   },
   "education": {
+    "wordOfTheDay": {
+      "title": "今日の単語",
+      "learnMore": "もっと見る"
+    },
     "landing": {
       "title": "教育モード",
       "teacher": "私は教師です",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -7961,6 +7961,10 @@ const sv = {
     }
   },
   "education": {
+    "wordOfTheDay": {
+      "title": "Dagens Ord",
+      "learnMore": "Läs Mer"
+    },
     "landing": {
       "title": "Utbildningsläge",
       "teacher": "Jag är lärare",


### PR DESCRIPTION
## Summary
- Add **PulseGlow** component: pulsing glow ring wrapper using box-shadow animation for drawing attention to active game buttons. Respects reduced motion.
- Add **WordOfTheDay** component: neo-brutalist vocab card with staggered character entrance animation using framer-motion springs.
- 11 tests covering both components (rendering, active/inactive states, test IDs, i18n)
- Translation keys added for all 5 languages (en, he, sv, ja, es)

## Test plan
- [x] 11 unit tests pass (`PulseGlow.test.tsx`, `WordOfTheDay.test.tsx`)
- [x] Full test suite passes (13336 tests)
- [x] Lint and type check pass
- [ ] Visual verification: test PulseGlow with `active={true/false}` and WordOfTheDay with various words

🤖 Generated with [Claude Code](https://claude.com/claude-code)