### PR TITLE
style(blast): improve mobile responsive UI

### DIFF
--- a/fe-next/components/blast/BlastHUD.tsx
+++ b/fe-next/components/blast/BlastHUD.tsx
@@ -85,7 +85,7 @@ export function BlastHUD({
 
   return (
     <div
-      className="flex items-center justify-between gap-2 px-3 py-2"
+      className="flex items-center justify-between gap-2 px-3 py-2 pt-safe"
       style={{
         background: 'linear-gradient(180deg, rgba(15,12,41,0.85) 0%, rgba(15,12,41,0.6) 100%)',
         backdropFilter: 'blur(8px)',

--- a/fe-next/components/blast/BlastStage.tsx
+++ b/fe-next/components/blast/BlastStage.tsx
@@ -133,7 +133,7 @@ export function BlastStage({
   const comboFlashTier = comboFlash?.tier ?? 0;
 
   return (
-    <div className="flex-1 flex flex-col h-full overflow-hidden relative" data-testid="blast-stage">
+    <div className="flex-1 flex flex-col h-full overflow-hidden relative pb-safe" data-testid="blast-stage">
       {/* Reactive background */}
       <BlastBackground intensity={sequencerState?.chainLevel ?? 0} />
       {/* Effects overlay */}

--- a/fe-next/components/blast/BlastTile.tsx
+++ b/fe-next/components/blast/BlastTile.tsx
@@ -288,19 +288,20 @@ export const BlastTile = memo(function BlastTile({
         ...(visual.style ?? {}),
         ...phaseStyle,
         ...(needsWillChange && { willChange: 'transform, opacity' }),
+        containerType: 'inline-size',
       }}
       aria-label={`${letter}${type !== 'standard' ? ` ${type} tile` : ''}`}
       title={tooltip ? `${tooltip.name}: ${tooltip.desc}` : undefined}
     >
       <span className="relative z-10" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}>{letter}</span>
       {visual.indicator && (
-        <span className="absolute top-0.5 end-0.5 text-[0.55rem] leading-none pointer-events-none" aria-hidden="true">
+        <span className="absolute top-0.5 end-0.5 text-[clamp(0.45rem,1.8cqw,0.65rem)] leading-none pointer-events-none" aria-hidden="true">
           {visual.indicator}
         </span>
       )}
       {hitsRemaining != null && hitsRemaining > 0 && (
         <span
-          className="absolute bottom-0.5 start-0.5 text-[0.5rem] font-neo-body font-semibold bg-white/60 rounded px-0.5 leading-tight"
+          className="absolute bottom-0.5 start-0.5 text-[clamp(0.4rem,1.5cqw,0.55rem)] font-neo-body font-semibold bg-white/60 rounded px-0.5 leading-tight"
           aria-label={`${hitsRemaining} hits remaining`}
         >
           {hitsRemaining}
@@ -308,7 +309,7 @@ export const BlastTile = memo(function BlastTile({
       )}
       {MULTIPLIER_BADGES[type] && (
         <span
-          className="absolute bottom-0.5 end-0.5 text-[0.45rem] font-neo-body font-bold bg-black/40 text-white rounded px-0.5 leading-tight"
+          className="absolute bottom-0.5 end-0.5 text-[clamp(0.35rem,1.3cqw,0.5rem)] font-neo-body font-bold bg-black/40 text-white rounded px-0.5 leading-tight"
           aria-hidden="true"
         >
           {MULTIPLIER_BADGES[type]}

--- a/fe-next/components/blast/__tests__/BlastMobileResponsive.test.tsx
+++ b/fe-next/components/blast/__tests__/BlastMobileResponsive.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * BlastMobileResponsive — TDD tests for mobile responsive UI improvements.
+ * Covers: safe area insets, container queries on indicators, gap scaling.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BlastTile } from '../BlastTile';
+import { BlastHUD } from '../BlastHUD';
+
+// Mock reduced motion
+jest.mock('@/hooks/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => false,
+}));
+
+const baseTileProps = {
+  letter: 'A',
+  type: 'standard' as const,
+  phase: 'idle' as const,
+  isSelected: false,
+  isCleared: false,
+  onClick: jest.fn(),
+};
+
+describe('Blast Mobile Responsive', () => {
+  describe('BlastTile indicator scaling with container queries', () => {
+    it('renders indicator emoji with cqw-based clamp sizing', () => {
+      render(<BlastTile {...baseTileProps} type="bomb" />);
+      const button = screen.getByRole('button');
+      const indicator = button.querySelector('[aria-hidden="true"]');
+      expect(indicator).toBeTruthy();
+      expect(indicator?.className).toContain('text-[clamp(0.45rem,1.8cqw,0.65rem)]');
+    });
+
+    it('renders hits remaining with cqw-based clamp sizing', () => {
+      render(<BlastTile {...baseTileProps} type="ice" hitsRemaining={2} />);
+      const hitsEl = screen.getByLabelText('2 hits remaining');
+      expect(hitsEl.className).toContain('text-[clamp(0.4rem,1.5cqw,0.55rem)]');
+    });
+
+    it('renders multiplier badge with cqw-based clamp sizing', () => {
+      render(<BlastTile {...baseTileProps} type="gold" />);
+      const button = screen.getByRole('button');
+      const badges = button.querySelectorAll('[aria-hidden="true"]');
+      const multiplierBadge = Array.from(badges).find(el => el.textContent === '\u00d73');
+      expect(multiplierBadge).toBeTruthy();
+      expect(multiplierBadge?.className).toContain('text-[clamp(0.35rem,1.3cqw,0.5rem)]');
+    });
+
+    it('tile button has container-type inline-size for cqw units', () => {
+      render(<BlastTile {...baseTileProps} type="bomb" />);
+      const button = screen.getByRole('button');
+      expect(button.style.containerType).toBe('inline-size');
+    });
+  });
+
+  describe('BlastHUD safe area', () => {
+    const hudProps = {
+      score: 100,
+      wordsFoundCount: 5,
+      movesRemaining: 10,
+      totalMoves: 20,
+      waveNumber: 1,
+      comboLevel: 0,
+      tilesCleared: 5,
+      totalTiles: 36,
+      onQuit: jest.fn(),
+      t: (key: string) => key,
+    };
+
+    it('renders HUD with pt-safe class for notch phones', () => {
+      render(<BlastHUD {...hudProps} />);
+      const hud = screen.getByTestId('blast-hud');
+      expect(hud.className).toContain('pt-safe');
+    });
+  });
+});

--- a/fe-next/components/grid/gridLayoutConstants.ts
+++ b/fe-next/components/grid/gridLayoutConstants.ts
@@ -9,7 +9,8 @@ export const GRID_PADDING = '0.4rem';
 /**
  * Responsive gap strategy — viewport breakpoints map to tile-gap sizes:
  *
- *   default (≤639px / mobile portrait):  gap-1    →  4px
+ *   default (≤359px / small mobile):     gap-0.5  →  2px
+ *   360px+  (standard mobile portrait): gap-1    →  4px
  *   sm      (640-767px / large phone):   gap-1.5  →  6px
  *   md      (768-1023px / tablet):       gap-2    →  8px
  *   lg      (1024px+ / desktop):         gap-2    →  8px
@@ -21,4 +22,4 @@ export const GRID_PADDING = '0.4rem';
  * because the grid is the primary content and tracks viewport width in
  * portrait orientation and viewport height in landscape.
  */
-export const GRID_GAP_CLASS = 'gap-1 sm:gap-1.5 md:gap-2 lg:gap-2';
+export const GRID_GAP_CLASS = 'gap-0.5 min-[360px]:gap-1 sm:gap-1.5 md:gap-2 lg:gap-2';


### PR DESCRIPTION
## Summary
- Add container query scaling (`cqw` units) for BlastTile indicators (emoji, hits, multiplier badges) so they scale with tile size
- Add safe area inset padding (`pt-safe`, `pb-safe`) for notch phones and home bar devices
- Tighten grid gap on very small screens (<360px): `gap-0.5` instead of `gap-1`

## Test plan
- [x] 5 new tests in `BlastMobileResponsive.test.tsx` covering indicator scaling, container-type, and safe area classes
- [x] All 645 blast tests passing
- [x] Pre-push lint, type check, and test suite passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)