### PR TITLE
feat(blast): enhanced tile feel with progressive selection and spring bounce

### DIFF
--- a/fe-next/app/globals.css
+++ b/fe-next/app/globals.css
@@ -973,11 +973,11 @@ body {
   }
 
   .blast-tile-bomb {
-    animation: blast-pulse 1.8s ease-in-out infinite;
+    animation: blast-pulse 2s ease-in-out infinite;
   }
 
   .blast-tile-rainbow {
-    animation: blast-rainbow 4s linear infinite;
+    animation: blast-rainbow 5s linear infinite;
     background-size: 300% 300% !important;
   }
 
@@ -1004,16 +1004,16 @@ body {
     }
     50% {
       box-shadow: inset 0 0 26px rgba(255,30,0,0.5), 0 0 20px rgba(255,50,20,0.4), 0 0 32px rgba(255,0,0,0.25);
-      transform: scale(1.04);
+      transform: scale(1.02);
     }
   }
 
   @keyframes blast-rainbow {
-    0% { background-position: 0% 50%; filter: brightness(1); }
-    25% { filter: brightness(1.1); }
-    50% { background-position: 100% 50%; filter: brightness(1); }
-    75% { filter: brightness(1.1); }
-    100% { background-position: 0% 50%; filter: brightness(1); }
+    0% { background-position: 0% 50%; filter: hue-rotate(0deg) brightness(1); }
+    25% { filter: hue-rotate(90deg) brightness(1.1); }
+    50% { background-position: 100% 50%; filter: hue-rotate(180deg) brightness(1); }
+    75% { filter: hue-rotate(270deg) brightness(1.1); }
+    100% { background-position: 0% 50%; filter: hue-rotate(360deg) brightness(1); }
   }
 
   .blast-tile-ice {
@@ -1155,6 +1155,17 @@ body {
     50% { box-shadow: inset 0 0 30px rgba(180,220,255,0.5), 0 0 20px rgba(200,230,255,0.4), 0 0 36px rgba(150,200,255,0.2); }
   }
 
+  /* Selection pop — brief 100ms bounce when tile is first selected */
+  .blast-tile-select-pop {
+    animation: blast-select-pop 100ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  @keyframes blast-select-pop {
+    0% { transform: scale(0.92); }
+    60% { transform: scale(1.1); }
+    100% { transform: scale(1); }
+  }
+
   /* Selection glow when dragging across special tiles — single pop, not infinite pulse */
   .blast-tile-selected {
     box-shadow: 0 0 10px rgba(255,255,255,0.5), 0 0 20px rgba(0,255,255,0.25);
@@ -1210,7 +1221,8 @@ body {
     .blast-tile-frozen,
     .blast-tile-mirror,
     .blast-tile-silver,
-    .blast-tile-diamond {
+    .blast-tile-diamond,
+    .blast-tile-select-pop {
       animation: none;
     }
     .blast-tile-weakened {
@@ -1347,7 +1359,8 @@ body {
   .blast-game[data-cascade="active"] .blast-tile-mirror,
   .blast-game[data-cascade="active"] .blast-tile-silver,
   .blast-game[data-cascade="active"] .blast-tile-diamond,
-  .blast-game[data-cascade="active"] .blast-tile-weakened {
+  .blast-game[data-cascade="active"] .blast-tile-weakened,
+  .blast-game[data-cascade="active"] .blast-tile-select-pop {
     animation-play-state: paused;
   }
 

--- a/fe-next/components/blast/BlastTile.tsx
+++ b/fe-next/components/blast/BlastTile.tsx
@@ -223,13 +223,23 @@ function getPhaseStyles(phase: TilePhase, type: BlastTileType, fallOffset?: numb
       };
     case 'landing':
       return {
-        transform: 'scaleY(1.1) scaleX(0.92)',
-        transition: 'transform 80ms ease-out',
+        transform: 'scaleY(1.15) scaleX(0.88)',
+        transition: 'transform 120ms cubic-bezier(0.34, 1.56, 0.64, 1)',
         animationFillMode: 'forwards',
       };
     default:
       return {};
   }
+}
+
+/**
+ * Compute progressive selection scale: first tile 1.05x, last tile 1.12x.
+ */
+function getSelectionScale(selectionIndex?: number, selectionTotal?: number): number {
+  if (selectionIndex == null || !selectionTotal || selectionTotal <= 1) return 1.05;
+  const t = selectionIndex / (selectionTotal - 1);
+  // Round to 3 decimals to avoid floating point noise
+  return Math.round((1.05 + t * 0.07) * 1000) / 1000;
 }
 
 function getPhaseClasses(phase: TilePhase, isSelected: boolean, selectionIndex?: number, selectionTotal?: number): string {
@@ -239,9 +249,16 @@ function getPhaseClasses(phase: TilePhase, isSelected: boolean, selectionIndex?:
       ? Math.min(0.4 + (selectionIndex / (selectionTotal - 1)) * 0.6, 1.0)
       : 0.6;
     const glowSize = Math.round(8 + intensity * 12);
-    return `scale-105 ring-2 ring-neo-lime ring-offset-1 ring-offset-neo-navy shadow-[0_0_${glowSize}px_rgba(191,255,0,${intensity})]`;
+    return `ring-2 ring-neo-lime ring-offset-1 ring-offset-neo-navy shadow-[0_0_${glowSize}px_rgba(191,255,0,${intensity})] blast-tile-select-pop`;
   }
   return '';
+}
+
+/** Inline styles for selected tiles: progressive scale */
+function getSelectionStyles(isSelected: boolean, selectionIndex?: number, selectionTotal?: number): React.CSSProperties {
+  if (!isSelected) return {};
+  const scale = getSelectionScale(selectionIndex, selectionTotal);
+  return { transform: `scale(${scale})` };
 }
 
 export const BlastTile = memo(function BlastTile({
@@ -261,7 +278,8 @@ export const BlastTile = memo(function BlastTile({
   const phaseStyle = effectivePhase !== 'idle' && effectivePhase !== 'selected'
     ? getPhaseStyles(effectivePhase, type, fallOffset, clearRotate, spawnOffset)
     : {};
-  const needsWillChange = ANIMATED_PHASES.has(effectivePhase);
+  const selectionStyle = getSelectionStyles(isSelected, selectionIndex, selectionTotal);
+  const needsWillChange = ANIMATED_PHASES.has(effectivePhase) || isSelected;
 
   return (
     <button
@@ -287,6 +305,7 @@ export const BlastTile = memo(function BlastTile({
       style={{
         ...(visual.style ?? {}),
         ...phaseStyle,
+        ...selectionStyle,
         ...(needsWillChange && { willChange: 'transform, opacity' }),
       }}
       aria-label={`${letter}${type !== 'standard' ? ` ${type} tile` : ''}`}

--- a/fe-next/components/blast/__tests__/BlastTile.test.tsx
+++ b/fe-next/components/blast/__tests__/BlastTile.test.tsx
@@ -237,6 +237,68 @@ describe('BlastTile', () => {
     });
   });
 
+  describe('progressive selection scale', () => {
+    it('scales first tile at 1.05x (selectionIndex=0)', () => {
+      const { container } = render(
+        <BlastTile {...baseProps} type="standard" isSelected selectionIndex={0} selectionTotal={5} />
+      );
+      const button = container.querySelector('button');
+      expect(button?.style.transform).toContain('scale(1.05)');
+    });
+
+    it('scales last tile at 1.12x (selectionIndex=total-1)', () => {
+      const { container } = render(
+        <BlastTile {...baseProps} type="standard" isSelected selectionIndex={4} selectionTotal={5} />
+      );
+      const button = container.querySelector('button');
+      expect(button?.style.transform).toContain('scale(1.12)');
+    });
+
+    it('interpolates scale for middle tiles', () => {
+      const { container } = render(
+        <BlastTile {...baseProps} type="standard" isSelected selectionIndex={2} selectionTotal={5} />
+      );
+      const button = container.querySelector('button');
+      // midpoint: 1.05 + (2/4) * 0.07 = 1.085
+      expect(button?.style.transform).toContain('scale(1.085)');
+    });
+  });
+
+  describe('landing bounce spring curve', () => {
+    it('uses spring cubic-bezier for landing phase', () => {
+      const { container } = render(
+        <BlastTile {...baseProps} type="standard" phase="landing" />
+      );
+      const button = container.querySelector('button');
+      expect(button?.style.transition).toContain('cubic-bezier(0.34, 1.56, 0.64, 1)');
+    });
+
+    it('uses enhanced bounce amplitude for landing', () => {
+      const { container } = render(
+        <BlastTile {...baseProps} type="standard" phase="landing" />
+      );
+      const button = container.querySelector('button');
+      expect(button?.style.transform).toContain('scaleY(1.15)');
+      expect(button?.style.transform).toContain('scaleX(0.88)');
+    });
+  });
+
+  describe('selection pop animation', () => {
+    it('applies blast-tile-select-pop class when selected', () => {
+      render(
+        <BlastTile {...baseProps} type="standard" isSelected selectionIndex={0} selectionTotal={1} />
+      );
+      const button = screen.getByRole('button');
+      expect(button.className).toContain('blast-tile-select-pop');
+    });
+
+    it('does NOT apply blast-tile-select-pop when not selected', () => {
+      render(<BlastTile {...baseProps} type="standard" />);
+      const button = screen.getByRole('button');
+      expect(button.className).not.toContain('blast-tile-select-pop');
+    });
+  });
+
   describe('accessibility', () => {
     it('includes tile type in aria-label for special tiles', () => {
       render(<BlastTile {...baseProps} type="bomb" />);


### PR DESCRIPTION
## Summary
- Progressive selection scale: tiles scale 1.05x to 1.12x along word path for visual momentum
- Landing bounce uses spring cubic-bezier curve with increased amplitude (scaleY 1.15, scaleX 0.88)
- New `blast-tile-select-pop` CSS animation for 100ms bounce on tile selection
- Bomb idle pulse refined to subtler scale(1.02) with 2s cycle
- Rainbow idle now includes hue-rotate for richer 5s color cycling
- All animations respect `prefers-reduced-motion` and cascade pause

## Test plan
- [x] 7 new unit tests for progressive scale, spring landing, and selection pop
- [x] All 546 blast tests passing
- [x] TypeScript strict check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)