### PR TITLE
feat(classroom): auto-tag rooms with classroom context

### DIFF
--- a/fe-next/backend/handlers/__tests__/classroomGameHandler.test.ts
+++ b/fe-next/backend/handlers/__tests__/classroomGameHandler.test.ts
@@ -120,6 +120,7 @@ describe('ClassroomGameHandler', () => {
       expect(mockIo.to).toHaveBeenCalledWith(`classroom:${gameData.classroomId}`);
       expect(mockIo.emit).toHaveBeenCalledWith('classroomGameCreated', {
         gameCode: gameData.gameCode,
+        classroomId: gameData.classroomId,
         teacherName: gameData.teacherName,
         lessonNames: gameData.lessonNames,
       });
@@ -233,6 +234,47 @@ describe('ClassroomGameHandler', () => {
       expect(mockSocket.emit).toHaveBeenCalledWith('joinedClassroomGame', {
         success: true,
         gameCode: data.gameCode,
+      });
+    });
+  });
+
+  describe('startClassroomGame handler', () => {
+    it('should include vocabularyWords in classroomGameStarted event', async () => {
+      // GIVEN
+      const gameCode = 'ABC123';
+      const teacherId = '00000000-0000-4000-8000-000000000001';
+      const game = {
+        gameCode,
+        classroomId: '00000000-0000-4000-8000-000000000002',
+        teacherId,
+        teacherName: 'Mr Smith',
+        lessonIds: ['00000000-0000-4000-8000-000000000003'],
+        vocabularyWords: ['cat', 'dog', 'bird'],
+        settings: { gameMode: 'classic' },
+        players: [{ userId: 'student-1', username: 'Alice', socketId: 's1' }],
+        status: 'waiting' as const,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      };
+
+      (classroomGameManager.getClassroomGame as jest.Mock).mockResolvedValue(game);
+      (classroomGameManager.updateClassroomGameStatus as jest.Mock).mockResolvedValue(undefined);
+
+      registerClassroomGameHandlers(mockIo, mockSocket);
+
+      const startHandler = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'startClassroomGame'
+      )[1];
+
+      // WHEN
+      await startHandler({ gameCode });
+
+      // THEN
+      expect(mockIo.emit).toHaveBeenCalledWith('classroomGameStarted', {
+        gameCode,
+        gameMode: 'classic',
+        settings: game.settings,
+        playerCount: 1,
+        vocabularyWords: ['cat', 'dog', 'bird'],
       });
     });
   });

--- a/fe-next/backend/handlers/classroomGameHandler.ts
+++ b/fe-next/backend/handlers/classroomGameHandler.ts
@@ -145,6 +145,7 @@ export function registerClassroomGameHandlers(io: Server, socket: Socket): void 
       // Broadcast to classroom that a game has been created
       io.to(`classroom:${payload.classroomId}`).emit('classroomGameCreated', {
         gameCode: payload.gameCode,
+        classroomId: payload.classroomId,
         teacherName: payload.teacherName,
         lessonNames: payload.lessonNames,
       });
@@ -348,6 +349,7 @@ export function registerClassroomGameHandlers(io: Server, socket: Socket): void 
         gameMode: game.settings.gameMode || 'classic',
         settings: game.settings,
         playerCount: game.players.length,
+        vocabularyWords: game.vocabularyWords,
       });
 
       logger.info('CLASSROOM_GAME', `Teacher ${authUserId} started game ${payload.gameCode}`);

--- a/fe-next/backend/modules/__tests__/classroomGameManager.test.ts
+++ b/fe-next/backend/modules/__tests__/classroomGameManager.test.ts
@@ -6,6 +6,7 @@
 import {
   createClassroomGame,
   getClassroomGame,
+  getClassroomGameByCode,
   getActiveClassroomGames,
   deleteClassroomGame,
   addPlayerToClassroomGame,
@@ -67,6 +68,32 @@ describe('ClassroomGameManager', () => {
         `classroom_games:${gameData.classroomId}`,
         gameData.gameCode
       );
+    });
+
+    it('should persist classroomId and lessonIds in Redis', async () => {
+      // GIVEN
+      const gameData = {
+        gameCode: 'XYZ789',
+        classroomId: 'classroom-99',
+        teacherId: 'teacher-1',
+        teacherName: 'Ms. Jones',
+        lessonIds: ['lesson-A', 'lesson-B'],
+        lessonNames: ['Fruits', 'Veggies'],
+        vocabularyWords: ['apple', 'carrot'],
+        settings: {},
+      };
+
+      mockRedis.setex.mockResolvedValue('OK');
+      mockRedis.sadd.mockResolvedValue(1);
+
+      // WHEN
+      await createClassroomGame(gameData);
+
+      // THEN
+      const savedJson = (mockRedis.setex as jest.Mock).mock.calls[0][2];
+      const saved = JSON.parse(savedJson);
+      expect(saved.classroomId).toBe('classroom-99');
+      expect(saved.lessonIds).toEqual(['lesson-A', 'lesson-B']);
     });
 
     it('should throw error if Redis fails', async () => {
@@ -251,6 +278,47 @@ describe('ClassroomGameManager', () => {
         (mockRedis.setex as jest.Mock).mock.calls[0][2]
       );
       expect(savedData.players).toHaveLength(1);
+    });
+  });
+
+  describe('getClassroomGameByCode', () => {
+    it('should return classroom metadata for a game code', async () => {
+      // GIVEN
+      const gameData = {
+        gameCode: 'ABC123',
+        classroomId: 'classroom-1',
+        teacherId: 'teacher-1',
+        teacherName: 'Mr. Smith',
+        lessonIds: ['lesson-1', 'lesson-2'],
+        lessonNames: ['Animals', 'Colors'],
+        vocabularyWords: ['cat', 'dog'],
+        players: [],
+        status: 'waiting',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      };
+
+      (mockRedis.get as jest.Mock).mockResolvedValue(JSON.stringify(gameData));
+
+      // WHEN
+      const result = await getClassroomGameByCode('ABC123');
+
+      // THEN
+      expect(result).toEqual({
+        classroomId: 'classroom-1',
+        lessonIds: ['lesson-1', 'lesson-2'],
+        teacherName: 'Mr. Smith',
+      });
+    });
+
+    it('should return null if game does not exist', async () => {
+      // GIVEN
+      (mockRedis.get as jest.Mock).mockResolvedValue(null);
+
+      // WHEN
+      const result = await getClassroomGameByCode('NONEXISTENT');
+
+      // THEN
+      expect(result).toBeNull();
     });
   });
 

--- a/fe-next/backend/modules/classroomGameManager.ts
+++ b/fe-next/backend/modules/classroomGameManager.ts
@@ -106,6 +106,20 @@ export async function getClassroomGame(gameCode: string): Promise<ClassroomGame 
 }
 
 /**
+ * Get classroom metadata by game code (classroomId, lessonIds, teacherName)
+ */
+export async function getClassroomGameByCode(gameCode: string): Promise<{ classroomId: string; lessonIds: string[]; teacherName: string } | null> {
+  const game = await getClassroomGame(gameCode);
+  if (!game) return null;
+
+  return {
+    classroomId: game.classroomId,
+    lessonIds: game.lessonIds,
+    teacherName: game.teacherName,
+  };
+}
+
+/**
  * Get all active classroom games for a classroom
  */
 export async function getActiveClassroomGames(classroomId: string): Promise<ClassroomGame[]> {


### PR DESCRIPTION
## Summary
- Add `classroomId` to `classroomGameCreated` event so frontend can identify classroom rooms
- Add `vocabularyWords` to `classroomGameStarted` event so game board can be seeded with lesson words
- Add `getClassroomGameByCode()` function returning classroom metadata (classroomId, lessonIds, teacherName) for MP page context display
- Verify `classroomId` and `lessonIds` are persisted in Redis on game creation

## Test plan
- [x] `createClassroomGame` stores classroomId and lessonIds in Redis
- [x] `classroomGameCreated` event includes classroomId
- [x] `classroomGameStarted` event includes vocabularyWords
- [x] `getClassroomGameByCode` returns correct metadata
- [x] All backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)