### PR TITLE
feat(education): add vocabulary milestone badges

### DIFF
--- a/fe-next/components/education/VocabEarnedBadge.tsx
+++ b/fe-next/components/education/VocabEarnedBadge.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Compass, Crown, Zap } from 'lucide-react';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+interface VocabEarnedBadgeProps {
+  type: 'explorer' | 'master' | 'speed';
+  unlocked: boolean;
+  className?: string;
+}
+
+const BADGE_CONFIG = {
+  explorer: {
+    icon: Compass,
+    color: 'bg-neo-cyan',
+    labelKey: 'education.badges.wordExplorer',
+  },
+  master: {
+    icon: Crown,
+    color: 'bg-neo-lime',
+    labelKey: 'education.badges.vocabMaster',
+  },
+  speed: {
+    icon: Zap,
+    color: 'bg-neo-pink',
+    labelKey: 'education.badges.speedScholar',
+  },
+} as const;
+
+export function VocabEarnedBadge({ type, unlocked, className = '' }: VocabEarnedBadgeProps) {
+  const { t } = useLanguage();
+  const { icon: Icon, color, labelKey } = BADGE_CONFIG[type];
+
+  return (
+    <motion.div
+      data-testid="vocab-badge"
+      initial={unlocked ? { scale: 0 } : false}
+      animate={unlocked ? { scale: 1 } : undefined}
+      transition={unlocked ? { type: 'spring', stiffness: 300, damping: 15 } : undefined}
+      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-neo border-2 border-black shadow-hard-sm font-neo-body text-sm ${
+        unlocked ? `${color} text-black` : 'bg-neo-navy/50 opacity-50 grayscale text-neo-cream'
+      } ${className}`}
+    >
+      <Icon size={16} />
+      <span>{unlocked ? t(labelKey) : t('education.badges.locked')}</span>
+    </motion.div>
+  );
+}
+
+interface VocabBadgeRowProps {
+  wordsFound: number;
+  totalWords: number;
+  earlyWordsCount: number;
+}
+
+export function VocabBadgeRow({ wordsFound, totalWords, earlyWordsCount }: VocabBadgeRowProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <VocabEarnedBadge type="explorer" unlocked={wordsFound >= 5} />
+      <VocabEarnedBadge type="master" unlocked={wordsFound === totalWords && totalWords > 0} />
+      <VocabEarnedBadge type="speed" unlocked={earlyWordsCount >= 3} />
+    </div>
+  );
+}

--- a/fe-next/components/education/__tests__/VocabEarnedBadge.test.tsx
+++ b/fe-next/components/education/__tests__/VocabEarnedBadge.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { VocabEarnedBadge, VocabBadgeRow } from '../VocabEarnedBadge';
+
+const mockT = vi.fn((key: string) => key);
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: mockT, language: 'en', dir: 'ltr' }),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, className, ...props }: React.PropsWithChildren<{ className?: string }>) => (
+      <div className={className} data-testid={props['data-testid']}>{children}</div>
+    ),
+  },
+}));
+
+describe('VocabEarnedBadge', () => {
+  it('renders explorer badge with correct translation key', () => {
+    render(<VocabEarnedBadge type="explorer" unlocked />);
+    expect(mockT).toHaveBeenCalledWith('education.badges.wordExplorer');
+  });
+
+  it('renders master badge with correct translation key', () => {
+    render(<VocabEarnedBadge type="master" unlocked />);
+    expect(mockT).toHaveBeenCalledWith('education.badges.vocabMaster');
+  });
+
+  it('renders speed badge with correct translation key', () => {
+    render(<VocabEarnedBadge type="speed" unlocked />);
+    expect(mockT).toHaveBeenCalledWith('education.badges.speedScholar');
+  });
+
+  it('unlocked badge has colored background', () => {
+    const { container } = render(<VocabEarnedBadge type="explorer" unlocked />);
+    const badge = container.firstElementChild;
+    expect(badge?.className).toContain('bg-neo-cyan');
+    expect(badge?.className).not.toContain('opacity-50');
+  });
+
+  it('locked badge has opacity class', () => {
+    const { container } = render(<VocabEarnedBadge type="explorer" unlocked={false} />);
+    const badge = container.firstElementChild;
+    expect(badge?.className).toContain('opacity-50');
+    expect(badge?.className).toContain('bg-neo-navy/50');
+  });
+});
+
+describe('VocabBadgeRow', () => {
+  it('unlocks explorer when wordsFound >= 5', () => {
+    render(<VocabBadgeRow wordsFound={5} totalWords={10} earlyWordsCount={0} />);
+    expect(mockT).toHaveBeenCalledWith('education.badges.wordExplorer');
+    // explorer unlocked, master and speed locked
+    const badges = screen.getAllByTestId('vocab-badge');
+    expect(badges[0].className).toContain('bg-neo-cyan');
+    expect(badges[1].className).toContain('opacity-50');
+    expect(badges[2].className).toContain('opacity-50');
+  });
+
+  it('unlocks master when wordsFound === totalWords', () => {
+    render(<VocabBadgeRow wordsFound={10} totalWords={10} earlyWordsCount={0} />);
+    const badges = screen.getAllByTestId('vocab-badge');
+    // explorer + master unlocked
+    expect(badges[0].className).toContain('bg-neo-cyan');
+    expect(badges[1].className).toContain('bg-neo-lime');
+  });
+
+  it('unlocks speed when earlyWordsCount >= 3', () => {
+    render(<VocabBadgeRow wordsFound={1} totalWords={10} earlyWordsCount={3} />);
+    const badges = screen.getAllByTestId('vocab-badge');
+    // only speed unlocked
+    expect(badges[0].className).toContain('opacity-50');
+    expect(badges[1].className).toContain('opacity-50');
+    expect(badges[2].className).toContain('bg-neo-pink');
+  });
+});

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -8170,6 +8170,12 @@ const en = {
     }
   },
   "education": {
+    "badges": {
+      "wordExplorer": "Word Explorer",
+      "vocabMaster": "Vocab Master",
+      "speedScholar": "Speed Scholar",
+      "locked": "Locked"
+    },
     "wordOfTheDay": {
       "title": "Word of the Day",
       "learnMore": "Learn More"

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -8027,6 +8027,12 @@ const es = {
     }
   },
   "education": {
+    "badges": {
+      "wordExplorer": "Explorador de Palabras",
+      "vocabMaster": "Maestro del Vocabulario",
+      "speedScholar": "Erudito Veloz",
+      "locked": "Bloqueado"
+    },
     "wordOfTheDay": {
       "title": "Palabra del Dia",
       "learnMore": "Saber Mas"

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -7996,6 +7996,12 @@ const he = {
     }
   },
   "education": {
+    "badges": {
+      "wordExplorer": "חוקר מילים",
+      "vocabMaster": "אלוף אוצר המילים",
+      "speedScholar": "תלמיד מהיר",
+      "locked": "נעול"
+    },
     "wordOfTheDay": {
       "title": "המילה היומית",
       "learnMore": "למד עוד"

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -8013,6 +8013,12 @@ const ja = {
     }
   },
   "education": {
+    "badges": {
+      "wordExplorer": "ワードエクスプローラー",
+      "vocabMaster": "語彙マスター",
+      "speedScholar": "スピードスカラー",
+      "locked": "ロック中"
+    },
     "wordOfTheDay": {
       "title": "今日の単語",
       "learnMore": "もっと見る"

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -7961,6 +7961,12 @@ const sv = {
     }
   },
   "education": {
+    "badges": {
+      "wordExplorer": "Ordutforskare",
+      "vocabMaster": "Ordmästare",
+      "speedScholar": "Snabblärd",
+      "locked": "Låst"
+    },
     "wordOfTheDay": {
       "title": "Dagens Ord",
       "learnMore": "Läs Mer"


### PR DESCRIPTION
## Summary
- New `VocabEarnedBadge` and `VocabBadgeRow` components for post-game word review
- Three badge types: Word Explorer (5+ words), Vocab Master (all words), Speed Scholar (3+ in 30s)
- Neo-brutalist styling with framer-motion spring unlock animation
- i18n keys added for all 5 languages (en, he, sv, ja, es)
- 8 tests passing

## Test plan
- [x] Unit tests cover all badge types, locked/unlocked states, and row logic
- [ ] Visual check in classroom post-game flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)