### PR TITLE
feat(crazygames): gate non-multiplayer surfaces for multiplayer-only distribution

### DIFF
--- a/fe-next/__tests__/crazygames/multiplayer-only-gating.test.tsx
+++ b/fe-next/__tests__/crazygames/multiplayer-only-gating.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * CrazyGames "multiplayer-only" gating tests.
+ *
+ * On CrazyGames the game is published with only the multiplayer mode reachable.
+ * These tests lock down the navigation surfaces that previously leaked off-mode:
+ *   - AuthButtonDropdownMenu (profile / leaderboard / friends / settings / admin)
+ *   - HeaderMobileMenu (entire menu portal + external Ko-fi/Instagram links)
+ *   - PostGameEngagement (WotdTeaser links to /daily)
+ *   - ResultsCtaSection (NextStepPrompt cross-mode CTAs)
+ */
+
+import { vi, type MockedFunction } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { AuthButtonDropdownMenu } from '@/components/auth/AuthButtonDropdownMenu';
+import PostGameEngagement from '@/components/growth/PostGameEngagement';
+import { ResultsCtaSection } from '@/components/results/ResultsCtaSection';
+import { useCrazyGames } from '@/components/CrazyGamesSDK';
+import { useAuth } from '@/contexts/AuthContext';
+
+vi.mock('@/components/CrazyGamesSDK');
+vi.mock('@/contexts/AuthContext');
+// Heavy children of PostGameEngagement — stub so we can assert the shell renders
+vi.mock('@/components/leagues/LeagueRivalsCard', () => ({
+  LeagueRivalsCard: () => <div data-testid="league-rivals-card" />,
+}));
+vi.mock('@/components/landing/WotdTeaser', () => ({
+  WotdTeaser: () => <a href="/daily" data-testid="wotd-teaser">WOTD</a>,
+}));
+vi.mock('@/components/vocabulary/WordCollectionCard', () => ({
+  WordCollectionCard: () => <div data-testid="word-collection-card" />,
+}));
+
+const mockUseCrazyGames = useCrazyGames as MockedFunction<typeof useCrazyGames>;
+const mockUseAuth = useAuth as unknown as MockedFunction<() => any>;
+
+function cgContext(isOnPlatform: boolean) {
+  return {
+    isOnCrazyGamesPlatform: isOnPlatform,
+    isAvailable: isOnPlatform,
+    environment: isOnPlatform ? 'crazygames' : null,
+    isLoading: false,
+    deviceType: 'desktop',
+    isLandscape: true,
+    viewportSize: { width: 1024, height: 768 },
+    gameplayStart: vi.fn(),
+    gameplayStop: vi.fn(),
+    loadingStart: vi.fn(),
+    loadingStop: vi.fn(),
+    happyTime: vi.fn(),
+    showMidgameAd: vi.fn(),
+    showRewardedAd: vi.fn(),
+    hasAdblock: vi.fn(),
+    requestBanner: vi.fn(),
+    requestResponsiveBanner: vi.fn(),
+    clearBanner: vi.fn(),
+    clearAllBanners: vi.fn(),
+    saveData: vi.fn(),
+    loadData: vi.fn(),
+    removeData: vi.fn(),
+    clearData: vi.fn(),
+    getUser: vi.fn(),
+    showAuthPrompt: vi.fn(),
+    isUserAccountAvailable: vi.fn(),
+    getSystemInfo: vi.fn(),
+    inviteLink: vi.fn(),
+    showInviteButton: vi.fn(),
+    hideInviteButton: vi.fn(),
+    getInviteParam: vi.fn(),
+    getInviteParams: vi.fn(),
+    isInstantMultiplayer: false,
+    addJoinRoomListener: vi.fn(),
+    removeJoinRoomListener: vi.fn(),
+    getSettings: vi.fn(),
+    addSettingsChangeListener: vi.fn(),
+    removeSettingsChangeListener: vi.fn(),
+    addAuthListener: vi.fn(),
+    removeAuthListener: vi.fn(),
+    getUserToken: vi.fn(),
+    listFriends: vi.fn(),
+    showAccountLinkPrompt: vi.fn(),
+    submitLeaderboardScore: vi.fn(),
+  } as any;
+}
+
+describe('CrazyGames multiplayer-only gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: 'u1' }, profile: {} });
+  });
+
+  describe('AuthButtonDropdownMenu', () => {
+    const baseProps = {
+      dropdownRef: { current: null } as React.RefObject<HTMLDivElement | null>,
+      dropdownPosition: { top: 0, left: 0, right: 0 },
+      isRTL: false,
+      isDarkMode: true,
+      language: 'en',
+      currentLang: { code: 'en' as const, name: 'English', flag: 'US' },
+      isAdmin: true,
+      isSigningOut: false,
+      hasUnclaimedReward: false,
+      t: (k: string) => k,
+      router: { push: vi.fn() },
+      setLanguage: vi.fn(),
+      setShowUserMenu: vi.fn(),
+      setShowCalendarModal: vi.fn(),
+      onSignOut: vi.fn(),
+    };
+
+    it('hides Profile / Leaderboard / Friends / Settings / Admin links on CG', () => {
+      render(<AuthButtonDropdownMenu {...baseProps} isCrazyGames />);
+      expect(screen.queryByText('profile.title')).not.toBeInTheDocument();
+      expect(screen.queryByText('leaderboard.title')).not.toBeInTheDocument();
+      expect(screen.queryByText('friends.title')).not.toBeInTheDocument();
+      expect(screen.queryByText('settings.title')).not.toBeInTheDocument();
+      expect(screen.queryByText('common.adminDashboard')).not.toBeInTheDocument();
+    });
+
+    it('still allows language switching and sign out on CG', () => {
+      render(<AuthButtonDropdownMenu {...baseProps} isCrazyGames />);
+      // Language row + Sign out remain
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('auth.signOut')).toBeInTheDocument();
+    });
+
+    it('still shows all items off CG', () => {
+      render(<AuthButtonDropdownMenu {...baseProps} isCrazyGames={false} />);
+      expect(screen.getByText('profile.title')).toBeInTheDocument();
+      expect(screen.getByText('leaderboard.title')).toBeInTheDocument();
+      expect(screen.getByText('friends.title')).toBeInTheDocument();
+      expect(screen.getByText('settings.title')).toBeInTheDocument();
+      expect(screen.getByText('common.adminDashboard')).toBeInTheDocument();
+    });
+  });
+
+  describe('PostGameEngagement', () => {
+    it('renders nothing on CrazyGames (WotdTeaser links to /daily)', () => {
+      mockUseCrazyGames.mockReturnValue(cgContext(true));
+      const { container } = render(<PostGameEngagement />);
+      expect(container).toBeEmptyDOMElement();
+      expect(screen.queryByTestId('wotd-teaser')).not.toBeInTheDocument();
+    });
+
+    it('renders engagement cards off CG', () => {
+      mockUseCrazyGames.mockReturnValue(cgContext(false));
+      render(<PostGameEngagement />);
+      expect(screen.getByTestId('post-game-engagement')).toBeInTheDocument();
+      expect(screen.getByTestId('wotd-teaser')).toBeInTheDocument();
+    });
+  });
+
+  describe('ResultsCtaSection (multiplayer bots-only mode)', () => {
+    const baseProps = {
+      sortedScores: [],
+      currentPlayerData: null,
+      currentPlayerRank: 1,
+      currentPlayerValidWords: [],
+      hasZeroScore: true,
+      isHost: false,
+      onStartGame: vi.fn(),
+      onMarkReady: vi.fn(),
+      onExit: vi.fn(),
+      isBotsOnlyGame: true,
+      isCurrentPlayerReady: false,
+      normalizeUsername: (n?: string | null) => n ?? '',
+      username: 'me',
+      breathingShadow: ['none'],
+      reducedMotion: true,
+      ctaDelay: 0,
+      t: (k: string) => k,
+    };
+
+    it('does not render NextStepPrompt cross-mode CTA on CG', () => {
+      mockUseCrazyGames.mockReturnValue(cgContext(true));
+      render(<ResultsCtaSection {...baseProps} />);
+      // Cross-mode CTAs use these translation keys
+      expect(screen.queryByText('nextStep.tryDailyChallenge')).not.toBeInTheDocument();
+      expect(screen.queryByText('nextStep.challengeBots')).not.toBeInTheDocument();
+    });
+
+    it('renders the NextStepPrompt off CG when bot game ends for guest', () => {
+      mockUseCrazyGames.mockReturnValue(cgContext(false));
+      render(<ResultsCtaSection {...baseProps} />);
+      // multiplayer-bots branch suggests daily challenge
+      expect(screen.getByText('nextStep.tryDailyChallenge')).toBeInTheDocument();
+    });
+  });
+});

--- a/fe-next/components/auth/AuthButton.tsx
+++ b/fe-next/components/auth/AuthButton.tsx
@@ -233,6 +233,7 @@ const AuthButton = ({ inline = false, onClose, onSignInClick, onSignUpClick }: A
             setShowUserMenu={setShowUserMenu}
             setShowCalendarModal={setShowCalendarModal}
             onSignOut={handleSignOut}
+            isCrazyGames={isCrazyGames}
           />,
           document.body
         )}

--- a/fe-next/components/auth/AuthButtonDropdownMenu.tsx
+++ b/fe-next/components/auth/AuthButtonDropdownMenu.tsx
@@ -38,6 +38,12 @@ interface AuthButtonDropdownMenuProps {
   setShowUserMenu: (show: boolean) => void;
   setShowCalendarModal: (show: boolean) => void;
   onSignOut: () => Promise<void>;
+  /**
+   * When true, the game is running inside the CrazyGames iframe and only
+   * the multiplayer mode is allowed. Hides Profile / Leaderboard / Friends /
+   * Settings / Admin links, leaving language switching and sign out.
+   */
+  isCrazyGames?: boolean;
 }
 
 export function AuthButtonDropdownMenu({
@@ -56,6 +62,7 @@ export function AuthButtonDropdownMenu({
   setShowUserMenu,
   setShowCalendarModal,
   onSignOut,
+  isCrazyGames = false,
 }: AuthButtonDropdownMenuProps): React.JSX.Element {
   const [isLanguageExpanded, setIsLanguageExpanded] = useState(false);
 
@@ -91,90 +98,99 @@ export function AuthButtonDropdownMenu({
           ...(isRTL ? { left: dropdownPosition.left } : { right: dropdownPosition.right })
         }}
       >
-        {/* Profile Link */}
-        <Button
-          role="menuitem"
-          variant="ghost"
-          onClick={() => { router.push(`/${language}/profile`); setShowUserMenu(false); }}
-          className={cn(menuItemClass, 'rounded-t-lg')}
-        >
-          <User size={14} />
-          <span>{t('profile.title')}</span>
-        </Button>
+        {/*
+          CrazyGames distribution: only the multiplayer mode is published.
+          Hide every link that navigates off-mode (profile, leaderboard,
+          friends, settings, daily rewards calendar, admin dashboard).
+        */}
+        {!isCrazyGames && (
+          <>
+            {/* Profile Link */}
+            <Button
+              role="menuitem"
+              variant="ghost"
+              onClick={() => { router.push(`/${language}/profile`); setShowUserMenu(false); }}
+              className={cn(menuItemClass, 'rounded-t-lg')}
+            >
+              <User size={14} />
+              <span>{t('profile.title')}</span>
+            </Button>
 
-        {/* Leaderboard Link */}
-        <Button
-          role="menuitem"
-          variant="ghost"
-          onClick={() => { router.push(`/${language}/leaderboard`); setShowUserMenu(false); }}
-          className={menuItemClass}
-        >
-          <Trophy size={14} aria-hidden="true" />
-          <span>{t('leaderboard.title')}</span>
-        </Button>
+            {/* Leaderboard Link */}
+            <Button
+              role="menuitem"
+              variant="ghost"
+              onClick={() => { router.push(`/${language}/leaderboard`); setShowUserMenu(false); }}
+              className={menuItemClass}
+            >
+              <Trophy size={14} aria-hidden="true" />
+              <span>{t('leaderboard.title')}</span>
+            </Button>
 
-        {/* Friends Link */}
-        <Button
-          role="menuitem"
-          variant="ghost"
-          onClick={() => { router.push(`/${language}/friends`); setShowUserMenu(false); }}
-          className={menuItemClass}
-        >
-          <Users size={14} aria-hidden="true" />
-          <span>{t('friends.title')}</span>
-        </Button>
+            {/* Friends Link */}
+            <Button
+              role="menuitem"
+              variant="ghost"
+              onClick={() => { router.push(`/${language}/friends`); setShowUserMenu(false); }}
+              className={menuItemClass}
+            >
+              <Users size={14} aria-hidden="true" />
+              <span>{t('friends.title')}</span>
+            </Button>
 
-        <div className={dividerClass} />
+            <div className={dividerClass} />
 
-        {/* Settings Link */}
-        <Button
-          role="menuitem"
-          variant="ghost"
-          onClick={() => { router.push(`/${language}/settings`); setShowUserMenu(false); }}
-          className={menuItemClass}
-        >
-          <Settings size={14} aria-hidden="true" />
-          <span>{t('settings.title')}</span>
-        </Button>
+            {/* Settings Link */}
+            <Button
+              role="menuitem"
+              variant="ghost"
+              onClick={() => { router.push(`/${language}/settings`); setShowUserMenu(false); }}
+              className={menuItemClass}
+            >
+              <Settings size={14} aria-hidden="true" />
+              <span>{t('settings.title')}</span>
+            </Button>
 
-        {/* Daily Rewards Calendar */}
-        <Button
-          role="menuitem"
-          variant="ghost"
-          onClick={() => setShowCalendarModal(true)}
-          className={cn(menuItemClass, 'relative')}
-        >
-          <div className="relative">
-            <Calendar size={14} aria-hidden="true" />
-            {hasUnclaimedReward && (
-              <div className="absolute -top-1.5 -right-1.5 rtl:-right-auto rtl:-left-1.5 w-2.5 h-2.5 bg-neo-lime rounded-full border border-neo-black" />
+            {/* Daily Rewards Calendar */}
+            <Button
+              role="menuitem"
+              variant="ghost"
+              onClick={() => setShowCalendarModal(true)}
+              className={cn(menuItemClass, 'relative')}
+            >
+              <div className="relative">
+                <Calendar size={14} aria-hidden="true" />
+                {hasUnclaimedReward && (
+                  <div className="absolute -top-1.5 -right-1.5 rtl:-right-auto rtl:-left-1.5 w-2.5 h-2.5 bg-neo-lime rounded-full border border-neo-black" />
+                )}
+              </div>
+              <span>{t('calendar.title')}</span>
+              {hasUnclaimedReward && (
+                <Gift size={12} className="ms-auto text-neo-lime" aria-label={t('calendar.rewardAvailable')} />
+              )}
+            </Button>
+
+            {/* Admin Dashboard Link */}
+            {isAdmin && (
+              <Button
+                role="menuitem"
+                variant="ghost"
+                onClick={() => { router.push(`/${language}/admin`); setShowUserMenu(false); }}
+                className={cn(
+                  'w-full justify-start gap-3',
+                  isDarkMode
+                    ? 'text-neo-pink hover:bg-slate-700 hover:text-neo-pink'
+                    : 'text-neo-pink hover:bg-gray-50 hover:text-neo-pink'
+                )}
+              >
+                <Shield size={14} aria-hidden="true" />
+                <span>{t('common.adminDashboard')}</span>
+              </Button>
             )}
-          </div>
-          <span>{t('calendar.title')}</span>
-          {hasUnclaimedReward && (
-            <Gift size={12} className="ms-auto text-neo-lime" aria-label={t('calendar.rewardAvailable')} />
-          )}
-        </Button>
 
-        {/* Admin Dashboard Link */}
-        {isAdmin && (
-          <Button
-            role="menuitem"
-            variant="ghost"
-            onClick={() => { router.push(`/${language}/admin`); setShowUserMenu(false); }}
-            className={cn(
-              'w-full justify-start gap-3',
-              isDarkMode
-                ? 'text-neo-pink hover:bg-slate-700 hover:text-neo-pink'
-                : 'text-neo-pink hover:bg-gray-50 hover:text-neo-pink'
-            )}
-          >
-            <Shield size={14} aria-hidden="true" />
-            <span>{t('common.adminDashboard')}</span>
-          </Button>
+            <div className={dividerClass} />
+          </>
         )}
-
-        <div className={dividerClass} />
 
         {/* Language Section - Collapsible */}
         <div>

--- a/fe-next/components/growth/PostGameEngagement.tsx
+++ b/fe-next/components/growth/PostGameEngagement.tsx
@@ -10,6 +10,7 @@
 import React, { memo } from 'react';
 import dynamic from 'next/dynamic';
 import { useAuth } from '@/contexts/AuthContext';
+import { useCrazyGames } from '@/components/CrazyGamesSDK';
 
 const LeagueRivalsCard = dynamic(
   () => import('@/components/leagues/LeagueRivalsCard').then(m => m.LeagueRivalsCard),
@@ -26,9 +27,13 @@ const WordCollectionCard = dynamic(
 
 export const PostGameEngagement: React.FC = memo(function PostGameEngagement() {
   const { isAuthenticated } = useAuth();
+  const { isOnCrazyGamesPlatform } = useCrazyGames();
 
   // Only show for authenticated users — guests see the sign-up CTA instead
   if (!isAuthenticated) return null;
+  // CrazyGames distribution is multiplayer-only — WotdTeaser links to /daily,
+  // which would navigate the player off-mode. Hide the whole block.
+  if (isOnCrazyGamesPlatform) return null;
 
   return (
     <div

--- a/fe-next/components/header/HeaderMobileMenu.tsx
+++ b/fe-next/components/header/HeaderMobileMenu.tsx
@@ -222,45 +222,52 @@ const HeaderMobileMenu = memo<HeaderMobileMenuProps>(({ unclaimedCount, onOpenGi
                     </button>
                 )}
 
-                {/* Animated Hamburger Button */}
-                <button
-                    onClick={() => {
-                        if (!showMobileMenu) {
-                            markBadgeSeen(badgeCount);
-                            if (notificationCount > 0) {
-                                markAllAsRead();
+                {/*
+                  Animated Hamburger Button.
+                  Hidden on CrazyGames: the menu exposes profile / settings /
+                  leaderboard / cookie banner / Ko-fi / Instagram links that
+                  would all navigate the player off-mode (CG is multiplayer-only).
+                */}
+                {!isCrazyGames && (
+                    <button
+                        onClick={() => {
+                            if (!showMobileMenu) {
+                                markBadgeSeen(badgeCount);
+                                if (notificationCount > 0) {
+                                    markAllAsRead();
+                                }
                             }
-                        }
-                        setShowMobileMenu(!showMobileMenu);
-                    }}
-                    className={cn(
-                        "relative flex items-center justify-center shrink-0",
-                        "w-11 h-11 min-w-[44px] min-h-[44px]",
-                        "bg-neo-cream text-neo-black",
-                        "border-3 border-neo-black",
-                        "rounded-neo shadow-hard-sm",
-                        "hover:-translate-x-px hover:-translate-y-px hover:shadow-hard",
-                        "active:translate-x-px active:translate-y-px active:shadow-none",
-                        "transition-all duration-100"
-                    )}
-                    aria-label={showMobileMenu ? t('common.closeMenu') : t('common.openMenu')}
-                    aria-expanded={showMobileMenu}
-                >
-                    <m.div
-                        animate={{ rotate: showMobileMenu ? 90 : 0 }}
-                        transition={{ type: 'spring', damping: 15, stiffness: 200 }}
+                            setShowMobileMenu(!showMobileMenu);
+                        }}
+                        className={cn(
+                            "relative flex items-center justify-center shrink-0",
+                            "w-11 h-11 min-w-[44px] min-h-[44px]",
+                            "bg-neo-cream text-neo-black",
+                            "border-3 border-neo-black",
+                            "rounded-neo shadow-hard-sm",
+                            "hover:-translate-x-px hover:-translate-y-px hover:shadow-hard",
+                            "active:translate-x-px active:translate-y-px active:shadow-none",
+                            "transition-all duration-100"
+                        )}
+                        aria-label={showMobileMenu ? t('common.closeMenu') : t('common.openMenu')}
+                        aria-expanded={showMobileMenu}
                     >
-                        {showMobileMenu ? <X size={18} /> : <Menu size={18} />}
-                    </m.div>
-                    {/* Aggregated badge */}
-                    {badgeCount > 0 && !showMobileMenu && !badgeSeen && (
-                        <div className="absolute -top-1.5 -inset-e-1.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center bg-neo-red rounded-full border-2 border-neo-cream text-[10px] font-black text-white leading-none">{badgeCount}</div>
-                    )}
-                </button>
+                        <m.div
+                            animate={{ rotate: showMobileMenu ? 90 : 0 }}
+                            transition={{ type: 'spring', damping: 15, stiffness: 200 }}
+                        >
+                            {showMobileMenu ? <X size={18} /> : <Menu size={18} />}
+                        </m.div>
+                        {/* Aggregated badge */}
+                        {badgeCount > 0 && !showMobileMenu && !badgeSeen && (
+                            <div className="absolute -top-1.5 -inset-e-1.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center bg-neo-red rounded-full border-2 border-neo-cream text-[10px] font-black text-white leading-none">{badgeCount}</div>
+                        )}
+                    </button>
+                )}
             </div>
 
-            {/* Mobile Menu Slide-out Pane */}
-            {mounted && createPortal(
+            {/* Mobile Menu Slide-out Pane (also hidden on CrazyGames) */}
+            {!isCrazyGames && mounted && createPortal(
                 <LazyMotion features={domAnimation}>
                 <AnimatePresence>
                     {showMobileMenu && (

--- a/fe-next/components/results/ResultsCtaSection.tsx
+++ b/fe-next/components/results/ResultsCtaSection.tsx
@@ -7,6 +7,7 @@ import type { Player } from '@/components/results/types';
 import NextStepPrompt from '@/components/results/NextStepPrompt';
 import ShareButton from '@/components/results/ShareButton';
 import { GameModeSelector, type GameModeOption } from '@/components/GameModeSelector';
+import { useCrazyGames } from '@/components/CrazyGamesSDK';
 import type { ShareParams } from '@/shared/utils/shareResultGenerator';
 
 type TFunction = (key: string, params?: Record<string, string | number>) => string;
@@ -54,13 +55,19 @@ export const ResultsCtaSection: React.FC<ResultsCtaSectionProps> = ({
   ctaDelay,
   t,
 }) => {
+  const { isOnCrazyGamesPlatform } = useCrazyGames();
+  // On CrazyGames the only published mode is multiplayer, so the
+  // bots-only NextStepPrompt (which suggests Daily Challenge) would
+  // navigate the player off-mode. Fall through to the normal ready/back UI.
+  const showBotsOnlyNextStep = isBotsOnlyGame && !isHost && !isOnCrazyGamesPlatform;
+
   return (
     <motion.div
       initial={reducedMotion ? undefined : { opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ type: 'spring', stiffness: 200, damping: 20, delay: ctaDelay }}
     >
-      {isBotsOnlyGame && !isHost ? (
+      {showBotsOnlyNextStep ? (
         <NextStepPrompt
           currentMode="multiplayer-bots"
           onBackToLobby={onExit}


### PR DESCRIPTION
CrazyGames is shipping LexiClash as a multiplayer-only game. Audited every
navigation surface that could leak the player off /multiplayer when
isOnCrazyGamesPlatform is true and gated each one:

- AuthButtonDropdownMenu: hide Profile/Leaderboard/Friends/Settings/Calendar/
  Admin links via new isCrazyGames prop; keep language switcher and sign out.
  AuthButton threads isCrazyGames through from useCrazyGamesAuth.
- PostGameEngagement: return null on CG (WotdTeaser links to /daily).
- ResultsCtaSection: skip the bots-only NextStepPrompt branch on CG
  (multiplayer-bots flow suggests Daily Challenge).
- HeaderMobileMenu: hide hamburger button + slide-out portal on CG; this
  also removes the unguarded Ko-fi and Instagram external links and every
  Info section link that pointed off-mode. MusicControls stays visible.

Adds __tests__/crazygames/multiplayer-only-gating.test.tsx covering all four
gates with the same mock pattern as oauth-hiding.test.tsx.