### PR TITLE
fix(android): splash hang, language-select loop, and cold-start on legal pages

### DIFF
--- a/fe-next/capacitor.config.ts
+++ b/fe-next/capacitor.config.ts
@@ -22,7 +22,14 @@ const config: CapacitorConfig = {
 
   plugins: {
     SplashScreen: {
-      launchShowDuration: 2000,
+      // NativeAppProvider calls SplashScreen.hide() as soon as React mounts
+      // the first frame, so the splash disappears the instant the UI is ready.
+      // The 5s auto-hide is a safety net: if the WebView fails to bootstrap,
+      // users still see *something* (the error.html fallback) instead of an
+      // infinite splash. Previously this was 2s, which hid the splash before
+      // the remote WebView had finished the /→/{locale} redirect on slow
+      // connections, leaving a black screen.
+      launchShowDuration: 5000,
       launchAutoHide: true,
       backgroundColor: '#1a1a2e', // neo-navy from design system
       showSpinner: false,

--- a/fe-next/components/native/NativeAppProvider.tsx
+++ b/fe-next/components/native/NativeAppProvider.tsx
@@ -18,6 +18,7 @@ import { isNative } from '@/utils/platform';
 import logger from '@/utils/logger';
 
 const DeepLinkHandler = dynamic(() => import('@/components/DeepLinkHandler'), { ssr: false });
+const NativeColdStartGuard = dynamic(() => import('./NativeColdStartGuard'), { ssr: false });
 
 interface NativeAppProviderProps {
   children: React.ReactNode;
@@ -43,6 +44,22 @@ export function NativeAppProvider({ children }: NativeAppProviderProps): React.R
     });
   }, []);
 
+  // Hide the splash screen as soon as React has mounted the first frame.
+  // Capacitor's `launchAutoHide` fires after a fixed duration regardless of
+  // whether the WebView has finished loading the remote URL, which leaves
+  // Android users on a black WebView when the 301→locale redirect is slow.
+  useEffect(() => {
+    if (!isNative()) return;
+
+    import('@capacitor/splash-screen').then(({ SplashScreen }) => {
+      SplashScreen.hide().catch(() => {
+        // Splash already hidden or plugin unavailable — safe to ignore
+      });
+    }).catch((err) => {
+      logger.warn('[NativeAppProvider] Failed to hide splash screen:', err);
+    });
+  }, []);
+
   // Handle app lifecycle transitions
   useAppLifecycle({
     onForeground: () => {
@@ -64,6 +81,7 @@ export function NativeAppProvider({ children }: NativeAppProviderProps): React.R
 
   return (
     <>
+      <NativeColdStartGuard />
       <DeepLinkHandler />
       {children}
     </>

--- a/fe-next/components/native/NativeColdStartGuard.tsx
+++ b/fe-next/components/native/NativeColdStartGuard.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { isNative } from '@/utils/platform';
+
+const NATIVE_COLD_START_FLAG = 'lexiclash_native_cold_start_handled';
+
+const SUPPORTED_LOCALES = ['en', 'he', 'sv', 'ja', 'es'] as const;
+type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+// Paths users should NEVER land on when opening the app fresh. These are
+// dead-ends for a cold-start launch (legal docs reached via external links
+// or restored from a stale WebView session). If the app boots onto one of
+// these, bounce to the locale home so the user sees the landing page first.
+const COLD_START_FORBIDDEN_PREFIXES = ['/legal/'];
+
+function parseLocale(pathname: string): Locale {
+  const segment = pathname.split('/')[1];
+  return (SUPPORTED_LOCALES as readonly string[]).includes(segment)
+    ? (segment as Locale)
+    : 'en';
+}
+
+function stripLocale(pathname: string): string {
+  const segment = pathname.split('/')[1];
+  if ((SUPPORTED_LOCALES as readonly string[]).includes(segment)) {
+    return pathname.slice(`/${segment}`.length) || '/';
+  }
+  return pathname;
+}
+
+/**
+ * NativeColdStartGuard
+ *
+ * On Android/iOS cold start (first render of this session), redirect to the
+ * locale home when the WebView landed on a "dead-end" route like a legal
+ * document. This covers two regressions:
+ *   1. External privacy-policy links (e.g., Play Store listing) opening the
+ *      installed app directly at /legal/privacy instead of the landing page.
+ *   2. The WebView restoring a stale URL from a previous session where the
+ *      user had drilled into /legal/* before backgrounding the app.
+ *
+ * A sessionStorage flag ensures this only fires once per app session, so
+ * navigating to a legal page from within the app still works normally.
+ */
+export function NativeColdStartGuard(): null {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!isNative()) return;
+    if (sessionStorage.getItem(NATIVE_COLD_START_FLAG)) return;
+
+    sessionStorage.setItem(NATIVE_COLD_START_FLAG, '1');
+
+    const path = pathname ?? '/';
+    const withoutLocale = stripLocale(path);
+    const isForbidden = COLD_START_FORBIDDEN_PREFIXES.some((prefix) =>
+      withoutLocale.startsWith(prefix)
+    );
+    if (!isForbidden) return;
+
+    const locale = parseLocale(path);
+    router.replace(`/${locale}`);
+  }, [pathname, router]);
+
+  return null;
+}
+
+export default NativeColdStartGuard;

--- a/fe-next/components/native/__tests__/NativeAppProvider.test.tsx
+++ b/fe-next/components/native/__tests__/NativeAppProvider.test.tsx
@@ -5,16 +5,43 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { NativeAppProvider } from '../NativeAppProvider';
 import { useSafeArea } from '@/hooks/useSafeArea';
 import { useAppLifecycle } from '@/hooks/useAppLifecycle';
 import { getSharedSocketIfExists } from '@/utils/SocketContext';
+import { isNative } from '@/utils/platform';
 
 // Mock dependencies
 vi.mock('@/hooks/useSafeArea');
 vi.mock('@/hooks/useAppLifecycle');
 vi.mock('@/utils/SocketContext');
+vi.mock('@/utils/platform', () => ({
+  isNative: vi.fn(() => false),
+}));
+
+const mockSplashHide = vi.fn(() => Promise.resolve());
+vi.mock('@capacitor/splash-screen', () => ({
+  SplashScreen: {
+    hide: (...args: unknown[]) => mockSplashHide(...args),
+  },
+}));
+
+vi.mock('@capacitor/status-bar', () => ({
+  StatusBar: {
+    setOverlaysWebView: vi.fn(() => Promise.resolve()),
+    setBackgroundColor: vi.fn(() => Promise.resolve()),
+    setStyle: vi.fn(() => Promise.resolve()),
+  },
+  Style: { Dark: 'DARK' },
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: vi.fn(() => Promise.resolve({ remove: vi.fn() })),
+  },
+}));
+
 vi.mock('@/utils/logger', () => ({
   log: vi.fn(),
   __esModule: true,
@@ -30,6 +57,7 @@ const mockUseAppLifecycle = useAppLifecycle as jest.MockedFunction<typeof useApp
 const mockGetSharedSocketIfExists = getSharedSocketIfExists as jest.MockedFunction<
   typeof getSharedSocketIfExists
 >;
+const mockIsNative = isNative as jest.MockedFunction<typeof isNative>;
 
 describe('NativeAppProvider', () => {
   beforeEach(() => {
@@ -214,6 +242,43 @@ describe('NativeAppProvider', () => {
       // THEN
       expect(screen.getByTestId('child-1')).toBeInTheDocument();
       expect(screen.getByTestId('child-2')).toBeInTheDocument();
+    });
+  });
+
+  describe('splash screen', () => {
+    it('hides the Capacitor splash screen once the app has mounted on native', async () => {
+      // Regression: splash auto-hides at 2s regardless of WebView readiness,
+      // leaving users staring at a black WebView on slow networks. Hiding
+      // explicitly from the client guarantees the splash only goes away once
+      // React has painted the first screen.
+      // GIVEN
+      mockIsNative.mockReturnValue(true);
+
+      // WHEN
+      render(
+        <NativeAppProvider>
+          <div>Content</div>
+        </NativeAppProvider>
+      );
+
+      // THEN
+      await waitFor(() => expect(mockSplashHide).toHaveBeenCalled());
+    });
+
+    it('does not call SplashScreen.hide on web', async () => {
+      // GIVEN
+      mockIsNative.mockReturnValue(false);
+
+      // WHEN
+      render(
+        <NativeAppProvider>
+          <div>Content</div>
+        </NativeAppProvider>
+      );
+
+      // THEN - allow any pending microtasks to flush before asserting
+      await Promise.resolve();
+      expect(mockSplashHide).not.toHaveBeenCalled();
     });
   });
 });

--- a/fe-next/components/native/__tests__/NativeColdStartGuard.test.tsx
+++ b/fe-next/components/native/__tests__/NativeColdStartGuard.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { isNative } from '@/utils/platform';
+
+const mockReplace = vi.fn();
+const mockUsePathname = vi.fn<() => string>(() => '/en');
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace, push: vi.fn() }),
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock('@/utils/platform', () => ({
+  isNative: vi.fn(() => true),
+}));
+
+import { NativeColdStartGuard } from '../NativeColdStartGuard';
+
+const NATIVE_COLD_START_FLAG = 'lexiclash_native_cold_start_handled';
+const mockIsNative = isNative as unknown as ReturnType<typeof vi.fn>;
+
+describe('NativeColdStartGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockIsNative.mockReturnValue(true);
+  });
+
+  it('redirects cold-start launches landing on /legal/privacy to the locale home', () => {
+    mockUsePathname.mockReturnValue('/en/legal/privacy');
+
+    render(<NativeColdStartGuard />);
+
+    expect(mockReplace).toHaveBeenCalledWith('/en');
+    expect(sessionStorage.getItem(NATIVE_COLD_START_FLAG)).toBe('1');
+  });
+
+  it('redirects cold-start launches landing on /legal/terms to the locale home', () => {
+    mockUsePathname.mockReturnValue('/he/legal/terms');
+
+    render(<NativeColdStartGuard />);
+
+    expect(mockReplace).toHaveBeenCalledWith('/he');
+  });
+
+  it('does not redirect if the user is already on the locale home', () => {
+    mockUsePathname.mockReturnValue('/en');
+
+    render(<NativeColdStartGuard />);
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect once the flag has been set (subsequent navigations)', () => {
+    sessionStorage.setItem(NATIVE_COLD_START_FLAG, '1');
+    mockUsePathname.mockReturnValue('/en/legal/privacy');
+
+    render(<NativeColdStartGuard />);
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('sets the flag even when no redirect is needed so subsequent legal visits are allowed', () => {
+    mockUsePathname.mockReturnValue('/en');
+
+    render(<NativeColdStartGuard />);
+
+    expect(sessionStorage.getItem(NATIVE_COLD_START_FLAG)).toBe('1');
+  });
+
+  it('is a no-op on web', () => {
+    mockIsNative.mockReturnValue(false);
+    mockUsePathname.mockReturnValue('/en/legal/privacy');
+
+    render(<NativeColdStartGuard />);
+
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(NATIVE_COLD_START_FLAG)).toBeNull();
+  });
+
+  it('preserves the locale segment when redirecting from a legal page', () => {
+    mockUsePathname.mockReturnValue('/sv/legal/cookies');
+
+    render(<NativeColdStartGuard />);
+
+    expect(mockReplace).toHaveBeenCalledWith('/sv');
+  });
+
+  it('defaults to /en when the pathname has no recognized locale prefix', () => {
+    mockUsePathname.mockReturnValue('/legal/privacy');
+
+    render(<NativeColdStartGuard />);
+
+    expect(mockReplace).toHaveBeenCalledWith('/en');
+  });
+});

--- a/fe-next/components/onboarding/LanguageSelect.tsx
+++ b/fe-next/components/onboarding/LanguageSelect.tsx
@@ -23,15 +23,29 @@ const LanguageSelect: React.FC<LanguageSelectProps> = ({ onSelect }) => {
 
   const handleSelect = useCallback((lang: Language) => {
     if (lang === selected) {
+      // Tap-again confirms selection. Apply language only if it differs from
+      // the context (no-op when the user sticks with the default) so we don't
+      // trigger a router.push during the FTUE.
+      if (lang !== language) {
+        setLanguage(lang);
+      }
       onSelect();
       return;
     }
+    // Defer setLanguage until the user confirms. Calling it here triggers
+    // router.push() to `/{locale}`, which remounts the OnboardingFlow and
+    // loops the user back to this step.
     setSelected(lang);
-    setLanguage(lang);
-    // Celebratory burst from the tapped card area — gives tactile feedback
-    // that language actually changed under the hood.
     fireOnboardingBurst({ y: 0.45 });
-  }, [selected, onSelect, setLanguage]);
+  }, [selected, onSelect, setLanguage, language]);
+
+  const handleConfirm = useCallback(() => {
+    fireOnboardingBurst({ y: 0.7 }, ['#BFFF00', '#FFE135', '#00FFFF']);
+    if (selected !== language) {
+      setLanguage(selected);
+    }
+    onSelect();
+  }, [selected, language, setLanguage, onSelect]);
 
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] max-w-sm lg:max-w-2xl mx-auto gap-5 lg:gap-7">
@@ -126,10 +140,7 @@ const LanguageSelect: React.FC<LanguageSelectProps> = ({ onSelect }) => {
         transition={{ delay: 0.5, type: 'spring', stiffness: 300, damping: 22 }}
         whileHover={{ scale: 1.03, y: -2 }}
         whileTap={{ scale: 0.97, y: 2 }}
-        onClick={() => {
-          fireOnboardingBurst({ y: 0.7 }, ['#BFFF00', '#FFE135', '#00FFFF']);
-          onSelect();
-        }}
+        onClick={handleConfirm}
         className={cn(
           'mt-1 w-full lg:w-auto lg:px-12 py-3.5 lg:py-4 lg:self-center rounded-neo border-3 border-neo-black',
           'bg-neo-lime text-neo-navy font-neo-display font-black text-lg uppercase tracking-wide',

--- a/fe-next/components/onboarding/__tests__/LanguageSelect.test.tsx
+++ b/fe-next/components/onboarding/__tests__/LanguageSelect.test.tsx
@@ -58,18 +58,44 @@ describe('LanguageSelect', () => {
     expect(englishButton.className).toContain('border-neo-lime');
   });
 
-  it('calls setLanguage when a language card is clicked', () => {
+  it('does NOT call setLanguage immediately when tapping a language card', () => {
+    // Regression: setLanguage triggers router.push() to a new locale path,
+    // which remounts OnboardingFlow and loops the user back to LanguageSelect.
+    // Defer language change until the user confirms.
     render(<LanguageSelect onSelect={mockOnSelect} />);
     fireEvent.click(screen.getByTestId('lang-he'));
-    expect(mockSetLanguage).toHaveBeenCalledWith('he');
+    expect(mockSetLanguage).not.toHaveBeenCalled();
   });
 
-  it('calls onSelect after selecting and clicking continue', () => {
+  it('visually highlights the tapped language card', () => {
     render(<LanguageSelect onSelect={mockOnSelect} />);
     fireEvent.click(screen.getByTestId('lang-he'));
-    // Click the continue button
-    const continueBtn = screen.getByTestId('language-continue');
-    fireEvent.click(continueBtn);
+    const hebrewButton = screen.getByTestId('lang-he');
+    expect(hebrewButton.className).toContain('border-neo-lime');
+  });
+
+  it('applies the selected language and advances when the continue button is clicked', () => {
+    render(<LanguageSelect onSelect={mockOnSelect} />);
+    fireEvent.click(screen.getByTestId('lang-he'));
+    // Language change happens on confirmation, not on tap
+    expect(mockSetLanguage).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('language-continue'));
+
+    expect(mockSetLanguage).toHaveBeenCalledWith('he');
+    expect(mockOnSelect).toHaveBeenCalled();
+  });
+
+  it('does not call setLanguage when confirming with the current language unchanged', () => {
+    render(<LanguageSelect onSelect={mockOnSelect} />);
+    fireEvent.click(screen.getByTestId('language-continue'));
+    expect(mockSetLanguage).not.toHaveBeenCalled();
+    expect(mockOnSelect).toHaveBeenCalled();
+  });
+
+  it('tapping the already-selected language advances immediately', () => {
+    render(<LanguageSelect onSelect={mockOnSelect} />);
+    fireEvent.click(screen.getByTestId('lang-en')); // already selected
     expect(mockOnSelect).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Three user-reported Android startup regressions:

1. Black screen on launch — Capacitor's launchAutoHide fires after 2s
   regardless of WebView readiness, so on slow networks the splash vanished
   before the /→/{locale} redirect + remote HTML had finished loading.
   NativeAppProvider now hides the splash explicitly as soon as React mounts;
   the config keeps a 5s auto-hide as a safety net.

2. Language-select step looping — tapping a card called setLanguage() which
   triggered router.push('/{newLocale}'), remounting the OnboardingFlow and
   resetting `step` back to 'language'. LanguageSelect now defers setLanguage
   until the user taps the confirm button (or taps the already-selected card
   to advance), so no navigation fires mid-FTUE.

3. First launch landing on /legal/privacy — the Android WebView can restore
   stale history across app sessions, and App Links route external privacy
   links directly into the installed app. New NativeColdStartGuard runs once
   per native session: if the cold-start pathname sits under /legal/*, it
   redirects to /{locale} so users see the landing page instead of a legal
   doc. In-session navigation to legal pages is unaffected.