### PR TITLE
fix(daily-facts): suppress "Only X%" first-try fact when rate isn't rare

### DIFF
--- a/fe-next/utils/__tests__/dailyWordHuntFactsCalculator.test.ts
+++ b/fe-next/utils/__tests__/dailyWordHuntFactsCalculator.test.ts
@@ -54,6 +54,20 @@ describe('getWordHuntFacts', () => {
     expect(facts[0].type).toBe('firstTry');
   });
 
+  it('uses rare variant only when solve rate is actually rare', () => {
+    const result = makeResult({ attemptsUsed: 1, wordsDiscovered: [] });
+    const facts = getWordHuntFacts(result, makeStats({ solveRate: 15 }));
+    expect(facts[0].translationKey).toBe('wordHunt.facts.firstTryRare');
+  });
+
+  it('uses personal variant (no "Only X%" phrasing) when solve rate is high', () => {
+    const result = makeResult({ attemptsUsed: 1, wordsDiscovered: [] });
+    const facts = getWordHuntFacts(result, makeStats({ solveRate: 100 }));
+    expect(facts[0].type).toBe('firstTry');
+    expect(facts[0].translationKey).toBe('wordHunt.facts.firstTryPersonal');
+    expect(facts[0].translationParams.solveRate).toBeUndefined();
+  });
+
   it('prioritizes perfect score brag', () => {
     const result = makeResult({ efficiencyScore: 1000, attemptsUsed: 2 });
     const facts = getWordHuntFacts(result, makeStats());

--- a/fe-next/utils/dailyWordHuntFactsCalculator.ts
+++ b/fe-next/utils/dailyWordHuntFactsCalculator.ts
@@ -68,6 +68,7 @@ export interface WordHuntFact {
 const TOP_PERFORMER_THRESHOLD = 1;       // top 1% only — true brag territory
 const STREAK_LEGEND_DAYS = 30;           // 30+ days — rare
 const ELITE_SOLVE_RATE_THRESHOLD = 20;   // <20% solve rate
+const RARE_FIRST_TRY_THRESHOLD = 50;     // <50% first-try solve rate — "Only X%" wording only makes sense when X is low
 const LOW_LIFE_THRESHOLD = 50;           // speed pillar weak
 const LOW_EXPLORATION_THRESHOLD = 5;     // < 5 survival words
 const MANY_GUESSES_THRESHOLD = 5;        // 5+ guesses — accuracy pillar weak
@@ -100,7 +101,10 @@ function getFirstTryFact(result: WordHuntResult, stats: WordHuntStats): WordHunt
   ];
   const fallback = pickVariant(variants, result);
 
-  if (stats.totalPlayers < MIN_PLAYERS_FOR_STATS) {
+  if (
+    stats.totalPlayers < MIN_PLAYERS_FOR_STATS ||
+    stats.solveRate >= RARE_FIRST_TRY_THRESHOLD
+  ) {
     return {
       type: 'firstTry',
       translationKey: 'wordHunt.facts.firstTryPersonal',


### PR DESCRIPTION
The firstTryRare variant showed "Only {solveRate}% solve from the first
guess" whenever stats were available. When solveRate was high (e.g. 100%),
this produced nonsensical copy like "רק 100% פותרים מהניחוש הראשון"
("Only 100% solve from the first guess"). Gate the rare-phrased variant on
solveRate < 50% and fall back to the personal (no-percentage) variant
otherwise, mirroring the eliteClubRare rarity check.

https://claude.ai/code/session_014oi5V2FUS45WoWL3JvkvFz