### PR TITLE
fix(adventure): dedupe upgrade toasts and stop dropping fast word selections

### DIFF
--- a/fe-next/components/adventure/AdventureToast.tsx
+++ b/fe-next/components/adventure/AdventureToast.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { AdaptiveMotion, AdaptiveAnimatePresence } from '@/components/motion/AdaptiveMotion';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { getUpgradeVisualEffect } from '@/lib/adventure/upgradeEffects';
@@ -13,6 +13,8 @@ interface AdventureToastProps {
 
 interface ToastItem {
   id: string;
+  /** Stable key used to dedupe repeated triggers of the same upgrade/type. */
+  dedupeKey: string;
   icon: string;
   message: string;
   type: 'upgrade' | 'themed';
@@ -20,36 +22,88 @@ interface ToastItem {
 
 let _seq = 0;
 
+const THEMED_DEDUPE_KEY = 'themed';
+
 export function AdventureToast({
   upgradeTriggered,
   lastWordWasThemed,
 }: AdventureToastProps) {
   const { t } = useLanguage();
   const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const dismissTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   const dismiss = useCallback((id: string) => {
     setToasts(prev => prev.filter(t => t.id !== id));
+    const timer = dismissTimersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      dismissTimersRef.current.delete(id);
+    }
   }, []);
+
+  // Replace any existing toast with the same dedupeKey — rapid repeats of the
+  // same upgrade (e.g. collecting gold on consecutive words) must not stack.
+  const pushToast = useCallback((next: ToastItem, autoDismissMs: number) => {
+    setToasts(prev => {
+      const filtered = prev.filter(t => t.dedupeKey !== next.dedupeKey);
+      // Cancel the timer for any toast we're replacing so it can't dismiss the new one.
+      for (const t of prev) {
+        if (t.dedupeKey === next.dedupeKey) {
+          const existing = dismissTimersRef.current.get(t.id);
+          if (existing) {
+            clearTimeout(existing);
+            dismissTimersRef.current.delete(t.id);
+          }
+        }
+      }
+      return [...filtered, next];
+    });
+    const timer = setTimeout(() => dismiss(next.id), autoDismissMs);
+    dismissTimersRef.current.set(next.id, timer);
+  }, [dismiss]);
 
   useEffect(() => {
     if (!upgradeTriggered) return;
     const effect = getUpgradeVisualEffect(upgradeTriggered.upgradeId);
     if (!effect) return;
-    const id = `upg-${++_seq}`;
-    setToasts(prev => [...prev, { id, icon: effect.hudIcon, message: t(effect.triggerToastKey), type: 'upgrade' }]);
-    const timer = setTimeout(() => dismiss(id), 2000);
-    return () => clearTimeout(timer);
+    pushToast(
+      {
+        id: `upg-${++_seq}`,
+        dedupeKey: `upg-${upgradeTriggered.upgradeId}`,
+        icon: effect.hudIcon,
+        message: t(effect.triggerToastKey),
+        type: 'upgrade',
+      },
+      2000,
+    );
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [upgradeTriggered]);
 
   useEffect(() => {
     if (!lastWordWasThemed) return;
-    const id = `themed-${++_seq}`;
-    setToasts(prev => [...prev, { id, icon: '🌿', message: t('adventure.toast.themedWord'), type: 'themed' }]);
-    const timer = setTimeout(() => dismiss(id), 1500);
-    return () => clearTimeout(timer);
+    pushToast(
+      {
+        id: `themed-${++_seq}`,
+        dedupeKey: THEMED_DEDUPE_KEY,
+        icon: '🌿',
+        message: t('adventure.toast.themedWord'),
+        type: 'themed',
+      },
+      1500,
+    );
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastWordWasThemed]);
+
+  // Clean up pending dismiss timers on unmount.
+  useEffect(() => {
+    const timers = dismissTimersRef.current;
+    return () => {
+      for (const timer of timers.values()) {
+        clearTimeout(timer);
+      }
+      timers.clear();
+    };
+  }, []);
 
   return (
     <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-30 flex flex-col items-center gap-2 pointer-events-none">

--- a/fe-next/components/adventure/__tests__/AdventureToast.test.tsx
+++ b/fe-next/components/adventure/__tests__/AdventureToast.test.tsx
@@ -90,4 +90,54 @@ describe('AdventureToast', () => {
     const toast = screen.getByRole('status');
     expect(toast).toHaveAttribute('aria-live', 'polite');
   });
+
+  it('deduplicates repeated triggers of the same upgrade into a single toast', () => {
+    const { rerender } = render(
+      <AdventureToast
+        upgradeTriggered={{ upgradeId: 'luckyPickaxe', effectValue: 1 }}
+        lastWordWasThemed={false}
+      />
+    );
+    // Fire the same upgrade trigger multiple times in quick succession
+    rerender(
+      <AdventureToast
+        upgradeTriggered={{ upgradeId: 'luckyPickaxe', effectValue: 2 }}
+        lastWordWasThemed={false}
+      />
+    );
+    rerender(
+      <AdventureToast
+        upgradeTriggered={{ upgradeId: 'luckyPickaxe', effectValue: 3 }}
+        lastWordWasThemed={false}
+      />
+    );
+    rerender(
+      <AdventureToast
+        upgradeTriggered={{ upgradeId: 'luckyPickaxe', effectValue: 4 }}
+        lastWordWasThemed={false}
+      />
+    );
+
+    // Only a single toast for that upgrade should be visible — not 4
+    const toasts = screen.getAllByRole('status');
+    expect(toasts).toHaveLength(1);
+  });
+
+  it('keeps separate toasts for different upgrade ids', () => {
+    const { rerender } = render(
+      <AdventureToast
+        upgradeTriggered={{ upgradeId: 'deepDrill', effectValue: 1 }}
+        lastWordWasThemed={false}
+      />
+    );
+    rerender(
+      <AdventureToast
+        upgradeTriggered={{ upgradeId: 'luckyPickaxe', effectValue: 1 }}
+        lastWordWasThemed={false}
+      />
+    );
+
+    const toasts = screen.getAllByRole('status');
+    expect(toasts).toHaveLength(2);
+  });
 });

--- a/fe-next/components/adventure/hooks/__tests__/useAdventureWordSubmit.test.ts
+++ b/fe-next/components/adventure/hooks/__tests__/useAdventureWordSubmit.test.ts
@@ -131,7 +131,7 @@ describe('useAdventureWordSubmit', () => {
     expect(mockValidateWord).not.toHaveBeenCalled();
   });
 
-  it('should block submission during cascade to prevent state overlap', async () => {
+  it('should defer submission during cascade (not validate immediately)', async () => {
     mockValidateWord.mockResolvedValue({ isValid: true, score: 50 });
 
     const { result } = renderHook(() =>
@@ -142,7 +142,64 @@ describe('useAdventureWordSubmit', () => {
       await result.current.handleWordSubmit('hello', [0, 1, 2, 3, 4]);
     });
 
+    // While cascade is active, validation is deferred
     expect(mockValidateWord).not.toHaveBeenCalled();
+  });
+
+  it('flushes a queued submission after cascade ends', async () => {
+    mockValidateWord.mockResolvedValue({ isValid: true, score: 50 });
+
+    const { result, rerender } = renderHook(
+      ({ isCascading }: { isCascading: boolean }) =>
+        useAdventureWordSubmit({ ...defaultProps, isCascading }),
+      { initialProps: { isCascading: true } }
+    );
+
+    // Submit a word while cascade is in progress — it should queue
+    await act(async () => {
+      await result.current.handleWordSubmit('hello', [0, 1, 2, 3, 4]);
+    });
+    expect(mockValidateWord).not.toHaveBeenCalled();
+
+    // Cascade ends → queued submission flushes
+    await act(async () => {
+      rerender({ isCascading: false });
+    });
+
+    expect(mockValidateWord).toHaveBeenCalledWith('hello', expect.any(Array));
+  });
+
+  it('allows different concurrent words without silently dropping the second', async () => {
+    mockValidateWord.mockResolvedValue({ isValid: true, score: 50 });
+
+    const { result } = renderHook(() => useAdventureWordSubmit(defaultProps));
+
+    // Fire two different words back-to-back before the first's validation
+    // promise microtask settles. Second call must not be silently dropped.
+    await act(async () => {
+      const p1 = result.current.handleWordSubmit('hello', [0, 1, 2, 3, 4]);
+      const p2 = result.current.handleWordSubmit('world', [5, 6, 7, 8, 9]);
+      await Promise.all([p1, p2]);
+    });
+
+    expect(mockValidateWord).toHaveBeenCalledWith('hello', expect.any(Array));
+    expect(mockValidateWord).toHaveBeenCalledWith('world', expect.any(Array));
+  });
+
+  it('drops duplicate submission of the same in-flight word', async () => {
+    mockValidateWord.mockResolvedValue({ isValid: true, score: 50 });
+
+    const { result } = renderHook(() => useAdventureWordSubmit(defaultProps));
+
+    // Fire the SAME word twice before the first validation settles.
+    // The second must be dropped so we don't emit double popups/feedback.
+    await act(async () => {
+      const p1 = result.current.handleWordSubmit('hello', [0, 1, 2, 3, 4]);
+      const p2 = result.current.handleWordSubmit('hello', [0, 1, 2, 3, 4]);
+      await Promise.all([p1, p2]);
+    });
+
+    expect(mockValidateWord).toHaveBeenCalledTimes(1);
   });
 
   it('should handle valid word submission', async () => {

--- a/fe-next/components/adventure/hooks/useAdventureWordSubmit.ts
+++ b/fe-next/components/adventure/hooks/useAdventureWordSubmit.ts
@@ -143,15 +143,20 @@ export function useAdventureWordSubmit(props: UseAdventureWordSubmitProps): UseA
   const wordSubmittedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSubmittedWordRef = useRef<{ word: string; path: Array<{ row: number; col: number }> } | null>(null);
   const prevComboCountRef = useRef(0);
-  // Synchronous guard to prevent double-submission from React state batching
-  const isSubmittingRef = useRef(false);
+  // Track same-word submissions currently in-flight. Different words are
+  // allowed to validate concurrently; only identical duplicates are dropped.
+  const inFlightWordsRef = useRef<Set<string>>(new Set());
+  // Holds a submission received during cascade so we can replay it once the
+  // cascade finishes — otherwise fast consecutive words get silently dropped.
+  const pendingCascadeSubmissionRef = useRef<{ word: string; indices: number[] } | null>(null);
 
   // Cleanup timeouts and guards on unmount
   useEffect(() => {
     return () => {
       if (validationErrorTimeoutRef.current) clearTimeout(validationErrorTimeoutRef.current);
       if (wordSubmittedTimeoutRef.current) clearTimeout(wordSubmittedTimeoutRef.current);
-      isSubmittingRef.current = false;
+      inFlightWordsRef.current.clear();
+      pendingCascadeSubmissionRef.current = null;
     };
   }, []);
 
@@ -160,7 +165,7 @@ export function useAdventureWordSubmit(props: UseAdventureWordSubmitProps): UseA
       const word = submittedWord || currentWord;
       const indices = submittedIndices.length > 0 ? submittedIndices : selectedIndices;
 
-      if (!isPlaying || isPaused || isCascading || isSubmittingRef.current) {
+      if (!isPlaying || isPaused) {
         clearSelection();
         return;
       }
@@ -168,7 +173,24 @@ export function useAdventureWordSubmit(props: UseAdventureWordSubmitProps): UseA
         clearSelection();
         return;
       }
-      isSubmittingRef.current = true;
+
+      const normalizedWord = word.toLowerCase();
+
+      // Queue the submission during cascade so rapid swipes aren't lost.
+      // Replay after cascade ends (useEffect below).
+      if (isCascading) {
+        pendingCascadeSubmissionRef.current = { word, indices };
+        clearSelection();
+        return;
+      }
+
+      // Drop only duplicates of a word already being validated — different
+      // words must be allowed through concurrently.
+      if (inFlightWordsRef.current.has(normalizedWord)) {
+        clearSelection();
+        return;
+      }
+      inFlightWordsRef.current.add(normalizedWord);
 
       tap();
 
@@ -193,11 +215,11 @@ export function useAdventureWordSubmit(props: UseAdventureWordSubmitProps): UseA
         result = await validateWord(word, path);
       } catch {
         // Network error or unexpected failure — unblock future submissions
-        isSubmittingRef.current = false;
+        inFlightWordsRef.current.delete(normalizedWord);
         setValidationFeedback(prev => ({ ...prev, error: 'validationError' }));
         return;
       }
-      isSubmittingRef.current = false;
+      inFlightWordsRef.current.delete(normalizedWord);
 
       // Silently ignore cancelled validations (aborted by a newer submission)
       // Still clear selection so tiles don't stay highlighted ("stuck word" bug)
@@ -355,6 +377,19 @@ export function useAdventureWordSubmit(props: UseAdventureWordSubmitProps): UseA
     [isPlaying, isPaused, isCascading, currentWord, selectedIndices, tiles, gridSize, validateWord, submitWordWithPath, clearSelection, t, getPopupStartPosition, comboCount, wordsFound, clearCurrentHint, recordActivity, resetOnGameAction, isBossActive, bossConfig, checkBossWord, triggerBossTaunt, dealBossDamage, minWordLength, upgradeBonuses.scoreBonus, skillEffects, handleEarnAchievement, recordAIWord, handleAITransition, addScorePopup, getScoreMultiplier, worldMechanic, bossCurrentPhase, tap, hapticSuccess, bossHealPerWord, healPlayerHealth, detonateActive]
   );
 
+  // Flush a submission queued during cascade once cascade ends. Tile letters
+  // may have shifted — validateWord re-checks path-word match and will reject
+  // with proper feedback instead of silently dropping the word.
+  const handleWordSubmitRef = useRef(handleWordSubmit);
+  useEffect(() => { handleWordSubmitRef.current = handleWordSubmit; }, [handleWordSubmit]);
+  useEffect(() => {
+    if (isCascading) return;
+    const pending = pendingCascadeSubmissionRef.current;
+    if (!pending) return;
+    pendingCascadeSubmissionRef.current = null;
+    void handleWordSubmitRef.current(pending.word, pending.indices);
+  }, [isCascading]);
+
   const resetWordSubmitState = useCallback(() => {
     setValidationFeedback({ error: null, wasSubmitted: false, isValid: false });
     setLastAccepted(null);
@@ -363,7 +398,8 @@ export function useAdventureWordSubmit(props: UseAdventureWordSubmitProps): UseA
     setMechanicHitCount(0);
     lastSubmittedWordRef.current = null;
     prevComboCountRef.current = 0;
-    isSubmittingRef.current = false;
+    inFlightWordsRef.current.clear();
+    pendingCascadeSubmissionRef.current = null;
     if (validationErrorTimeoutRef.current) {
       clearTimeout(validationErrorTimeoutRef.current);
       validationErrorTimeoutRef.current = null;


### PR DESCRIPTION
- AdventureToast: repeated triggers of the same upgrade (e.g. luckyPickaxe
  on consecutive words) now replace the existing toast instead of stacking,
  and their dismiss timers are reset. Fixes the pile of 4x
  "Lucky Pickaxe - Bonus Gold!" banners reported in blast mode.
- useAdventureWordSubmit: replace the global isSubmittingRef boolean with
  a per-word in-flight Set so different words can validate concurrently
  (previously the second of two fast submissions was silently dropped).
  Submissions received during cascade are now queued and replayed when
  cascade ends, instead of disappearing entirely.

https://claude.ai/code/session_01MLimuoKAFrW99WT2i5tXpm