### PR TITLE
fix(mobile-nav): lift GlobalBottomNav above AdSense anchor ad

### DIFF
--- a/fe-next/app/[locale]/layout.tsx
+++ b/fe-next/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import DesktopGameNav from '@/components/DesktopGameNav';
 import GoogleConsentMode from '@/components/GoogleConsentMode';
 import GoogleAnalytics from '@/components/GoogleAnalytics';
 import GoogleAdSense from '@/components/GoogleAdSense';
+import AdSenseAnchorTracker from '@/components/ads/AdSenseAnchorTracker';
 import CrazyGamesScriptServer from '@/components/CrazyGamesScriptServer';
 import WebVitalsReporter from '@/components/WebVitalsReporter';
 import PWAInstallPrompt from '@/components/PWAInstallPrompt';
@@ -519,6 +520,8 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
                 {/* Load external scripts with optimized strategies to prevent blocking */}
                 <GoogleAnalytics />
                 <GoogleAdSense />
+                {/* Tracks Google's sticky bottom anchor ad so GlobalBottomNav can offset above it */}
+                <AdSenseAnchorTracker />
                 <SocialMediaPixels />
                 <WebVitalsReporter />
                 <ServiceWorkerRegistration />

--- a/fe-next/app/animations.css
+++ b/fe-next/app/animations.css
@@ -820,6 +820,9 @@
   /* AdMob anchored banner height — set by AnchoredNativeBanner on SizeChanged */
   --admob-banner-height: 0px;
 
+  /* Google AdSense anchor (sticky bottom) ad height — set by useAdSenseAnchorHeight */
+  --adsense-anchor-height: 0px;
+
   /* Combined safe area - use Capacitor values if set, fall back to env() */
   --combined-safe-area-top: max(var(--safe-area-top), var(--cap-safe-area-top));
   --combined-safe-area-bottom: calc(max(var(--safe-area-bottom), var(--cap-safe-area-bottom)) + var(--admob-banner-height));

--- a/fe-next/components/GlobalBottomNav.tsx
+++ b/fe-next/components/GlobalBottomNav.tsx
@@ -166,14 +166,16 @@ export const GlobalBottomNav = memo(function GlobalBottomNav() {
     return (
         <nav
             className={cn(
-                "fixed bottom-0 left-0 right-0 z-[80]",
+                "fixed left-0 right-0 z-[80]",
                 "bg-neo-navy",
                 "border-t-3 border-neo-black",
                 "shadow-[0_-4px_0_0_rgba(0,0,0,1)]",
                 "sm:hidden",
             )}
             style={{
-                // Nav sits at screen bottom. Banner (when shown) floats above nav via AdMob margin, so nav keeps the full safe-area as its own padding.
+                // Float above AdSense's sticky bottom anchor ad when present (0 otherwise).
+                // Native AdMob banner stacks via its own plugin margin — see AnchoredNativeBanner.
+                bottom: 'var(--adsense-anchor-height, 0px)',
                 paddingBottom: safeArea.bottom > 0 ? `${safeArea.bottom}px` : 'env(safe-area-inset-bottom, 0px)',
             }}
             aria-label={t('nav.bottomNavigation')}

--- a/fe-next/components/ads/AdSenseAnchorTracker.tsx
+++ b/fe-next/components/ads/AdSenseAnchorTracker.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useAdSenseAnchorHeight } from '@/hooks/useAdSenseAnchorHeight';
+
+/**
+ * Mounts the AdSense anchor-ad tracker so fixed bottom UI (e.g. GlobalBottomNav)
+ * can offset itself above Google's auto-placed sticky bottom ad via the
+ * `--adsense-anchor-height` CSS variable.
+ */
+export function AdSenseAnchorTracker() {
+  useAdSenseAnchorHeight();
+  return null;
+}
+
+export default AdSenseAnchorTracker;

--- a/fe-next/hooks/__tests__/useAdSenseAnchorHeight.test.tsx
+++ b/fe-next/hooks/__tests__/useAdSenseAnchorHeight.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAdSenseAnchorHeight } from '../useAdSenseAnchorHeight';
+
+const ANCHOR_VAR = '--adsense-anchor-height';
+
+function setElementHeight(el: HTMLElement, height: number) {
+  Object.defineProperty(el, 'offsetHeight', {
+    configurable: true,
+    get: () => height,
+  });
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      top: window.innerHeight - height,
+      bottom: window.innerHeight,
+      left: 0,
+      right: window.innerWidth,
+      width: window.innerWidth,
+      height,
+      x: 0,
+      y: window.innerHeight - height,
+      toJSON: () => ({}),
+    }),
+  });
+}
+
+function makeAnchorAd(height: number): HTMLElement {
+  const ins = document.createElement('ins');
+  ins.className = 'adsbygoogle';
+  ins.setAttribute('data-anchor-status', 'displayed');
+  ins.style.position = 'fixed';
+  ins.style.bottom = '0';
+  ins.style.left = '0';
+  ins.style.right = '0';
+  setElementHeight(ins, height);
+  return ins;
+}
+
+describe('useAdSenseAnchorHeight', () => {
+  beforeEach(() => {
+    document.documentElement.style.removeProperty(ANCHOR_VAR);
+    document.body.innerHTML = '';
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 400 });
+  });
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty(ANCHOR_VAR);
+    document.body.innerHTML = '';
+  });
+
+  it('sets CSS variable to 0 when no AdSense anchor ad is present', () => {
+    renderHook(() => useAdSenseAnchorHeight());
+    expect(document.documentElement.style.getPropertyValue(ANCHOR_VAR)).toBe('0px');
+  });
+
+  it('updates CSS variable with ad height when an anchor ad is added to body', async () => {
+    renderHook(() => useAdSenseAnchorHeight());
+
+    await act(async () => {
+      const ad = makeAnchorAd(90);
+      document.body.appendChild(ad);
+      // Allow MutationObserver microtask to flush
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.documentElement.style.getPropertyValue(ANCHOR_VAR)).toBe('90px');
+  });
+
+  it('resets CSS variable to 0 when the anchor ad is removed', async () => {
+    const ad = makeAnchorAd(70);
+    document.body.appendChild(ad);
+
+    renderHook(() => useAdSenseAnchorHeight());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.documentElement.style.getPropertyValue(ANCHOR_VAR)).toBe('70px');
+
+    await act(async () => {
+      ad.remove();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.documentElement.style.getPropertyValue(ANCHOR_VAR)).toBe('0px');
+  });
+
+  it('ignores non-fixed adsbygoogle elements (inline content ads)', async () => {
+    renderHook(() => useAdSenseAnchorHeight());
+
+    await act(async () => {
+      const inline = document.createElement('ins');
+      inline.className = 'adsbygoogle';
+      inline.style.display = 'block';
+      setElementHeight(inline, 250);
+      document.body.appendChild(inline);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.documentElement.style.getPropertyValue(ANCHOR_VAR)).toBe('0px');
+  });
+
+  it('clears CSS variable on unmount', async () => {
+    const ad = makeAnchorAd(60);
+    document.body.appendChild(ad);
+
+    const { unmount } = renderHook(() => useAdSenseAnchorHeight());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.documentElement.style.getPropertyValue(ANCHOR_VAR)).toBe('60px');
+
+    unmount();
+
+    expect(document.documentElement.style.getPropertyValue(ANCHOR_VAR)).toBe('0px');
+  });
+});

--- a/fe-next/hooks/useAdSenseAnchorHeight.ts
+++ b/fe-next/hooks/useAdSenseAnchorHeight.ts
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const ANCHOR_VAR = '--adsense-anchor-height';
+
+const ANCHOR_SELECTOR = [
+  'ins.adsbygoogle[data-anchor-status="displayed"]',
+  'ins.adsbygoogle[data-anchor-shown="true"]',
+  'ins.adsbygoogle[data-anchor-status]',
+  'ins.adsbygoogle.google-anchor',
+  '.google-auto-placed[data-anchor-status="displayed"]',
+].join(',');
+
+function isFixedToBottom(el: HTMLElement): boolean {
+  const cs = (typeof window !== 'undefined' ? window.getComputedStyle(el) : null);
+  const position = cs?.position ?? el.style.position;
+  if (position !== 'fixed') return false;
+
+  const rect = el.getBoundingClientRect();
+  const viewportH = typeof window !== 'undefined' ? window.innerHeight : 0;
+  // Consider "near bottom" when the element's bottom is within 8px of viewport bottom.
+  return rect.height > 0 && Math.abs(rect.bottom - viewportH) <= 8;
+}
+
+function findAnchorAd(): HTMLElement | null {
+  if (typeof document === 'undefined') return null;
+  const nodes = document.querySelectorAll<HTMLElement>(ANCHOR_SELECTOR);
+  for (const el of Array.from(nodes)) {
+    if (isFixedToBottom(el)) return el;
+  }
+  return null;
+}
+
+function setVar(height: number) {
+  if (typeof document === 'undefined') return;
+  document.documentElement.style.setProperty(ANCHOR_VAR, `${height}px`);
+}
+
+/**
+ * Tracks Google AdSense "anchor" (sticky bottom overlay) ads and exposes their
+ * current height via the `--adsense-anchor-height` CSS variable.
+ *
+ * AdSense auto-ads inject a fixed-position overlay at the bottom of the
+ * viewport which otherwise covers our fixed mobile bottom navigation. Other
+ * fixed-bottom UI reads this variable to offset itself above the ad.
+ */
+export function useAdSenseAnchorHeight(): void {
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    let trackedEl: HTMLElement | null = null;
+    let resizeObserver: ResizeObserver | null = null;
+
+    const measure = () => {
+      if (!trackedEl || !trackedEl.isConnected || !isFixedToBottom(trackedEl)) {
+        setVar(0);
+        return;
+      }
+      const h = trackedEl.getBoundingClientRect().height || trackedEl.offsetHeight || 0;
+      setVar(Math.round(h));
+    };
+
+    const track = (el: HTMLElement | null) => {
+      if (trackedEl === el) {
+        measure();
+        return;
+      }
+      resizeObserver?.disconnect();
+      resizeObserver = null;
+      trackedEl = el;
+      if (el && typeof ResizeObserver !== 'undefined') {
+        resizeObserver = new ResizeObserver(() => measure());
+        resizeObserver.observe(el);
+      }
+      measure();
+    };
+
+    const rescan = () => track(findAnchorAd());
+
+    rescan();
+
+    const mutationObserver = new MutationObserver(rescan);
+    mutationObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class', 'style', 'data-anchor-status', 'data-anchor-shown'],
+    });
+
+    const onResize = () => measure();
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      mutationObserver.disconnect();
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', onResize);
+      setVar(0);
+    };
+  }, []);
+}
+
+export default useAdSenseAnchorHeight;


### PR DESCRIPTION
Google AdSense auto-ads inject a fixed-position sticky banner at the
bottom of the viewport which covered the mobile bottom-tab nav. Track
the anchor ad with a MutationObserver + ResizeObserver, publish its
height to a --adsense-anchor-height CSS var, and use that var as the
nav's bottom offset so the nav floats above the ad.

https://claude.ai/code/session_01MG3C8EP3FCjcPPEtoAanzg