### PR TITLE
fix(ads): position mobile ads above bottom nav with no gap

### DIFF
--- a/fe-next/__tests__/components/GlobalBottomNav.test.tsx
+++ b/fe-next/__tests__/components/GlobalBottomNav.test.tsx
@@ -164,7 +164,28 @@ describe('GlobalBottomNav', () => {
 
             const { container } = render(<GlobalBottomNav />);
             const nav = container.querySelector('nav');
-            expect(nav).toHaveStyle({ paddingBottom: 'max(0px, 34px - var(--admob-banner-height, 0px))' });
+            // Nav sits flush at viewport bottom; safe-area padding is applied directly
+            // (ads are positioned above the nav, not beneath it).
+            expect(nav).toHaveStyle({ paddingBottom: '34px', bottom: '0px' });
+        });
+
+        it('should sit flush at viewport bottom with no safe-area inset', () => {
+            const { container } = render(<GlobalBottomNav />);
+            const nav = container.querySelector('nav');
+            expect(nav).toHaveStyle({ bottom: '0px' });
+        });
+
+        it('should set has-global-bottom-nav class on html while visible', () => {
+            const { unmount } = render(<GlobalBottomNav />);
+            expect(document.documentElement.classList.contains('has-global-bottom-nav')).toBe(true);
+            unmount();
+            expect(document.documentElement.classList.contains('has-global-bottom-nav')).toBe(false);
+        });
+
+        it('should not set has-global-bottom-nav class when hidden (in game)', () => {
+            (useNavigation as Mock).mockReturnValue({ isInGame: true });
+            render(<GlobalBottomNav />);
+            expect(document.documentElement.classList.contains('has-global-bottom-nav')).toBe(false);
         });
     });
 

--- a/fe-next/app/globals.css
+++ b/fe-next/app/globals.css
@@ -3114,6 +3114,19 @@ html {
   }
 }
 
+/* Offset Google AdSense anchor (sticky-bottom) ads above GlobalBottomNav so the
+   nav stays flush at the viewport bottom. Scoped to mobile viewports where the
+   nav renders, and only when GlobalBottomNav has mounted (sets the html class).
+   AdSense injects these as inline style="bottom:0", so !important is required. */
+@media (max-width: 639px) {
+  html.has-global-bottom-nav ins.adsbygoogle[data-anchor-status="displayed"],
+  html.has-global-bottom-nav ins.adsbygoogle[data-anchor-shown="true"],
+  html.has-global-bottom-nav ins.adsbygoogle.google-anchor,
+  html.has-global-bottom-nav .google-auto-placed[data-anchor-status="displayed"] {
+    bottom: calc(var(--bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px)) !important;
+  }
+}
+
 /* Fixed positioning utilities with safe areas */
 .fixed-safe-top {
   top: max(env(safe-area-inset-top, 0px), 0px);

--- a/fe-next/components/GlobalBottomNav.tsx
+++ b/fe-next/components/GlobalBottomNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { Home, Swords, ScrollText, Users } from 'lucide-react';
@@ -161,25 +161,34 @@ export const GlobalBottomNav = memo(function GlobalBottomNav() {
     }, [pathname, language]);
 
     // Hide entire bottom nav on CrazyGames — external links and social features prohibited
-    if (isInGame || shouldHideOnCurrentPath || isOnCrazyGamesPlatform) return null;
+    const isHidden = isInGame || shouldHideOnCurrentPath || isOnCrazyGamesPlatform;
+
+    // Signal nav visibility to CSS so sticky ads (AdSense anchor) can offset above it.
+    useEffect(() => {
+        if (typeof document === 'undefined') return;
+        document.documentElement.classList.toggle('has-global-bottom-nav', !isHidden);
+        return () => {
+            document.documentElement.classList.remove('has-global-bottom-nav');
+        };
+    }, [isHidden]);
+
+    if (isHidden) return null;
 
     return (
         <nav
             className={cn(
-                "fixed left-0 right-0 z-[80]",
+                "fixed left-0 right-0 bottom-0 z-[80]",
                 "bg-neo-navy",
                 "border-t-3 border-neo-black",
                 "shadow-[0_-4px_0_0_rgba(0,0,0,1)]",
                 "sm:hidden",
             )}
             style={{
-                // Float above whichever sticky bottom ad is present:
-                // --adsense-anchor-height (web) or --admob-banner-height (native Capacitor).
-                // Both fall back to 0px when inactive, so the sum is safe cross-platform.
-                bottom: 'calc(var(--adsense-anchor-height, 0px) + var(--admob-banner-height, 0px))',
-                // AdMob banner anchors at true bottom and absorbs safe-area itself —
-                // subtract it from padding to avoid double gap. AdSense doesn't, so padding persists.
-                paddingBottom: `max(0px, ${safeArea.bottom > 0 ? `${safeArea.bottom}px` : 'env(safe-area-inset-bottom, 0px)'} - var(--admob-banner-height, 0px))`,
+                // Nav sits flush at the viewport bottom. Sticky ads (AdSense anchor / AdMob
+                // banner) are positioned ABOVE this nav via CSS override / plugin margin,
+                // so no bottom offset is needed here.
+                bottom: 0,
+                paddingBottom: safeArea.bottom > 0 ? `${safeArea.bottom}px` : 'env(safe-area-inset-bottom, 0px)',
             }}
             aria-label={t('nav.bottomNavigation')}
         >

--- a/fe-next/components/ads/AnchoredNativeBanner.tsx
+++ b/fe-next/components/ads/AnchoredNativeBanner.tsx
@@ -25,10 +25,37 @@ const GAME_ROUTES = [
   '/profile',
 ];
 
+// Paths where GlobalBottomNav is hidden — on these, the banner can sit flush at the bottom.
+// Kept in sync with pathsWithOwnNav in GlobalBottomNav.
+const PATHS_WITH_OWN_NAV = [
+  '/multiplayer',
+  '/singleplayer',
+  '/daily',
+  '/adventure',
+  '/education',
+  '/student',
+  '/teacher',
+  '/admin',
+  '/brain',
+  '/challenge',
+  '/custom',
+  '/join',
+];
+
+// Matches h-16 on GlobalBottomNav (64px). Safe-area padding is absorbed by the
+// AdMob plugin at BOTTOM_CENTER, so the margin only needs to clear the nav's content.
+const GLOBAL_BOTTOM_NAV_HEIGHT = 64;
+
 function isAllowedRoute(pathname: string | null): boolean {
   if (!pathname) return false;
   const path = pathname.replace(/^\/(en|he|sv|ja|es)/, '') || '/';
   return !GAME_ROUTES.some((r) => path.startsWith(r));
+}
+
+function hasGlobalBottomNav(pathname: string | null): boolean {
+  if (!pathname) return false;
+  const path = pathname.replace(/^\/(en|he|sv|ja|es)/, '') || '/';
+  return !PATHS_WITH_OWN_NAV.some((r) => path.startsWith(r));
 }
 
 export default function AnchoredNativeBanner() {
@@ -65,13 +92,14 @@ export default function AnchoredNativeBanner() {
     let cancelled = false;
 
     if (isAllowedRoute(pathname)) {
-      // Anchor banner at true screen bottom (margin=0; plugin auto-excludes iOS notch).
-      // GlobalBottomNav reads --admob-banner-height CSS var (set via SizeChanged)
-      // and offsets itself up, so nav stacks flush above banner without magic constants.
+      // Banner sits ABOVE the GlobalBottomNav (when present) so the nav stays flush
+      // at the viewport bottom. Plugin auto-excludes iOS safe-area, so margin only
+      // needs to clear the nav's visible height; on pages without the nav, margin=0.
+      const margin = hasGlobalBottomNav(pathname) ? GLOBAL_BOTTOM_NAV_HEIGHT : 0;
       (async () => {
         await hideBanner();
         if (cancelled) return;
-        await showBanner(BannerAdPosition.BOTTOM_CENTER, 0);
+        await showBanner(BannerAdPosition.BOTTOM_CENTER, margin);
       })();
     } else {
       hideBanner();

--- a/fe-next/components/ads/__tests__/AnchoredNativeBanner.test.tsx
+++ b/fe-next/components/ads/__tests__/AnchoredNativeBanner.test.tsx
@@ -48,6 +48,27 @@ describe('AnchoredNativeBanner', () => {
     expect(showBanner).toHaveBeenCalledTimes(1);
   });
 
+  it('shows banner above GlobalBottomNav on home route (margin=64)', async () => {
+    mockPathname.current = '/';
+    render(<AnchoredNativeBanner />);
+    await Promise.resolve();
+    expect(showBanner).toHaveBeenCalledWith('BOTTOM_CENTER', 64);
+  });
+
+  it('shows banner above GlobalBottomNav on /settings (margin=64)', async () => {
+    mockPathname.current = '/settings';
+    render(<AnchoredNativeBanner />);
+    await Promise.resolve();
+    expect(showBanner).toHaveBeenCalledWith('BOTTOM_CENTER', 64);
+  });
+
+  it('shows banner flush at bottom on /education (nav hidden, margin=0)', async () => {
+    mockPathname.current = '/education';
+    render(<AnchoredNativeBanner />);
+    await Promise.resolve();
+    expect(showBanner).toHaveBeenCalledWith('BOTTOM_CENTER', 0);
+  });
+
   it('shows banner on locale-prefixed home', async () => {
     mockPathname.current = '/he';
     render(<AnchoredNativeBanner />);


### PR DESCRIPTION
Invert the previous stack so the GlobalBottomNav sits flush at the
viewport bottom and sticky ads render directly above it. Previously the
nav was pushed up by --adsense-anchor-height + --admob-banner-height,
which left the ad at the true bottom and created the visual gap the
user reported.

- GlobalBottomNav: pin to bottom: 0, drop the banner-height subtraction
  from safe-area padding, and toggle a has-global-bottom-nav class on
  <html> so CSS can target sticky ads only when the nav is visible.
- AnchoredNativeBanner (native AdMob): pass nav-height (64px) as the
  margin to showBanner on routes where the nav renders; fall back to
  margin=0 on routes with their own nav. Plugin absorbs iOS safe-area.
- globals.css: override AdSense anchor-ad inline bottom:0 on mobile
  when has-global-bottom-nav is set, pushing the ad above the nav.
- Update tests to assert the new flush-at-bottom styling, class toggling
  and AdMob margin behavior on both hub and own-nav routes.