### PR TITLE
fix(friends): enable send button during Hebrew IME composition

### DIFF
--- a/fe-next/components/friends/messaging/MessageComposer.test.tsx
+++ b/fe-next/components/friends/messaging/MessageComposer.test.tsx
@@ -1,0 +1,86 @@
+// @ts-nocheck
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MessageComposer } from './MessageComposer';
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({
+    language: 'he',
+    dir: 'rtl',
+    t: (key: string, params?: Record<string, string | number>) => {
+      const translations: Record<string, string> = {
+        'friends.typeMessage': 'Type a message...',
+        'friends.sendMessage': 'Send',
+        'friends.messageLimit': '{current}/{max} chars',
+      };
+      let result = translations[key] || key;
+      if (params) {
+        Object.entries(params).forEach(([k, v]) => {
+          result = result.replace(`{${k}}`, String(v));
+        });
+      }
+      return result;
+    },
+  }),
+}));
+
+vi.mock('@/utils/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'dark' }),
+}));
+
+describe('MessageComposer — Hebrew/IME composition', () => {
+  it('enables send button and sends text after IME composition ends (Android GBoard Hebrew)', () => {
+    // Given: A composer with onSend handler
+    const onSend = vi.fn();
+    render(<MessageComposer onSend={onSend} />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const sendButton = screen.getByLabelText('Send') as HTMLButtonElement;
+
+    // Initial state: send disabled, counter shows 0
+    expect(sendButton).toBeDisabled();
+    expect(screen.getByText('0/1000 chars')).toBeInTheDocument();
+
+    // When: Simulate Android IME composing Hebrew without firing onChange
+    // (GBoard with Hebrew: composition buffers into the DOM value but React
+    // onChange may not fire until the word commits)
+    fireEvent.compositionStart(textarea);
+    // Directly mutate DOM value as if IME buffered composition text
+    Object.defineProperty(textarea, 'value', {
+      configurable: true,
+      writable: true,
+      value: 'שלום',
+    });
+    fireEvent.compositionEnd(textarea, { data: 'שלום' });
+
+    // Then: state syncs from the DOM value
+    expect(screen.getByText('4/1000 chars')).toBeInTheDocument();
+    expect(sendButton).not.toBeDisabled();
+
+    // And: clicking send emits the text
+    fireEvent.click(sendButton);
+    expect(onSend).toHaveBeenCalledWith('שלום');
+  });
+
+  it('sends text even when composition never ends (fallback reads DOM value)', () => {
+    // Given: composer
+    const onSend = vi.fn();
+    render(<MessageComposer onSend={onSend} />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const sendButton = screen.getByLabelText('Send') as HTMLButtonElement;
+
+    // When: IME writes to DOM value without compositionEnd firing
+    Object.defineProperty(textarea, 'value', {
+      configurable: true,
+      writable: true,
+      value: 'שלום',
+    });
+    fireEvent.input(textarea);
+
+    // Then: send button becomes enabled and click sends the buffered text
+    expect(sendButton).not.toBeDisabled();
+    fireEvent.click(sendButton);
+    expect(onSend).toHaveBeenCalledWith('שלום');
+  });
+});

--- a/fe-next/components/friends/messaging/MessageComposer.tsx
+++ b/fe-next/components/friends/messaging/MessageComposer.tsx
@@ -86,39 +86,42 @@ export const MessageComposer: React.FC<MessageComposerProps> = ({
   }, [onTyping]);
 
   /**
-   * Handle text change
+   * Sync state from a raw value (shared by change/input/compositionEnd handlers).
+   * Android GBoard in Hebrew buffers composition; onChange alone can leave React
+   * state empty while the DOM value already has text.
    */
-  const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const newText = e.target.value;
-
-    // Don't exceed max length
-    if (newText.length <= maxLength) {
-      setText(newText);
-
-      // Emit typing indicator if text is being added
-      if (newText.length > 0) {
-        emitTyping(true);
-      } else {
-        emitTyping(false);
-      }
+  const syncText = useCallback((raw: string) => {
+    if (raw.length <= maxLength) {
+      setText(raw);
+      emitTyping(raw.length > 0);
     }
   }, [maxLength, emitTyping]);
 
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    syncText(e.target.value);
+  }, [syncText]);
+
+  const handleCompositionEnd = useCallback((e: React.CompositionEvent<HTMLTextAreaElement>) => {
+    syncText(e.currentTarget.value);
+  }, [syncText]);
+
   /**
-   * Handle send
+   * Handle send — reads the DOM value directly because React state can be stale
+   * mid-IME composition (Android GBoard with Hebrew doesn't always fire input
+   * events until the word commits).
    */
   const handleSend = useCallback(() => {
-    const trimmed = text.trim();
+    const raw = textareaRef.current?.value ?? text;
+    const trimmed = raw.trim();
 
     if (trimmed && !disabled && trimmed.length <= maxLength) {
       onSend(trimmed);
       setText('');
-      emitTyping(false);
-
-      // Reset textarea height
       if (textareaRef.current) {
+        textareaRef.current.value = '';
         textareaRef.current.style.height = 'auto';
       }
+      emitTyping(false);
     }
   }, [text, disabled, maxLength, onSend, emitTyping]);
 
@@ -163,6 +166,8 @@ export const MessageComposer: React.FC<MessageComposerProps> = ({
           ref={textareaRef}
           value={text}
           onChange={handleChange}
+          onInput={handleChange}
+          onCompositionEnd={handleCompositionEnd}
           onKeyDown={handleKeyDown}
           placeholder={placeholder || t('friends.typeMessage')}
           disabled={disabled}
@@ -179,16 +184,17 @@ export const MessageComposer: React.FC<MessageComposerProps> = ({
           }}
         />
 
-        {/* Send button */}
+        {/* Send button — aria-disabled (not `disabled`) so clicks still commit
+            IME composition on Android GBoard; handleSend reads the DOM value. */}
         <button
           onClick={handleSend}
-          disabled={!isValid || disabled}
+          aria-disabled={!isValid || disabled}
           className={cn(
             'shrink-0 p-2 rounded-neo border-2 border-neo-black',
             'transition-all',
             isValid && !disabled
               ? 'bg-neo-cyan shadow-hard hover:shadow-hard-lg hover:-translate-y-0.5'
-              : 'bg-gray-600 opacity-50 cursor-not-allowed'
+              : 'bg-gray-600 opacity-50'
           )}
           aria-label={t('friends.sendMessage')}
         >


### PR DESCRIPTION
Android GBoard with Hebrew keeps an active IME composition until the user
commits with space/punctuation. Under that state the controlled textarea's
onChange does not fire, so React state stays at '', the char counter shows
0/1000, and the send button is disabled — the user sees their typed Hebrew
but cannot send it.

Adopt the same pattern already used in connections/PuzzleCard.tsx:
- Sync state on onCompositionEnd (and onInput) in addition to onChange, so
  the counter and validity update once composition commits.
- Read textareaRef.current.value as the source of truth inside handleSend,
  so a click that blurs the textarea (committing composition) sends the
  buffered text even if React state is momentarily stale.
- Swap the button's `disabled` attribute for `aria-disabled`; a disabled
  <button> swallows clicks, preventing the blur→compositionEnd sequence,
  so the IME buffer is never committed.