### PR TITLE
fix(messaging): use FormEvent type for textarea onInput handler

### DIFF
--- a/fe-next/components/friends/messaging/MessageComposer.tsx
+++ b/fe-next/components/friends/messaging/MessageComposer.tsx
@@ -101,6 +101,10 @@ export const MessageComposer: React.FC<MessageComposerProps> = ({
     syncText(e.target.value);
   }, [syncText]);
 
+  const handleInput = useCallback((e: React.FormEvent<HTMLTextAreaElement>) => {
+    syncText(e.currentTarget.value);
+  }, [syncText]);
+
   const handleCompositionEnd = useCallback((e: React.CompositionEvent<HTMLTextAreaElement>) => {
     syncText(e.currentTarget.value);
   }, [syncText]);
@@ -166,7 +170,7 @@ export const MessageComposer: React.FC<MessageComposerProps> = ({
           ref={textareaRef}
           value={text}
           onChange={handleChange}
-          onInput={handleChange}
+          onInput={handleInput}
           onCompositionEnd={handleCompositionEnd}
           onKeyDown={handleKeyDown}
           placeholder={placeholder || t('friends.typeMessage')}


### PR DESCRIPTION
Next.js 16 / React 19 tightened the onInput type to InputEventHandler,
so reusing the onChange handler (ChangeEvent) fails type checking.
Split into a dedicated handleInput that reads from e.currentTarget.