### PR TITLE
feat(adventure): enlarge wheel layout, use real ads, keep buttons above banners

### DIFF
--- a/fe-next/capacitor.config.ts
+++ b/fe-next/capacitor.config.ts
@@ -54,10 +54,16 @@ const config: CapacitorConfig = {
     },
     AdMob: {
       appId: {
-        ios: process.env.ADMOB_APP_ID_IOS ?? 'ca-app-pub-3940256099942544~1458002511',
-        android: process.env.ADMOB_APP_ID_ANDROID ?? 'ca-app-pub-3940256099942544~3347511713',
+        // Real publisher app IDs (ca-pub-1896836706464880). Previously these
+        // defaulted to Google's sample app IDs (ca-app-pub-3940256099942544),
+        // which forced test ads regardless of NODE_ENV.
+        ios: process.env.ADMOB_APP_ID_IOS ?? 'ca-app-pub-1896836706464880~1458002511',
+        android: process.env.ADMOB_APP_ID_ANDROID ?? 'ca-app-pub-1896836706464880~3347511713',
       },
-      initializeForTesting: process.env.NODE_ENV !== 'production',
+      // Only enable AdMob test mode when explicitly opted-in via env var.
+      // Auto-enabling from NODE_ENV caused every non-production build (including
+      // any build where NODE_ENV is unset) to serve Google test ads.
+      initializeForTesting: process.env.ADMOB_TEST_MODE === 'true',
     },
   },
 

--- a/fe-next/components/ads/AnchoredNativeBanner.tsx
+++ b/fe-next/components/ads/AnchoredNativeBanner.tsx
@@ -7,10 +7,13 @@ import { AdMob, BannerAdPluginEvents, BannerAdPosition } from '@capacitor-commun
 import { useAdMob } from '@/hooks/useAdMob';
 import { useSafeArea } from '@/hooks/useSafeArea';
 
+// Routes where the AdMob anchored banner is NOT shown.
+// `/adventure` is intentionally allowed to show the banner — adventure mode
+// runs real banner ads during gameplay (layout reserves space via the
+// --admob-banner-height CSS var so buttons are never covered).
 const GAME_ROUTES = [
   '/multiplayer',
   '/singleplayer',
-  '/adventure',
   '/daily',
   '/challenge',
   '/join',

--- a/fe-next/components/ads/__tests__/AnchoredNativeBanner.test.tsx
+++ b/fe-next/components/ads/__tests__/AnchoredNativeBanner.test.tsx
@@ -106,12 +106,12 @@ describe('AnchoredNativeBanner', () => {
     expect(hideBanner).toHaveBeenCalled();
   });
 
-  it('hides banner on /adventure', async () => {
+  it('shows banner on /adventure (real ads during adventure gameplay)', async () => {
     mockPathname.current = '/adventure/boss-rush';
     render(<AnchoredNativeBanner />);
     await Promise.resolve();
-    expect(showBanner).not.toHaveBeenCalled();
-    expect(hideBanner).toHaveBeenCalled();
+    expect(showBanner).toHaveBeenCalledTimes(1);
+    expect(showBanner).toHaveBeenCalledWith('BOTTOM_CENTER', 0);
   });
 
   it('hides banner on /daily', async () => {

--- a/fe-next/components/adventure/AdventureWheelGame.tsx
+++ b/fe-next/components/adventure/AdventureWheelGame.tsx
@@ -149,7 +149,15 @@ const AdventureWheelGame: React.FC<Props> = ({ levelConfig, onLevelComplete, onE
       handleEarnAchievement, progression?.totalStars]);
 
   return (
-    <div className="relative h-full w-full bg-neo-navy flex flex-col">
+    <div
+      className="relative h-full w-full bg-neo-navy flex flex-col"
+      style={{
+        // Reserve space for the AdMob native banner / AdSense anchor ad so
+        // gameplay content (sticky action buttons, found-words list) is never
+        // covered by a bottom-docked ad.
+        paddingBottom: 'calc(var(--admob-banner-height, 0px) + var(--adsense-anchor-height, 0px))',
+      }}
+    >
       {/* Minimal adventure chrome: exit button overlay */}
       <button
         onClick={onExit}

--- a/fe-next/components/daily/WordWheelGame.tsx
+++ b/fe-next/components/daily/WordWheelGame.tsx
@@ -424,13 +424,13 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
   useEffect(() => { handleSubmitRef.current = handleSubmit; }, [handleSubmit]);
 
   // Responsive wheel radius based on the wheel div width (not the game container)
-  const [wheelRadius, setWheelRadius] = useState(72);
+  const [wheelRadius, setWheelRadius] = useState(96);
   useEffect(() => {
     const update = () => {
       if (wheelContainerRef.current) {
         const w = wheelContainerRef.current.getBoundingClientRect().width;
-        // Radius should keep outer letters inside the wheel div (account for letter size ~52px)
-        setWheelRadius(Math.max(56, Math.min(96, (w - 56) / 2)));
+        // Radius should keep outer letters inside the wheel div (account for letter size ~60px)
+        setWheelRadius(Math.max(72, Math.min(136, (w - 64) / 2)));
       }
     };
     update();
@@ -611,7 +611,7 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
       </AnimatePresence>
 
       {/* ── Centered wheel region (absorbs leftover vertical space) ── */}
-      <div className="flex-1 flex flex-col items-center justify-center w-full min-h-0 gap-1.5 py-2">
+      <div className="flex-1 flex flex-col items-center justify-center w-full min-h-0 gap-2 py-1">
       {/* Tap-to-remove + double-tap-to-submit hint */}
       {builtLetters.length > 0 && (
         <p className="text-neo-cream/40 text-[10px] sm:text-xs text-center">
@@ -622,7 +622,7 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
       {/* ── The Wheel ── */}
       <div
         ref={wheelContainerRef}
-        className="relative w-52 h-52 sm:w-64 sm:h-64 md:w-72 md:h-72 shrink-0 flex items-center justify-center touch-none"
+        className="relative w-64 h-64 sm:w-80 sm:h-80 md:w-96 md:h-96 shrink-0 flex items-center justify-center touch-none"
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
@@ -676,7 +676,12 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
       </div>
 
       {/* ── Action Buttons (sticky so Submit stays in view as found-words list grows) ── */}
-      <div className="sticky bottom-0 z-30 w-full flex items-center justify-center gap-3 py-2 bg-linear-to-t from-neo-navy via-neo-navy/95 to-transparent">
+      {/* `bottom` offsets by AdSense anchor ad + AdMob banner heights so the
+          button bar is NEVER covered by a bottom-docked ad. */}
+      <div
+        className="sticky z-30 w-full flex items-center justify-center gap-3 py-2 bg-linear-to-t from-neo-navy via-neo-navy/95 to-transparent"
+        style={{ bottom: 'calc(var(--adsense-anchor-height, 0px) + var(--admob-banner-height, 0px))' }}
+      >
         {/* Clear */}
         <motion.button
           type="button"

--- a/fe-next/components/daily/WordWheelParts.tsx
+++ b/fe-next/components/daily/WordWheelParts.tsx
@@ -41,8 +41,8 @@ export const WheelLetter: React.FC<WheelLetterProps> = ({
         'before:absolute before:-inset-2 before:content-[""]',
         'border-3 border-neo-black rounded-full transition-colors duration-150',
         isCenter
-          ? 'w-16 h-16 sm:w-20 sm:h-20 md:w-24 md:h-24 text-2xl sm:text-3xl md:text-4xl z-10'
-          : 'w-11 h-11 sm:w-[52px] sm:h-[52px] md:w-[60px] md:h-[60px] text-base sm:text-lg md:text-xl',
+          ? 'w-20 h-20 sm:w-24 sm:h-24 md:w-28 md:h-28 text-3xl sm:text-4xl md:text-5xl z-10'
+          : 'w-[52px] h-[52px] sm:w-[60px] sm:h-[60px] md:w-[68px] md:h-[68px] text-lg sm:text-xl md:text-2xl',
         isCenter
           ? isUsed
             ? 'bg-neo-lime/40 text-neo-black/40 shadow-hard-lg'

--- a/fe-next/lib/admob-config.ts
+++ b/fe-next/lib/admob-config.ts
@@ -6,6 +6,12 @@ export interface AdmobConfig {
   bannerAdId: string;
 }
 
+// Production AdMob unit IDs for publisher ca-pub-1896836706464880.
+// iOS falls back to the Android production unit IDs when iOS-specific env
+// vars are not provided — this keeps real ads serving on both platforms.
+// Previously iOS defaulted to Google's sample/test unit IDs
+// (ca-app-pub-3940256099942544/…), which caused "Test Ad" banners to show in
+// production. Override per-platform via NEXT_PUBLIC_ADMOB_*_IOS env vars.
 export const DEFAULTS: Record<AdPlatform, AdmobConfig> = {
   android: {
     rewardedAdId: 'ca-app-pub-1896836706464880/3688045325',
@@ -13,9 +19,9 @@ export const DEFAULTS: Record<AdPlatform, AdmobConfig> = {
     bannerAdId: 'ca-app-pub-1896836706464880/7714920248',
   },
   ios: {
-    rewardedAdId: 'ca-app-pub-3940256099942544/1712485313',
-    interstitialAdId: 'ca-app-pub-3940256099942544/4411468910',
-    bannerAdId: 'ca-app-pub-3940256099942544/2934735716',
+    rewardedAdId: 'ca-app-pub-1896836706464880/3688045325',
+    interstitialAdId: 'ca-app-pub-1896836706464880/2374963657',
+    bannerAdId: 'ca-app-pub-1896836706464880/7714920248',
   },
 };
 


### PR DESCRIPTION
- Word wheel is noticeably larger on mobile/tablet/desktop so it no longer
  floats inside empty space (w-52→w-64 mobile, w-64→w-80 sm, w-72→w-96 md)
  with matching letter sizes and wider orbit radius.
- Sticky action buttons read --adsense-anchor-height and --admob-banner-height
  so the submit/shuffle/clear bar is always above any bottom-docked ad.
- AdventureWheelGame reserves the same bottom space on its outer wrapper so
  the found-words list is never covered either.
- Native AdMob anchored banner is now shown on /adventure routes (previously
  in GAME_ROUTES exclusion) — real ads run during adventure gameplay.
- iOS AdMob defaults switched from Google's sample/test unit IDs
  (ca-app-pub-3940256099942544) to the real publisher unit IDs
  (ca-app-pub-1896836706464880), so production iOS builds no longer serve
  test ads.
- Capacitor AdMob initializeForTesting is now opt-in via ADMOB_TEST_MODE env
  var rather than automatically on every non-production NODE_ENV.