### PR TITLE
fix(ads): surface AdMob errors and reconcile Android appId docs

### DIFF
--- a/fe-next/capacitor.config.ts
+++ b/fe-next/capacitor.config.ts
@@ -53,12 +53,16 @@ const config: CapacitorConfig = {
       presentationOptions: ['badge', 'sound', 'alert'],
     },
     AdMob: {
+      // NOTE: this `appId` block is documentation only — the @capacitor-community/admob
+      // plugin reads the runtime App ID from AndroidManifest.xml (`com.google.android.gms.ads.APPLICATION_ID`)
+      // and from iOS Info.plist (`GADApplicationIdentifier`), NOT from this config.
+      // Keep these values in sync with android/app/build.gradle (`ADMOB_APP_ID`)
+      // and the iOS Info.plist so future devs know which IDs are actually live.
+      // Previously the Android value here was `~3347511713`, which is a Google sample-publisher
+      // suffix — an obvious copy/paste error that caused confusion when ads stopped serving.
       appId: {
-        // Real publisher app IDs (ca-pub-1896836706464880). Previously these
-        // defaulted to Google's sample app IDs (ca-app-pub-3940256099942544),
-        // which forced test ads regardless of NODE_ENV.
         ios: process.env.ADMOB_APP_ID_IOS ?? 'ca-app-pub-1896836706464880~1458002511',
-        android: process.env.ADMOB_APP_ID_ANDROID ?? 'ca-app-pub-1896836706464880~3347511713',
+        android: process.env.ADMOB_APP_ID_ANDROID ?? 'ca-app-pub-1896836706464880~7614847892',
       },
       // Only enable AdMob test mode when explicitly opted-in via env var.
       // Auto-enabling from NODE_ENV caused every non-production build (including

--- a/fe-next/contexts/AdMobContext.tsx
+++ b/fe-next/contexts/AdMobContext.tsx
@@ -25,7 +25,11 @@ export function AdMobProvider({ children }: { children: ReactNode }) {
     initPromise.current = isNative
       ? AdMob.initialize({ initializeForTesting: process.env.NODE_ENV !== 'production' })
           .then(() => undefined)
-          .catch(() => undefined)
+          .catch((err) => {
+            // Surface init failures so Crashlytics/Sentry can capture them — silent swallow
+            // here was masking the root cause of "no ads showing" reports.
+            console.error('[AdMob] initialize failed', err);
+          })
       : Promise.resolve();
   }
 

--- a/fe-next/hooks/useAdMob.ts
+++ b/fe-next/hooks/useAdMob.ts
@@ -88,14 +88,23 @@ export function useAdMob() {
         isTesting: isDev,
         ...(typeof margin === 'number' ? { margin } : {}),
       });
-    } catch {}
+    } catch (err) {
+      console.error('[AdMob] showBanner failed', err);
+    }
   }, [hasNoAds, getConfig, isDev, whenReady]);
 
   const hideBanner = useCallback(async () => {
     try {
       await whenReady();
       await AdMob.hideBanner();
-    } catch {}
+    } catch (err) {
+      // hideBanner throws when no banner is mounted yet (expected on first call); only log
+      // when we actually have a meaningful error.
+      if (err && typeof err === 'object' && 'message' in err) {
+        const msg = String((err as { message: unknown }).message);
+        if (!msg.toLowerCase().includes('no banner')) console.warn('[AdMob] hideBanner failed', err);
+      }
+    }
   }, [whenReady]);
 
   return { showRewarded, showInterstitial, showBanner, hideBanner };

--- a/fe-next/package-lock.json
+++ b/fe-next/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "fe-next",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@9am/fire-flame-react": "^0.3.2",
         "@arvidbt/swedish-words": "^1.0.6",


### PR DESCRIPTION
- AdMobContext / useAdMob: log init, showBanner, and hideBanner failures via
  console.error/warn instead of swallowing silently. The previous empty-catch
  pattern made "no ads showing" reports impossible to triage from Crashlytics
  or Sentry — failures will now appear in production logs.
- hideBanner: skip the expected "no banner" warning on first call so logs
  surface only meaningful errors.
- capacitor.config.ts: align the documented Android appId with the runtime
  value baked into android/app/build.gradle (~7614847892). The previous value
  (~3347511713) was the Google sample-publisher suffix kept by mistake when
  the publisher prefix was switched to the real one. Note added that this
  config field is documentation only — the plugin reads the App ID from
  AndroidManifest.xml on Android and Info.plist on iOS.

The Android NPE patch (patches/@capacitor-community+admob+8.0.0.patch) is
already in place and was verified to apply via patch-package postinstall —
this commit does not modify it. Banner positioning above GlobalBottomNav
(margin = navHeight + safeArea on Android, navHeight on iOS) is unchanged.

https://claude.ai/code/session_0114XHfz8T1PMQ5gpw8Wk4Qn