### PR TITLE
fix(daily): mobile bottom padding and word-wheel ready layout

### DIFF
--- a/fe-next/components/daily/DailyReadyScreen.tsx
+++ b/fe-next/components/daily/DailyReadyScreen.tsx
@@ -151,7 +151,7 @@ const DailyReadyScreenInner: React.FC<DailyReadyScreenProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -20 }}
-      className="flex-1 flex flex-col items-center justify-start pt-2 sm:pt-4 page-content-safe px-4 pb-10 min-h-0 overflow-y-auto"
+      className="flex-1 flex flex-col items-center justify-start pt-2 sm:pt-4 px-4 pb-[calc(var(--mobile-bottom-safe)+5rem)] sm:pb-10 min-h-0 overflow-y-auto"
     >
       {/* Top bar with back and language */}
       <div className="w-full max-w-md lg:max-w-5xl xl:max-w-6xl flex items-center justify-between mb-2">

--- a/fe-next/components/daily/WordWheelChallenge.tsx
+++ b/fe-next/components/daily/WordWheelChallenge.tsx
@@ -24,6 +24,7 @@ import {
 import type { Language } from '@/types';
 import { useSoundEffects } from '@/contexts/SoundEffectsContext';
 import { useAuth } from '@/contexts/AuthContext';
+import { useHideNavigation } from '@/contexts/NavigationContext';
 import { getGuestFingerprint } from '@/utils/guestManager';
 import type { WordWheelEffect } from './WordWheelEffectsCanvas';
 
@@ -49,6 +50,7 @@ const WordWheelChallenge: React.FC = () => {
   const { t, language } = useLanguage();
   const { setGameActive } = useSoundEffects();
   const { profile, isAuthenticated } = useAuth();
+  const setIsInGame = useHideNavigation();
 
   const [phase, setPhase] = useState<WordWheelPhase>('loading');
   const [puzzle, setPuzzle] = useState<WordWheelPuzzle | null>(null);
@@ -62,6 +64,11 @@ const WordWheelChallenge: React.FC = () => {
   useEffect(() => {
     setGuestFingerprint(getGuestFingerprint());
   }, []);
+
+  useEffect(() => {
+    setIsInGame(phase === 'playing');
+    return () => setIsInGame(false);
+  }, [phase, setIsInGame]);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -217,7 +224,7 @@ const WordWheelChallenge: React.FC = () => {
         {phase === 'ready' && puzzle && (
           <motion.div
             key="ready"
-            className="flex-1 flex flex-col items-center justify-center gap-6 px-4"
+            className="flex-1 flex flex-col items-center gap-6 px-4 pt-4 pb-(--mobile-bottom-safe) sm:pb-6 overflow-y-auto"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -271,10 +278,9 @@ const WordWheelChallenge: React.FC = () => {
                 return (
                   <motion.div
                     key={`${letter}-${i}`}
-                    className="absolute w-10 h-10 rounded-full border-2 border-neo-black bg-neo-white flex items-center justify-center font-neo-display font-bold text-sm text-neo-navy shadow-[2px_2px_0px_black,0_0_6px_rgba(191,255,0,0.12)]"
-                    style={{ transform: `translate(${x}px, ${y}px)` }}
-                    initial={{ scale: 0 }}
-                    animate={{ scale: 1 }}
+                    className="absolute inset-0 m-auto w-10 h-10 rounded-full border-2 border-neo-black bg-neo-white flex items-center justify-center font-neo-display font-bold text-sm text-neo-navy shadow-[2px_2px_0px_black,0_0_6px_rgba(191,255,0,0.12)]"
+                    initial={{ scale: 0, x, y }}
+                    animate={{ scale: 1, x, y }}
                     transition={{ delay: i * 0.06, type: 'spring', stiffness: 400 }}
                   >
                     {letter}

--- a/fe-next/components/daily/__tests__/WordWheelChallenge.readyLeaderboard.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelChallenge.readyLeaderboard.test.tsx
@@ -44,6 +44,9 @@ vi.mock('@/contexts/SoundEffectsContext', () => ({
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({ profile: null, isAuthenticated: false }),
 }));
+vi.mock('@/contexts/NavigationContext', () => ({
+  useHideNavigation: () => vi.fn(),
+}));
 
 // --- Utils ---
 vi.mock('@/utils/dailyChallenge', () => ({


### PR DESCRIPTION
- WordWheelChallenge: hide global bottom nav during gameplay so the
  sticky action buttons (Clear/Submit/Shuffle) are not hidden behind it
- WordWheelChallenge ready phase: make content scrollable with
  bottom-safe padding so the leaderboard is not cut off on mobile
- WordWheelChallenge ready preview wheel: center outer letters around
  the container center instead of the top-left corner (inset-0 m-auto +
  motion x/y), so the preview renders as a proper wheel
- DailyReadyScreen: replace `pb-10` with `--mobile-bottom-safe` + 5rem
  on mobile to clear both the fixed bottom nav and the sticky mobile
  Play button; keep `pb-10` on desktop