### PR TITLE
feat(ads): enable AdMob banners on content pages (inline, non-sticky)

### DIFF
--- a/fe-next/app/[locale]/about/PageClient.tsx
+++ b/fe-next/app/[locale]/about/PageClient.tsx
@@ -6,6 +6,7 @@ import { useTheme } from '@/utils/ThemeContext';
 import { cn } from '@/lib/utils';
 import { Mail, Gamepad2, Globe, BookOpen, Users, Shield, Zap } from 'lucide-react';
 import { InstagramIcon } from '@/components/icons/SocialIcons';
+import { InlineBannerAd } from '@/components/ads';
 import { contentByLocale, type AboutContent } from './content';
 
 function FeatureCard({
@@ -125,6 +126,8 @@ export default function AboutPageClient(): React.ReactElement {
         </div>
       </section>
 
+      <InlineBannerAd webZone="content-page" className="my-6" />
+
       {/* Section 5: What We Do */}
       <section className="mb-8">
         <h2 className={sectionHeadingClass}>{c.whatWeDo.title}</h2>
@@ -152,6 +155,8 @@ export default function AboutPageClient(): React.ReactElement {
         <p className={cn(paragraphClass, 'mb-4')}>{c.community.content}</p>
         <p className={paragraphClass}>{c.community.content2}</p>
       </section>
+
+      <InlineBannerAd webZone="content-page" className="my-6" />
 
       {/* Section 9: Values */}
       <section className="mb-8">

--- a/fe-next/app/[locale]/blog/10-surprising-benefits-word-games/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/10-surprising-benefits-word-games/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -127,7 +127,7 @@ export default function BenefitsPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         {/* Article Content */}
         <div className={cn(
@@ -160,7 +160,7 @@ export default function BenefitsPageClient(): React.ReactElement {
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           {/* Simple navigation */}
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>

--- a/fe-next/app/[locale]/blog/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, BookOpen, Clock, Calendar } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 
 interface BlogPost {
   slug: string;
@@ -755,7 +755,7 @@ export default function BlogIndexPageClient(): React.ReactElement {
         </div>
 
         {/* Ad: Between header and post grid */}
-        <AdPlaceholder zone="content-page" className="mb-6" />
+        <InlineBannerAd webZone="content-page" className="mb-6" />
 
         {/* Blog Posts Grid */}
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/fe-next/app/[locale]/blog/best-boggle-alternatives-2026/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/best-boggle-alternatives-2026/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { faqByLocale, faqHeadingByLocale } from './faq';
@@ -162,7 +162,7 @@ export default function BoggleAlternativesPageClient(): React.ReactElement {
           </div>
         </header>
 
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         {/* Table of Contents */}
         <nav
@@ -282,7 +282,7 @@ export default function BoggleAlternativesPageClient(): React.ReactElement {
             </div>
           ))}
 
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           {/* FAQ Section */}
           <section className="mt-12" id="faq">

--- a/fe-next/app/[locale]/blog/boggle-vs-scrabble/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/boggle-vs-scrabble/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -113,7 +113,7 @@ export default function BoggleVsScrabblePageClient(): React.ReactElement {
           </div>
         </header>
 
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -143,7 +143,7 @@ export default function BoggleVsScrabblePageClient(): React.ReactElement {
             </div>
           ))}
 
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/boggle-vs-wordle/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/boggle-vs-wordle/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -113,7 +113,7 @@ export default function BoggleVsWordlePageClient(): React.ReactElement {
           </div>
         </header>
 
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -143,7 +143,7 @@ export default function BoggleVsWordlePageClient(): React.ReactElement {
             </div>
           ))}
 
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/boggle-vs-words-with-friends/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/boggle-vs-words-with-friends/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -112,7 +112,7 @@ export default function BoggleVsWwfPageClient(): React.ReactElement {
           </div>
         </header>
 
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -142,7 +142,7 @@ export default function BoggleVsWwfPageClient(): React.ReactElement {
             </div>
           ))}
 
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/daily-challenge-strategies/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/daily-challenge-strategies/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -128,7 +128,7 @@ export default function StrategiesPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -160,7 +160,7 @@ export default function StrategiesPageClient(): React.ReactElement {
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/hebrew-word-games-guide/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/hebrew-word-games-guide/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -125,7 +125,7 @@ export default function HebrewGuidePageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -157,7 +157,7 @@ export default function HebrewGuidePageClient(): React.ReactElement {
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/improve-word-game-skills/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/improve-word-game-skills/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -125,7 +125,7 @@ export default function ImproveSkillsPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -157,7 +157,7 @@ export default function ImproveSkillsPageClient(): React.ReactElement {
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/multilingual-word-learning/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/multilingual-word-learning/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -127,7 +127,7 @@ export default function MultilingualPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         {/* Article Content */}
         <div className={cn(
@@ -160,7 +160,7 @@ export default function MultilingualPageClient(): React.ReactElement {
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           {/* Simple navigation */}
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>

--- a/fe-next/app/[locale]/blog/multiplayer-word-games-social/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/multiplayer-word-games-social/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -129,7 +129,7 @@ export default function MultiplayerSocialPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -157,13 +157,13 @@ export default function MultiplayerSocialPageClient(): React.ReactElement {
                 </p>
               ))}
               {/* Ad after 4th section */}
-              {index === 3 && <AdPlaceholder zone="content-page" className="my-6" />}
+              {index === 3 && <InlineBannerAd webZone="content-page" className="my-6" />}
             </div>
           ))}
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/science-behind-word-games/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/science-behind-word-games/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -128,7 +128,7 @@ export default function SciencePageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -160,7 +160,7 @@ export default function SciencePageClient(): React.ReactElement {
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/top-player-secrets/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/top-player-secrets/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -127,7 +127,7 @@ export default function SecretsPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         {/* Article Content */}
         <div className={cn(
@@ -160,7 +160,7 @@ export default function SecretsPageClient(): React.ReactElement {
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           {/* Simple navigation */}
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>

--- a/fe-next/app/[locale]/blog/vocabulary-building-strategies/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/vocabulary-building-strategies/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -129,7 +129,7 @@ export default function VocabularyPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -157,13 +157,13 @@ export default function VocabularyPageClient(): React.ReactElement {
                 </p>
               ))}
               {/* Ad after 4th section */}
-              {index === 3 && <AdPlaceholder zone="content-page" className="my-6" />}
+              {index === 3 && <InlineBannerAd webZone="content-page" className="my-6" />}
             </div>
           ))}
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/why-word-games-are-addictive/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/why-word-games-are-addictive/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
 
@@ -98,7 +98,7 @@ export default function WhyAddictivePageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -132,7 +132,7 @@ export default function WhyAddictivePageClient(): React.ReactElement {
           <AuthorBioCard />
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/word-game-history/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/word-game-history/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -128,7 +128,7 @@ export default function WordGameHistoryPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After header */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -156,13 +156,13 @@ export default function WordGameHistoryPageClient(): React.ReactElement {
                 </p>
               ))}
               {/* Ad: After 4th section */}
-              {index === 3 && <AdPlaceholder zone="content-page" className="my-6" />}
+              {index === 3 && <InlineBannerAd webZone="content-page" className="my-6" />}
             </div>
           ))}
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/word-games-and-mental-health/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/word-games-and-mental-health/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -125,7 +125,7 @@ export default function MentalHealthPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -157,7 +157,7 @@ export default function MentalHealthPageClient(): React.ReactElement {
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/word-games-for-brain-training/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/word-games-for-brain-training/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
 
@@ -98,7 +98,7 @@ export default function BrainTrainingPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After hero */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -132,7 +132,7 @@ export default function BrainTrainingPageClient(): React.ReactElement {
           <AuthorBioCard />
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/blog/word-games-for-kids-education/PageClient.tsx
+++ b/fe-next/app/[locale]/blog/word-games-for-kids-education/PageClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { RelatedArticles } from '@/components/blog/RelatedArticles';
 import { contentByLocale } from './content';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
@@ -128,7 +128,7 @@ export default function WordGamesEducationPageClient(): React.ReactElement {
         </header>
 
         {/* Ad: After header */}
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         <div className={cn(
           'prose prose-lg max-w-none',
@@ -156,13 +156,13 @@ export default function WordGamesEducationPageClient(): React.ReactElement {
                 </p>
               ))}
               {/* Ad: After 4th section */}
-              {index === 3 && <AdPlaceholder zone="content-page" className="my-6" />}
+              {index === 3 && <InlineBannerAd webZone="content-page" className="my-6" />}
             </div>
           ))}
 
 
           {/* Ad: Before CTAs */}
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>
             <div className="flex gap-4">

--- a/fe-next/app/[locale]/daily/archive/page.tsx
+++ b/fe-next/app/[locale]/daily/archive/page.tsx
@@ -4,6 +4,7 @@ import { loadTranslation } from '@/translations/loadTranslation';
 import { generatePageMetadata } from '@/lib/seo/generatePageMetadata';
 import { DAILY_CHALLENGE_EPOCH } from '@/utils/dailyChallenge/constants';
 import { safeToLocaleDateString } from '@/utils/bcp47Locale';
+import { InlineBannerAd } from '@/components/ads';
 
 export const dynamic = 'force-dynamic';
 
@@ -124,8 +125,10 @@ export default async function DailyArchivePage({ params }: PageParams) {
             </p>
           </div>
 
+          <InlineBannerAd webZone="content-page" className="mb-6" />
+
           {/* Grouped by month */}
-          {Object.entries(groupedByMonth).map(([monthKey, entries]) => (
+          {Object.entries(groupedByMonth).map(([monthKey, entries], monthIdx) => (
             <section key={monthKey} className="mb-8">
               <h2 className="text-lg font-neo-display font-bold text-neo-cyan mb-3 border-b border-slate-700/50 pb-1">
                 {formatMonth(monthKey)}
@@ -151,6 +154,7 @@ export default async function DailyArchivePage({ params }: PageParams) {
                   </Link>
                 ))}
               </div>
+              {monthIdx === 2 && <InlineBannerAd webZone="content-page" className="mt-6" />}
             </section>
           ))}
         </div>

--- a/fe-next/app/[locale]/glossary/PageClient.tsx
+++ b/fe-next/app/[locale]/glossary/PageClient.tsx
@@ -10,7 +10,7 @@ import { safeLocaleCompare } from '@/utils/bcp47Locale';
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { contentByLocale } from './content';
 
 export default function GlossaryPageClient(): React.ReactElement {
@@ -90,7 +90,7 @@ export default function GlossaryPageClient(): React.ReactElement {
           ))}
         </nav>
 
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         {/* Glossary Terms as Definition List */}
         <div data-speakable="true">
@@ -138,13 +138,13 @@ export default function GlossaryPageClient(): React.ReactElement {
                     </div>
                   ))}
                 </dl>
-                {li === 2 && <AdPlaceholder zone="content-page" className="mt-6" />}
+                {li === 2 && <InlineBannerAd webZone="content-page" className="mt-6" />}
               </section>
             );
           })}
         </div>
 
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
       </main>
     </div>
   );

--- a/fe-next/app/[locale]/guides/PageClient.tsx
+++ b/fe-next/app/[locale]/guides/PageClient.tsx
@@ -7,7 +7,7 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
 import { BookOpen, Zap, Target } from 'lucide-react';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 
 const guidesContent: Record<string, {
   title: string;
@@ -135,7 +135,7 @@ export default function GuidesIndexPageClient(): React.ReactElement {
           })}
         </div>
 
-        <AdPlaceholder zone="content-page" className="mt-8" />
+        <InlineBannerAd webZone="content-page" className="mt-8" />
       </main>
     </div>
   );

--- a/fe-next/app/[locale]/guides/blast-strategy/PageClient.tsx
+++ b/fe-next/app/[locale]/guides/blast-strategy/PageClient.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
 import { contentByLocale } from './content';
 
@@ -98,7 +98,7 @@ export default function BlastStrategyPageClient(): React.ReactElement {
           </ol>
         </section>
 
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         {/* Combo Multiplier Table */}
         <section className="mb-8">
@@ -160,7 +160,7 @@ export default function BlastStrategyPageClient(): React.ReactElement {
                   {paragraph}
                 </p>
               ))}
-              {index === 2 && <AdPlaceholder zone="content-page" className="my-6" />}
+              {index === 2 && <InlineBannerAd webZone="content-page" className="my-6" />}
             </div>
           ))}
 
@@ -194,7 +194,7 @@ export default function BlastStrategyPageClient(): React.ReactElement {
 
           <AuthorBioCard />
 
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           {/* CTA */}
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>

--- a/fe-next/app/[locale]/guides/classic-strategy/PageClient.tsx
+++ b/fe-next/app/[locale]/guides/classic-strategy/PageClient.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
 import { contentByLocale } from './content';
 
@@ -98,7 +98,7 @@ export default function ClassicStrategyPageClient(): React.ReactElement {
           </ol>
         </section>
 
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         {/* Scoring Table */}
         <section className="mb-8">
@@ -156,7 +156,7 @@ export default function ClassicStrategyPageClient(): React.ReactElement {
                   {paragraph}
                 </p>
               ))}
-              {index === 2 && <AdPlaceholder zone="content-page" className="my-6" />}
+              {index === 2 && <InlineBannerAd webZone="content-page" className="my-6" />}
             </div>
           ))}
 
@@ -190,7 +190,7 @@ export default function ClassicStrategyPageClient(): React.ReactElement {
 
           <AuthorBioCard />
 
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           {/* CTA */}
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>

--- a/fe-next/app/[locale]/guides/word-hunt-strategy/PageClient.tsx
+++ b/fe-next/app/[locale]/guides/word-hunt-strategy/PageClient.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils';
 import { ArrowLeft, Clock, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import AutoHideHeader from '@/components/AutoHideHeader';
-import { AdPlaceholder } from '@/components/ads';
+import { InlineBannerAd } from '@/components/ads';
 import { AuthorBioCard } from '@/components/blog/AuthorBioCard';
 import { contentByLocale } from './content';
 
@@ -98,7 +98,7 @@ export default function WordHuntStrategyPageClient(): React.ReactElement {
           </ol>
         </section>
 
-        <AdPlaceholder zone="content-page" className="my-6" />
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         {/* Article Content */}
         <div className={cn('prose prose-lg max-w-none', isDarkMode ? 'prose-invert' : '')}>
@@ -120,7 +120,7 @@ export default function WordHuntStrategyPageClient(): React.ReactElement {
                   {paragraph}
                 </p>
               ))}
-              {index === 2 && <AdPlaceholder zone="content-page" className="my-6" />}
+              {index === 2 && <InlineBannerAd webZone="content-page" className="my-6" />}
             </div>
           ))}
 
@@ -154,7 +154,7 @@ export default function WordHuntStrategyPageClient(): React.ReactElement {
 
           <AuthorBioCard />
 
-          <AdPlaceholder zone="content-page" className="my-6" />
+          <InlineBannerAd webZone="content-page" className="my-6" />
 
           {/* CTA */}
           <div className={cn('mt-12 pt-6 border-t', isDarkMode ? 'border-slate-700' : 'border-gray-200')}>

--- a/fe-next/app/[locale]/rules/PageClient.tsx
+++ b/fe-next/app/[locale]/rules/PageClient.tsx
@@ -9,6 +9,7 @@ import { Gamepad2, Trophy, Lightbulb, Users, ArrowLeft, Play, Bot, CheckCircle }
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Header from '@/components/Header';
+import { InlineBannerAd } from '@/components/ads';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 // Generate localized JSON-LD Schema for How to Play page
@@ -228,6 +229,8 @@ export default function RulesPageClient(): React.JSX.Element {
                     </Card>
                 </motion.section>
 
+                <InlineBannerAd webZone="content-page" className="my-4 sm:my-6" />
+
                 {/* Compact Scoring System - 3 Rows */}
                 <motion.section
                     className="mb-4 sm:mb-8"
@@ -314,6 +317,8 @@ export default function RulesPageClient(): React.JSX.Element {
                         </CardContent>
                     </Card>
                 </motion.section>
+
+                <InlineBannerAd webZone="content-page" className="my-4 sm:my-6" />
 
                 {/* Call to Action */}
                 <motion.div

--- a/fe-next/app/[locale]/words/[n]-letter-words/page.tsx
+++ b/fe-next/app/[locale]/words/[n]-letter-words/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { InlineBannerAd } from '@/components/ads';
 import {
   getWordsByLength,
   groupByFirstLetter,
@@ -235,9 +236,11 @@ export default async function NLetterWordsPage({ params }: PageParams) {
             </section>
           )}
 
+          <InlineBannerAd webZone="content-page" className="mb-8" />
+
           {/* Word list by letter group */}
           <div className="space-y-8">
-            {sortedLetters.map(letter => (
+            {sortedLetters.map((letter, letterIdx) => (
               <section key={letter}>
                 <h2 className="text-2xl font-neo-display font-black text-neo-cyan mb-3 border-b-2 border-slate-700 pb-2">
                   {letter}
@@ -258,6 +261,7 @@ export default async function NLetterWordsPage({ params }: PageParams) {
                     </Link>
                   ))}
                 </div>
+                {letterIdx === 3 && <InlineBannerAd webZone="content-page" className="mt-6" />}
               </section>
             ))}
           </div>

--- a/fe-next/app/[locale]/words/[word]/page.tsx
+++ b/fe-next/app/[locale]/words/[word]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { calculateWordScore, getComboBonus } from '@/shared/utils/scoring';
+import { InlineBannerAd } from '@/components/ads';
 
 export const dynamic = 'force-dynamic';
 
@@ -230,6 +231,8 @@ export default async function WordExplorerPage({ params }: PageParams) {
               </div>
             )}
           </div>
+
+          <InlineBannerAd webZone="content-page" className="mb-6" />
 
           {/* Word facts */}
           <div className="bg-slate-900 border-2 border-neo-black rounded-neo p-4 mb-6 shadow-hard-sm">

--- a/fe-next/app/[locale]/words/page.tsx
+++ b/fe-next/app/[locale]/words/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { InlineBannerAd } from '@/components/ads';
 
 export const dynamic = 'force-dynamic';
 
@@ -127,6 +128,8 @@ export default async function WordsHubPage({ params }: PageParams) {
             ))}
           </div>
         </section>
+
+        <InlineBannerAd webZone="content-page" className="my-6" />
 
         {/* Words by Starting Letter */}
         <section className="mb-10">

--- a/fe-next/app/[locale]/words/starting-with/[letter]/page.tsx
+++ b/fe-next/app/[locale]/words/starting-with/[letter]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { InlineBannerAd } from '@/components/ads';
 import {
   getWordsByLetter,
   groupByLength,
@@ -354,6 +355,8 @@ export default async function StartingWithLetterPage({ params }: PageParams) {
               </div>
             ))}
           </div>
+
+          <InlineBannerAd webZone="content-page" className="mt-10" />
 
           {/* FAQ section — renders as FAQ rich snippet in Google */}
           <ScrollReveal className="mt-12 pt-8 border-t-2 border-slate-700">


### PR DESCRIPTION
Convert dev-only AdPlaceholder usages to InlineBannerAd across blog, guides,
and glossary so native (Android) serves real AdMob banners at those slots.
Web behavior is unchanged (AdPlaceholder is null in production).

Add new InlineBannerAd slots to content-rich pages that previously had no
ads: rules, about, daily archive, words hub, words-by-length,
words-by-letter, and single-word pages.

All placements are inline content breaks between sections — no sticky
overlays or persistent banners.

https://claude.ai/code/session_01PraarYci3MPrQCw2BL8jTS