### PR TITLE
fix(blog): render newest 3 posts on home — drop dead duplicate grid

### DIFF
--- a/fe-next/components/landing/LandingSEOSection.tsx
+++ b/fe-next/components/landing/LandingSEOSection.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { type Variants } from 'framer-motion';
 import { AdaptiveMotion } from '@/components/motion/AdaptiveMotion';
@@ -62,14 +60,6 @@ const STEP_GLOW = [
   'shadow-[0_0_20px_rgba(0,255,255,0.3)]',
   'shadow-[0_0_20px_rgba(191,255,0,0.3)]',
   'shadow-[0_0_20px_rgba(139,92,246,0.3)]',
-] as const;
-
-/* ── Blog images ───────────────────────────────────────── */
-
-const BLOG_IMAGES = [
-  '/images/blog/science-brain.jpg',
-  '/images/blog/why-addictive.jpg',
-  '/images/blog/daily-strategies.jpg',
 ] as const;
 
 /* ── FAQ Accordion item (SEO-safe: always in DOM) ──────── */
@@ -265,68 +255,6 @@ export function LandingSEOSection({ className }: LandingSEOSectionProps) {
         </AdaptiveMotion.div>
       </AdaptiveMotion.div>
 
-      {/* ── Blog Links ── */}
-      <AdaptiveMotion.div
-        variants={sectionReveal}
-        initial="hidden"
-        whileInView="visible"
-        viewport={{ once: true, margin: '-40px' }}
-      >
-        <div className="flex items-center justify-between mb-5">
-          <h2 className="text-lg sm:text-xl font-black uppercase text-neo-white">
-            {c.blogTitle}
-          </h2>
-          <Link
-            href={`/${locale}/blog`}
-            className={cn(
-              'text-xs sm:text-sm font-bold',
-              'text-neo-white/60 hover:text-neo-white transition-colors',
-              'underline underline-offset-2'
-            )}
-          >
-            {c.viewAllPosts}
-          </Link>
-        </div>
-        <AdaptiveMotion.div
-          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
-          variants={staggerContainer}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, margin: '-30px' }}
-        >
-          {c.blogLinks.map((blog, i) => (
-            <AdaptiveMotion.div key={blog.slug} variants={staggerItem}>
-              <Link
-                href={`/${locale}/blog/${blog.slug}`}
-                className={cn(
-                  'group block rounded-neo border-2 border-neo-white/10 overflow-hidden',
-                  'bg-neo-white/3',
-                  'hover:border-neo-white/20 hover:bg-neo-white/6 hover:-translate-y-0.5',
-                  'transition-all duration-200'
-                )}
-              >
-                <div className="relative aspect-video overflow-hidden">
-                  <Image
-                    src={BLOG_IMAGES[i]}
-                    alt={blog.title}
-                    fill
-                    className="object-cover group-hover:scale-105 transition-transform duration-300"
-                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                  />
-                  <span className="absolute top-2 inset-s-2 inline-block px-2 py-0.5 text-[10px] font-bold uppercase text-neo-white bg-neo-black/60 rounded-neo tracking-wider">
-                    {blog.category}
-                  </span>
-                </div>
-                <div className="p-3">
-                  <p className="text-sm font-bold text-neo-white/80 group-hover:text-neo-white transition-colors line-clamp-2">
-                    {blog.title}
-                  </p>
-                </div>
-              </Link>
-            </AdaptiveMotion.div>
-          ))}
-        </AdaptiveMotion.div>
-      </AdaptiveMotion.div>
     </section>
   );
 }

--- a/fe-next/components/landing/LandingView.tsx
+++ b/fe-next/components/landing/LandingView.tsx
@@ -18,6 +18,7 @@ import { InlineBannerAd } from '@/components/ads';
 const CrazyGamesBanner = dynamic(() => import('@/components/CrazyGamesBanner'), { ssr: false });
 import { hasCompletedOnboarding, markOnboardingComplete } from '@/utils/onboardingStorage';
 import { LandingSEOSection, ScrollIndicator } from './LandingSEOSection';
+import { LandingBlogSection } from './LandingBlogSection';
 import { LandingHero } from './LandingHero';
 const LandingSocialProofBar = dynamic(() => import('./LandingSocialProofBar').then(m => m.LandingSocialProofBar), {
   ssr: false,
@@ -241,6 +242,10 @@ const LandingView: React.FC<LandingViewProps> = ({ initialData }) => {
       )}
 
       <LandingSEOSection />
+
+      <div className="w-full px-4 sm:px-6 lg:px-8 pb-12 sm:pb-16 relative z-20">
+        <LandingBlogSection />
+      </div>
     </div>
   );
 };

--- a/fe-next/components/landing/__tests__/LandingView.blogSection.test.tsx
+++ b/fe-next/components/landing/__tests__/LandingView.blogSection.test.tsx
@@ -1,11 +1,16 @@
 /**
- * RED test: LandingView must start ambient music via a single mount-time
- * call to playTrack(BOSSA). It must NOT register window pointerdown/keydown
- * listeners that duplicate MusicContext's own auto-unlock path (which caused
- * double playback of the Bossa track).
+ * Homepage blog section: must surface the 3 NEWEST blog posts (the ones
+ * authored most recently per LandingBlogSection's `recentPosts` array).
+ *
+ * Regression guard: the previous version of the homepage rendered three
+ * stale slugs (science-behind-word-games / why-word-games-are-addictive /
+ * daily-challenge-strategies) hardcoded inside LandingSEOSection's
+ * `blogLinks`. That data path was duplicated and went unmaintained — so
+ * even after `recentPosts` was updated to the new posts, the homepage
+ * kept showing the old ones.
  */
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import LandingView from '../LandingView';
 import { useAuth } from '@/contexts/AuthContext';
@@ -56,6 +61,9 @@ vi.mock('@/hooks/useEvents', () => ({
 }));
 vi.mock('@/utils/perfVariant', () => ({ getPerfVariant: () => 'low' }));
 vi.mock('@/utils/growthTracking', () => ({ trackModeSelected: vi.fn() }));
+vi.mock('@/components/CrazyGamesSDK', () => ({
+  useCrazyGames: () => ({ isOnCrazyGamesPlatform: false, isLoading: false }),
+}));
 vi.mock('next/dynamic', () => ({ default: () => () => <div /> }));
 vi.mock('framer-motion', () => {
   const motionObj: Record<string, React.FC<React.PropsWithChildren<Record<string, unknown>>>> = new Proxy(
@@ -72,11 +80,13 @@ vi.mock('framer-motion', () => {
 vi.mock('next/link', () => ({
   default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
 }));
+vi.mock('next/image', () => ({
+  default: ({ alt, ...rest }: { alt: string }) => <img alt={alt} {...rest} />,
+}));
 vi.mock('@/components/Header', () => ({ default: () => <header /> }));
 vi.mock('../LandingHero', () => ({ LandingHero: () => <div /> }));
 vi.mock('../LandingChallengeCards', () => ({ LandingChallengeCards: () => <div /> }));
 vi.mock('../LandingLeaderboardPreview', () => ({ LandingLeaderboardPreview: () => <div /> }));
-vi.mock('../LandingSEOSection', () => ({ LandingSEOSection: () => <div />, ScrollIndicator: () => <div /> }));
 vi.mock('@/components/ads', () => ({ AdPlaceholder: () => <div />, InlineBannerAd: () => <div /> }));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -85,47 +95,36 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
   </QueryClientProvider>
 );
 
-describe('LandingView — music init', () => {
-  const playTrack = vi.fn();
-  const unlockAudio = vi.fn();
-
+describe('LandingView — homepage blog section', () => {
   beforeEach(() => {
-    playTrack.mockClear();
-    unlockAudio.mockClear();
     (useAuth as unknown as vi.Mock).mockReturnValue({ isAuthenticated: false, loading: false, profile: null });
     (useLanguage as unknown as vi.Mock).mockReturnValue({ t: (k: string) => k, language: 'en', dir: 'ltr' });
     (useMusic as unknown as vi.Mock).mockReturnValue({
-      playTrack, unlockAudio, fadeToTrack: playTrack, TRACKS: { BOSSA: 'bossa', LOBBY: 'lobby' },
+      playTrack: vi.fn(), unlockAudio: vi.fn(), fadeToTrack: vi.fn(),
+      TRACKS: { BOSSA: 'bossa', LOBBY: 'lobby' },
     });
   });
 
-  it('calls playTrack(BOSSA) exactly once on mount, without requiring a user gesture', () => {
-    render(<LandingView />, { wrapper });
+  it('renders the 3 newest blog post links (not the legacy stale set)', () => {
+    const { container } = render(<LandingView />, { wrapper });
+    const hrefs = Array.from(container.querySelectorAll('a')).map((a) => a.getAttribute('href') || '');
 
-    const bossaCalls = playTrack.mock.calls.filter((c) => c[0] === 'bossa');
-    expect(bossaCalls).toHaveLength(1);
-  });
+    // Newest 3 (per LandingBlogSection.recentPosts) must be present.
+    expect(hrefs).toEqual(expect.arrayContaining([
+      '/en/blog/netflix-word-game-2026-rise',
+      '/en/blog/boggle-vs-wordle',
+      '/en/blog/boggle-vs-scrabble',
+    ]));
 
-  it('does not register window pointerdown/keydown listeners that would trigger duplicate playback', () => {
-    const addSpy = vi.spyOn(window, 'addEventListener');
-    render(<LandingView />, { wrapper });
-
-    const landingListeners = addSpy.mock.calls.filter(
-      ([evt]) => evt === 'pointerdown' || evt === 'keydown'
-    );
-    expect(landingListeners).toHaveLength(0);
-    addSpy.mockRestore();
-  });
-
-  it('does not re-trigger playTrack when the user taps the document', () => {
-    render(<LandingView />, { wrapper });
-    playTrack.mockClear();
-
-    act(() => {
-      window.dispatchEvent(new Event('pointerdown'));
-      document.dispatchEvent(new Event('click'));
-    });
-
-    expect(playTrack).not.toHaveBeenCalled();
+    // The legacy slugs that were hardcoded in LandingSEOSection.blogLinks
+    // must NOT leak through any other path on the homepage.
+    const legacy = [
+      '/en/blog/science-behind-word-games',
+      '/en/blog/why-word-games-are-addictive',
+      '/en/blog/daily-challenge-strategies',
+    ];
+    for (const stale of legacy) {
+      expect(hrefs).not.toContain(stale);
+    }
   });
 });

--- a/fe-next/components/landing/__tests__/LandingView.botLaunch.test.tsx
+++ b/fe-next/components/landing/__tests__/LandingView.botLaunch.test.tsx
@@ -18,6 +18,7 @@ vi.mock('next/navigation', () => ({
   }),
   usePathname: () => '/en',
   useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({ locale: 'en' }),
 }));
 
 // Mock next/link

--- a/fe-next/components/landing/__tests__/LandingView.spacing.test.tsx
+++ b/fe-next/components/landing/__tests__/LandingView.spacing.test.tsx
@@ -72,6 +72,7 @@ vi.mock('next/navigation', () => ({
     push: vi.fn(),
     replace: vi.fn(),
   }),
+  useParams: () => ({ locale: 'en' }),
 }));
 
 vi.mock('@/utils/onboardingStorage', () => ({

--- a/fe-next/components/landing/landingSEOContent.ts
+++ b/fe-next/components/landing/landingSEOContent.ts
@@ -31,9 +31,6 @@ export interface LandingSEOContent {
   faq: { question: string; answer: string }[];
   communityTitle: string;
   communityContent: string;
-  blogTitle: string;
-  viewAllPosts: string;
-  blogLinks: { slug: string; title: string; category: string }[];
 }
 
 const en: LandingSEOContent = {
@@ -167,25 +164,6 @@ const en: LandingSEOContent = {
   communityTitle: 'Join Thousands of Word Game Enthusiasts',
   communityContent:
     'LexiClash players span over 40 countries and five languages. Join the community to compete on global leaderboards, share daily challenge results, and discover new word strategies. Follow us on Instagram @lexi.clash for tips, updates, and community highlights.',
-  blogTitle: 'From Our Blog',
-  viewAllPosts: 'View all posts →',
-  blogLinks: [
-    {
-      slug: 'science-behind-word-games',
-      title: 'The Science Behind Word Games',
-      category: 'Science',
-    },
-    {
-      slug: 'why-word-games-are-addictive',
-      title: 'Why Word Games Are So Addictive',
-      category: 'Psychology',
-    },
-    {
-      slug: 'daily-challenge-strategies',
-      title: 'Daily Challenge Strategies',
-      category: 'Strategy',
-    },
-  ],
 };
 
 const he: LandingSEOContent = {
@@ -326,25 +304,6 @@ const he: LandingSEOContent = {
   communityTitle: 'הצטרפו לאלפי חובבי משחקי מילים',
   communityContent:
     'שחקני LexiClash פרוסים על פני יותר מ-40 מדינות וחמש שפות. הצטרפו לקהילה כדי להתחרות בלוחות דירוג גלובליים, לשתף תוצאות אתגרים יומיים ולגלות אסטרטגיות מילים חדשות. עקבו אחרינו באינסטגרם @lexi.clash לטיפים, עדכונים ואירועי קהילה.',
-  blogTitle: 'מהבלוג שלנו',
-  viewAllPosts: 'לכל הפוסטים ←',
-  blogLinks: [
-    {
-      slug: 'science-behind-word-games',
-      title: 'המדע מאחורי משחקי מילים',
-      category: 'מדע',
-    },
-    {
-      slug: 'why-word-games-are-addictive',
-      title: 'למה משחקי מילים כל כך ממכרים',
-      category: 'פסיכולוגיה',
-    },
-    {
-      slug: 'daily-challenge-strategies',
-      title: 'אסטרטגיות לאתגר היומי',
-      category: 'אסטרטגיה',
-    },
-  ],
 };
 
 const sv: LandingSEOContent = {
@@ -485,25 +444,6 @@ const sv: LandingSEOContent = {
   communityTitle: 'Gå med tusentals ordspelsentusiaster',
   communityContent:
     'LexiClash-spelare finns i över 40 länder och på fem språk. Gå med i gemenskapen för att tävla på globala topplistor, dela dagliga utmaningsresultat och upptäck nya ordstrategier. Följ oss på Instagram @lexi.clash för tips, uppdateringar och gemenskapshöjdpunkter.',
-  blogTitle: 'Från vår blogg',
-  viewAllPosts: 'Visa alla inlägg →',
-  blogLinks: [
-    {
-      slug: 'science-behind-word-games',
-      title: 'Vetenskapen bakom ordspel',
-      category: 'Vetenskap',
-    },
-    {
-      slug: 'why-word-games-are-addictive',
-      title: 'Varför ordspel är så beroendeframkallande',
-      category: 'Psykologi',
-    },
-    {
-      slug: 'daily-challenge-strategies',
-      title: 'Strategier för dagliga utmaningar',
-      category: 'Strategi',
-    },
-  ],
 };
 
 const ja: LandingSEOContent = {
@@ -644,25 +584,6 @@ const ja: LandingSEOContent = {
   communityTitle: '数千人のワードゲーム愛好家と一緒に',
   communityContent:
     'LexiClashのプレイヤーは40カ国以上、5言語にわたっています。コミュニティに参加して、グローバルランキングで競い、デイリーチャレンジの結果をシェアし、新しいワード戦略を発見しよう。Instagram @lexi.clash でヒント、アップデート、コミュニティハイライトをチェック。',
-  blogTitle: 'ブログから',
-  viewAllPosts: '全ての投稿を見る →',
-  blogLinks: [
-    {
-      slug: 'science-behind-word-games',
-      title: 'ワードゲームの科学',
-      category: 'サイエンス',
-    },
-    {
-      slug: 'why-word-games-are-addictive',
-      title: 'ワードゲームがやめられない理由',
-      category: '心理学',
-    },
-    {
-      slug: 'daily-challenge-strategies',
-      title: 'デイリーチャレンジ攻略法',
-      category: '戦略',
-    },
-  ],
 };
 
 const es: LandingSEOContent = {
@@ -803,25 +724,6 @@ const es: LandingSEOContent = {
   communityTitle: 'Únete a miles de entusiastas de los juegos de palabras',
   communityContent:
     'Los jugadores de LexiClash están repartidos en más de 40 países y cinco idiomas. Únete a la comunidad para competir en tablas de clasificación globales, compartir resultados de desafíos diarios y descubrir nuevas estrategias de vocabulario. Síguenos en Instagram @lexi.clash para consejos, actualizaciones y destacados de la comunidad.',
-  blogTitle: 'De nuestro blog',
-  viewAllPosts: 'Ver todas las entradas →',
-  blogLinks: [
-    {
-      slug: 'science-behind-word-games',
-      title: 'La ciencia detrás de los juegos de palabras',
-      category: 'Ciencia',
-    },
-    {
-      slug: 'why-word-games-are-addictive',
-      title: 'Por qué los juegos de palabras son tan adictivos',
-      category: 'Psicología',
-    },
-    {
-      slug: 'daily-challenge-strategies',
-      title: 'Estrategias para el desafío diario',
-      category: 'Estrategia',
-    },
-  ],
 };
 
 export const contentByLocale: Record<string, LandingSEOContent> = {


### PR DESCRIPTION
The previous "newest posts on home" change updated LandingBlogSection.recentPosts,
but that component was never imported anywhere. The homepage was rendering a
parallel hardcoded blog grid embedded inside LandingSEOSection, fed by
`blogLinks` in landingSEOContent.ts — frozen on the legacy science /
why-addictive / daily-strategies trio.

- Render <LandingBlogSection /> from LandingView so the corrected data path
  actually reaches users.
- Delete the duplicate grid + BLOG_IMAGES from LandingSEOSection.
- Strip blogTitle / viewAllPosts / blogLinks from LandingSEOContent and all
  five locales (en / he / sv / ja / es) so this can't desync again.
- Add LandingView.blogSection regression test asserting the home page links
  to netflix-word-game-2026-rise / boggle-vs-wordle / boggle-vs-scrabble
  and not the legacy slugs.
- Three existing LandingView tests now need useParams mocked because
  LandingBlogSection is statically imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>