### PR TITLE
fix(blast-mp): rewrite letterGrid on wave advance so scoring resumes

### DIFF
--- a/fe-next/backend/handlers/__tests__/wordHandler.blast.test.ts
+++ b/fe-next/backend/handlers/__tests__/wordHandler.blast.test.ts
@@ -438,6 +438,19 @@ describe('wordHandler - blastComboSync broadcast (52-02)', () => {
       expect(game.letterPositions.get('a')).toEqual([[0, 0]]);
     });
 
+    // Without this, isWordOnBoardAsync walks the wave-1 grid using new-wave
+    // positions; nearly every word in wave 2+ gets rejected as wordNotOnBoard
+    // and the leaderboard never updates (the visible MP-blast scoring bug).
+    it('rewrites game.letterGrid to the new-wave grid on wave advance', async () => {
+      (isBlastBoardCleared as Mock).mockReturnValue(true);
+      const game = makeBlastGame({ blastModeState: makeCleared(1) });
+      (getGame as Mock).mockReturnValue(game);
+
+      await handlers['submitWord']({ word: 'test' });
+
+      expect(game.letterGrid).toEqual([['A']]);
+    });
+
     it('resets playerWords/playerWordsSet on wave advance (M4)', async () => {
       (isBlastBoardCleared as Mock).mockReturnValue(true);
       const game = makeBlastGame({

--- a/fe-next/backend/handlers/wordValidationHandler.ts
+++ b/fe-next/backend/handlers/wordValidationHandler.ts
@@ -162,7 +162,12 @@ function handleValidatedWord(io: Server, socket: Socket, game: GameState, gameCo
               playerBonusMoves: next.playerBonusMoves,
               totalMoves: next.totalMoves,
             });
-            game.letterPositions = makePositionsMap(next.grid ?? gravityResult.newGrid, (game.language || 'en'));
+            const nextGrid = next.grid ?? gravityResult.newGrid;
+            // Keep letterGrid in lock-step with letterPositions; wordHandler's
+            // isWordOnBoardAsync walks letterGrid using letterPositions, and a
+            // mismatch silently rejects every wave 2+ word as wordNotOnBoard.
+            game.letterGrid = nextGrid;
+            game.letterPositions = makePositionsMap(nextGrid, (game.language || 'en'));
             if (game.playerWords) {
               for (const u of Object.keys(game.playerWords)) {
                 game.playerWords[u] = [];

--- a/fe-next/backend/services/gameLifecycle/__tests__/botGame.blast.test.ts
+++ b/fe-next/backend/services/gameLifecycle/__tests__/botGame.blast.test.ts
@@ -133,6 +133,7 @@ function makeBlastGame(wave: number) {
   return {
     gameMode: 'blast' as const,
     gameState: 'in-progress' as const,
+    letterGrid: [['A']],
     letterPositions: new Map(),
     blastModeState: {
       grid: [['A']],
@@ -250,6 +251,26 @@ describe('Bot blast mode — wave advance + endGame parity with human path', () 
     expect(game.letterPositions.get('y')).toEqual([[0, 1]]);
     expect(game.letterPositions.get('z')).toEqual([[1, 0]]);
     expect(game.letterPositions.get('w')).toEqual([[1, 1]]);
+  });
+
+  // Companion to letterPositions: wordHandler validates submissions with
+  // isWordOnBoardAsync(game.letterGrid, game.letterPositions). Mismatched
+  // grid/positions silently rejects every word in wave 2+, so leaderboard
+  // freezes at 0.
+  it('wave advance rewrites game.letterGrid to the new-wave grid', async () => {
+    mocks.isBlastBoardCleared.mockReturnValue(true);
+    const newGrid = [['X', 'Y'], ['Z', 'W']];
+    mocks.advanceBlastWave.mockImplementation((state) => ({
+      wave: (state.wave ?? 1) + 1,
+      overlay: [], overlayMap: new Map(),
+      tileStates: [[{ isCleared: false }]],
+      seed: 999, grid: newGrid,
+      playerMoves: {}, playerBonusMoves: {}, totalMoves: 0,
+      playerStats: state.playerStats,
+    }));
+    const game = makeBlastGame(1);
+    await invokeBotCallback(makeBot(), game);
+    expect(game.letterGrid).toEqual(newGrid);
   });
 
   it('wave advance resets playerWords/playerWordsSet so repeats unblock (M4)', async () => {

--- a/fe-next/backend/services/gameLifecycle/botGame.ts
+++ b/fe-next/backend/services/gameLifecycle/botGame.ts
@@ -296,6 +296,10 @@ export function startBotsForGame(
                     totalMoves: next.totalMoves,
                   });
                   if (currentGame) {
+                    // Keep letterGrid + letterPositions in lock-step. The human
+                    // submitWord path walks letterGrid using letterPositions;
+                    // mismatches silently reject every wave 2+ word.
+                    currentGame.letterGrid = nextGrid;
                     currentGame.letterPositions = makePositionsMap(nextGrid, (currentGame.language || 'en'));
                     if (currentGame.playerWords) {
                       for (const u of Object.keys(currentGame.playerWords)) {


### PR DESCRIPTION
On wave advance, both the human and bot blast paths updated
game.letterPositions to the new wave's grid but left game.letterGrid
pointing at the wave-1 grid. wordHandler then called
isWordOnBoardAsync(game.letterGrid, game.letterPositions), which walks
letterGrid starting from positions taken from a *different* grid — every
wave 2+ submission was silently rejected as wordNotOnBoard, so
updatePlayerScore never fired and the broadcast leaderboard froze at 0
even though clients showed local engine scores.

Assign letterGrid alongside letterPositions in both call sites and add
regression tests on each path.