### PR TITLE
SEO: daily improvements (2026-05-01)

### DIFF
--- a/docs/seo-daily/2026-05-01.md
+++ b/docs/seo-daily/2026-05-01.md
@@ -1,0 +1,114 @@
+# SEO Daily — 2026-05-01
+
+**Window:** 2026-04-02 → 2026-04-29 (28d, GSC has 2-day lag)
+**Recent vs prior 7d:** 2026-04-23–2026-04-29 vs 2026-04-16–2026-04-22
+
+## Headline metrics
+
+| Engine | Clicks | Impressions | CTR |
+|---|---:|---:|---:|
+| Google | 9 | 279 | 3.23% |
+| Bing | 40 | 670 | 5.97% |
+| **Total** | **49** | **949** | **5.16%** |
+
+> Bing drives **82% of total clicks** despite being the smaller search engine — Bing parity gaps below are high-leverage.
+
+## Top 10 CTR opportunities (Google)
+
+Queries underperforming expected CTR by ≥30%, sorted by potential clicks gained.
+
+| # | Query | Page | Pos | Impr | CTR | Expected | Δ Clicks | Suggested fix |
+|--:|---|---|--:|--:|--:|--:|--:|---|
+| 1 | `boggle vs scrabble` | `/en/blog/boggle-vs-scrabble` | 8.5 | 19 | 0.00% | 2.50% | +0.5 | Add comparison schema; lead title with verdict word |
+| 2 | `best competitive word games with global ...` | `/en/leaderboard` | 7.1 | 12 | 0.00% | 3.00% | +0.4 | Add SoftwareApplication+rating schema; current year in title |
+| 3 | `best word games 2026` | `/en/best-online-word-games` | 8.8 | 13 | 0.00% | 2.00% | +0.3 | Add SoftwareApplication+rating schema; current year in title |
+| 4 | `browser games like words with friends on...` | `/sv/words-with-friends-alternative` | 18.9 | 26 | 0.00% | 1.00% | +0.3 | Front-load query in title; add stronger benefit hook in meta desc |
+| 5 | `best online word games 2025 2026` | `/en/best-online-word-games` | 7.1 | 8 | 0.00% | 3.00% | +0.2 | Add SoftwareApplication+rating schema; current year in title |
+| 6 | `juegos de palabras online multijugador` | `/es/juego-de-palabras-multijugador` | 15.3 | 16 | 0.00% | 1.00% | +0.2 | Front-load query in title; add stronger benefit hook in meta desc |
+| 7 | `"magical-religious origins" legal concep...` | `/en/blog/word-game-history` | 11 | 8 | 0.00% | 1.00% | +0.1 | Front-load query in title; add stronger benefit hook in meta desc |
+| 8 | `play word game online with friends brows...` | `/en/multiplayer-word-game-online` | 23.6 | 7 | 0.00% | 1.00% | +0.1 | Front-load query in title; add stronger benefit hook in meta desc |
+| 9 | `popular online word games 2026` | `/en/best-online-word-games` | 11.4 | 5 | 0.00% | 1.00% | +0.1 | Front-load query in title; add stronger benefit hook in meta desc |
+| 10 | `why word games` | `/en/blog/10-surprising-benefits-word-games` | 76.2 | 6 | 0.00% | 1.00% | +0.1 | Front-load query in title; add stronger benefit hook in meta desc |
+
+## Top 10 rank-up opportunities (Google, pos 8–25)
+
+Queries on page 1 edge or page 2 — small wins push them to page 1.
+
+| # | Query | Page | Pos | Impr | Action |
+|--:|---|---|--:|--:|---|
+| 1 | `browser games like words with friends on...` | `/sv/words-with-friends-alternative` | 18.9 | 26 | Content gap — likely needs new section/page targeting query intent |
+| 2 | `boggle vs scrabble` | `/en/blog/boggle-vs-scrabble` | 8.5 | 19 | Add internal links from high-authority pages; expand H2 covering query |
+| 3 | `juegos de palabras online multijugador` | `/es/juego-de-palabras-multijugador` | 15.3 | 16 | Content gap — likely needs new section/page targeting query intent |
+| 4 | `best word games 2026` | `/en/best-online-word-games` | 8.8 | 13 | Add internal links from high-authority pages; expand H2 covering query |
+| 5 | `"magical-religious origins" legal concep...` | `/en/blog/word-game-history` | 11 | 8 | Add long-tail variations in body; build 2–3 internal links |
+| 6 | `play word game online with friends brows...` | `/en/multiplayer-word-game-online` | 23.6 | 7 | Content gap — likely needs new section/page targeting query intent |
+| 7 | `ordpussel gratis` | `/sv/daily` | 8.8 | 6 | Add internal links from high-authority pages; expand H2 covering query |
+| 8 | `מישחקי שפה עברית און ליין` | `/he` | 18.5 | 6 | Content gap — likely needs new section/page targeting query intent |
+| 9 | `popular online word games 2026` | `/en/best-online-word-games` | 11.4 | 5 | Add long-tail variations in body; build 2–3 internal links |
+| 10 | `סקרבל אונליין` | `/he/blog/hebrew-word-games-guide` | 9.4 | 5 | Add internal links from high-authority pages; expand H2 covering query |
+
+## Bing parity gaps
+
+Queries ranking on Google but invisible on Bing. Submit URLs via IndexNow + check Bing sitemap.
+
+| Query | Google pos | Google impr | Bing | Fix |
+|---|--:|--:|---|---|
+| `boggle vs scrabble` | 8.5 | 19 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
+| `best word games 2026` | 8.8 | 13 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
+| `best competitive word games with global ...` | 7.1 | 12 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
+| `best online word games 2025 2026` | 7.1 | 8 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
+| `ordpussel gratis` | 8.8 | 6 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
+| `סקרבל אונליין` | 9.4 | 5 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
+
+## GEO / AI visibility candidates
+
+Question-style queries — add FAQPage schema + clear single-paragraph answers (boosts AI Overview / ChatGPT citation likelihood).
+
+| Query | Page | Pos | Impr | FAQ Q (draft) |
+|---|---|--:|--:|---|
+| `best word games 2026` | `/en/best-online-word-games` | 8.8 | 13 | Best word games 2026? |
+| `best competitive word games with global ...` | `/en/leaderboard` | 7.1 | 12 | Best competitive word games with global leaderboards? |
+| `best online word games 2025 2026` | `/en/best-online-word-games` | 7.1 | 8 | Best online word games 2025 2026? |
+| `why word games` | `/en/blog/10-surprising-benefits-word-games` | 76.2 | 6 | Why word games? |
+| `best online word games` | `/en/best-online-word-games` | 69.3 | 3 | Best online word games? |
+| `best online word game` | `/en/best-online-word-games` | 70 | 2 | Best online word game? |
+
+## Trends — rising queries (last 7d vs prior 7d)
+
+| Query | Recent 7d | Prior 7d | Change |
+|---|--:|--:|--:|
+| `play word game online with friends brows...` | 5 | 2 | +150% |
+| `browser games like words with friends on...` | 26 | 0 | +100% |
+| `"magical-religious origins" legal concep...` | 8 | 0 | +100% |
+
+## Trends — falling queries
+
+| Query | Recent 7d | Prior 7d | Change |
+|---|--:|--:|--:|
+| `מישחקי שפה עברית און ליין` | 0 | 6 | -100% |
+| `best word games 2026` | 3 | 9 | -67% |
+| `boggle vs scrabble` | 5 | 10 | -50% |
+
+## Bing top performers
+
+Where Bing already drives traffic — protect/expand these.
+
+| # | Query | Pos | Impr | Clicks | CTR |
+|--:|---|--:|--:|--:|--:|
+| 1 | `daily express word wheel` | 0.0 | 62 | 0 | 0.00% |
+| 2 | `boggle shake` | 0.0 | 29 | 0 | 0.00% |
+| 3 | `daily word wheel` | 0.0 | 18 | 1 | 5.56% |
+| 4 | `daily word wheel` | 0.0 | 16 | 0 | 0.00% |
+| 5 | `daily word wheel` | 0.0 | 14 | 1 | 7.14% |
+| 6 | `daily word wheel` | 0.0 | 13 | 0 | 0.00% |
+| 7 | `lexiclash` | 0.0 | 12 | 1 | 8.33% |
+| 8 | `play boggle word shake free no download` | 0.0 | 11 | 1 | 9.09% |
+
+## Today's actions
+
+- **Fix top-5 CTR opportunities** (~+2 clicks/28d): focus on titles/meta for `boggle-vs-scrabble`, `best-online-word-games`, and other comparison/listicle pages — current titles already include keywords but rank pos 7–9 with 0% CTR suggesting weak SERP appeal vs competitors.
+- **Fix Bing parity** (6 queries) — submit top-ranking Google pages to Bing via IndexNow API: `curl -X POST 'https://www.bing.com/indexnow' -H 'Content-Type: application/json' -d '{"host":"lexiclash.live","key":"<key>","urlList":[...]}'`
+- **Add FAQPage schema** for 6 question-style queries — ChatGPT/Gemini cite FAQ answers directly. Draft answers are in the GEO table above.
+
+---
+_Generated by SEO daily routine. Data: GSC `sc-domain:lexiclash.live` + Bing WMT API._

--- a/fe-next/app/[locale]/leaderboard/page.tsx
+++ b/fe-next/app/[locale]/leaderboard/page.tsx
@@ -29,6 +29,11 @@ const seoContent: Record<string, {
     ],
     faq: [
       {
+        question: 'What are the best competitive word games with global leaderboards in 2026?',
+        answer:
+          'LexiClash is the best free competitive word game in 2026 with global leaderboards across daily, weekly, and all-time rankings — plus separate leaderboards per mode (Classic, Blast, Word Hunt, Daily Challenge). Words With Friends offers async tournaments but no live global ranking. Wordle does not have a competitive leaderboard at all. For real-time multiplayer + persistent global rankings, LexiClash is the only browser option that combines both.',
+      },
+      {
         question: 'How is the leaderboard score calculated?',
         answer:
           'Leaderboard rankings are based on your total score across games. Points come from word length, combo multipliers, and bonus tiles. Daily leaderboards reset at midnight UTC.',
@@ -42,6 +47,11 @@ const seoContent: Record<string, {
         question: 'How often does the leaderboard update?',
         answer:
           'The leaderboard updates in real time as games finish. Your position reflects your most recent score within seconds of completing a match.',
+      },
+      {
+        question: 'Is the LexiClash leaderboard free to compete on?',
+        answer:
+          'Yes. Every leaderboard — daily, weekly, all-time, and per-mode — is free for all players. There is no paid tier or VIP-only ranking. Climb purely by playing well.',
       },
     ],
   },

--- a/fe-next/components/seo/GamePageSeoContent.tsx
+++ b/fe-next/components/seo/GamePageSeoContent.tsx
@@ -54,6 +54,21 @@ export function GamePageSeoContent({
           ))}
         </div>
       )}
+
+      {faq && faq.length > 0 && <FaqJsonLd faq={faq} />}
     </section>
   );
+}
+
+function FaqJsonLd({ faq }: { faq: FaqItem[] }) {
+  const json = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faq.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+    })),
+  });
+  return <script type="application/ld+json">{json}</script>;
 }


### PR DESCRIPTION
## Summary

Daily SEO routine — first run. See [docs/seo-daily/2026-05-01.md](./docs/seo-daily/2026-05-01.md) for the full report.

**Code changes (target the highest-leverage GEO/AI-visibility gap):**

- **FAQ schema gap fixed in `GamePageSeoContent`** — the shared component used by `/leaderboard` and every game-mode page rendered FAQ as plain HTML only. Now co-emits `FAQPage` JSON-LD so AI Overviews / ChatGPT search / Perplexity can cite the answers. Zero impact on UI (component is `sr-only`).
- **Leaderboard page targets `best competitive word games with global leaderboards`** (GSC pos 7.1, 12 impr, 0% CTR — top-3 CTR opportunity in today's report). Added a FAQ Q&A naturally answering that query. Also added a free-to-compete fairness Q.

**Already executed (no code change needed):**
- Submitted 11 Google-ranking URLs to **IndexNow** to close Bing parity gaps (`boggle-vs-scrabble`, `best-online-word-games`, `leaderboard`, `multiplayer-word-game-online`, etc. — all currently missing on Bing despite Google pos ≤ 10). HTTP 200 from `api.indexnow.org`.

## Data behind the changes

28-day window, GSC `sc-domain:lexiclash.live` + Bing WMT API:

| Engine | Clicks | Impr | CTR |
|---|--:|--:|--:|
| Google | 9 | 279 | 3.23% |
| Bing | 40 | 670 | 5.97% |

Bing drives **82% of total clicks** despite being smaller — the parity gaps are the single biggest near-term opportunity. IndexNow submission addresses 6 high-impression queries that rank top-10 on Google but are invisible on Bing.

## Why these changes specifically

The CTR opportunities table flagged 12 queries underperforming expected CTR, but on inspection the existing meta titles/descriptions already include the target keywords correctly. The bottleneck is not meta copy — it's **ranking** (most underperformers are pos 7–9, where SERP appeal is dominated by competing brand pages). Two real levers:

1. **AI search visibility** — FAQ schema makes the site quotable. ChatGPT search and Google AI Overviews preferentially cite FAQPage answers. The leaderboard page now competes for "best competitive word games with global leaderboards" via a direct schema-backed answer rather than relying on rank-1 SERP positioning.
2. **Bing parity** — Bing already drives 4× more clicks than Google for this site. Closing parity gaps via IndexNow is the highest-leverage action.

Skipped meta-tag-only edits — existing titles already include the queries.

## Test plan

- [ ] Visit `/en/leaderboard` and verify FAQ JSON-LD renders in HTML source (`<script type="application/ld+json">`)
- [ ] Run https://search.google.com/test/rich-results on the deployed leaderboard URL — should detect `FAQPage` with 5 questions
- [ ] Within 1–7 days: re-pull GSC data via `/seo-daily` skill and verify CTR uplift on `boggle vs scrabble` + leaderboard queries
- [ ] Within 1–3 days: check Bing WMT for impressions on `boggle vs scrabble` and other parity-gap queries (IndexNow indexing window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)