### PR TITLE
feat(practice): mascot intros, distinct mode mechanics, min 2 letters, hub polish

### DIFF
--- a/fe-next/app/[locale]/practice/PageClient.tsx
+++ b/fe-next/app/[locale]/practice/PageClient.tsx
@@ -5,14 +5,41 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { AdaptiveMotion } from '@/components/motion/AdaptiveMotion';
 import { useSoundEffects } from '@/contexts/SoundEffectsContext';
 import { haptics } from '@/utils/haptics';
+import { Mascot, type MascotVariant } from '@/components/ui/Mascot';
 import { PRACTICE_MODES } from '@/lib/practice/practiceRoute';
 import { usePracticeProgress } from '@/components/practice/usePracticeProgress';
 import type { PracticeMode } from '@/lib/practice/practiceTutorialSteps';
 
-const MODE_ACCENT: Record<PracticeMode, string> = {
-  classic: 'border-neo-cyan/80 hover:border-neo-cyan',
-  wordHunt: 'border-neo-lime/80 hover:border-neo-lime',
-  wheelRush: 'border-neo-purple/80 hover:border-neo-purple',
+interface ModeStyle {
+  mascot: MascotVariant;
+  border: string;
+  badge: string;
+  cta: string;
+  bg: string;
+}
+
+const MODE_STYLE: Record<PracticeMode, ModeStyle> = {
+  classic: {
+    mascot: 'scholar',
+    border: 'border-neo-cyan',
+    badge: 'cyan',
+    cta: 'bg-neo-cyan',
+    bg: 'from-neo-cyan/10 to-transparent',
+  },
+  wordHunt: {
+    mascot: 'explorer',
+    border: 'border-neo-lime',
+    badge: 'lime',
+    cta: 'bg-neo-lime',
+    bg: 'from-neo-lime/10 to-transparent',
+  },
+  wheelRush: {
+    mascot: 'dj',
+    border: 'border-neo-purple',
+    badge: 'purple',
+    cta: 'bg-neo-purple text-neo-white',
+    bg: 'from-neo-purple/10 to-transparent',
+  },
 };
 
 interface Props {
@@ -20,8 +47,8 @@ interface Props {
 }
 
 /**
- * Cozy practice hub. One mode per row, breathing accents, no badges or
- * counters. Tap → /practice/<mode> which shows the intro card.
+ * Practice hub. Hero mascot greeting + bigger, mascot-fronted mode cards so
+ * the screen pops on first landing. Tap → /practice/<mode>.
  */
 export default function PracticeHubClient({ locale }: Props) {
   const { t, language } = useLanguage();
@@ -33,25 +60,28 @@ export default function PracticeHubClient({ locale }: Props) {
   };
 
   return (
-    <div className="min-h-[100dvh] w-full bg-linear-to-b from-neo-navy to-neo-navy-light px-6 py-10">
+    <div className="min-h-[100dvh] w-full bg-linear-to-b from-neo-navy to-neo-navy-light px-5 py-6">
       <div className="max-w-md mx-auto">
         <AdaptiveMotion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, ease: 'easeOut' }}
-          className="mb-6 text-center"
+          className="mb-5 flex items-center gap-3"
         >
-          <h1 className="text-3xl font-neo-display font-bold text-neo-cream mb-2">
-            {t('practiceHub.title')}
-          </h1>
-          <p className="text-sm font-neo-body text-neo-cream/85 italic">
-            {t('practiceHub.subtitle')}
-          </p>
+          <Mascot variant="waving" size="sm" clipShape="circle" clipBorder="lime" />
+          <div className="flex-1 bg-neo-cream text-neo-black border-3 border-neo-black rounded-neo px-3 py-2 shadow-hard-sm">
+            <h1 className="text-lg font-neo-display font-black uppercase tracking-tight leading-none">
+              {t('practiceHub.title')}
+            </h1>
+            <p className="text-xs font-neo-body font-bold leading-tight mt-0.5">
+              {t('practiceHub.greet')}
+            </p>
+          </div>
         </AdaptiveMotion.div>
 
         <div
           data-testid="practice-progress-headline"
-          className="mb-6 flex items-center justify-center gap-2 text-xs uppercase tracking-wider font-neo-display font-black text-neo-lime"
+          className="mb-4 flex items-center justify-center gap-2 text-xs uppercase tracking-wider font-neo-display font-black text-neo-lime"
         >
           <span aria-hidden>★</span>
           <span>
@@ -67,7 +97,7 @@ export default function PracticeHubClient({ locale }: Props) {
             transition={{ duration: 0.5, ease: 'easeOut' }}
             role="status"
             aria-live="polite"
-            className="mb-6 px-4 py-3 rounded-neo border-3 border-neo-black bg-neo-lime text-neo-black shadow-hard text-center"
+            className="mb-5 px-4 py-3 rounded-neo border-3 border-neo-black bg-neo-lime text-neo-black shadow-hard text-center"
           >
             <p className="font-neo-display font-black text-base mb-0.5">
               {t('practiceHub.allCompleteTitle')}
@@ -81,6 +111,7 @@ export default function PracticeHubClient({ locale }: Props) {
         <div className="flex flex-col gap-3">
           {PRACTICE_MODES.map((mode, idx) => {
             const isDone = completed.has(mode);
+            const style = MODE_STYLE[mode];
             return (
               <AdaptiveMotion.div
                 key={mode}
@@ -98,7 +129,7 @@ export default function PracticeHubClient({ locale }: Props) {
                       ? `${t(`gameModes.${mode}.name`)} — ${t('practiceHub.completedBadge')}`
                       : t(`gameModes.${mode}.name`)
                   }
-                  className={`relative block rounded-neo border-2 ${MODE_ACCENT[mode]} bg-neo-navy-light px-5 py-4 transition-colors active:translate-y-px shadow-hard-sm`}
+                  className={`relative block rounded-neo border-3 ${style.border} bg-linear-to-r ${style.bg} bg-neo-navy-light px-3 py-3 transition-transform active:translate-y-px shadow-hard-sm overflow-hidden`}
                 >
                   {isDone && (
                     <span
@@ -108,17 +139,27 @@ export default function PracticeHubClient({ locale }: Props) {
                       ✓
                     </span>
                   )}
-                  <h2 className="text-lg font-neo-display font-bold text-neo-cream">
-                    {t(`gameModes.${mode}.name`)}
-                  </h2>
-                  <p className="text-sm font-neo-body text-neo-cream/90 mt-1 pe-8">
-                    {t(`gameModes.${mode}.description`)}
-                  </p>
-                  {isDone && (
-                    <p className="text-xs font-neo-body text-neo-lime/90 mt-2 italic">
-                      {t('practiceHub.completedDesc')}
-                    </p>
-                  )}
+                  <div className="flex items-center gap-3">
+                    <Mascot
+                      variant={style.mascot}
+                      size="xs"
+                      clipShape="circle"
+                      clipBorder={style.badge as 'cyan' | 'lime' | 'purple'}
+                    />
+                    <div className="flex-1 min-w-0 pe-8">
+                      <h2 className="text-lg font-neo-display font-black text-neo-cream leading-tight">
+                        {t(`gameModes.${mode}.name`)}
+                      </h2>
+                      <p className="text-xs font-neo-body font-bold text-neo-cream/80 leading-tight mt-0.5">
+                        {t(`gameModes.${mode}.description`)}
+                      </p>
+                    </div>
+                    <span
+                      className={`shrink-0 px-3 py-1.5 rounded-neo border-2 border-neo-black text-neo-black font-neo-display font-black text-xs uppercase tracking-wide shadow-hard-sm ${style.cta}`}
+                    >
+                      {isDone ? t('practiceHub.playAgainLabel') : t('practiceHub.playLabel')}
+                    </span>
+                  </div>
                 </Link>
               </AdaptiveMotion.div>
             );

--- a/fe-next/components/onboarding/TutorialGame.tsx
+++ b/fe-next/components/onboarding/TutorialGame.tsx
@@ -1,183 +1,79 @@
 'use client';
 
-import React, { useState, useCallback, useMemo } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { Sparkles } from 'lucide-react';
+import React, { useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { ArrowRight } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { Mascot } from '@/components/ui/Mascot';
 import { trackOnboardingFirstWord } from '@/utils/growthTracking';
-import MiniGrid from './MiniGrid';
-import { getTutorialBoard, isValidTutorialWord } from './tutorialBoardConfig';
 
 interface TutorialGameProps {
   onComplete: (score: number, wordsFound: string[]) => void;
-  /** Retry index from parent — increments on each "Try Again". PostHog uses it
-   *  to join the first-word event to score_reveal:retry friction. */
+  /** Retry index from parent — preserved for funnel parity. */
   attemptNumber?: number;
 }
 
-const WORDS_GOAL = 3;
-const LONG_WORD_LENGTH = 5;
-
 /**
- * TutorialGame - Full-screen tutorial with a pre-seeded 4x4 grid.
- * Step 1 of the FTUE: Instant Play (0-30s).
- * After 3 words: combo celebration.
- * After 5+ letter word: confetti + "AMAZING!" celebration.
+ * Onboarding "transition to practice" step.
+ * Replaced the old "find 3 words" mini-game — players jump straight into the
+ * full practice hub where the modes themselves teach mechanics. This screen
+ * is just a friendly handoff: cheering mascot, one line, one CTA.
+ *
+ * Signature kept as `onComplete(score, wordsFound)` so OnboardingFlow + tests
+ * don't have to change. Score is 0 — ScoreReveal still works (lowest tier).
  */
 const TutorialGame: React.FC<TutorialGameProps> = ({ onComplete, attemptNumber = 1 }) => {
-  const { t, language } = useLanguage();
+  const { t } = useLanguage();
 
-  const board = useMemo(() => getTutorialBoard(language), [language]);
-  const [wordsFound, setWordsFound] = useState<string[]>([]);
-  const [score, setScore] = useState(0);
-  const [showAmazing, setShowAmazing] = useState(false);
-  const [completed, setCompleted] = useState(false);
+  // Funnel parity: emit a synthetic first-word event at mount so the first-
+  // word PostHog metric isn't lost when this step is skipped on continue.
+  useEffect(() => {
+    trackOnboardingFirstWord('PRACTICE', attemptNumber);
+  }, [attemptNumber]);
 
-  // Current demo word to guide the player (first target not yet found)
-  const currentTarget = useMemo(() => {
-    return board.targetWords.find((tw) => !wordsFound.includes(tw.word));
-  }, [board.targetWords, wordsFound]);
-
-  const handleWordFound = useCallback(
-    (word: string) => {
-      const upperWord = word.toUpperCase();
-      if (wordsFound.includes(upperWord)) return;
-      if (!isValidTutorialWord(upperWord, language)) return;
-
-      // First valid word this mount — friction-signal event for the FTUE funnel.
-      // Checked BEFORE setWordsFound so the fire can't leak twice under StrictMode.
-      if (wordsFound.length === 0) {
-        trackOnboardingFirstWord(upperWord, attemptNumber);
-      }
-
-      const newWords = [...wordsFound, upperWord];
-      const wordScore = upperWord.length * 10;
-      const newScore = score + wordScore;
-
-      setWordsFound(newWords);
-      setScore(newScore);
-
-      // Check for 5+ letter word celebration
-      if (upperWord.length >= LONG_WORD_LENGTH && !showAmazing) {
-        setShowAmazing(true);
-        setTimeout(() => setShowAmazing(false), 2000);
-      }
-
-      // Check for 3 words goal
-      if (newWords.length >= WORDS_GOAL && !completed) {
-        setCompleted(true);
-        setTimeout(() => {
-          onComplete(newScore, newWords);
-        }, 600);
-      }
-    },
-    [wordsFound, score, language, showAmazing, completed, onComplete, attemptNumber]
-  );
-
-  const handleDemoComplete = useCallback(() => {
-    if (currentTarget) {
-      handleWordFound(currentTarget.word);
-    }
-  }, [currentTarget, handleWordFound]);
+  const handleContinue = () => {
+    onComplete(0, []);
+  };
 
   return (
     <div
       data-testid="tutorial-game"
       className="flex flex-col items-center justify-center min-h-screen bg-neo-navy p-4 relative overflow-hidden"
     >
-      {/* Mascot speech bubble */}
       <motion.div
-        initial={{ y: -20, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.2, type: 'spring', stiffness: 300, damping: 26 }}
-        className="flex items-center gap-3 lg:gap-4 mb-4 lg:mb-6"
-      >
-        <Mascot variant="encouraging" size="sm" clipBorder="none" />
-        <div className="bg-neo-cream border-3 border-neo-black rounded-neo p-3 shadow-hard-sm relative max-w-xs">
-          <span className="font-bold text-neo-black text-sm">
-            {t('onboarding.ftue.findMultipleWords')}
-          </span>
-          {/* Speech bubble arrow — RTL-aware */}
-          <div className="absolute ltr:-left-2 rtl:-right-2 top-1/2 -translate-y-1/2 w-3 h-3 bg-neo-cream ltr:border-l-3 ltr:border-b-3 rtl:border-r-3 rtl:border-b-3 border-neo-black ltr:rotate-45 rtl:-rotate-45" />
-        </div>
-      </motion.div>
-
-      {/* Word counter */}
-      <motion.div
-        data-testid="word-counter"
         initial={{ scale: 0.8, opacity: 0 }}
         animate={{ scale: 1, opacity: 1 }}
-        transition={{ delay: 0.3 }}
-        className="mb-4 bg-neo-lime border-3 border-neo-black rounded-neo px-4 py-2 shadow-hard-sm"
+        transition={{ type: 'spring', stiffness: 280, damping: 22 }}
+        className="flex flex-col items-center gap-6 max-w-sm"
       >
-        <span className="font-black text-neo-black text-lg">
-          {t('onboarding.ftue.wordsFound', { count: wordsFound.length })}
-        </span>
-      </motion.div>
+        <Mascot variant="celebration" size="xl" clipShape="circle" clipBorder="lime" />
 
-      {/* Tutorial grid */}
-      <motion.div
-        initial={{ scale: 0.9, opacity: 0 }}
-        animate={{ scale: 1, opacity: 1 }}
-        transition={{ delay: 0.4, type: 'spring', stiffness: 280, damping: 26 }}
-        className="w-full max-w-sm lg:max-w-md"
-      >
-        <MiniGrid
-          size={4}
-          letters={board.letters}
-          demoWord={currentTarget?.word || board.targetWords[0].word}
-          demoPath={currentTarget?.path || board.targetWords[0].path}
-          onDemoComplete={handleDemoComplete}
-          showHints={true}
-        />
-      </motion.div>
-
-      {/* Found words list */}
-      {wordsFound.length > 0 && (
         <motion.div
-          initial={{ y: 10, opacity: 0 }}
+          initial={{ y: 16, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          className="mt-4 flex gap-3 flex-wrap justify-center"
-          dir={language === 'he' ? 'rtl' : 'ltr'}
+          transition={{ delay: 0.2, duration: 0.4 }}
+          className="bg-neo-cream border-3 border-neo-black rounded-neo p-4 text-center shadow-hard"
         >
-          {wordsFound.map((word) => (
-            <motion.span
-              key={word}
-              initial={{ scale: 0 }}
-              animate={{ scale: 1 }}
-              transition={{ type: 'spring', stiffness: 400, damping: 20 }}
-              className="bg-neo-lime border-3 border-neo-black rounded-neo px-4 py-1.5 font-black text-neo-black text-base shadow-hard-sm"
-            >
-              {word}
-            </motion.span>
-          ))}
+          <h1 className="text-2xl font-neo-display font-black text-neo-black uppercase mb-1">
+            {t('practiceWelcome.greet')}
+          </h1>
+          <p className="text-sm font-neo-body font-bold text-neo-black/80">
+            {t('practiceWelcome.tip')}
+          </p>
         </motion.div>
-      )}
 
-      {/* AMAZING! celebration for 5+ letter words */}
-      <AnimatePresence>
-        {showAmazing && (
-          <motion.div
-            initial={{ scale: 0, rotate: -10 }}
-            animate={{ scale: 1, rotate: 0 }}
-            exit={{ scale: 0, opacity: 0 }}
-            transition={{ type: 'spring', stiffness: 400, damping: 15 }}
-            className="absolute inset-0 flex items-center justify-center pointer-events-none z-50"
-          >
-            <div className="bg-neo-pink border-4 border-neo-black rounded-neo px-8 py-4 shadow-hard-lg transform rotate-[-2deg]">
-              <div className="flex items-center gap-2">
-                <Sparkles className="text-neo-lime w-8 h-8" />
-                <span className="text-4xl font-black text-neo-white uppercase tracking-wider">
-                  {t('onboarding.ftue.amazing')}
-                </span>
-                <Sparkles className="text-neo-lime w-8 h-8" />
-              </div>
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
+        <motion.button
+          data-testid="tutorial-continue"
+          initial={{ y: 12, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          transition={{ delay: 0.4, duration: 0.4 }}
+          onClick={handleContinue}
+          className="flex items-center gap-2 px-6 py-3 bg-neo-lime border-3 border-neo-black rounded-neo font-neo-display font-black text-neo-black uppercase tracking-wide shadow-hard active:translate-y-px active:shadow-hard-pressed"
+        >
+          {t('practiceWelcome.cta')}
+          <ArrowRight className="w-5 h-5" strokeWidth={3} />
+        </motion.button>
+      </motion.div>
     </div>
   );
 };

--- a/fe-next/components/onboarding/__tests__/TutorialGame.analytics.test.tsx
+++ b/fe-next/components/onboarding/__tests__/TutorialGame.analytics.test.tsx
@@ -1,8 +1,7 @@
 /**
- * TutorialGame analytics — fires onboarding_first_word_found on first valid
- * word per mount. Subsequent words within the same attempt do NOT re-fire.
- * `attemptNumber` flows from parent (default 1) so PostHog can see retry
- * friction (attempt>1 pairs with score_reveal:retry upstream).
+ * TutorialGame is now a transition step (no mini-grid). It fires
+ * onboarding_first_word_found once on mount with the synthetic 'PRACTICE'
+ * marker so the existing FTUE funnel still pairs with score_reveal events.
  */
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -25,41 +24,15 @@ vi.mock('framer-motion', () => {
 });
 
 vi.mock('lucide-react', () => ({
-  Sparkles: () => null,
-  Trophy: () => null,
-  Target: () => null,
+  ArrowRight: () => null,
 }));
 
 vi.mock('@/components/ui/Mascot', () => ({
   Mascot: () => null,
 }));
 
-vi.mock('../MiniGrid', () => ({
-  __esModule: true,
-  default: (props: any) => (
-    <div
-      data-testid="mini-grid"
-      onClick={() => props.onDemoComplete?.()}
-    />
-  ),
-}));
-
 vi.mock('@/contexts/LanguageContext', () => ({
-  useLanguage: () => ({ t: (k: string, f?: any) => (typeof f === 'string' ? f : k), language: 'en', dir: 'ltr' }),
-}));
-
-vi.mock('../tutorialBoardConfig', () => ({
-  getTutorialBoard: () => ({
-    letters: [['C','A','T','S'],['R','O','P','E'],['S','T','A','R'],['D','O','G','S']],
-    targetWords: [
-      { word: 'CAT', path: [], length: 3 },
-      { word: 'DOG', path: [], length: 3 },
-      { word: 'STARS', path: [], length: 5 },
-    ],
-    validWords: new Set(['CAT', 'DOG', 'STARS']),
-  }),
-  isValidTutorialWord: (w: string) =>
-    new Set(['CAT', 'DOG', 'STARS']).has(w.toUpperCase()),
+  useLanguage: () => ({ t: (k: string) => k, language: 'en', dir: 'ltr' }),
 }));
 
 import TutorialGame from '../TutorialGame';
@@ -68,23 +41,21 @@ import { trackOnboardingFirstWord } from '@/utils/growthTracking';
 describe('TutorialGame analytics', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('fires first-word event with attemptNumber=1 on first valid word', () => {
+  it('fires first-word event once on mount with default attemptNumber=1', () => {
     render(<TutorialGame onComplete={vi.fn()} />);
-    fireEvent.click(screen.getByTestId('mini-grid'));
     expect(trackOnboardingFirstWord).toHaveBeenCalledTimes(1);
-    expect(trackOnboardingFirstWord).toHaveBeenCalledWith('CAT', 1);
-  });
-
-  it('does NOT re-fire for second word within the same attempt', () => {
-    render(<TutorialGame onComplete={vi.fn()} />);
-    fireEvent.click(screen.getByTestId('mini-grid')); // CAT
-    fireEvent.click(screen.getByTestId('mini-grid')); // DOG
-    expect(trackOnboardingFirstWord).toHaveBeenCalledTimes(1);
+    expect(trackOnboardingFirstWord).toHaveBeenCalledWith('PRACTICE', 1);
   });
 
   it('carries attemptNumber prop through to event', () => {
     render(<TutorialGame onComplete={vi.fn()} attemptNumber={3} />);
-    fireEvent.click(screen.getByTestId('mini-grid'));
-    expect(trackOnboardingFirstWord).toHaveBeenCalledWith('CAT', 3);
+    expect(trackOnboardingFirstWord).toHaveBeenCalledWith('PRACTICE', 3);
+  });
+
+  it('fires onComplete with zero score and empty words when CTA tapped', () => {
+    const onComplete = vi.fn();
+    render(<TutorialGame onComplete={onComplete} />);
+    fireEvent.click(screen.getByTestId('tutorial-continue'));
+    expect(onComplete).toHaveBeenCalledWith(0, []);
   });
 });

--- a/fe-next/components/onboarding/__tests__/TutorialGame.test.tsx
+++ b/fe-next/components/onboarding/__tests__/TutorialGame.test.tsx
@@ -1,140 +1,79 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+/**
+ * TutorialGame is now a transition step — friendly mascot greeting + CTA that
+ * hands the player off to /practice. The actual mechanic-teaching lives in the
+ * practice modes. Public surface: data-testids `tutorial-game` + `tutorial-continue`.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock framer-motion
 vi.mock('framer-motion', () => {
   const React = require('react');
-  const MotionDiv = React.forwardRef(function MotionDiv(
-    { children, onAnimationComplete, ...props }: any,
-    ref: any
-  ) {
-    return (
-      <div ref={ref} {...props}>
-        {children}
-      </div>
-    );
-  });
-  const MotionSpan = React.forwardRef(function MotionSpan(
-    { children, ...props }: any,
-    ref: any
-  ) {
-    return (
-      <span ref={ref} {...props}>
-        {children}
-      </span>
-    );
+  const Wrap = React.forwardRef(function Wrap({ children, ...p }: any, ref: any) {
+    return <div ref={ref} {...p}>{children}</div>;
   });
   return {
-    motion: { div: MotionDiv, span: MotionSpan, button: MotionDiv },
-    AnimatePresence: function AnimatePresence({ children }: any) {
-      return <>{children}</>;
-    },
+    motion: new Proxy({} as any, { get: () => Wrap }),
+    AnimatePresence: ({ children }: any) => <>{children}</>,
   };
 });
 
-// Mock lucide-react
 vi.mock('lucide-react', () => ({
-  Sparkles: () => <div data-testid="sparkles-icon" />,
-  Trophy: () => <div data-testid="trophy-icon" />,
-  Target: () => <div data-testid="target-icon" />,
+  ArrowRight: () => null,
 }));
 
-// Mock Mascot
 vi.mock('@/components/ui/Mascot', () => ({
   Mascot: ({ variant }: any) => <div data-testid={`mascot-${variant}`} />,
 }));
 
-// Mock MiniGrid
-vi.mock('../MiniGrid', () => {
-  const React = require('react');
-  return {
-    __esModule: true,
-    default: (props: any) => (
-      <div
-        data-testid="mini-grid"
-        data-size={props.size}
-        onClick={() => props.onDemoComplete?.()}
-      />
-    ),
-  };
-});
+vi.mock('@/utils/growthTracking', () => ({
+  trackOnboardingFirstWord: vi.fn(),
+}));
 
-// Mock LanguageContext
 vi.mock('@/contexts/LanguageContext', () => ({
   useLanguage: () => ({
-    t: (key: string, fallback?: any) => {
-      const translations: Record<string, string> = {
-        'onboarding.ftue.swipeToConnect': 'Swipe to connect letters!',
-        'onboarding.ftue.findMultipleWords': 'Find 3 words! Swipe across letters to spell them.',
-        'onboarding.ftue.wordsFound': '{{count}}/3 words found',
-        'onboarding.ftue.amazing': 'AMAZING!',
-        'onboarding.ftue.keepGoing': 'Keep going!',
-      };
-      if (typeof fallback === 'string') return fallback;
-      return translations[key] || key;
-    },
+    t: (key: string, fallback?: any) => (typeof fallback === 'string' ? fallback : key),
     language: 'en',
     dir: 'ltr',
   }),
 }));
 
-// Mock tutorialBoardConfig
-vi.mock('../tutorialBoardConfig', () => ({
-  getTutorialBoard: () => ({
-    letters: [
-      ['C', 'A', 'T', 'S'],
-      ['R', 'O', 'P', 'E'],
-      ['S', 'T', 'A', 'R'],
-      ['D', 'O', 'G', 'S'],
-    ],
-    targetWords: [
-      { word: 'CAT', path: [], length: 3 },
-      { word: 'DOG', path: [], length: 3 },
-      { word: 'STARS', path: [], length: 5 },
-    ],
-    validWords: new Set(['CAT', 'DOG', 'STAR', 'STARS', 'ROPE', 'TOP']),
-  }),
-  isValidTutorialWord: (word: string) =>
-    new Set(['CAT', 'DOG', 'STAR', 'STARS', 'ROPE', 'TOP']).has(word.toUpperCase()),
-}));
-
 import TutorialGame from '../TutorialGame';
 
-describe('TutorialGame', () => {
-  const defaultProps = {
-    onComplete: vi.fn(),
-  };
+describe('TutorialGame (practice transition)', () => {
+  const defaultProps = { onComplete: vi.fn() };
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders the tutorial grid with 4x4 size', () => {
+  it('renders the transition surface', () => {
     render(<TutorialGame {...defaultProps} />);
-    const grid = screen.getByTestId('mini-grid');
-    expect(grid).toBeInTheDocument();
-    expect(grid).toHaveAttribute('data-size', '4');
+    expect(screen.getByTestId('tutorial-game')).toBeInTheDocument();
   });
 
-  it('shows mascot speech bubble with find-multiple-words instruction', () => {
+  it('renders a celebration-variant mascot', () => {
     render(<TutorialGame {...defaultProps} />);
-    expect(screen.getByText('Find 3 words! Swipe across letters to spell them.')).toBeInTheDocument();
+    expect(screen.getByTestId('mascot-celebration')).toBeInTheDocument();
   });
 
-  it('displays word counter showing 0/3', () => {
+  it('renders the welcome greeting + tip + CTA', () => {
     render(<TutorialGame {...defaultProps} />);
-    // The word counter should show the count
-    expect(screen.getByTestId('word-counter')).toBeInTheDocument();
+    expect(screen.getByText('practiceWelcome.greet')).toBeInTheDocument();
+    expect(screen.getByText('practiceWelcome.tip')).toBeInTheDocument();
+    expect(screen.getByTestId('tutorial-continue')).toBeInTheDocument();
   });
 
-  it('renders in full-screen mode with no chrome', () => {
+  it('does NOT render the old mini-grid mechanic', () => {
     render(<TutorialGame {...defaultProps} />);
-    const container = screen.getByTestId('tutorial-game');
-    expect(container).toBeInTheDocument();
+    expect(screen.queryByTestId('mini-grid')).toBeNull();
+    expect(screen.queryByTestId('word-counter')).toBeNull();
   });
 
-  it('shows mascot with encouraging variant', () => {
-    render(<TutorialGame {...defaultProps} />);
-    expect(screen.getByTestId('mascot-encouraging')).toBeInTheDocument();
+  it('fires onComplete with zero score and no words on CTA tap', () => {
+    const onComplete = vi.fn();
+    render(<TutorialGame onComplete={onComplete} />);
+    fireEvent.click(screen.getByTestId('tutorial-continue'));
+    expect(onComplete).toHaveBeenCalledWith(0, []);
   });
 });

--- a/fe-next/components/practice/PracticeSwipeBoard.tsx
+++ b/fe-next/components/practice/PracticeSwipeBoard.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import Link from 'next/link';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useSoundEffects } from '@/contexts/SoundEffectsContext';
 import { haptics } from '@/utils/haptics';
+import { Mascot, type MascotVariant } from '@/components/ui/Mascot';
 import GridComponent from '@/components/GridComponent';
 import WordFormingArea from '@/components/game/WordFormingArea';
 import { useWordSubmission } from '@/hooks/useWordSubmission';
@@ -22,16 +24,42 @@ interface Props {
   goal: number;
 }
 
-const ACCENT: Record<Props['mode'], { dot: string; pill: string }> = {
-  classic: { dot: 'bg-neo-cyan', pill: 'border-neo-cyan/60 text-neo-cyan' },
-  wordHunt: { dot: 'bg-neo-lime', pill: 'border-neo-lime/60 text-neo-lime' },
+const ACCENT: Record<Props['mode'], { dot: string; pill: string; bubble: string; ring: string }> = {
+  classic: {
+    dot: 'bg-neo-cyan',
+    pill: 'border-neo-cyan/60 text-neo-cyan',
+    bubble: 'bg-neo-cyan',
+    ring: 'border-neo-cyan',
+  },
+  wordHunt: {
+    dot: 'bg-neo-lime',
+    pill: 'border-neo-lime/60 text-neo-lime',
+    bubble: 'bg-neo-lime',
+    ring: 'border-neo-lime',
+  },
 };
+
+const IDLE_MASCOT: Record<Props['mode'], MascotVariant> = {
+  classic: 'encouraging',
+  wordHunt: 'explorer',
+};
+
+const WIN_MASCOT: Record<Props['mode'], MascotVariant> = {
+  classic: 'celebration',
+  wordHunt: 'flexing',
+};
+
+/** Pick desired hunt slot lengths from board size — small variety. */
+function huntLengthsFor(goal: number): number[] {
+  const lengths = [3, 4, 5];
+  return Array.from({ length: goal }, (_, i) => lengths[i % lengths.length]);
+}
 
 /**
  * Real swipe-over-letters practice. Uses the production GridComponent and
- * dictionary-backed validation — same feel as the real game, minus the timer
- * and HUD chrome. Goal is intentionally tiny (3 words) so beginners reach the
- * win moment fast and get the celebration.
+ * dictionary-backed validation. Adds a friendly mascot, bigger per-word
+ * celebration moments, and a Word Hunt variant where slots represent specific
+ * word lengths to fill (distinct mini-game feel from Classic).
  */
 export default function PracticeSwipeBoard({ mode, rows, cols, goal }: Props) {
   const { language, t } = useLanguage();
@@ -55,7 +83,52 @@ export default function PracticeSwipeBoard({ mode, rows, cols, goal }: Props) {
 
   const [formingWord, setFormingWord] = useState('');
   const [letterCount, setLetterCount] = useState(0);
+  const [pop, setPop] = useState<{ id: number; word: string; label: string } | null>(null);
+  const popIdRef = useRef(0);
   const celebratedRef = useRef(false);
+
+  // Word Hunt slots: each slot wants a word of a specific length. Once a
+  // valid word matches a slot's length, the slot fills with that word.
+  const huntLengths = useMemo(() => huntLengthsFor(goal), [goal]);
+  const [huntSlots, setHuntSlots] = useState<(string | null)[]>(() =>
+    Array.from({ length: goal }, () => null),
+  );
+
+  const handleAccepted = useCallback(
+    (word: string, _score: number) => {
+      playWordAcceptedSound();
+      haptics.success();
+      // Pop a tiny celebration label per word
+      const labels = [
+        t('practiceSwipe.celebrate1'),
+        t('practiceSwipe.celebrate2'),
+        t('practiceSwipe.celebrate3'),
+        t('practiceSwipe.celebrate4'),
+      ];
+      popIdRef.current += 1;
+      setPop({
+        id: popIdRef.current,
+        word,
+        label: labels[Math.min(labels.length - 1, Math.floor(Math.random() * labels.length))],
+      });
+      setTimeout(() => {
+        setPop((cur) => (cur && cur.id === popIdRef.current ? null : cur));
+      }, 900);
+      fireOnboardingBurst({ x: 0.5, y: 0.4 });
+
+      // Word Hunt: try to fill an empty slot whose required length matches
+      if (mode === 'wordHunt') {
+        setHuntSlots((prev) => {
+          const idx = prev.findIndex((s, i) => s === null && huntLengths[i] === word.length);
+          if (idx === -1) return prev;
+          const next = [...prev];
+          next[idx] = word.toUpperCase();
+          return next;
+        });
+      }
+    },
+    [playWordAcceptedSound, t, mode, huntLengths],
+  );
 
   const {
     foundWords,
@@ -66,21 +139,17 @@ export default function PracticeSwipeBoard({ mode, rows, cols, goal }: Props) {
   } = useWordSubmission({
     grid,
     language,
-    minWordLength: 3,
+    minWordLength: 2,
     mode: 'practice',
     t,
-    onWordAccepted: () => {
-      playWordAcceptedSound();
-      haptics.success();
-      // Tiny burst per word — keeps the win loop tight.
-      fireOnboardingBurst({ x: 0.5, y: 0.45 });
-    },
+    onWordAccepted: handleAccepted,
     onWordRejected: () => {
       playWordRejectedSound();
     },
   });
 
-  const isComplete = validWordCount >= goal;
+  const huntFilled = huntSlots.filter(Boolean).length;
+  const isComplete = mode === 'wordHunt' ? huntFilled >= goal : validWordCount >= goal;
 
   useEffect(() => {
     if (isComplete && !celebratedRef.current) {
@@ -101,18 +170,27 @@ export default function PracticeSwipeBoard({ mode, rows, cols, goal }: Props) {
     celebratedRef.current = false;
     setFormingWord('');
     setLetterCount(0);
-  }, [generateBoard, resetSubmission]);
+    setHuntSlots(Array.from({ length: goal }, () => null));
+  }, [generateBoard, resetSubmission, goal]);
 
   const validWords = useMemo(
     () => foundWords.filter((w) => w.isValid === true).map((w) => w.word.toUpperCase()),
     [foundWords],
   );
 
+  const mascotVariant = isComplete ? WIN_MASCOT[mode] : IDLE_MASCOT[mode];
+  const greet = mode === 'wordHunt' ? t('practiceSwipe.greetWordHunt') : t('practiceSwipe.greet');
+  const instruction = isComplete
+    ? t('practiceSwipe.done')
+    : mode === 'wordHunt'
+      ? t('practiceSwipe.instructionWordHunt', { goal })
+      : t('practiceSwipe.instruction', { goal });
+
   return (
     <div
       data-testid="practice-swipe-board"
       data-mode={mode}
-      className="min-h-[100dvh] w-full bg-linear-to-b from-neo-navy to-neo-navy-light px-4 pt-4 pb-bottom-stack flex flex-col items-center gap-3"
+      className="min-h-[100dvh] w-full bg-linear-to-b from-neo-navy to-neo-navy-light px-4 pt-3 pb-bottom-stack flex flex-col items-center gap-3"
     >
       <div className="w-full max-w-md flex items-center justify-between">
         <Link
@@ -121,31 +199,80 @@ export default function PracticeSwipeBoard({ mode, rows, cols, goal }: Props) {
         >
           {t('practiceSwipe.back')}
         </Link>
-        <div
-          data-testid="practice-progress"
-          aria-label={t('practiceSwipe.progress', { found: validWordCount, goal })}
-          className="flex items-center gap-1.5"
-        >
-          {Array.from({ length: goal }).map((_, i) => (
-            <span
-              key={i}
-              className={
-                'w-3 h-3 rounded-full border-2 border-neo-black ' +
-                (i < validWordCount ? accent.dot : 'bg-neo-navy')
-              }
-            />
-          ))}
+        {mode !== 'wordHunt' && (
+          <div
+            data-testid="practice-progress"
+            aria-label={t('practiceSwipe.progress', { found: validWordCount, goal })}
+            className="flex items-center gap-1.5"
+          >
+            {Array.from({ length: goal }).map((_, i) => (
+              <span
+                key={i}
+                className={
+                  'w-3 h-3 rounded-full border-2 border-neo-black ' +
+                  (i < validWordCount ? accent.dot : 'bg-neo-navy')
+                }
+              />
+            ))}
+          </div>
+        )}
+        {mode === 'wordHunt' && (
+          <div
+            data-testid="practice-progress"
+            aria-label={t('practiceSwipe.progress', { found: huntFilled, goal })}
+            className="flex items-center gap-1.5"
+          >
+            {Array.from({ length: goal }).map((_, i) => (
+              <span
+                key={i}
+                className={
+                  'w-3 h-3 rounded-full border-2 border-neo-black ' +
+                  (huntSlots[i] ? accent.dot : 'bg-neo-navy')
+                }
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="w-full max-w-md flex items-center gap-2">
+        <Mascot variant={mascotVariant} size="xs" clipShape="circle" clipBorder={mode === 'classic' ? 'cyan' : 'lime'} />
+        <div className={`relative flex-1 ${accent.bubble} text-neo-black border-2 border-neo-black rounded-neo px-3 py-2 shadow-hard-sm`}>
+          <p className="text-xs font-neo-display font-black uppercase tracking-wide leading-tight">
+            {greet}
+          </p>
+          <p data-testid="practice-instruction" className="text-sm font-neo-body font-bold leading-tight">
+            {instruction}
+          </p>
         </div>
       </div>
 
-      <h1
-        data-testid="practice-instruction"
-        className="text-base font-neo-display font-black text-neo-cream text-center max-w-md leading-tight"
-      >
-        {isComplete
-          ? t('practiceSwipe.done')
-          : t('practiceSwipe.instruction', { goal })}
-      </h1>
+      {mode === 'wordHunt' && (
+        <div data-testid="practice-hunt-slots" className="w-full max-w-md flex justify-center gap-2">
+          {huntSlots.map((slot, i) => {
+            const length = huntLengths[i];
+            return (
+              <div
+                key={i}
+                data-testid={`practice-hunt-slot-${i}`}
+                data-filled={slot ? 'true' : 'false'}
+                className={
+                  'flex-1 rounded-neo border-2 border-neo-black px-2 py-1 text-center transition-colors ' +
+                  (slot ? 'bg-neo-lime text-neo-black' : 'bg-neo-navy-light text-neo-cream/70')
+                }
+              >
+                {slot ? (
+                  <span className="font-neo-display font-black text-base tracking-wider">{slot}</span>
+                ) : (
+                  <span className="font-neo-body font-bold text-xs uppercase tracking-wider">
+                    {t('practiceSwipe.huntSlot', { length })}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       <WordFormingArea
         word={formingWord}
@@ -155,7 +282,7 @@ export default function PracticeSwipeBoard({ mode, rows, cols, goal }: Props) {
         className="justify-center"
       />
 
-      <div className="w-full max-w-md flex items-center justify-center">
+      <div className="relative w-full max-w-md flex items-center justify-center">
         <div className="w-full" style={{ aspectRatio: '1 / 1' }}>
           <GridComponent
             grid={grid}
@@ -167,6 +294,25 @@ export default function PracticeSwipeBoard({ mode, rows, cols, goal }: Props) {
             animateOnMount
           />
         </div>
+        <AnimatePresence>
+          {pop && (
+            <motion.div
+              key={pop.id}
+              initial={{ opacity: 0, scale: 0.6, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: -10 }}
+              exit={{ opacity: 0, scale: 0.7, y: -40 }}
+              transition={{ type: 'spring', stiffness: 360, damping: 18 }}
+              className="absolute pointer-events-none z-10 bg-neo-pink text-neo-white border-3 border-neo-black rounded-neo px-4 py-2 shadow-hard"
+            >
+              <span className="font-neo-display font-black text-lg uppercase tracking-wide">
+                {pop.label}
+              </span>
+              <span className="block text-xs font-neo-body font-bold opacity-90 text-center">
+                +{pop.word.toUpperCase()}
+              </span>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
 
       {validWords.length > 0 && (

--- a/fe-next/components/practice/PracticeWheelSandbox.tsx
+++ b/fe-next/components/practice/PracticeWheelSandbox.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import Link from 'next/link';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Shuffle } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useSoundEffects } from '@/contexts/SoundEffectsContext';
 import { haptics } from '@/utils/haptics';
 import { useDictionaryCache } from '@/hooks/useDictionaryCache';
+import { Mascot } from '@/components/ui/Mascot';
 import { fireOnboardingBurst, fireVictoryConfetti } from '@/utils/confettiUtils';
 import { markPracticeMode, PRACTICE_GOALS } from '@/lib/practice/practiceProgress';
 import { normalizeWord } from '@/shared/utils/wordNormalization';
@@ -13,7 +16,8 @@ import { normalizeWord } from '@/shared/utils/wordNormalization';
 /**
  * Wheel mode practice. Same constraint as the real wheel: every word must
  * include the centre letter. Validation hits the real client-side dictionary
- * cache, so the player can find any real word — no curated allow-list.
+ * cache. Adds the real-game UX bits: tap-toggle to add/remove a letter,
+ * drag through letters to build, and a shuffle button — but no timer.
  */
 interface WheelLetters {
   center: string;
@@ -29,24 +33,34 @@ const LETTERS: Record<string, WheelLetters> = {
 };
 
 const GOAL = PRACTICE_GOALS.wheelRush;
+const MIN_LEN = 2;
+
+interface BuiltLetter {
+  letter: string;
+  /** -1 for centre, 0..n-1 for outer index */
+  source: number;
+}
 
 export default function PracticeWheelSandbox() {
   const { language, t } = useLanguage();
-  const { playWordAcceptedSound, playWordRejectedSound, setGameActive } = useSoundEffects();
+  const { playWordAcceptedSound, playWordRejectedSound, setGameActive, playButtonClickSound, playBoardShuffleSound } = useSoundEffects();
   const { checkWord, isLoaded } = useDictionaryCache(language);
-  const wheel = LETTERS[language] ?? LETTERS.en;
+  const baseWheel = LETTERS[language] ?? LETTERS.en;
 
   useEffect(() => {
     setGameActive(true);
     return () => setGameActive(false);
   }, [setGameActive]);
 
-  const [built, setBuilt] = useState<string[]>([]);
+  const [outer, setOuter] = useState<string[]>(baseWheel.outer);
+  const [built, setBuilt] = useState<BuiltLetter[]>([]);
   const [foundWords, setFoundWords] = useState<string[]>([]);
-  const [feedback, setFeedback] = useState<{ kind: 'ok' | 'bad' | 'dup' | 'noCenter'; message: string } | null>(null);
+  const [feedback, setFeedback] = useState<{ kind: 'ok' | 'bad' | 'dup' | 'noCenter' | 'tooShort'; message: string } | null>(null);
+  const [pop, setPop] = useState<{ id: number; word: string; label: string } | null>(null);
+  const popIdRef = useRef(0);
   const celebratedRef = useRef(false);
 
-  const currentWord = useMemo(() => built.join(''), [built]);
+  const currentWord = useMemo(() => built.map((b) => b.letter).join(''), [built]);
   const isComplete = foundWords.length >= GOAL;
 
   useEffect(() => {
@@ -57,19 +71,51 @@ export default function PracticeWheelSandbox() {
     }
   }, [isComplete, language]);
 
-  const addLetter = useCallback((letter: string) => {
-    setFeedback(null);
-    setBuilt((prev) => [...prev, letter]);
-  }, []);
+  const addLetter = useCallback(
+    (letter: string, source: number) => {
+      if (isComplete) return;
+      setFeedback(null);
+      // Toggle: if this exact source is already in built, remove it
+      setBuilt((prev) => {
+        const existingIdx = prev.findIndex((b) => b.source === source);
+        if (existingIdx !== -1) {
+          return prev.filter((_, i) => i !== existingIdx);
+        }
+        return [...prev, { letter, source }];
+      });
+      playButtonClickSound();
+      haptics.tap();
+    },
+    [isComplete, playButtonClickSound],
+  );
 
   const reset = useCallback(() => {
     setBuilt([]);
     setFeedback(null);
   }, []);
 
+  const shuffle = useCallback(() => {
+    if (isComplete) return;
+    setOuter((prev) => {
+      const arr = [...prev];
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      // Remap built letters: keep centre, drop outer (positions changed)
+      setBuilt((b) => b.filter((bl) => bl.source === -1));
+      return arr;
+    });
+    playBoardShuffleSound();
+    haptics.tap();
+  }, [isComplete, playBoardShuffleSound]);
+
   const submit = useCallback(() => {
-    if (currentWord.length < 3) return;
-    if (!built.includes(wheel.center)) {
+    if (currentWord.length < MIN_LEN) {
+      setFeedback({ kind: 'tooShort', message: t('practice.wheelRush.tooShort') });
+      return;
+    }
+    if (!built.some((b) => b.source === -1)) {
       setFeedback({ kind: 'noCenter', message: t('practice.wheelRush.needsCenter') });
       playWordRejectedSound();
       return;
@@ -86,15 +132,71 @@ export default function PracticeWheelSandbox() {
       setBuilt([]);
       playWordAcceptedSound();
       haptics.success();
+      const labels = [
+        t('practiceSwipe.celebrate1'),
+        t('practiceSwipe.celebrate2'),
+        t('practiceSwipe.celebrate3'),
+        t('practiceSwipe.celebrate4'),
+      ];
+      popIdRef.current += 1;
+      setPop({
+        id: popIdRef.current,
+        word: normalized.toUpperCase(),
+        label: labels[Math.floor(Math.random() * labels.length)],
+      });
+      setTimeout(() => {
+        setPop((cur) => (cur && cur.id === popIdRef.current ? null : cur));
+      }, 900);
       fireOnboardingBurst({ x: 0.5, y: 0.45 });
     } else {
       setFeedback({ kind: 'bad', message: t('practice.wheelRush.notAWord') });
       playWordRejectedSound();
     }
-  }, [built, currentWord, foundWords, wheel.center, t, language, isLoaded, checkWord, playWordAcceptedSound, playWordRejectedSound]);
+  }, [built, currentWord, foundWords, t, language, isLoaded, checkWord, playWordAcceptedSound, playWordRejectedSound]);
+
+  // ── drag-to-build ────────────────────────────────────────────────
+  const draggingRef = useRef(false);
+  const lastSourceRef = useRef<number | null>(null);
+
+  const tryDragHit = useCallback(
+    (clientX: number, clientY: number) => {
+      const el = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
+      const btn = el?.closest<HTMLButtonElement>('[data-wheel-source]');
+      if (!btn) return;
+      const source = Number(btn.dataset.wheelSource);
+      if (source === lastSourceRef.current) return;
+      lastSourceRef.current = source;
+      const letter = btn.dataset.wheelLetter || '';
+      addLetter(letter, source);
+    },
+    [addLetter],
+  );
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    draggingRef.current = true;
+    lastSourceRef.current = null;
+    tryDragHit(e.clientX, e.clientY);
+  }, [tryDragHit]);
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!draggingRef.current) return;
+      tryDragHit(e.clientX, e.clientY);
+    },
+    [tryDragHit],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
+    lastSourceRef.current = null;
+    if (built.length >= MIN_LEN) submit();
+  }, [built.length, submit]);
+
+  const mascotVariant = isComplete ? 'celebration' : 'dj';
 
   return (
-    <div className="min-h-[100dvh] w-full bg-linear-to-b from-neo-navy to-neo-navy-light px-4 pt-4 pb-bottom-stack flex flex-col items-center gap-3">
+    <div className="min-h-[100dvh] w-full bg-linear-to-b from-neo-navy to-neo-navy-light px-4 pt-3 pb-bottom-stack flex flex-col items-center gap-3">
       <div className="w-full max-w-md flex items-center justify-between">
         <Link
           href={`/${language}/practice`}
@@ -118,21 +220,46 @@ export default function PracticeWheelSandbox() {
         </div>
       </div>
 
-      <h1 className="text-base font-neo-display font-black text-neo-cream text-center max-w-md leading-tight">
-        {isComplete ? t('practiceSwipe.done') : t('practice.wheelRush.instructionShort', { goal: GOAL })}
-      </h1>
+      <div className="w-full max-w-md flex items-center gap-2">
+        <Mascot variant={mascotVariant} size="xs" clipShape="circle" clipBorder="purple" />
+        <div className="relative flex-1 bg-neo-purple text-neo-white border-2 border-neo-black rounded-neo px-3 py-2 shadow-hard-sm">
+          <p className="text-xs font-neo-display font-black uppercase tracking-wide leading-tight">
+            {t('practiceSwipe.wheelGreet')}
+          </p>
+          <p className="text-sm font-neo-body font-bold leading-tight">
+            {isComplete ? t('practiceSwipe.done') : t('practice.wheelRush.instructionShort', { goal: GOAL })}
+          </p>
+        </div>
+      </div>
 
-      <div className="relative w-56 h-56 mx-auto">
-        {wheel.outer.map((letter, i) => {
-          const angle = (i * (360 / wheel.outer.length) - 90) * (Math.PI / 180);
-          const x = 96 * Math.cos(angle);
-          const y = 96 * Math.sin(angle);
+      <div
+        data-testid="practice-current-word"
+        className="min-h-[2.25rem] font-neo-display font-black text-2xl text-neo-cream tracking-widest"
+      >
+        {currentWord}
+      </div>
+
+      <div
+        className="relative w-60 h-60 mx-auto select-none touch-none"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+      >
+        {outer.map((letter, i) => {
+          const angle = (i * (360 / outer.length) - 90) * (Math.PI / 180);
+          const x = 100 * Math.cos(angle);
+          const y = 100 * Math.sin(angle);
+          const isUsed = built.some((b) => b.source === i);
           return (
             <button
               key={`${letter}-${i}`}
               type="button"
               data-testid={`practice-wheel-outer-${i}`}
-              onClick={() => addLetter(letter)}
+              data-wheel-source={i}
+              data-wheel-letter={letter}
+              onClick={() => addLetter(letter, i)}
               disabled={isComplete}
               style={{
                 position: 'absolute',
@@ -140,7 +267,10 @@ export default function PracticeWheelSandbox() {
                 left: '50%',
                 transform: `translate(${x}px, ${y}px) translate(-50%, -50%)`,
               }}
-              className="w-14 h-14 rounded-full border-2 border-neo-black bg-neo-cream text-neo-black font-neo-display font-black text-xl shadow-hard-sm active:scale-95 disabled:opacity-50"
+              className={
+                'w-14 h-14 rounded-full border-2 border-neo-black font-neo-display font-black text-xl shadow-hard-sm active:scale-95 disabled:opacity-50 transition-colors ' +
+                (isUsed ? 'bg-neo-purple text-neo-white' : 'bg-neo-cream text-neo-black')
+              }
             >
               {letter}
             </button>
@@ -149,29 +279,36 @@ export default function PracticeWheelSandbox() {
         <button
           type="button"
           data-testid="practice-wheel-center"
-          onClick={() => addLetter(wheel.center)}
+          data-wheel-source={-1}
+          data-wheel-letter={baseWheel.center}
+          onClick={() => addLetter(baseWheel.center, -1)}
           disabled={isComplete}
-          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-16 h-16 rounded-full border-3 border-neo-black bg-neo-lime text-neo-black font-neo-display font-black text-2xl shadow-hard active:scale-95 disabled:opacity-50"
+          className={
+            'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-16 h-16 rounded-full border-3 border-neo-black font-neo-display font-black text-2xl shadow-hard active:scale-95 disabled:opacity-50 transition-colors ' +
+            (built.some((b) => b.source === -1) ? 'bg-neo-lime/80 text-neo-black' : 'bg-neo-lime text-neo-black')
+          }
         >
-          {wheel.center}
+          {baseWheel.center}
         </button>
-      </div>
-
-      <div
-        data-testid="practice-current-word"
-        className="min-h-[2rem] font-neo-display font-black text-xl text-neo-cream tracking-wider"
-      >
-        {currentWord}
       </div>
 
       <div className="flex gap-2 w-full max-w-md">
         <button
           type="button"
           onClick={submit}
-          disabled={currentWord.length < 3 || isComplete}
+          disabled={currentWord.length < MIN_LEN || isComplete}
           className="flex-1 bg-neo-cyan text-neo-black border-2 border-neo-black rounded-neo py-2 font-neo-display font-black text-sm shadow-hard active:shadow-hard-pressed disabled:opacity-50"
         >
           {t('practice.wheelRush.submit')}
+        </button>
+        <button
+          type="button"
+          onClick={shuffle}
+          disabled={isComplete}
+          aria-label={t('practiceSwipe.wheelShuffle')}
+          className="bg-neo-pink text-neo-white border-2 border-neo-black rounded-neo px-3 py-2 font-neo-display font-black text-sm shadow-hard-sm disabled:opacity-50"
+        >
+          <Shuffle className="w-4 h-4" />
         </button>
         <button
           type="button"
@@ -183,22 +320,43 @@ export default function PracticeWheelSandbox() {
         </button>
       </div>
 
-      {feedback && (
-        <div
-          role="status"
-          aria-live="polite"
-          className={
-            'text-sm font-neo-body px-3 py-1.5 rounded-neo border-2 border-neo-black ' +
-            (feedback.kind === 'ok'
-              ? 'bg-neo-lime text-neo-black'
-              : feedback.kind === 'dup' || feedback.kind === 'noCenter'
-                ? 'bg-neo-yellow text-neo-black'
-                : 'bg-neo-red text-neo-white')
-          }
-        >
-          {feedback.message}
-        </div>
-      )}
+      <div className="relative w-full max-w-md min-h-[2rem] flex justify-center">
+        {feedback && !pop && (
+          <div
+            role="status"
+            aria-live="polite"
+            className={
+              'text-sm font-neo-body px-3 py-1.5 rounded-neo border-2 border-neo-black ' +
+              (feedback.kind === 'ok'
+                ? 'bg-neo-lime text-neo-black'
+                : feedback.kind === 'dup' || feedback.kind === 'noCenter' || feedback.kind === 'tooShort'
+                  ? 'bg-neo-yellow text-neo-black'
+                  : 'bg-neo-red text-neo-white')
+            }
+          >
+            {feedback.message}
+          </div>
+        )}
+        <AnimatePresence>
+          {pop && (
+            <motion.div
+              key={pop.id}
+              initial={{ opacity: 0, scale: 0.6, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.7, y: -30 }}
+              transition={{ type: 'spring', stiffness: 360, damping: 18 }}
+              className="absolute pointer-events-none z-10 bg-neo-pink text-neo-white border-3 border-neo-black rounded-neo px-4 py-1.5 shadow-hard"
+            >
+              <span className="font-neo-display font-black text-base uppercase tracking-wide">
+                {pop.label}
+              </span>
+              <span className="block text-xs font-neo-body font-bold opacity-90 text-center">
+                +{pop.word}
+              </span>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
 
       {foundWords.length > 0 && (
         <ul className="flex flex-wrap gap-1.5 justify-center max-w-md">

--- a/fe-next/components/practice/__tests__/PracticeWheelSandbox.completion.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeWheelSandbox.completion.test.tsx
@@ -16,6 +16,8 @@ vi.mock('@/contexts/SoundEffectsContext', () => ({
   useSoundEffects: () => ({
     playWordAcceptedSound: vi.fn(),
     playWordRejectedSound: vi.fn(),
+    playButtonClickSound: vi.fn(),
+    playBoardShuffleSound: vi.fn(),
     setGameActive: vi.fn(),
   }),
 }));

--- a/fe-next/components/practice/__tests__/PracticeWheelSandbox.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeWheelSandbox.test.tsx
@@ -16,6 +16,8 @@ vi.mock('@/contexts/SoundEffectsContext', () => ({
   useSoundEffects: () => ({
     playWordAcceptedSound: vi.fn(),
     playWordRejectedSound: vi.fn(),
+    playButtonClickSound: vi.fn(),
+    playBoardShuffleSound: vi.fn(),
     setGameActive: vi.fn(),
   }),
 }));

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -5053,6 +5053,7 @@ const en = {
       "submit": "Submit",
       "reset": "Reset",
       "needsCenter": "Word must use the center letter.",
+      "tooShort": "Need at least 2 letters.",
       "found": "Nice! Word added.",
       "notAWord": "Not a word — try another.",
       "duplicate": "Already found.",
@@ -5061,11 +5062,27 @@ const en = {
   },
   "practiceSwipe": {
     "back": "← Practice",
-    "instruction": "Swipe over letters to spell {goal} words.",
-    "done": "Nice — you found them all.",
+    "instruction": "Swipe to spell {goal} words.",
+    "instructionWordHunt": "Find {goal} hidden words.",
+    "done": "Nice — you got them all!",
     "continue": "Back to practice",
     "newBoard": "New board",
-    "progress": "{found} of {goal} words"
+    "progress": "{found} of {goal} words",
+    "greet": "Drag across letters!",
+    "greetWordHunt": "Hunt the hidden words!",
+    "celebrate1": "Nice!",
+    "celebrate2": "Sweet!",
+    "celebrate3": "Boom!",
+    "celebrate4": "On fire!",
+    "huntSlot": "{length} letters",
+    "wheelGreet": "Use the lime letter!",
+    "wheelShuffle": "Shuffle",
+    "wheelClear": "Clear"
+  },
+  "practiceWelcome": {
+    "greet": "Welcome to Practice!",
+    "tip": "Try every mode at your own pace. No timer, no pressure.",
+    "cta": "Let's go!"
   },
   "wizard": {
     "selectMode": "Select Game Mode",
@@ -10373,11 +10390,14 @@ const en = {
   "practiceHub": {
     "title": "Practice",
     "subtitle": "A quiet place to learn each mode",
+    "greet": "Pick a mode and play!",
     "progress": "{done} of {total} modes complete",
     "completedBadge": "Completed",
     "completedDesc": "Tap to play again",
     "navAria": "Practice modes",
     "backToHub": "← Hub",
+    "playLabel": "Play",
+    "playAgainLabel": "Play again",
     "allCompleteTitle": "All practice complete!",
     "allCompleteBody": "You're ready for the real modes."
   },

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -4980,16 +4980,33 @@ const es = {
       "found": "¡Bien! Palabra añadida.",
       "notAWord": "No es una palabra — prueba otra.",
       "duplicate": "Ya encontrada.",
+      "tooShort": "Mínimo 2 letras.",
       "foundWordsLabel": "Encontradas ({count})"
     }
   },
   "practiceSwipe": {
     "back": "← Práctica",
-    "instruction": "Desliza sobre las letras para formar {goal} palabras.",
+    "instruction": "Desliza para formar {goal} palabras.",
+    "instructionWordHunt": "Encuentra {goal} palabras ocultas.",
     "done": "¡Bien — las encontraste todas!",
     "continue": "Volver a práctica",
     "newBoard": "Tablero nuevo",
-    "progress": "{found} de {goal} palabras"
+    "progress": "{found} de {goal} palabras",
+    "greet": "¡Desliza por las letras!",
+    "greetWordHunt": "¡Caza las palabras!",
+    "celebrate1": "¡Bien!",
+    "celebrate2": "¡Genial!",
+    "celebrate3": "¡Boom!",
+    "celebrate4": "¡En llamas!",
+    "huntSlot": "{length} letras",
+    "wheelGreet": "¡Usa la letra lima!",
+    "wheelShuffle": "Mezclar",
+    "wheelClear": "Limpiar"
+  },
+  "practiceWelcome": {
+    "greet": "¡Bienvenido a Práctica!",
+    "tip": "Prueba cada modo a tu ritmo. Sin tiempo, sin presión.",
+    "cta": "¡Vamos!"
   },
   "wizard": {
     "selectMode": "Seleccionar Modo de Juego",
@@ -10006,11 +10023,14 @@ const es = {
   "practiceHub": {
     "title": "Práctica",
     "subtitle": "Un lugar tranquilo para aprender cada modo",
+    "greet": "¡Elige un modo y juega!",
     "progress": "{done} de {total} modos completos",
     "completedBadge": "Completado",
     "completedDesc": "Toca para jugar de nuevo",
     "navAria": "Modos de práctica",
     "backToHub": "← Inicio",
+    "playLabel": "Jugar",
+    "playAgainLabel": "Jugar de nuevo",
     "allCompleteTitle": "¡Toda la práctica completa!",
     "allCompleteBody": "Estás listo para los modos reales."
   },

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -4958,6 +4958,7 @@ const he = {
       "submit": "שלח",
       "reset": "אפס",
       "needsCenter": "המילה חייבת להשתמש באות שבמרכז.",
+      "tooShort": "צריך לפחות 2 אותיות.",
       "found": "יפה! המילה נוספה.",
       "notAWord": "זו לא מילה — נסה אחרת.",
       "duplicate": "כבר נמצאה.",
@@ -4966,11 +4967,27 @@ const he = {
   },
   "practiceSwipe": {
     "back": "→ תרגול",
-    "instruction": "החלק על האותיות כדי לאיית {goal} מילים.",
-    "done": "יפה — מצאת את כולן.",
+    "instruction": "החלק כדי לאיית {goal} מילים.",
+    "instructionWordHunt": "מצא {goal} מילים נסתרות.",
+    "done": "יפה — מצאת את כולן!",
     "continue": "חזרה לתרגול",
     "newBoard": "לוח חדש",
-    "progress": "{found} מתוך {goal} מילים"
+    "progress": "{found} מתוך {goal} מילים",
+    "greet": "החלק על האותיות!",
+    "greetWordHunt": "צוד את המילים!",
+    "celebrate1": "יפה!",
+    "celebrate2": "מעולה!",
+    "celebrate3": "סוף הדרך!",
+    "celebrate4": "אש!",
+    "huntSlot": "{length} אותיות",
+    "wheelGreet": "השתמש באות הירוקה!",
+    "wheelShuffle": "ערבב",
+    "wheelClear": "נקה"
+  },
+  "practiceWelcome": {
+    "greet": "ברוך הבא לתרגול!",
+    "tip": "נסה כל מצב בקצב שלך. אין טיימר, אין לחץ.",
+    "cta": "קדימה!"
   },
   "wizard": {
     "selectMode": "בחר מצב משחק",
@@ -10153,11 +10170,14 @@ const he = {
   "practiceHub": {
     "title": "תרגול",
     "subtitle": "מקום שקט ללמוד כל מצב",
+    "greet": "בחר מצב ושחק!",
     "progress": "{done} מתוך {total} מצבים הושלמו",
     "completedBadge": "הושלם",
     "completedDesc": "הקש כדי לשחק שוב",
     "navAria": "מצבי תרגול",
     "backToHub": "→ תפריט",
+    "playLabel": "שחק",
+    "playAgainLabel": "שחק שוב",
     "allCompleteTitle": "כל מצבי התרגול הושלמו!",
     "allCompleteBody": "אתם מוכנים למצבים האמיתיים."
   },

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -4932,6 +4932,7 @@ const ja = {
       "submit": "送信",
       "reset": "リセット",
       "needsCenter": "中央の文字を使う必要があります。",
+      "tooShort": "2文字以上必要。",
       "found": "いいね！単語を追加しました。",
       "notAWord": "単語ではありません — 別を試してください。",
       "duplicate": "すでに見つけました。",
@@ -4940,11 +4941,27 @@ const ja = {
   },
   "practiceSwipe": {
     "back": "← 練習",
-    "instruction": "文字をなぞって{goal}個の単語を作ろう。",
+    "instruction": "なぞって{goal}個の単語を作ろう。",
+    "instructionWordHunt": "隠された{goal}個の単語を見つけよう。",
     "done": "やった — 全部見つけた！",
     "continue": "練習に戻る",
     "newBoard": "新しい盤",
-    "progress": "{found}/{goal}語"
+    "progress": "{found}/{goal}語",
+    "greet": "文字をなぞって！",
+    "greetWordHunt": "隠れた単語を狩ろう！",
+    "celebrate1": "いいね！",
+    "celebrate2": "やるじゃん！",
+    "celebrate3": "ドーン！",
+    "celebrate4": "燃えてる！",
+    "huntSlot": "{length}文字",
+    "wheelGreet": "ライムの文字を使って！",
+    "wheelShuffle": "シャッフル",
+    "wheelClear": "クリア"
+  },
+  "practiceWelcome": {
+    "greet": "練習へようこそ！",
+    "tip": "自分のペースで各モードを試してみよう。タイマーなし、プレッシャーなし。",
+    "cta": "始めよう！"
   },
   "wizard": {
     "selectMode": "ゲームモードを選択",
@@ -10118,11 +10135,14 @@ const ja = {
   "practiceHub": {
     "title": "練習",
     "subtitle": "それぞれのモードを学ぶ静かな場所",
+    "greet": "モードを選んでプレイ！",
     "progress": "{total}つ中{done}つ完了",
     "completedBadge": "完了",
     "completedDesc": "もう一度プレイ",
     "navAria": "練習モード",
     "backToHub": "← ハブ",
+    "playLabel": "プレイ",
+    "playAgainLabel": "もう一度",
     "allCompleteTitle": "全ての練習が完了！",
     "allCompleteBody": "本番モードに挑戦する準備ができました。"
   },

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -4947,6 +4947,7 @@ const sv = {
       "submit": "Skicka",
       "reset": "Rensa",
       "needsCenter": "Ordet måste använda mittbokstaven.",
+      "tooShort": "Minst 2 bokstäver.",
       "found": "Bra! Ordet tillagt.",
       "notAWord": "Inte ett ord — prova ett annat.",
       "duplicate": "Redan hittat.",
@@ -4955,11 +4956,27 @@ const sv = {
   },
   "practiceSwipe": {
     "back": "← Övning",
-    "instruction": "Svep över bokstäverna för att stava {goal} ord.",
-    "done": "Bra — du hittade alla.",
+    "instruction": "Svep för att stava {goal} ord.",
+    "instructionWordHunt": "Hitta {goal} dolda ord.",
+    "done": "Bra — du hittade alla!",
     "continue": "Tillbaka till övning",
     "newBoard": "Ny tavla",
-    "progress": "{found} av {goal} ord"
+    "progress": "{found} av {goal} ord",
+    "greet": "Svep över bokstäverna!",
+    "greetWordHunt": "Jaga de dolda orden!",
+    "celebrate1": "Snyggt!",
+    "celebrate2": "Galant!",
+    "celebrate3": "Boom!",
+    "celebrate4": "Eld i baken!",
+    "huntSlot": "{length} bokstäver",
+    "wheelGreet": "Använd lime-bokstaven!",
+    "wheelShuffle": "Blanda",
+    "wheelClear": "Rensa"
+  },
+  "practiceWelcome": {
+    "greet": "Välkommen till Övning!",
+    "tip": "Prova varje läge i din egen takt. Ingen tid, ingen press.",
+    "cta": "Kör!"
   },
   "wizard": {
     "selectMode": "Välj spelläge",
@@ -10184,11 +10201,14 @@ const sv = {
   "practiceHub": {
     "title": "Övning",
     "subtitle": "En lugn plats att lära sig varje läge",
+    "greet": "Välj ett läge och spela!",
     "progress": "{done} av {total} lägen klara",
     "completedBadge": "Klart",
     "completedDesc": "Tryck för att spela igen",
     "navAria": "Övningslägen",
     "backToHub": "← Hubb",
+    "playLabel": "Spela",
+    "playAgainLabel": "Spela igen",
     "allCompleteTitle": "All övning klar!",
     "allCompleteBody": "Du är redo för de riktiga lägena."
   },

--- a/fe-next/utils/generatedRoutes.ts
+++ b/fe-next/utils/generatedRoutes.ts
@@ -6,6 +6,7 @@ export const PUBLIC_ROUTES: string[] = [
   "/accessibility",
   "/account/delete",
   "/adventure",
+  "/adventure-prototype",
   "/adventure/achievements",
   "/adventure/boss-rush",
   "/adventure/endless",
@@ -88,6 +89,7 @@ export const PUBLIC_ROUTES: string[] = [
   "/party",
   "/party/join",
   "/play-boggle-online-free",
+  "/practice",
   "/profile",
   "/quests",
   "/referrals",
@@ -111,6 +113,7 @@ export const PUBLIC_ROUTES: string[] = [
   "/word-forge",
   "/word-games-online-free",
   "/word-of-the-day",
+  "/word-vault",
   "/words",
   "/words-with-friends-alternative"
 ];


### PR DESCRIPTION
## Summary
- Brings back the per-mode mascot + short greeting (inline, no separate intro screen) so each practice mode has a clear "what to do" character without slowing the player down
- Each mode now feels like its own mini-game:
  - **Classic**: free-form swipe, pick 3 words, mascot pops "Nice/Sweet/Boom!" celebration over the grid for every word
  - **Word Hunt**: distinct hidden-word feel — three length slots ("3 letters", "4 letters", "5 letters") that fill in when you swipe a matching word
  - **Word Wheel**: tap-toggle to add/remove a letter, drag through letters to build, shuffle button — matches real wheel UX
- Min word length lowered to **2** in every mode
- Practice hub gets a hero mascot greeting + bigger mascot-fronted mode cards with bright Play CTA pills and gradient accents per mode
- Onboarding `TutorialGame` ("find 3 words" mini-grid) replaced with a fast cheering-mascot transition that hands off to `/practice` — practice itself is now the teacher

## Files
- `app/[locale]/practice/PageClient.tsx` – new hub UI
- `components/practice/PracticeSwipeBoard.tsx` – mascot, min 2, celebrations, WordHunt slots
- `components/practice/PracticeWheelSandbox.tsx` – tap-toggle, drag-to-build, shuffle, mascot
- `components/onboarding/TutorialGame.tsx` – mascot transition screen
- `translations/{en,he,es,sv,ja}.js` – new keys for greetings, celebrations, hunt slots, welcome

## Test plan
- [x] `vitest` `components/practice/`, `components/onboarding/`, `app/[locale]/practice/` (286 tests pass)
- [x] `tsc --noEmit` (clean)
- [x] `eslint` on changed dirs (clean)
- [x] `next build` (succeeds)
- [ ] Manual: walk through onboarding → practice hub → each mode → confirm mascot greeting, min-2 word, celebration pop, hunt slots fill, wheel shuffle/drag work

https://claude.ai/code/session_012zT5hkFpuXn72Grxozou5m

---
_Generated by [Claude Code](https://claude.ai/code/session_012zT5hkFpuXn72Grxozou5m)_