### PR TITLE
fix(bot): make removeBot idempotent to prevent "Bot not found" error

### DIFF
--- a/fe-next/backend/handlers/__tests__/botHandler.removeBot.test.ts
+++ b/fe-next/backend/handlers/__tests__/botHandler.removeBot.test.ts
@@ -1,0 +1,168 @@
+import { vi, type Mock } from 'vitest';
+import { registerBotHandlers } from '../botHandler';
+import {
+  getGame,
+  getGameBySocketId,
+  getGameUsers,
+  removeUserFromGame,
+  isRoomEmpty,
+  getActiveRooms,
+} from '../../modules/gameStateManager';
+import * as botManager from '../../modules/botManager';
+import { isInProgress } from '../../utils/gameStateMachine';
+import { checkRateLimit } from '../../utils/rateLimiter';
+
+vi.mock('../../utils/logger', () => ({ default: {
+  info: vi.fn(),
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} }));
+vi.mock('../../modules/gameStateManager');
+vi.mock('../../modules/botManager');
+vi.mock('../../utils/socketHelpers', () => ({
+  broadcastToRoom: vi.fn(),
+  broadcastActiveRooms: vi.fn(),
+  getGameRoom: (code: string) => `game:${code}`,
+}));
+vi.mock('../../utils/errorHandler', () => ({
+  emitError: vi.fn((socket: any, code: string, payload?: any) => {
+    socket.emit('error', { code, message: payload?.message });
+  }),
+  ErrorCodes: {
+    GAME_NOT_FOUND: 'GAME_NOT_FOUND',
+    PLAYER_NOT_IN_GAME: 'PLAYER_NOT_IN_GAME',
+    PLAYER_NOT_HOST: 'PLAYER_NOT_HOST',
+    GAME_ALREADY_STARTED: 'GAME_ALREADY_STARTED',
+    GAME_FULL: 'GAME_FULL',
+    AUTH_FORBIDDEN: 'AUTH_FORBIDDEN',
+    VALIDATION_INVALID_PAYLOAD: 'VALIDATION_INVALID_PAYLOAD',
+  },
+}));
+vi.mock('../../utils/rateLimiter', () => ({ checkRateLimit: vi.fn().mockReturnValue(true) }));
+vi.mock('../../utils/timerManager', () => ({ clearGameTimer: vi.fn() }));
+vi.mock('../../utils/socketValidation', () => ({
+  validatePayload: vi.fn().mockReturnValue({ success: true, data: {} }),
+  addBotSchema: {},
+  removeBotSchema: {},
+}));
+vi.mock('../../utils/gameStateMachine');
+
+const mockGetGame = getGame as Mock;
+const mockGetGameBySocketId = getGameBySocketId as Mock;
+const mockGetGameUsers = getGameUsers as Mock;
+const mockRemoveUserFromGame = removeUserFromGame as Mock;
+const mockIsRoomEmpty = isRoomEmpty as Mock;
+const mockGetActiveRooms = getActiveRooms as Mock;
+const mockGetGameBots = botManager.getGameBots as Mock;
+const mockRemoveBot = botManager.removeBot as Mock;
+const mockIsInProgress = isInProgress as Mock;
+const mockCheckRateLimit = checkRateLimit as Mock;
+
+function createMockSocket(id = 'socket-host') {
+  const handlers: Record<string, Function> = {};
+  return {
+    socket: {
+      id,
+      on: vi.fn((event: string, handler: Function) => { handlers[event] = handler; }),
+      emit: vi.fn(),
+    } as any,
+    handlers,
+  };
+}
+
+describe('botHandler.removeBot - idempotency', () => {
+  const mockIo = {} as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue(true);
+    mockIsInProgress.mockReturnValue(false);
+    mockGetGameBySocketId.mockReturnValue('GAME1');
+    mockGetGameUsers.mockReturnValue([]);
+    mockIsRoomEmpty.mockReturnValue(false);
+    mockGetActiveRooms.mockReturnValue([]);
+  });
+
+  it('treats removing an already-gone bot as success (no "Bot not found" error)', () => {
+    // Bot is NOT in botManager and NOT in game.users — already fully removed,
+    // but the client UI still shows it (stale state, race, double-click, etc).
+    const game: any = {
+      gameCode: 'GAME1',
+      hostSocketId: 'socket-host',
+      gameState: 'waiting',
+      users: {
+        Host: { socketId: 'socket-host', isHost: true, isBot: false },
+      },
+    };
+    mockGetGame.mockReturnValue(game);
+    mockGetGameBots.mockReturnValue([]);
+
+    const { socket, handlers } = createMockSocket();
+    registerBotHandlers(mockIo, socket);
+
+    handlers['removeBot']({ username: 'GhostBot' });
+
+    // Must NOT emit an error — that's what surfaces as "Bot not found" on the client.
+    const errorCalls = (socket.emit as Mock).mock.calls.filter((c: any[]) => c[0] === 'error');
+    expect(errorCalls).toHaveLength(0);
+
+    // Must confirm botRemoved success so the client clears its stale entry.
+    expect(socket.emit).toHaveBeenCalledWith('botRemoved', expect.objectContaining({
+      success: true,
+      username: 'GhostBot',
+    }));
+  });
+
+  it('falls back to game.users when bot is not in botManager but is in game.users', () => {
+    const game: any = {
+      gameCode: 'GAME1',
+      hostSocketId: 'socket-host',
+      gameState: 'waiting',
+      users: {
+        Host: { socketId: 'socket-host', isHost: true, isBot: false },
+        StaleBot: { socketId: 'bot-stale', isHost: false, isBot: true },
+      },
+    };
+    mockGetGame.mockReturnValue(game);
+    mockGetGameBots.mockReturnValue([]);
+
+    const { socket, handlers } = createMockSocket();
+    registerBotHandlers(mockIo, socket);
+
+    handlers['removeBot']({ username: 'StaleBot' });
+
+    expect(mockRemoveUserFromGame).toHaveBeenCalledWith('GAME1', 'StaleBot');
+    expect(socket.emit).toHaveBeenCalledWith('botRemoved', expect.objectContaining({
+      success: true,
+      username: 'StaleBot',
+    }));
+  });
+
+  it('removes bot via the normal botManager path', () => {
+    const bot = { id: 'bot-1', username: 'Bot1', difficulty: 'medium', avatar: { emoji: '🤖' } };
+    const game: any = {
+      gameCode: 'GAME1',
+      hostSocketId: 'socket-host',
+      gameState: 'waiting',
+      users: {
+        Host: { socketId: 'socket-host', isHost: true, isBot: false },
+        Bot1: { socketId: 'bot-1', isHost: false, isBot: true },
+      },
+    };
+    mockGetGame.mockReturnValue(game);
+    mockGetGameBots.mockReturnValue([bot]);
+
+    const { socket, handlers } = createMockSocket();
+    registerBotHandlers(mockIo, socket);
+
+    handlers['removeBot']({ botId: 'bot-1' });
+
+    expect(mockRemoveBot).toHaveBeenCalledWith('GAME1', 'bot-1');
+    expect(mockRemoveUserFromGame).toHaveBeenCalledWith('GAME1', 'Bot1');
+    expect(socket.emit).toHaveBeenCalledWith('botRemoved', expect.objectContaining({
+      success: true,
+      username: 'Bot1',
+    }));
+  });
+});

--- a/fe-next/backend/handlers/botHandler.ts
+++ b/fe-next/backend/handlers/botHandler.ts
@@ -233,7 +233,19 @@ function registerBotHandlers(io: Server, socket: Socket): void {
     }
 
     if (!botToRemove) {
-      emitError(socket, ErrorCodes.VALIDATION_INVALID_PAYLOAD, { message: 'Bot not found' });
+      // Idempotent: bot is already gone from both botManager and game.users.
+      // The client UI is stale (race, double-click, reconnect) — confirm success
+      // and resync user list so the client clears the ghost entry. Erroring here
+      // surfaces as a thrown "Bot not found" exception in the browser.
+      logger.info('BOT', `removeBot: bot "${botId || botUsernameToFind || 'unknown'}" already absent from game ${gameCode} — treating as success`);
+      broadcastToRoom(io, getGameRoom(gameCode), 'updateUsers', {
+        users: getGameUsers(gameCode) as GameUser[]
+      });
+      socket.emit('botRemoved', {
+        success: true,
+        botId,
+        username: botUsernameToFind
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary

- Removes the "Bot not found" runtime error users were seeing in the browser when the host clicks remove on a bot that's already gone from server state (stale UI, race, double-click, reconnect).
- `removeBot` is now idempotent: if the bot is absent from both `botManager` and `game.users`, the server logs it, re-broadcasts the current user list (so the client clears its ghost entry), and emits `botRemoved` with success — instead of erroring.
- Adds `botHandler.removeBot.test.ts` covering the idempotent path, the fallback path (bot in `game.users` only), and the normal `botManager` removal path.

## Root cause

`botHandler.ts:236` emitted `VALIDATION_INVALID_PAYLOAD { message: 'Bot not found' }` whenever the lookup failed in both sources. That `error` event surfaced in the client's socket.io listener chain as a thrown exception with the message `Bot not found`, matching the reported stack trace (`j.emit` / `e.value` are socket.io-client `Emitter.emit` and chunked listener wrappers).

The user's intent — "remove this bot" — is already satisfied when the bot doesn't exist. There's no validation failure to surface; the right behavior is to confirm and resync.

## Test plan

- [x] `npm run test:backend -- bot` — 129 tests pass (10 files), including 3 new tests in `botHandler.removeBot.test.ts`
- [x] `tsc --noEmit` — clean
- [ ] Manual verification: add a bot, click remove twice quickly — second click should no longer trigger a client-side error


---
_Generated by [Claude Code](https://claude.ai/code/session_0141SYiXUMdV3zCqyFbkDy5u)_