### PR TITLE
fix(adventure): make grid square on mobile landscape

### DIFF
--- a/fe-next/app/animations.css
+++ b/fe-next/app/animations.css
@@ -2273,6 +2273,21 @@ html.reduce-motion *::after {
   margin: 0 auto;
 }
 
+/* ==================== Adventure Grid Container ==================== */
+/* The adventure layout (GameGridArea) wraps the grid in an aspect-square
+   flex container that sizes itself to the available space. The inner
+   GridComponent's .game-board-frame element must fill that wrapper rather
+   than honoring the legacy mobile-landscape width/height rules above —
+   otherwise flex-shrink squashes width-only, leaving height at the CSS
+   value and producing rectangular cells. */
+.adventure-grid-container .game-board-frame {
+  width: 100% !important;
+  height: 100% !important;
+  max-width: 100% !important;
+  max-height: 100% !important;
+  margin: 0 auto;
+}
+
 /* ====================================
    CLUE BOX ATTENTION ANIMATIONS
    For Daily Challenge Target Word Hints

--- a/fe-next/components/adventure/ui/GameGridArea.tsx
+++ b/fe-next/components/adventure/ui/GameGridArea.tsx
@@ -222,7 +222,14 @@ export const GameGridArea = memo(function GameGridArea({
         <div className="flex-1 flex items-center justify-center min-h-0 w-full" style={{ maxWidth: 'min(100%, 88cqh, 760px)' }}>
           <AdaptiveMotion.div
             className={cn(
-              'w-full aspect-square max-h-full rounded-neo-lg',
+              // `adventure-grid-container` opts the inner GridComponent out of the
+              // legacy mobile-landscape `.game-board-frame` width/height rules in
+              // animations.css. Without it, those rules force explicit width AND
+              // height on .game-board-frame; flex-shrink then squashes width to
+              // fit this aspect-square parent while height stays at the CSS
+              // value, producing rectangular cells. Mirrors the existing
+              // .desktop-grid-container / .tv-grid-container pattern.
+              'adventure-grid-container w-full aspect-square max-h-full rounded-neo-lg',
               // Stronger glow when a word is accepted — ring + outer shadow pulse
               wasWordSubmitted && lastAccepted
                 ? 'ring-4 ring-neo-lime ring-offset-2 ring-offset-neo-navy/80 shadow-[0_0_24px_4px_rgba(163,230,53,0.45)]'

--- a/fe-next/components/adventure/ui/__tests__/GameGridArea.test.tsx
+++ b/fe-next/components/adventure/ui/__tests__/GameGridArea.test.tsx
@@ -154,4 +154,18 @@ describe('GameGridArea', () => {
     render(<GameGridArea {...defaultProps} />);
     expect(screen.getByTestId('adventure-grid')).toBeInTheDocument();
   });
+
+  // Regression: mobile-landscape CSS rules in animations.css set explicit
+  // width AND height on .game-board-frame. Inside the aspect-square flex
+  // wrapper, flex-shrink shrinks width but not height, breaking the square
+  // grid. The wrapper must carry the `adventure-grid-container` class so the
+  // CSS override (.adventure-grid-container .game-board-frame { width:100%;
+  // height:100% !important }) forces .game-board-frame to fill the square
+  // parent. Mirrors .desktop-grid-container / .tv-grid-container pattern.
+  it('should mark grid wrapper with adventure-grid-container class so .game-board-frame fills the square parent', () => {
+    const { container } = render(<GameGridArea {...defaultProps} />);
+    const wrapper = container.querySelector('.adventure-grid-container');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).toContain('aspect-square');
+  });
 });


### PR DESCRIPTION
## Summary
- Adventure grid was rendering rectangular (taller than wide) on mobile landscape — cells were not equal width × height.
- Root cause: legacy mobile-landscape rules in `app/animations.css` set explicit `width` AND `height` on `.game-board-frame`. Inside `GameGridArea`'s `aspect-square` flex wrapper, `flex-shrink` squashes width to fit the parent but leaves height at the CSS value. Result: `.game-board-frame` becomes rectangular, the inner `position: absolute; inset: 0` grid inherits that box, and `repeat(N, 1fr)` cells stretch unevenly.
- Fix: tag the wrapper with `adventure-grid-container` and add a CSS override that forces `.game-board-frame` to fill the square wrapper. Mirrors the existing `.desktop-grid-container` / `.tv-grid-container` pattern.

## Test plan
- [x] Added regression test in `GameGridArea.test.tsx` asserting the wrapper has `adventure-grid-container` and `aspect-square` classes (RED → GREEN).
- [x] All 32 tests in `components/adventure/ui/__tests__/` pass.
- [ ] Verify on a real mobile-landscape device (the original repro from LogRocket) — grid renders as a perfect square; cells are square.
- [ ] Sanity check desktop adventure layout — unaffected (`.desktop-grid-container` already handles it; new selector is independent).
- [ ] Sanity check singleplayer landscape (`game-board-frame-landscape` wrapper) — unaffected (it doesn't carry `adventure-grid-container`, so existing CSS still applies).

https://claude.ai/code/session_01Du3uRrSdpUWTZ2p3QzFnrs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Du3uRrSdpUWTZ2p3QzFnrs)_