### PR TITLE
fix(blast): drop debris floor below canvas so shards don't stick to bottom-row tiles

### DIFF
--- a/fe-next/components/blast/__tests__/useBlastDebris.test.ts
+++ b/fe-next/components/blast/__tests__/useBlastDebris.test.ts
@@ -232,4 +232,36 @@ describe('useBlastDebris — static walls', () => {
 
     physics.destroy();
   });
+
+  it('debris settles below the visible canvas so fragments do not rest on bottom-row tiles', () => {
+    // Given — 8x8 grid, 40px cells. Canvas spans y=0..boardPx (320). Floor was
+    // positioned with its top edge at boardPx, so settled fragments rested at
+    // y ≈ boardPx (just inside the bottom of the bottom-row tiles), creating
+    // a "leftover red shards stuck on a tile after explosion" visual in blast
+    // mode after bomb clears.
+    const physics = new PhysicsWorld({ gravity: { x: 0, y: 1 } });
+    const camera = new Container();
+    const cellSize = 40;
+    const gridSize = 8;
+    const boardPx = cellSize * gridSize;
+
+    const { result, unmount } = renderHook(() =>
+      useBlastDebris(cellSize, gridSize, camera, physics),
+    );
+
+    result.current.spawnDebris([{ row: 4, col: 4, type: 'bomb' }]);
+
+    // Run physics long enough for fragments to settle on the floor.
+    for (let i = 0; i < 600; i++) physics.update(16.67);
+
+    const dynamic = physics
+      .getAllBodyStates()
+      .filter(b => b.label !== 'wall');
+    expect(dynamic.length).toBeGreaterThan(0);
+    for (const body of dynamic) {
+      expect(body.position.y).toBeGreaterThan(boardPx);
+    }
+
+    unmount();
+  });
 });

--- a/fe-next/components/blast/useBlastDebris.ts
+++ b/fe-next/components/blast/useBlastDebris.ts
@@ -74,26 +74,36 @@ export function useBlastDebris(
     // Static collision walls — floor + left + right so debris bounces
     // and never escapes the play area. Walls extend past the board so
     // high-velocity fragments don't tunnel around corners.
+    //
+    // Floor sits a full cell below the canvas (top edge at y = boardPx +
+    // cellSize) so settled fragments rest off-screen instead of perched on
+    // the bottom-row tiles — the floor used to sit flush with boardPx,
+    // which left red bomb shards visibly stuck on bottom-row letters after
+    // explosions. Side walls extend equally far so a fragment can't bounce
+    // out the corner before the floor catches it.
     const boardPx = gridSize * cellSize;
     const thickness = 40;
     const overshoot = 200;
+    const floorOffset = cellSize;
     const floorId = physics.createWall(
       boardPx / 2,
-      boardPx + thickness / 2,
+      boardPx + thickness / 2 + floorOffset,
       boardPx + overshoot,
       thickness,
     );
+    const sideHeight = boardPx + overshoot + floorOffset;
+    const sideCenterY = boardPx / 2 + floorOffset / 2;
     const leftId = physics.createWall(
       -thickness / 2,
-      boardPx / 2,
+      sideCenterY,
       thickness,
-      boardPx + overshoot,
+      sideHeight,
     );
     const rightId = physics.createWall(
       boardPx + thickness / 2,
-      boardPx / 2,
+      sideCenterY,
       thickness,
-      boardPx + overshoot,
+      sideHeight,
     );
     wallBodyIdsRef.current = [floorId, leftId, rightId];
 


### PR DESCRIPTION
## Summary
Bomb-clear shards in blast mode were visibly perched on bottom-row tile letters for ~1s after every explosion. Root cause: the physics floor wall in `useBlastDebris` sat flush with the canvas bottom (`y = boardPx`), so fragments resting on it had centers at `~boardPx - 2.5` — half-clipped, half-visible right on top of the bottom row.

Fix: push the floor down by one `cellSize` (and extend the side walls to match) so settled fragments come to rest below the canvas, out of frame.

## Changes
- `fe-next/components/blast/useBlastDebris.ts`: floor center y = `boardPx + thickness/2 + cellSize`; side walls extended by the same offset so corners stay sealed.
- `fe-next/components/blast/__tests__/useBlastDebris.test.ts`: regression test — spawn debris, run physics 600 steps, assert every dynamic body settles at `y > boardPx`.

## Test plan
- [x] New regression test fails on `master`, passes on this branch
- [x] Full `components/blast` suite (1439 tests) passes
- [x] TypeScript + ESLint clean on changed files
- [ ] Manual: trigger a bomb clear in blast mode and confirm no red shards linger on bottom-row tile letters

https://claude.ai/code/session_01JnyYBSi4jkybpfcY8Hs2eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnyYBSi4jkybpfcY8Hs2eg)_