### PR TITLE
feat(word-craft): gsap juice + pixi celebration on admin Scrabble sandbox

### DIFF
--- a/fe-next/app/[locale]/admin/word-craft/PageClient.tsx
+++ b/fe-next/app/[locale]/admin/word-craft/PageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ArrowLeft, Shield } from 'lucide-react';
 import Header from '@/components/Header';
@@ -13,6 +13,8 @@ import { WordCraftBoard } from '@/components/word-craft/WordCraftBoard';
 import { WordCraftRack } from '@/components/word-craft/WordCraftRack';
 import { WordCraftScoreboard } from '@/components/word-craft/WordCraftScoreboard';
 import { WordCraftControls } from '@/components/word-craft/WordCraftControls';
+import { WordCraftCelebration, type CelebrationKind } from '@/components/word-craft/WordCraftCelebration';
+import { useWordCraftJuice } from '@/components/word-craft/useWordCraftJuice';
 import { cn } from '@/lib/utils';
 
 export default function WordCraftPageClient() {
@@ -44,6 +46,85 @@ export default function WordCraftPageClient() {
   }, [isAdmin]);
 
   const game = useWordCraftGame({ seed, dict });
+  const juice = useWordCraftJuice();
+
+  const [celebration, setCelebration] = useState<{ kind: CelebrationKind; burstId: number; origin?: { x: number; y: number } }>({
+    kind: null,
+    burstId: 0,
+  });
+
+  const prevPendingIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const next = new Set(game.state.pendingPlacements.map((p) => p.rackTileId));
+    for (const p of game.state.pendingPlacements) {
+      if (!prevPendingIdsRef.current.has(p.rackTileId)) {
+        const el = document.querySelector(`[data-tile-id="${p.rackTileId}"]`);
+        juice.tilePlace(el);
+      }
+    }
+    prevPendingIdsRef.current = next;
+  }, [game.state.pendingPlacements, juice]);
+
+  const prevSelectedRef = useRef<string | null>(null);
+  useEffect(() => {
+    const id = game.state.selectedRackTileId;
+    if (id && id !== prevSelectedRef.current) {
+      const el = document.querySelector(`[data-rack-tile-id="${id}"]`);
+      juice.rackSelect(el);
+    }
+    prevSelectedRef.current = id;
+  }, [game.state.selectedRackTileId, juice]);
+
+  const prevHistoryLenRef = useRef(0);
+  useEffect(() => {
+    const len = game.state.history.length;
+    if (len === prevHistoryLenRef.current) return;
+    const newest = game.state.history[len - 1];
+    prevHistoryLenRef.current = len;
+    if (!newest || newest.score === 0) return;
+
+    const popEl = document.querySelector(`[data-score-value="${newest.who}"]`);
+    juice.scorePop(popEl, newest.score);
+
+    const placedEls = newest.placedTileIds
+      .map((id) => document.querySelector(`[data-tile-id="${id}"]`))
+      .filter((n): n is Element => Boolean(n));
+
+    if (newest.who === 'bot' && placedEls.length > 0) {
+      juice.botReveal(placedEls);
+    }
+
+    const isBingo = newest.placedTileIds.length >= 7;
+    if (isBingo || newest.score >= 50) {
+      const target = (placedEls[Math.floor(placedEls.length / 2)] as HTMLElement | undefined) ?? null;
+      const rect = target?.getBoundingClientRect();
+      setCelebration((prev) => ({
+        kind: 'bingo',
+        burstId: prev.burstId + 1,
+        origin: rect ? { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 } : undefined,
+      }));
+    }
+  }, [game.state.history, juice]);
+
+  useEffect(() => {
+    if (game.state.turn === 'over') {
+      setCelebration((prev) => ({ kind: 'gameOver', burstId: prev.burstId + 1 }));
+    }
+  }, [game.state.turn]);
+
+  const lastErrorRef = useRef<string | null>(null);
+  useEffect(() => {
+    const e = game.state.lastError;
+    if (!e || e === lastErrorRef.current) {
+      lastErrorRef.current = e;
+      return;
+    }
+    lastErrorRef.current = e;
+    const cellEls = game.state.pendingPlacements
+      .map((p) => document.querySelector(`[data-tile-id="${p.rackTileId}"]`))
+      .filter((n): n is Element => Boolean(n));
+    juice.invalidShake(cellEls);
+  }, [game.state.lastError, game.state.pendingPlacements, juice]);
 
   const isProfileLoading = !authLoading && user && !profile;
 
@@ -100,6 +181,7 @@ export default function WordCraftPageClient() {
   return (
     <div className={cn('flex-1 flex flex-col w-full overflow-x-hidden min-h-screen bg-neo-navy', isRTL && 'rtl')}>
       <Header />
+      <WordCraftCelebration kind={celebration.kind} burstId={celebration.burstId} origin={celebration.origin} />
 
       <main className="flex-1 px-3 sm:px-6 py-4 sm:py-6 pb-24 max-w-[820px] mx-auto w-full space-y-4">
         <div className="flex items-center gap-3">

--- a/fe-next/components/word-craft/WordCraftBoard.tsx
+++ b/fe-next/components/word-craft/WordCraftBoard.tsx
@@ -55,6 +55,9 @@ function WordCraftBoardImpl({ board, pendingPlacements, onCellClick, disabled }:
               key={key}
               type="button"
               role="gridcell"
+              data-board-cell={key}
+              data-tile-id={pending?.rackTileId ?? placedTile?.rackTileId ?? undefined}
+              data-tile-state={pending ? 'pending' : placedTile ? 'placed' : 'empty'}
               aria-label={`row ${r + 1} column ${c + 1}${cell.premium ? ` ${cell.premium}` : ''}`}
               disabled={!isInteractive}
               onClick={() => isInteractive && onCellClick(r, c)}

--- a/fe-next/components/word-craft/WordCraftRack.tsx
+++ b/fe-next/components/word-craft/WordCraftRack.tsx
@@ -30,6 +30,7 @@ function WordCraftRackImpl({
           <button
             key={tile.id}
             type="button"
+            data-rack-tile-id={tile.id}
             disabled={disabled || isPending}
             aria-pressed={isSelected}
             onClick={() => onSelect(isSelected ? null : tile.id)}

--- a/fe-next/components/word-craft/WordCraftScoreboard.tsx
+++ b/fe-next/components/word-craft/WordCraftScoreboard.tsx
@@ -25,21 +25,24 @@ function PlayerCard({
   score,
   active,
   rackCount,
+  who,
 }: {
   name: string;
   score: number;
   active: boolean;
   rackCount: number;
+  who: 'player' | 'bot';
 }) {
   return (
     <div
+      data-scoreboard-card={who}
       className={cn(
         'flex-1 min-w-[140px] p-3 rounded-neo border-neo border-black bg-neo-navy-light shadow-hard',
         active && 'ring-4 ring-neo-lime',
       )}
     >
       <div className="text-xs text-neo-cream/70 font-neo-body uppercase tracking-wide">{name}</div>
-      <div className="text-3xl font-neo-display font-bold text-neo-white mt-1">{score}</div>
+      <div data-score-value={who} className="text-3xl font-neo-display font-bold text-neo-white mt-1 inline-block origin-bottom-left">{score}</div>
       <div className="text-[10px] text-neo-cream/50 mt-1">{rackCount} tiles</div>
     </div>
   );
@@ -52,8 +55,8 @@ function WordCraftScoreboardImpl({ player, bot, turn, tilesRemaining, labels }: 
   return (
     <div className="space-y-3">
       <div className="flex gap-3">
-        <PlayerCard name={labels.you} score={player.score} active={turn === 'player'} rackCount={player.rack.length} />
-        <PlayerCard name={labels.bot} score={bot.score} active={turn === 'bot'} rackCount={bot.rack.length} />
+        <PlayerCard who="player" name={labels.you} score={player.score} active={turn === 'player'} rackCount={player.rack.length} />
+        <PlayerCard who="bot" name={labels.bot} score={bot.score} active={turn === 'bot'} rackCount={bot.rack.length} />
       </div>
       <div className="flex items-center justify-between text-sm bg-neo-navy/60 border-neo border-black rounded-neo px-3 py-2">
         <span className="font-neo-display text-neo-white">{status}</span>

--- a/fe-next/components/word-craft/__tests__/useWordCraftJuice.test.ts
+++ b/fe-next/components/word-craft/__tests__/useWordCraftJuice.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for useWordCraftJuice — the gsap-driven feel layer for WordCraft.
+ *
+ * Each trigger is gated by prefers-reduced-motion (no-op when set) and
+ * builds a gsap timeline that animates the supplied DOM target. We assert
+ * structural wiring: which primitives are called with which targets,
+ * not real tween timing.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const reducedMotionMock = vi.fn(() => false);
+vi.mock('@/utils/accessibility', () => ({
+  isReducedMotionPreferred: () => reducedMotionMock(),
+}));
+
+interface TimelineSpy {
+  fromToCalls: Array<{ target: unknown; from: unknown; to: unknown }>;
+  toCalls: Array<{ target: unknown; vars: unknown }>;
+  killed: boolean;
+}
+
+const timelines: TimelineSpy[] = [];
+
+function makeMockTl(): TimelineSpy & Record<string, unknown> {
+  const spy: TimelineSpy = { fromToCalls: [], toCalls: [], killed: false };
+  const tl: Record<string, unknown> = {};
+  Object.assign(tl, spy);
+  Object.assign(tl, {
+    to(target: unknown, vars: unknown) {
+      spy.toCalls.push({ target, vars });
+      return tl;
+    },
+    fromTo(target: unknown, from: unknown, to: unknown) {
+      spy.fromToCalls.push({ target, from, to });
+      return tl;
+    },
+    from: () => tl,
+    set: () => tl,
+    call: () => tl,
+    add: () => tl,
+    eventCallback: () => tl,
+    kill() { spy.killed = true; },
+  });
+  timelines.push(spy);
+  return tl as TimelineSpy & Record<string, unknown>;
+}
+
+vi.mock('gsap', () => ({
+  default: {
+    timeline: () => makeMockTl(),
+  },
+  gsap: {
+    timeline: () => makeMockTl(),
+  },
+}));
+
+import { useWordCraftJuice } from '../useWordCraftJuice';
+
+beforeEach(() => {
+  reducedMotionMock.mockReturnValue(false);
+  timelines.length = 0;
+});
+
+describe('useWordCraftJuice', () => {
+  it('returns the expected trigger surface', () => {
+    const { result } = renderHook(() => useWordCraftJuice());
+    expect(typeof result.current.tilePlace).toBe('function');
+    expect(typeof result.current.invalidShake).toBe('function');
+    expect(typeof result.current.scorePop).toBe('function');
+    expect(typeof result.current.botReveal).toBe('function');
+    expect(typeof result.current.rackSelect).toBe('function');
+  });
+
+  describe('tilePlace', () => {
+    it('animates the target with a snap-down fromTo when motion is allowed', () => {
+      const el = document.createElement('div');
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.tilePlace(el);
+      expect(timelines).toHaveLength(1);
+      expect(timelines[0].fromToCalls).toHaveLength(1);
+      expect(timelines[0].fromToCalls[0].target).toBe(el);
+    });
+
+    it('is a no-op when prefers-reduced-motion is set', () => {
+      reducedMotionMock.mockReturnValue(true);
+      const el = document.createElement('div');
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.tilePlace(el);
+      expect(timelines).toHaveLength(0);
+    });
+
+    it('handles a null target without throwing or animating', () => {
+      const { result } = renderHook(() => useWordCraftJuice());
+      expect(() => result.current.tilePlace(null)).not.toThrow();
+      expect(timelines).toHaveLength(0);
+    });
+  });
+
+  describe('invalidShake', () => {
+    it('shakes a list of targets along the x axis', () => {
+      const a = document.createElement('div');
+      const b = document.createElement('div');
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.invalidShake([a, b]);
+      expect(timelines).toHaveLength(1);
+      expect(timelines[0].fromToCalls.length).toBeGreaterThan(0);
+      const targets = timelines[0].fromToCalls.map((c) => c.target);
+      expect(targets).toContain(a);
+      expect(targets).toContain(b);
+    });
+
+    it('no-ops when prefers-reduced-motion is set', () => {
+      reducedMotionMock.mockReturnValue(true);
+      const el = document.createElement('div');
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.invalidShake([el]);
+      expect(timelines).toHaveLength(0);
+    });
+
+    it('no-ops on empty target list', () => {
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.invalidShake([]);
+      expect(timelines).toHaveLength(0);
+    });
+  });
+
+  describe('scorePop', () => {
+    it('pops a score badge upward and back', () => {
+      const el = document.createElement('div');
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.scorePop(el, 42);
+      expect(timelines).toHaveLength(1);
+      expect(timelines[0].fromToCalls.length + timelines[0].toCalls.length).toBeGreaterThan(0);
+      const targets = [
+        ...timelines[0].fromToCalls.map((c) => c.target),
+        ...timelines[0].toCalls.map((c) => c.target),
+      ];
+      expect(targets).toContain(el);
+    });
+
+    it('no-ops when prefers-reduced-motion is set', () => {
+      reducedMotionMock.mockReturnValue(true);
+      const el = document.createElement('div');
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.scorePop(el, 10);
+      expect(timelines).toHaveLength(0);
+    });
+  });
+
+  describe('botReveal', () => {
+    it('staggers a flip-in across each target', () => {
+      const els = [document.createElement('div'), document.createElement('div'), document.createElement('div')];
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.botReveal(els);
+      expect(timelines).toHaveLength(1);
+      expect(timelines[0].fromToCalls.length).toBe(3);
+      const targets = timelines[0].fromToCalls.map((c) => c.target);
+      for (const el of els) expect(targets).toContain(el);
+    });
+
+    it('no-ops when prefers-reduced-motion is set', () => {
+      reducedMotionMock.mockReturnValue(true);
+      const els = [document.createElement('div')];
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.botReveal(els);
+      expect(timelines).toHaveLength(0);
+    });
+  });
+
+  describe('rackSelect', () => {
+    it('bounces the selected rack tile', () => {
+      const el = document.createElement('div');
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.rackSelect(el);
+      expect(timelines).toHaveLength(1);
+      const targets = [
+        ...timelines[0].fromToCalls.map((c) => c.target),
+        ...timelines[0].toCalls.map((c) => c.target),
+      ];
+      expect(targets).toContain(el);
+    });
+
+    it('no-ops when prefers-reduced-motion is set', () => {
+      reducedMotionMock.mockReturnValue(true);
+      const el = document.createElement('div');
+      const { result } = renderHook(() => useWordCraftJuice());
+      result.current.rackSelect(el);
+      expect(timelines).toHaveLength(0);
+    });
+
+    it('handles a null target without throwing or animating', () => {
+      const { result } = renderHook(() => useWordCraftJuice());
+      expect(() => result.current.rackSelect(null)).not.toThrow();
+      expect(timelines).toHaveLength(0);
+    });
+  });
+});

--- a/fe-next/components/word-craft/__tests__/useWordCraftJuice.test.ts
+++ b/fe-next/components/word-craft/__tests__/useWordCraftJuice.test.ts
@@ -47,9 +47,6 @@ function makeMockTl(): TimelineSpy & Record<string, unknown> {
 }
 
 vi.mock('gsap', () => ({
-  default: {
-    timeline: () => makeMockTl(),
-  },
   gsap: {
     timeline: () => makeMockTl(),
   },

--- a/fe-next/components/word-craft/useWordCraftJuice.ts
+++ b/fe-next/components/word-craft/useWordCraftJuice.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCallback } from 'react';
+import gsap from 'gsap';
+import { isReducedMotionPreferred } from '@/utils/accessibility';
+
+export type JuiceTarget = Element | null | undefined;
+
+export interface UseWordCraftJuice {
+  tilePlace: (target: JuiceTarget) => void;
+  invalidShake: (targets: JuiceTarget[]) => void;
+  scorePop: (target: JuiceTarget, score: number) => void;
+  botReveal: (targets: JuiceTarget[]) => void;
+  rackSelect: (target: JuiceTarget) => void;
+}
+
+export function useWordCraftJuice(): UseWordCraftJuice {
+  const tilePlace = useCallback((target: JuiceTarget) => {
+    if (!target) return;
+    if (isReducedMotionPreferred()) return;
+    gsap.timeline().fromTo(
+      target,
+      { scale: 1.35, y: -10, opacity: 0.3 },
+      { scale: 1, y: 0, opacity: 1, duration: 0.22, ease: 'back.out(2.4)' },
+    );
+  }, []);
+
+  const invalidShake = useCallback((targets: JuiceTarget[]) => {
+    const list = targets.filter(Boolean) as Element[];
+    if (list.length === 0) return;
+    if (isReducedMotionPreferred()) return;
+    const tl = gsap.timeline();
+    list.forEach((el) => {
+      tl.fromTo(
+        el,
+        { x: 0 },
+        { x: -8, duration: 0.05, repeat: 5, yoyo: true, ease: 'power1.inOut' },
+        0,
+      );
+    });
+  }, []);
+
+  const scorePop = useCallback((target: JuiceTarget, _score: number) => {
+    if (!target) return;
+    if (isReducedMotionPreferred()) return;
+    gsap
+      .timeline()
+      .fromTo(
+        target,
+        { scale: 0.6, y: 12, opacity: 0 },
+        { scale: 1.25, y: -8, opacity: 1, duration: 0.18, ease: 'back.out(2.6)' },
+      )
+      .to(target, { scale: 1, y: 0, duration: 0.16, ease: 'power2.out' });
+  }, []);
+
+  const botReveal = useCallback((targets: JuiceTarget[]) => {
+    const list = targets.filter(Boolean) as Element[];
+    if (list.length === 0) return;
+    if (isReducedMotionPreferred()) return;
+    const tl = gsap.timeline();
+    list.forEach((el, i) => {
+      tl.fromTo(
+        el,
+        { rotationX: -90, opacity: 0, transformPerspective: 600 },
+        { rotationX: 0, opacity: 1, duration: 0.32, ease: 'back.out(1.7)' },
+        i * 0.08,
+      );
+    });
+  }, []);
+
+  const rackSelect = useCallback((target: JuiceTarget) => {
+    if (!target) return;
+    if (isReducedMotionPreferred()) return;
+    gsap
+      .timeline()
+      .fromTo(
+        target,
+        { y: 0, scale: 1 },
+        { y: -6, scale: 1.08, duration: 0.12, ease: 'back.out(2)' },
+      )
+      .to(target, { y: -3, scale: 1.04, duration: 0.16, ease: 'power2.out' });
+  }, []);
+
+  return { tilePlace, invalidShake, scorePop, botReveal, rackSelect };
+}

--- a/fe-next/components/word-craft/useWordCraftJuice.ts
+++ b/fe-next/components/word-craft/useWordCraftJuice.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
-import gsap from 'gsap';
+import { gsap } from 'gsap';
 import { isReducedMotionPreferred } from '@/utils/accessibility';
 
 export type JuiceTarget = Element | null | undefined;

--- a/fe-next/lib/word-craft/useWordCraftGame.ts
+++ b/fe-next/lib/word-craft/useWordCraftGame.ts
@@ -13,6 +13,7 @@ interface MoveHistoryEntry {
   who: 'player' | 'bot';
   words: string[];
   score: number;
+  placedTileIds: string[];
 }
 
 export interface WordCraftState {
@@ -85,7 +86,7 @@ function commitMove(
     bot: who === 'bot' ? updatedOwner : state.bot,
     pendingPlacements: [],
     selectedRackTileId: null,
-    history: [...state.history, { who, words, score }],
+    history: [...state.history, { who, words, score, placedTileIds: placements.map((p) => p.rackTileId) }],
     lastError: null,
     consecutivePasses: 0,
     turn: who === 'player' ? 'bot' : 'player',
@@ -131,7 +132,7 @@ function reducer(state: WordCraftState, action: Action): WordCraftState {
         selectedRackTileId: null,
         consecutivePasses: passes,
         turn,
-        history: [...state.history, { who: state.turn === 'player' ? 'player' : 'bot', words: [], score: 0 }],
+        history: [...state.history, { who: state.turn === 'player' ? 'player' : 'bot', words: [], score: 0, placedTileIds: [] }],
       };
     }
     case 'SWAP': {


### PR DESCRIPTION
## Summary

WordCraft (our Scrabble) already exists end-to-end at `/[locale]/admin/word-craft` and is admin-gated. This PR makes it *feel good*:

- **Pixi celebration**: the pre-built `WordCraftCelebration` overlay was never wired in. Now it fires `bingo` bursts on 7-tile plays or any 50+ point move, and `gameOver` rain on game end.
- **GSAP juice (`useWordCraftJuice`)**: tile snap-down on placement, x-axis shake on invalid moves, score-pop on commit, flip-in stagger for bot reveals, bounce on rack-tile selection. Every trigger no-ops under `prefers-reduced-motion`.
- **Targetable DOM**: `WordCraftBoard`, `WordCraftRack`, and `WordCraftScoreboard` now expose `data-tile-id` / `data-rack-tile-id` / `data-score-value` so the juice hook can find the right elements without coupling.
- **History fidelity**: `MoveHistoryEntry` now carries `placedTileIds`, so the bot-reveal animation targets exactly the tiles just placed and bingo bursts originate from the play centroid (not the last tile in DOM order).

Visibility is unchanged — the page is still admin-only via `isAdmin` in `PageClient`.

## Test plan
- [x] 14 new tests for `useWordCraftJuice` (each trigger animates the correct target, no-ops under reduced motion, no-ops on null/empty)
- [x] All existing word-craft tests still pass (92 tests across 7 files)
- [x] `tsc --noEmit` clean
- [x] `eslint --max-warnings=0` clean on touched files
- [ ] Smoke-test in browser: place tiles, submit valid word (score-pop), submit invalid word (shake), bot turn (flip-in stagger), play 50+ point move (bingo burst), end game (gameOver rain), `prefers-reduced-motion` (no animations, no pixi mount)

https://claude.ai/code/session_011en3tdnAXG7rZrFXzExnQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_011en3tdnAXG7rZrFXzExnQ5)_