### PR TITLE
fix: route MP invite notifications to /multiplayer instead of /join

### DIFF
--- a/fe-next/backend/modules/__tests__/pushNotificationTriggers.test.ts
+++ b/fe-next/backend/modules/__tests__/pushNotificationTriggers.test.ts
@@ -285,7 +285,7 @@ describe('pushNotificationTriggers', () => {
         body: 'Ohad invited you to play!',
         data: {
           type: 'game_invite',
-          deepLink: '/join/ABC123',
+          deepLink: '/multiplayer?room=ABC123',
         },
       }));
     });

--- a/fe-next/backend/modules/pushNotificationTriggers.ts
+++ b/fe-next/backend/modules/pushNotificationTriggers.ts
@@ -333,7 +333,7 @@ export async function notifyGameInvite(
     imageUrl: mascotImageUrl('play'),
     data: {
       type: 'game_invite',
-      deepLink: `/join/${roomCode}`,
+      deepLink: `/multiplayer?room=${roomCode}`,
     },
   }, 'both', inviterUserId);
 }
@@ -353,7 +353,7 @@ export async function notifyTurnReminder(
     imageUrl: mascotImageUrl('encouraging'),
     data: {
       type: 'turn_reminder',
-      deepLink: `/join/${roomCode}`,
+      deepLink: `/multiplayer?room=${roomCode}`,
     },
   });
 }
@@ -484,7 +484,7 @@ export async function notifyChallengeAccepted(
     imageUrl: mascotImageUrl('play'),
     data: {
       type: 'challenge_accepted',
-      deepLink: `/join/${roomCode}`,
+      deepLink: `/multiplayer?room=${roomCode}`,
     },
   }, 'both', acceptorUserId);
 }


### PR DESCRIPTION
## Summary

When a friend invites a player to a multiplayer lobby, tapping the resulting push or in-app notification was sending the recipient to the **classroom join page** (`JoinClassroomForm`) instead of the multiplayer room.

The deepLink was `/join/<roomCode>`, which routes to `app/[locale]/join/[code]/PageClient.tsx` — that page only validates classroom codes via `useJoinClassroom()` and has no logic for multiplayer room codes. So the invite always landed on the wrong screen.

Switched the deepLink to `/multiplayer?room=<roomCode>` — the same pattern already used by the in-app challenge-accept handler in `components/friends/FriendsList.tsx:116`. `MultiplayerPageClient` reads `?room=` via `useMultiplayerSession` and joins the room automatically.

## Changes

- `fe-next/backend/modules/pushNotificationTriggers.ts` — fix three triggers that produce roomCode deepLinks:
  - `notifyGameInvite` (line 336)
  - `notifyTurnReminder` (line 356)
  - `notifyChallengeAccepted` (line 487)
- `fe-next/backend/modules/__tests__/pushNotificationTriggers.test.ts` — update assertion to expect the multiplayer route.

## Test plan

- [ ] CI runs `notifyGameInvite` test and asserts new `/multiplayer?room=ABC123` deepLink.
- [ ] Manual: send a friend a game invite → recipient taps the in-app notification → lands in the MP lobby (not the classroom join screen).
- [ ] Manual: same flow via push notification (mobile / PWA) → `DeepLinkHandler` routes to `/<locale>/multiplayer?room=...`.
- [ ] Manual: accept an async challenge → challenger receives `challenge_accepted` push and lands in the room.

https://claude.ai/code/session_01UMDs7EAV5K1Qp4scfUjjpU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMDs7EAV5K1Qp4scfUjjpU)_