### PR TITLE
feat(admin): surface full guest history and acquisition metadata

### DIFF
--- a/fe-next/app/[locale]/admin/guests/PageClient.tsx
+++ b/fe-next/app/[locale]/admin/guests/PageClient.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, Shield, UserX } from 'lucide-react';
+import Header from '@/components/Header';
+import { Button } from '@/components/ui/button';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useAuth } from '@/contexts/AuthContext';
+import { getSession } from '@/lib/supabase';
+import { cn } from '@/lib/utils';
+import { GuestManager } from '@/components/admin/GuestManager';
+import { useTheme } from '@/utils/ThemeContext';
+import { PageLoader } from '@/components/ui/PageLoader';
+import { AdminSidebar } from '@/components/admin/sidebar/AdminSidebar';
+import { AdminBottomNav } from '@/components/admin/sidebar/AdminBottomNav';
+
+export default function GuestsPageClient() {
+  const router = useRouter();
+  const { language } = useLanguage();
+  const { theme } = useTheme();
+  const isDarkMode = theme === 'dark';
+  const { user, profile, isAdmin, loading: authLoading } = useAuth();
+
+  const [authToken, setAuthToken] = useState<string | null>(null);
+
+  const getAuthToken = useCallback(async () => {
+    try {
+      const { data: { session } } = await getSession();
+      return session?.access_token || null;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!authLoading && isAdmin) {
+      getAuthToken().then(setAuthToken);
+    }
+  }, [authLoading, isAdmin, getAuthToken]);
+
+  const isProfileLoading = !authLoading && user && !profile;
+
+  if (!authLoading && !isProfileLoading && (!user || !isAdmin)) {
+    return (
+      <div className="flex-1 bg-neo-navy text-neo-white flex items-center justify-center">
+        <div className="text-center">
+          <Shield className="w-16 h-16 text-neo-lime mx-auto mb-4" />
+          <h1 className="text-2xl font-neo-display text-neo-white mb-2">
+            Admin Access Required
+          </h1>
+          <Button onClick={() => router.push(`/${language}`)} variant="outline">
+            <ArrowLeft className="w-4 h-4 me-2" />
+            Back to Home
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (authLoading || isProfileLoading || !authToken) {
+    return (
+      <div className="flex-1 bg-neo-navy text-neo-white flex items-center justify-center">
+        <PageLoader size="lg" text="Loading..." />
+      </div>
+    );
+  }
+
+  const isRTL = language === 'he';
+
+  return (
+    <div className={cn(
+      'flex-1 flex flex-col w-full overflow-x-hidden min-h-screen',
+      isDarkMode ? 'bg-neo-navy' : 'bg-linear-to-br from-blue-50 via-white to-purple-50',
+      isRTL && 'rtl',
+    )}>
+      <Header />
+
+      <div className="flex flex-1">
+        <AdminSidebar />
+
+        <main className="flex-1 min-w-0 px-4 py-6 sm:px-6 lg:px-8 pb-20 sm:pb-6">
+          <div className="flex items-center gap-4 mb-6">
+            <UserX className="w-8 h-8 text-slate-400" />
+            <div>
+              <h1 className={cn('text-2xl font-bold', isDarkMode ? 'text-white' : 'text-gray-900')}>
+                Guest Players
+              </h1>
+              <p className="text-sm text-slate-500">
+                Anonymous sessions, their game history, and conversion to registered users
+              </p>
+            </div>
+          </div>
+
+          <GuestManager authToken={authToken} />
+        </main>
+      </div>
+
+      <AdminBottomNav />
+    </div>
+  );
+}

--- a/fe-next/app/[locale]/admin/guests/[sessionId]/PageClient.tsx
+++ b/fe-next/app/[locale]/admin/guests/[sessionId]/PageClient.tsx
@@ -1,0 +1,485 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import {
+  ArrowLeft, Shield, Smartphone, Monitor,
+  CheckCircle2, XCircle, Target, Puzzle, Gamepad2,
+} from 'lucide-react';
+import Header from '@/components/Header';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useAuth } from '@/contexts/AuthContext';
+import { getSession } from '@/lib/supabase';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/utils/ThemeContext';
+import { PageLoader } from '@/components/ui/PageLoader';
+import { AdminSidebar } from '@/components/admin/sidebar/AdminSidebar';
+import { AdminBottomNav } from '@/components/admin/sidebar/AdminBottomNav';
+import { Loader } from '@/components/ui/Loader';
+
+interface GuestProfile {
+  session_id: string;
+  device_type: string | null;
+  browser: string | null;
+  language: string | null;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  referrer: string | null;
+  country: string | null;
+  first_visit_at: string;
+  last_visit_at: string;
+  user_id: string | null;
+  linked_at: string | null;
+  created_at: string;
+  missing?: boolean;
+}
+
+interface GameSession {
+  id: string;
+  mode: string;
+  language: string;
+  score: number;
+  words_found: { word?: string; points?: number; length?: number }[] | null;
+  room_code: string | null;
+  final_rank: number | null;
+  duration_seconds: number;
+  started_at: string;
+  completed_at: string | null;
+  completed: boolean;
+  difficulty: string | null;
+  is_first_game: boolean;
+  player_count: number | null;
+  tokens_earned: number;
+  tokens_spent: number;
+  clues_used: number;
+}
+
+interface WordHuntAttempt {
+  id: string;
+  language: string;
+  puzzle_number: number;
+  solved: boolean;
+  attempts_used: number;
+  target_word: string;
+  efficiency_score: number;
+  completed_at: string | null;
+  created_at: string;
+}
+
+interface DailyPuzzleAttempt {
+  id: string;
+  puzzle_number: number;
+  language: string;
+  score: number;
+  word_count: number;
+  time_seconds: number;
+  longest_word: string | null;
+  completed_at: string;
+}
+
+interface DetailResponse {
+  success: boolean;
+  profile: GuestProfile;
+  gameSessions: GameSession[];
+  wordHuntAttempts: WordHuntAttempt[];
+  dailyPuzzleAttempts: DailyPuzzleAttempt[];
+}
+
+const COUNTRY_FLAG_OFFSET = 0x1f1a5;
+function countryToFlag(code?: string | null): string {
+  if (!code || code.length !== 2) return '';
+  const upper = code.toUpperCase();
+  return String.fromCodePoint(
+    upper.charCodeAt(0) + COUNTRY_FLAG_OFFSET,
+    upper.charCodeAt(1) + COUNTRY_FLAG_OFFSET,
+  );
+}
+
+function formatDuration(seconds: number): string {
+  if (!seconds) return '0s';
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+export default function GuestDetailPageClient() {
+  const router = useRouter();
+  const params = useParams<{ sessionId: string }>();
+  const sessionId = params?.sessionId as string;
+  const { language } = useLanguage();
+  const { theme } = useTheme();
+  const isDarkMode = theme === 'dark';
+  const { user, profile: userProfile, isAdmin, loading: authLoading } = useAuth();
+
+  const [authToken, setAuthToken] = useState<string | null>(null);
+  const [data, setData] = useState<DetailResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const getAuthToken = useCallback(async () => {
+    try {
+      const { data: { session } } = await getSession();
+      return session?.access_token || null;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!authLoading && isAdmin) {
+      getAuthToken().then(setAuthToken);
+    }
+  }, [authLoading, isAdmin, getAuthToken]);
+
+  useEffect(() => {
+    if (!authToken || !sessionId) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/admin/guests/${sessionId}`, {
+          headers: { Authorization: `Bearer ${authToken}` },
+        });
+        if (!res.ok) throw new Error('Failed to fetch guest detail');
+        const json = await res.json();
+        if (!cancelled) setData(json);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authToken, sessionId]);
+
+  const isProfileLoading = !authLoading && user && !userProfile;
+
+  if (!authLoading && !isProfileLoading && (!user || !isAdmin)) {
+    return (
+      <div className="flex-1 bg-neo-navy text-neo-white flex items-center justify-center">
+        <div className="text-center">
+          <Shield className="w-16 h-16 text-neo-lime mx-auto mb-4" />
+          <h1 className="text-2xl font-neo-display text-neo-white mb-2">Admin Access Required</h1>
+          <Button onClick={() => router.push(`/${language}`)} variant="outline">
+            <ArrowLeft className="w-4 h-4 me-2" /> Back to Home
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (authLoading || isProfileLoading || !authToken) {
+    return (
+      <div className="flex-1 bg-neo-navy text-neo-white flex items-center justify-center">
+        <PageLoader size="lg" text="Loading..." />
+      </div>
+    );
+  }
+
+  const isRTL = language === 'he';
+  const guest = data?.profile;
+  const totalGames =
+    (data?.gameSessions.length || 0) +
+    (data?.wordHuntAttempts.length || 0) +
+    (data?.dailyPuzzleAttempts.length || 0);
+
+  return (
+    <div className={cn(
+      'flex-1 flex flex-col w-full overflow-x-hidden min-h-screen',
+      isDarkMode ? 'bg-neo-navy' : 'bg-linear-to-br from-blue-50 via-white to-purple-50',
+      isRTL && 'rtl',
+    )}>
+      <Header />
+
+      <div className="flex flex-1">
+        <AdminSidebar />
+
+        <main className="flex-1 min-w-0 px-4 py-6 sm:px-6 lg:px-8 pb-20 sm:pb-6">
+          <div className="flex items-center gap-4 mb-6">
+            <Link
+              href={`/${language}/admin/guests`}
+              className="text-slate-400 hover:text-neo-white"
+            >
+              <ArrowLeft className="w-5 h-5" />
+            </Link>
+            <div>
+              <h1 className={cn('text-2xl font-bold font-mono', isDarkMode ? 'text-white' : 'text-gray-900')}>
+                {sessionId.slice(0, 12)}…
+              </h1>
+              <p className="text-sm text-slate-500">Guest player detail</p>
+            </div>
+          </div>
+
+          {loading ? (
+            <div className="flex justify-center py-12"><Loader size="lg" /></div>
+          ) : !guest ? (
+            <Card><CardContent className="p-6 text-slate-500">Guest session not found.</CardContent></Card>
+          ) : (
+            <div className="space-y-6">
+              {/* Profile card */}
+              <Card>
+                <CardContent className="p-6 space-y-4">
+                  <div className="flex flex-wrap items-center gap-3">
+                    {guest.converted_at || guest.user_id ? (
+                      <span className="inline-flex items-center gap-1 text-sm bg-neo-lime/20 text-neo-lime px-2 py-1 rounded">
+                        <CheckCircle2 className="w-4 h-4" /> Converted
+                        {guest.user_id && (
+                          <Link
+                            href={`/${language}/admin/players/${guest.user_id}`}
+                            className="ms-2 underline"
+                          >
+                            view profile
+                          </Link>
+                        )}
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 text-sm bg-slate-600/30 text-slate-400 px-2 py-1 rounded">
+                        <XCircle className="w-4 h-4" /> Not converted
+                      </span>
+                    )}
+                    {guest.country && (
+                      <span className="text-sm">
+                        {countryToFlag(guest.country)} {guest.country}
+                      </span>
+                    )}
+                    {guest.device_type && (
+                      <span className="inline-flex items-center gap-1 text-sm text-slate-400">
+                        {(guest.device_type || '').toLowerCase().match(/mobile|phone|android|ios/) ? (
+                          <Smartphone className="w-4 h-4" />
+                        ) : (
+                          <Monitor className="w-4 h-4" />
+                        )}
+                        {guest.device_type}
+                        {guest.browser && <span className="text-slate-500">· {guest.browser}</span>}
+                      </span>
+                    )}
+                  </div>
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                    <Field label="Session ID" value={guest.session_id} mono />
+                    <Field label="Language" value={guest.language || '—'} />
+                    <Field
+                      label="First visit"
+                      value={new Date(guest.first_visit_at).toLocaleString()}
+                    />
+                    <Field
+                      label="Last visit"
+                      value={new Date(guest.last_visit_at).toLocaleString()}
+                    />
+                    <Field label="UTM source" value={guest.utm_source || '—'} />
+                    <Field label="UTM medium" value={guest.utm_medium || '—'} />
+                    <Field label="UTM campaign" value={guest.utm_campaign || '—'} />
+                    <Field
+                      label="Referrer"
+                      value={guest.referrer || '—'}
+                      title={guest.referrer || undefined}
+                      truncate
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Activity summary */}
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                <SummaryCard label="Total games" value={totalGames} icon={<Gamepad2 className="w-4 h-4" />} />
+                <SummaryCard
+                  label="Multiplayer / single"
+                  value={data?.gameSessions.length || 0}
+                  icon={<Gamepad2 className="w-4 h-4" />}
+                />
+                <SummaryCard
+                  label="Word Hunt"
+                  value={data?.wordHuntAttempts.length || 0}
+                  icon={<Target className="w-4 h-4" />}
+                />
+                <SummaryCard
+                  label="Daily challenge"
+                  value={data?.dailyPuzzleAttempts.length || 0}
+                  icon={<Puzzle className="w-4 h-4" />}
+                />
+              </div>
+
+              {/* Game sessions */}
+              {data?.gameSessions && data.gameSessions.length > 0 && (
+                <SectionTable title="Boggle / multiplayer sessions" icon={<Gamepad2 className="w-4 h-4" />}>
+                  <table className="w-full text-sm">
+                    <thead className="text-xs text-slate-400 uppercase">
+                      <tr className="border-b border-slate-700">
+                        <th className="text-left py-2">Time</th>
+                        <th className="text-left py-2">Mode</th>
+                        <th className="text-left py-2">Lang</th>
+                        <th className="text-right py-2">Score</th>
+                        <th className="text-right py-2">Words</th>
+                        <th className="text-right py-2">Duration</th>
+                        <th className="text-left py-2">Room</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.gameSessions.map((s) => (
+                        <tr key={s.id} className="border-b border-slate-800/50">
+                          <td className="py-2 whitespace-nowrap">
+                            {new Date(s.started_at).toLocaleString()}
+                          </td>
+                          <td className="py-2">
+                            {s.mode}
+                            {s.is_first_game && (
+                              <span className="ms-1 text-xs text-neo-lime">★ first</span>
+                            )}
+                          </td>
+                          <td className="py-2">{s.language}</td>
+                          <td className="py-2 text-right font-mono">{s.score}</td>
+                          <td className="py-2 text-right font-mono">{s.words_found?.length ?? 0}</td>
+                          <td className="py-2 text-right">{formatDuration(s.duration_seconds)}</td>
+                          <td className="py-2 font-mono text-xs">{s.room_code || 'solo'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </SectionTable>
+              )}
+
+              {/* Word hunt */}
+              {data?.wordHuntAttempts && data.wordHuntAttempts.length > 0 && (
+                <SectionTable title="Word Hunt attempts" icon={<Target className="w-4 h-4" />}>
+                  <table className="w-full text-sm">
+                    <thead className="text-xs text-slate-400 uppercase">
+                      <tr className="border-b border-slate-700">
+                        <th className="text-left py-2">Time</th>
+                        <th className="text-left py-2">Lang</th>
+                        <th className="text-right py-2">Puzzle #</th>
+                        <th className="text-left py-2">Target</th>
+                        <th className="text-right py-2">Attempts</th>
+                        <th className="text-right py-2">Solved</th>
+                        <th className="text-right py-2">Score</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.wordHuntAttempts.map((a) => (
+                        <tr key={a.id} className="border-b border-slate-800/50">
+                          <td className="py-2 whitespace-nowrap">
+                            {new Date(a.created_at).toLocaleString()}
+                          </td>
+                          <td className="py-2">{a.language}</td>
+                          <td className="py-2 text-right font-mono">{a.puzzle_number}</td>
+                          <td className="py-2 font-mono">{a.target_word}</td>
+                          <td className="py-2 text-right font-mono">{a.attempts_used}</td>
+                          <td className="py-2 text-right">
+                            {a.solved ? (
+                              <CheckCircle2 className="w-4 h-4 inline text-neo-lime" />
+                            ) : (
+                              <XCircle className="w-4 h-4 inline text-slate-500" />
+                            )}
+                          </td>
+                          <td className="py-2 text-right font-mono">{a.efficiency_score}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </SectionTable>
+              )}
+
+              {/* Daily puzzle */}
+              {data?.dailyPuzzleAttempts && data.dailyPuzzleAttempts.length > 0 && (
+                <SectionTable title="Daily challenge attempts" icon={<Puzzle className="w-4 h-4" />}>
+                  <table className="w-full text-sm">
+                    <thead className="text-xs text-slate-400 uppercase">
+                      <tr className="border-b border-slate-700">
+                        <th className="text-left py-2">Time</th>
+                        <th className="text-left py-2">Lang</th>
+                        <th className="text-right py-2">Puzzle #</th>
+                        <th className="text-right py-2">Score</th>
+                        <th className="text-right py-2">Words</th>
+                        <th className="text-right py-2">Duration</th>
+                        <th className="text-left py-2">Longest</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.dailyPuzzleAttempts.map((a) => (
+                        <tr key={a.id} className="border-b border-slate-800/50">
+                          <td className="py-2 whitespace-nowrap">
+                            {new Date(a.completed_at).toLocaleString()}
+                          </td>
+                          <td className="py-2">{a.language}</td>
+                          <td className="py-2 text-right font-mono">{a.puzzle_number}</td>
+                          <td className="py-2 text-right font-mono">{a.score}</td>
+                          <td className="py-2 text-right font-mono">{a.word_count}</td>
+                          <td className="py-2 text-right">{formatDuration(a.time_seconds)}</td>
+                          <td className="py-2 font-mono text-xs">{a.longest_word || '—'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </SectionTable>
+              )}
+
+              {totalGames === 0 && (
+                <Card>
+                  <CardContent className="p-6 text-slate-500 text-center">
+                    This guest visited but never completed a game.
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+          )}
+        </main>
+      </div>
+
+      <AdminBottomNav />
+    </div>
+  );
+}
+
+function Field({
+  label, value, mono, truncate, title,
+}: { label: string; value: string; mono?: boolean; truncate?: boolean; title?: string }) {
+  return (
+    <div>
+      <div className="text-xs text-slate-400 uppercase">{label}</div>
+      <div
+        className={cn(
+          'text-sm',
+          mono && 'font-mono',
+          truncate && 'truncate',
+        )}
+        title={title}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({ label, value, icon }: { label: string; value: number; icon?: React.ReactNode }) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="text-xs text-slate-400 uppercase inline-flex items-center gap-1">
+          {icon}
+          {label}
+        </div>
+        <div className="text-2xl font-bold">{value.toLocaleString()}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SectionTable({
+  title, icon, children,
+}: { title: string; icon?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <h3 className="text-sm font-bold mb-3 inline-flex items-center gap-2">
+          {icon}
+          {title}
+        </h3>
+        <div className="overflow-x-auto">{children}</div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/fe-next/app/[locale]/admin/guests/[sessionId]/page.tsx
+++ b/fe-next/app/[locale]/admin/guests/[sessionId]/page.tsx
@@ -1,0 +1,5 @@
+import GuestDetailPageClient from './PageClient';
+
+export default function GuestDetailPage() {
+  return <GuestDetailPageClient />;
+}

--- a/fe-next/app/[locale]/admin/guests/page.tsx
+++ b/fe-next/app/[locale]/admin/guests/page.tsx
@@ -1,0 +1,5 @@
+import GuestsPageClient from './PageClient';
+
+export default function GuestsPage() {
+  return <GuestsPageClient />;
+}

--- a/fe-next/app/api/admin/game-logs/route.ts
+++ b/fe-next/app/api/admin/game-logs/route.ts
@@ -42,7 +42,34 @@ interface GameSessionRow {
   final_rank: number | null;
   duration_seconds: number | null;
   started_at: string;
+  completed_at: string | null;
   completed: boolean | null;
+  difficulty: string | null;
+  device_type: string | null;
+  browser: string | null;
+  country: string | null;
+  referrer_source: string | null;
+  is_first_game: boolean | null;
+  player_count: number | null;
+  tokens_earned: number | null;
+  tokens_spent: number | null;
+  clues_used: number | null;
+  life_gained: number | null;
+}
+
+interface GuestSessionRow {
+  session_id: string;
+  device_type: string | null;
+  browser: string | null;
+  country: string | null;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  referrer: string | null;
+  first_visit_at: string;
+  last_visit_at: string;
+  user_id: string | null;
+  linked_at: string | null;
 }
 
 interface WordHuntAttemptRow {
@@ -198,7 +225,19 @@ export async function GET(request: NextRequest) {
           final_rank,
           duration_seconds,
           started_at,
-          completed
+          completed_at,
+          completed,
+          difficulty,
+          device_type,
+          browser,
+          country,
+          referrer_source,
+          is_first_game,
+          player_count,
+          tokens_earned,
+          tokens_spent,
+          clues_used,
+          life_gained
         `, { count: 'exact' })
         .is('user_id', null)
         .not('guest_session_id', 'is', null)
@@ -232,28 +271,65 @@ export async function GET(request: NextRequest) {
           // Don't fail the whole request if guest query fails
         } else {
           guestCount = gCount || 0;
+          const guestSessionRows = ((guestData as unknown as GameSessionRow[]) || []);
+
+          // Pull acquisition metadata (utm + referrer) for these guest sessions in one query
+          const sessionIds = guestSessionRows
+            .map((g) => g.guest_session_id)
+            .filter((id): id is string => Boolean(id));
+          const guestMetaBySessionId: Record<string, GuestSessionRow> = {};
+          if (sessionIds.length > 0) {
+            const { data: guestMetaData } = await supabase
+              .from('guest_sessions')
+              .select('session_id, device_type, browser, country, utm_source, utm_medium, utm_campaign, referrer, first_visit_at, last_visit_at, user_id, linked_at')
+              .in('session_id', sessionIds);
+            ((guestMetaData as unknown as GuestSessionRow[]) || []).forEach((row) => {
+              guestMetaBySessionId[row.session_id] = row;
+            });
+          }
+
           // Transform guest games to match the expected format
-          guestGames = ((guestData as unknown as GameSessionRow[]) || []).map((session) => ({
-            id: session.id,
-            player_id: null,
-            guest_session_id: session.guest_session_id,
-            game_code: session.room_code || 'solo',
-            score: session.score || 0,
-            word_count: Array.isArray(session.words_found) ? session.words_found.length : 0,
-            longest_word: Array.isArray(session.words_found) && session.words_found.length > 0
-              ? session.words_found.reduce<string>((longest, w) =>
-                  (w.word?.length || 0) > (longest.length || 0) ? (w.word ?? longest) : longest, ''
-                )
-              : null,
-            placement: session.final_rank,
-            is_ranked: false,
-            is_guest: true,
-            mode: session.mode,
-            language: session.language,
-            time_played: session.duration_seconds || 0,
-            created_at: session.started_at,
-            profiles: null,
-          }));
+          guestGames = guestSessionRows.map((session) => {
+            const meta = session.guest_session_id ? guestMetaBySessionId[session.guest_session_id] : undefined;
+            return {
+              id: session.id,
+              player_id: null,
+              guest_session_id: session.guest_session_id,
+              game_code: session.room_code || 'solo',
+              score: session.score || 0,
+              word_count: Array.isArray(session.words_found) ? session.words_found.length : 0,
+              longest_word: Array.isArray(session.words_found) && session.words_found.length > 0
+                ? session.words_found.reduce<string>((longest, w) =>
+                    (w.word?.length || 0) > (longest.length || 0) ? (w.word ?? longest) : longest, ''
+                  )
+                : null,
+              placement: session.final_rank,
+              is_ranked: false,
+              is_guest: true,
+              mode: session.mode,
+              language: session.language,
+              time_played: session.duration_seconds || 0,
+              created_at: session.started_at,
+              completed_at: session.completed_at,
+              profiles: null,
+              difficulty: session.difficulty,
+              device_type: session.device_type ?? meta?.device_type ?? null,
+              browser: session.browser ?? meta?.browser ?? null,
+              country: session.country ?? meta?.country ?? null,
+              referrer_source: session.referrer_source ?? meta?.referrer ?? null,
+              utm_source: meta?.utm_source ?? null,
+              utm_medium: meta?.utm_medium ?? null,
+              utm_campaign: meta?.utm_campaign ?? null,
+              is_first_game: session.is_first_game ?? false,
+              player_count: session.player_count ?? null,
+              tokens_earned: session.tokens_earned ?? 0,
+              tokens_spent: session.tokens_spent ?? 0,
+              clues_used: session.clues_used ?? 0,
+              life_gained: session.life_gained ?? 0,
+              guest_first_visit_at: meta?.first_visit_at ?? null,
+              guest_last_visit_at: meta?.last_visit_at ?? null,
+            };
+          });
         }
       }
     }

--- a/fe-next/app/api/admin/guests/[sessionId]/route.ts
+++ b/fe-next/app/api/admin/guests/[sessionId]/route.ts
@@ -1,0 +1,90 @@
+/**
+ * API Route: /api/admin/guests/[sessionId]
+ * Returns full detail for one guest session: profile metadata + recent games
+ * across all game types.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyAdminAuth } from '@/lib/auth/adminAuth';
+import { getSupabaseAdmin } from '@/lib/admin/server';
+
+interface RouteContext {
+  params: Promise<{ sessionId: string }>;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const authResult = await verifyAdminAuth(request);
+    if (!authResult.success) {
+      return authResult.response!;
+    }
+
+    const supabase = getSupabaseAdmin();
+    if (!supabase) {
+      return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+    }
+
+    const { sessionId } = await context.params;
+    if (!sessionId) {
+      return NextResponse.json({ error: 'Missing sessionId' }, { status: 400 });
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('guest_sessions')
+      .select(
+        'session_id, device_type, browser, language, utm_source, utm_medium, utm_campaign, referrer, country, first_visit_at, last_visit_at, user_id, linked_at, created_at',
+      )
+      .eq('session_id', sessionId)
+      .maybeSingle();
+
+    if (profileError) {
+      console.error('[admin/guests/:id] profile error', profileError);
+      return NextResponse.json({ error: profileError.message }, { status: 500 });
+    }
+
+    const [
+      { data: gsData },
+      { data: whData },
+      { data: dpData },
+    ] = await Promise.all([
+      supabase
+        .from('game_sessions')
+        .select(
+          'id, mode, language, score, words_found, room_code, final_rank, duration_seconds, started_at, completed_at, completed, difficulty, device_type, browser, country, referrer_source, is_first_game, player_count, tokens_earned, tokens_spent, clues_used',
+        )
+        .eq('guest_session_id', sessionId)
+        .order('started_at', { ascending: false })
+        .limit(200),
+      supabase
+        .from('daily_word_hunt_attempts')
+        .select(
+          'id, language, puzzle_number, solved, attempts_used, target_word, words_discovered, efficiency_score, completed_at, created_at',
+        )
+        .eq('guest_fingerprint', sessionId)
+        .order('created_at', { ascending: false })
+        .limit(200),
+      supabase
+        .from('daily_puzzle_attempts')
+        .select(
+          'id, puzzle_number, language, score, word_count, time_seconds, longest_word, completed_at',
+        )
+        .eq('guest_fingerprint', sessionId)
+        .order('completed_at', { ascending: false })
+        .limit(200),
+    ]);
+
+    return NextResponse.json({
+      success: true,
+      profile: profile ?? { session_id: sessionId, missing: true },
+      gameSessions: gsData || [],
+      wordHuntAttempts: whData || [],
+      dailyPuzzleAttempts: dpData || [],
+    });
+  } catch (error) {
+    console.error('[admin/guests/:id] error', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/fe-next/app/api/admin/guests/__tests__/route.test.ts
+++ b/fe-next/app/api/admin/guests/__tests__/route.test.ts
@@ -1,0 +1,219 @@
+import { vi, type Mock, describe, beforeEach, it, expect } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextRequest: class MockNextRequest {
+    url: string;
+    headers = { get: () => null };
+    constructor(url: string) {
+      this.url = url;
+    }
+  },
+  NextResponse: {
+    json: vi.fn((data: unknown, init?: { status?: number }) => ({
+      json: () => Promise.resolve(data),
+      status: init?.status || 200,
+    })),
+  },
+}));
+
+vi.mock('@/lib/auth/adminAuth', () => ({
+  verifyAdminAuth: vi.fn(),
+}));
+
+vi.mock('@/lib/admin/server', () => ({
+  getSupabaseAdmin: vi.fn(),
+}));
+
+import { GET } from '../route';
+import { NextRequest } from 'next/server';
+import { verifyAdminAuth } from '@/lib/auth/adminAuth';
+import { getSupabaseAdmin } from '@/lib/admin/server';
+
+const mockVerifyAdminAuth = verifyAdminAuth as Mock;
+const mockGetSupabaseAdmin = getSupabaseAdmin as Mock;
+
+function buildSupabaseMock(rows: {
+  guest_sessions?: unknown[];
+  game_sessions?: unknown[];
+  daily_word_hunt_attempts?: unknown[];
+  daily_puzzle_attempts?: unknown[];
+}) {
+  const tableState: Record<string, { data: unknown[]; error: null }> = {
+    guest_sessions: { data: rows.guest_sessions || [], error: null },
+    game_sessions: { data: rows.game_sessions || [], error: null },
+    daily_word_hunt_attempts: { data: rows.daily_word_hunt_attempts || [], error: null },
+    daily_puzzle_attempts: { data: rows.daily_puzzle_attempts || [], error: null },
+  };
+
+  function makeQuery(table: string) {
+    const result = tableState[table];
+    const builder: Record<string, unknown> = {
+      select: vi.fn(() => builder),
+      eq: vi.fn(() => builder),
+      neq: vi.fn(() => builder),
+      is: vi.fn(() => builder),
+      not: vi.fn(() => builder),
+      in: vi.fn(() => builder),
+      gte: vi.fn(() => builder),
+      lte: vi.fn(() => builder),
+      or: vi.fn(() => builder),
+      order: vi.fn(() => builder),
+      // limit() is the awaited terminator for our queries
+      limit: vi.fn(() => Promise.resolve(result)),
+      // Allow direct await after select chain (no limit) for fallback
+      then: (resolve: (v: unknown) => void) => resolve(result),
+    };
+    return builder;
+  }
+
+  return {
+    from: vi.fn((table: string) => makeQuery(table)),
+  };
+}
+
+describe('GET /api/admin/guests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockVerifyAdminAuth.mockResolvedValueOnce({
+      success: false,
+      response: {
+        json: () => Promise.resolve({ error: 'Unauthorized' }),
+        status: 401,
+      },
+    });
+
+    const request = new NextRequest('http://localhost/api/admin/guests') as unknown as import('next/server').NextRequest;
+    const response = await GET(request);
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 500 when database not configured', async () => {
+    mockVerifyAdminAuth.mockResolvedValueOnce({ success: true });
+    mockGetSupabaseAdmin.mockReturnValueOnce(null);
+
+    const request = new NextRequest('http://localhost/api/admin/guests') as unknown as import('next/server').NextRequest;
+    const response = await GET(request);
+    expect(response.status).toBe(500);
+  });
+
+  it('aggregates per-guest stats across all game tables', async () => {
+    mockVerifyAdminAuth.mockResolvedValueOnce({ success: true });
+
+    const guestRow = {
+      session_id: 'guest-abc',
+      device_type: 'mobile',
+      browser: 'Chrome',
+      language: 'en',
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'launch',
+      referrer: 'https://google.com/',
+      country: 'US',
+      first_visit_at: '2026-05-01T10:00:00Z',
+      last_visit_at: '2026-05-09T12:00:00Z',
+      user_id: null,
+      linked_at: null,
+      created_at: '2026-05-01T10:00:00Z',
+    };
+
+    mockGetSupabaseAdmin.mockReturnValueOnce(
+      buildSupabaseMock({
+        guest_sessions: [guestRow],
+        game_sessions: [
+          {
+            guest_session_id: 'guest-abc',
+            score: 100,
+            duration_seconds: 60,
+            words_found: [{ word: 'cat' }, { word: 'house' }],
+            mode: 'singleplayer',
+            language: 'en',
+            started_at: '2026-05-09T11:00:00Z',
+            completed: true,
+          },
+        ],
+        daily_word_hunt_attempts: [
+          {
+            guest_fingerprint: 'guest-abc',
+            efficiency_score: 50,
+            language: 'en',
+            solved: true,
+            created_at: '2026-05-09T11:30:00Z',
+          },
+        ],
+        daily_puzzle_attempts: [
+          {
+            guest_fingerprint: 'guest-abc',
+            score: 200,
+            word_count: 5,
+            language: 'en',
+            completed_at: '2026-05-09T12:00:00Z',
+          },
+        ],
+      }),
+    );
+
+    const request = new NextRequest('http://localhost/api/admin/guests') as unknown as import('next/server').NextRequest;
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.guests).toHaveLength(1);
+    const guest = body.guests[0];
+    expect(guest.session_id).toBe('guest-abc');
+    expect(guest.total_games).toBe(3);
+    expect(guest.multiplayer_games).toBe(1);
+    expect(guest.word_hunt_games).toBe(1);
+    expect(guest.daily_challenge_games).toBe(1);
+    expect(guest.total_score).toBe(350);
+    expect(guest.total_words).toBe(7); // 2 from game_sessions + 5 from daily puzzle
+    expect(guest.longest_word).toBe('house');
+    expect(guest.utm_source).toBe('google');
+    expect(guest.country).toBe('US');
+    expect(guest.converted).toBe(false);
+
+    expect(body.stats.totalGuests).toBe(1);
+    expect(body.stats.guestsWhoPlayed).toBe(1);
+    expect(body.stats.totalGames).toBe(3);
+    expect(body.stats.convertedGuests).toBe(0);
+  });
+
+  it('marks guest as converted when user_id is set', async () => {
+    mockVerifyAdminAuth.mockResolvedValueOnce({ success: true });
+    mockGetSupabaseAdmin.mockReturnValueOnce(
+      buildSupabaseMock({
+        guest_sessions: [
+          {
+            session_id: 'guest-converted',
+            device_type: null,
+            browser: null,
+            language: 'en',
+            utm_source: null,
+            utm_medium: null,
+            utm_campaign: null,
+            referrer: null,
+            country: null,
+            first_visit_at: '2026-05-01T10:00:00Z',
+            last_visit_at: '2026-05-09T12:00:00Z',
+            user_id: 'user-123',
+            linked_at: '2026-05-05T10:00:00Z',
+            created_at: '2026-05-01T10:00:00Z',
+          },
+        ],
+      }),
+    );
+
+    const request = new NextRequest('http://localhost/api/admin/guests') as unknown as import('next/server').NextRequest;
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(body.guests[0].converted).toBe(true);
+    expect(body.guests[0].converted_user_id).toBe('user-123');
+    expect(body.guests[0].converted_at).toBe('2026-05-05T10:00:00Z');
+    expect(body.stats.convertedGuests).toBe(1);
+    expect(body.stats.conversionRate).toBe(1);
+  });
+});

--- a/fe-next/app/api/admin/guests/route.ts
+++ b/fe-next/app/api/admin/guests/route.ts
@@ -1,0 +1,352 @@
+/**
+ * API Route: /api/admin/guests
+ * Admin endpoint for listing guest (unauthenticated) players with aggregated
+ * game history and acquisition metadata. Powers the admin "Guests" view.
+ *
+ * Pulls from:
+ *   - guest_sessions (acquisition + device info)
+ *   - game_sessions (multiplayer/singleplayer history)
+ *   - daily_word_hunt_attempts, daily_puzzle_attempts (daily content)
+ *
+ * Aggregates per-guest counts so admins can see total games, total score,
+ * conversion status, last activity, and acquisition source.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyAdminAuth } from '@/lib/auth/adminAuth';
+import { getSupabaseAdmin } from '@/lib/admin/server';
+
+interface GuestSessionRow {
+  session_id: string;
+  device_type: string | null;
+  browser: string | null;
+  language: string | null;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  referrer: string | null;
+  country: string | null;
+  first_visit_at: string;
+  last_visit_at: string;
+  user_id: string | null;
+  linked_at: string | null;
+  created_at: string;
+}
+
+interface GuestGameSessionRow {
+  guest_session_id: string | null;
+  score: number | null;
+  duration_seconds: number | null;
+  words_found: { word?: string; length?: number }[] | null;
+  mode: string | null;
+  language: string | null;
+  started_at: string;
+  completed: boolean | null;
+}
+
+interface GuestDailyHuntRow {
+  guest_fingerprint: string | null;
+  efficiency_score: number | null;
+  language: string | null;
+  solved: boolean | null;
+  created_at: string;
+}
+
+interface GuestDailyPuzzleRow {
+  guest_fingerprint: string | null;
+  score: number | null;
+  word_count: number | null;
+  language: string | null;
+  completed_at: string;
+}
+
+export interface GuestPlayerSummary {
+  session_id: string;
+  device_type: string | null;
+  browser: string | null;
+  country: string | null;
+  language: string | null;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  referrer: string | null;
+  first_visit_at: string;
+  last_visit_at: string;
+  last_activity_at: string;
+  converted: boolean;
+  converted_user_id: string | null;
+  converted_at: string | null;
+  total_games: number;
+  multiplayer_games: number;
+  word_hunt_games: number;
+  daily_challenge_games: number;
+  total_score: number;
+  total_words: number;
+  total_time_played: number;
+  longest_word: string | null;
+  languages: string[];
+}
+
+const ALLOWED_SORT_COLUMNS = new Set([
+  'last_activity_at',
+  'first_visit_at',
+  'total_games',
+  'total_score',
+]);
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await verifyAdminAuth(request);
+    if (!authResult.success) {
+      return authResult.response!;
+    }
+
+    const supabase = getSupabaseAdmin();
+    if (!supabase) {
+      return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1'));
+    const pageSize = Math.min(200, Math.max(1, parseInt(searchParams.get('pageSize') || '25')));
+    const sortByRaw = searchParams.get('sortBy') || 'last_activity_at';
+    const sortBy = ALLOWED_SORT_COLUMNS.has(sortByRaw) ? sortByRaw : 'last_activity_at';
+    const sortOrder = searchParams.get('sortOrder') === 'asc' ? 'asc' : 'desc';
+    const country = searchParams.get('country');
+    const utmSource = searchParams.get('utmSource');
+    const conversionRaw = searchParams.get('converted');
+    const converted: 'all' | 'yes' | 'no' =
+      conversionRaw === 'yes' ? 'yes' : conversionRaw === 'no' ? 'no' : 'all';
+    const startDate = searchParams.get('startDate');
+    const endDate = searchParams.get('endDate');
+    const search = searchParams.get('search')?.trim() || '';
+    const minGames = parseInt(searchParams.get('minGames') || '0') || 0;
+
+    // Pull guest sessions (the "guest profiles") with filters
+    let sessionQuery = supabase
+      .from('guest_sessions')
+      .select(
+        'session_id, device_type, browser, language, utm_source, utm_medium, utm_campaign, referrer, country, first_visit_at, last_visit_at, user_id, linked_at, created_at',
+      );
+
+    if (country && country !== 'all') {
+      sessionQuery = sessionQuery.eq('country', country.toUpperCase());
+    }
+    if (utmSource && utmSource !== 'all') {
+      sessionQuery = sessionQuery.eq('utm_source', utmSource);
+    }
+    if (converted === 'yes') {
+      sessionQuery = sessionQuery.not('user_id', 'is', null);
+    } else if (converted === 'no') {
+      sessionQuery = sessionQuery.is('user_id', null);
+    }
+    if (startDate) {
+      sessionQuery = sessionQuery.gte('first_visit_at', startDate);
+    }
+    if (endDate) {
+      sessionQuery = sessionQuery.lte('first_visit_at', `${endDate}T23:59:59.999Z`);
+    }
+    if (search) {
+      // Match by session_id prefix or country code
+      sessionQuery = sessionQuery.or(
+        `session_id.ilike.%${search}%,country.ilike.%${search}%,utm_source.ilike.%${search}%`,
+      );
+    }
+
+    sessionQuery = sessionQuery.order('last_visit_at', { ascending: false }).limit(2000);
+
+    const { data: sessionsData, error: sessionsError } = await sessionQuery;
+    if (sessionsError) {
+      console.error('[admin/guests] guest_sessions query error:', sessionsError);
+      return NextResponse.json({ error: sessionsError.message }, { status: 500 });
+    }
+    const sessions = (sessionsData as GuestSessionRow[]) || [];
+    const sessionIds = sessions.map((s) => s.session_id);
+
+    // Aggregate game stats per guest_session_id across the three tables
+    type Aggregate = {
+      total_games: number;
+      multiplayer_games: number;
+      word_hunt_games: number;
+      daily_challenge_games: number;
+      total_score: number;
+      total_words: number;
+      total_time_played: number;
+      longest_word: string | null;
+      last_activity_at: string;
+      languages: Set<string>;
+    };
+    const aggregates: Record<string, Aggregate> = {};
+    const ensure = (id: string): Aggregate => {
+      if (!aggregates[id]) {
+        aggregates[id] = {
+          total_games: 0,
+          multiplayer_games: 0,
+          word_hunt_games: 0,
+          daily_challenge_games: 0,
+          total_score: 0,
+          total_words: 0,
+          total_time_played: 0,
+          longest_word: null,
+          last_activity_at: '1970-01-01T00:00:00Z',
+          languages: new Set<string>(),
+        };
+      }
+      return aggregates[id];
+    };
+
+    if (sessionIds.length > 0) {
+      // Multiplayer / singleplayer game_sessions
+      const { data: gsData } = await supabase
+        .from('game_sessions')
+        .select('guest_session_id, score, duration_seconds, words_found, mode, language, started_at, completed')
+        .in('guest_session_id', sessionIds)
+        .eq('completed', true)
+        .limit(50000);
+      ((gsData as GuestGameSessionRow[]) || []).forEach((row) => {
+        if (!row.guest_session_id) return;
+        const agg = ensure(row.guest_session_id);
+        agg.total_games += 1;
+        agg.multiplayer_games += 1;
+        agg.total_score += row.score || 0;
+        agg.total_time_played += row.duration_seconds || 0;
+        if (Array.isArray(row.words_found)) {
+          agg.total_words += row.words_found.length;
+          for (const w of row.words_found) {
+            const wl = w?.word ?? '';
+            if (wl && wl.length > (agg.longest_word?.length ?? 0)) {
+              agg.longest_word = wl;
+            }
+          }
+        }
+        if (row.language) agg.languages.add(row.language);
+        if (row.started_at > agg.last_activity_at) agg.last_activity_at = row.started_at;
+      });
+
+      // Daily Word Hunt
+      const { data: whData } = await supabase
+        .from('daily_word_hunt_attempts')
+        .select('guest_fingerprint, efficiency_score, language, solved, created_at')
+        .in('guest_fingerprint', sessionIds)
+        .limit(50000);
+      ((whData as GuestDailyHuntRow[]) || []).forEach((row) => {
+        if (!row.guest_fingerprint) return;
+        const agg = ensure(row.guest_fingerprint);
+        agg.total_games += 1;
+        agg.word_hunt_games += 1;
+        agg.total_score += row.efficiency_score || 0;
+        if (row.language) agg.languages.add(row.language);
+        if (row.created_at > agg.last_activity_at) agg.last_activity_at = row.created_at;
+      });
+
+      // Daily Puzzle
+      const { data: dpData } = await supabase
+        .from('daily_puzzle_attempts')
+        .select('guest_fingerprint, score, word_count, language, completed_at')
+        .in('guest_fingerprint', sessionIds)
+        .limit(50000);
+      ((dpData as GuestDailyPuzzleRow[]) || []).forEach((row) => {
+        if (!row.guest_fingerprint) return;
+        const agg = ensure(row.guest_fingerprint);
+        agg.total_games += 1;
+        agg.daily_challenge_games += 1;
+        agg.total_score += row.score || 0;
+        agg.total_words += row.word_count || 0;
+        if (row.language) agg.languages.add(row.language);
+        if (row.completed_at > agg.last_activity_at) agg.last_activity_at = row.completed_at;
+      });
+    }
+
+    // Build summary list
+    const summaries: GuestPlayerSummary[] = sessions.map((s) => {
+      const agg = aggregates[s.session_id];
+      const lastActivity = agg && agg.last_activity_at !== '1970-01-01T00:00:00Z'
+        ? agg.last_activity_at
+        : s.last_visit_at;
+      return {
+        session_id: s.session_id,
+        device_type: s.device_type,
+        browser: s.browser,
+        country: s.country,
+        language: s.language,
+        utm_source: s.utm_source,
+        utm_medium: s.utm_medium,
+        utm_campaign: s.utm_campaign,
+        referrer: s.referrer,
+        first_visit_at: s.first_visit_at,
+        last_visit_at: s.last_visit_at,
+        last_activity_at: lastActivity,
+        converted: Boolean(s.user_id),
+        converted_user_id: s.user_id,
+        converted_at: s.linked_at,
+        total_games: agg?.total_games ?? 0,
+        multiplayer_games: agg?.multiplayer_games ?? 0,
+        word_hunt_games: agg?.word_hunt_games ?? 0,
+        daily_challenge_games: agg?.daily_challenge_games ?? 0,
+        total_score: agg?.total_score ?? 0,
+        total_words: agg?.total_words ?? 0,
+        total_time_played: agg?.total_time_played ?? 0,
+        longest_word: agg?.longest_word ?? null,
+        languages: agg ? Array.from(agg.languages) : [],
+      };
+    });
+
+    // Filter by minGames
+    const filtered = minGames > 0
+      ? summaries.filter((s) => s.total_games >= minGames)
+      : summaries;
+
+    // Sort
+    const ascending = sortOrder === 'asc';
+    filtered.sort((a, b) => {
+      const va = a[sortBy as keyof GuestPlayerSummary];
+      const vb = b[sortBy as keyof GuestPlayerSummary];
+      if (typeof va === 'number' && typeof vb === 'number') {
+        return ascending ? va - vb : vb - va;
+      }
+      const da = new Date(String(va ?? 0)).getTime();
+      const db = new Date(String(vb ?? 0)).getTime();
+      return ascending ? da - db : db - da;
+    });
+
+    // Top-line stats
+    const totalGuests = filtered.length;
+    const convertedCount = filtered.reduce((acc, s) => acc + (s.converted ? 1 : 0), 0);
+    const playedCount = filtered.reduce((acc, s) => acc + (s.total_games > 0 ? 1 : 0), 0);
+    const totalGames = filtered.reduce((acc, s) => acc + s.total_games, 0);
+    const totalScore = filtered.reduce((acc, s) => acc + s.total_score, 0);
+    const conversionRate = totalGuests > 0 ? convertedCount / totalGuests : 0;
+
+    // Paginate
+    const start = (page - 1) * pageSize;
+    const guests = filtered.slice(start, start + pageSize);
+    const totalPages = Math.max(1, Math.ceil(totalGuests / pageSize));
+
+    return NextResponse.json({
+      success: true,
+      guests,
+      pagination: {
+        page,
+        pageSize,
+        totalCount: totalGuests,
+        totalPages,
+        hasNextPage: page < totalPages,
+        hasPrevPage: page > 1,
+      },
+      stats: {
+        totalGuests,
+        convertedGuests: convertedCount,
+        guestsWhoPlayed: playedCount,
+        totalGames,
+        totalScore,
+        conversionRate,
+      },
+    });
+  } catch (error) {
+    console.error('[admin/guests] Error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/fe-next/components/admin/GuestManager.tsx
+++ b/fe-next/components/admin/GuestManager.tsx
@@ -1,0 +1,428 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  Search, ChevronLeft, ChevronRight, Smartphone, Monitor,
+  CheckCircle2, XCircle, Globe, Clock, Trophy, Gamepad2, Target,
+} from 'lucide-react';
+import Link from 'next/link';
+import toast from 'react-hot-toast';
+import { Loader } from '@/components/ui/Loader';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { cn } from '@/lib/utils';
+
+interface GuestPlayerSummary {
+  session_id: string;
+  device_type: string | null;
+  browser: string | null;
+  country: string | null;
+  language: string | null;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  referrer: string | null;
+  first_visit_at: string;
+  last_visit_at: string;
+  last_activity_at: string;
+  converted: boolean;
+  converted_user_id: string | null;
+  converted_at: string | null;
+  total_games: number;
+  multiplayer_games: number;
+  word_hunt_games: number;
+  daily_challenge_games: number;
+  total_score: number;
+  total_words: number;
+  total_time_played: number;
+  longest_word: string | null;
+  languages: string[];
+}
+
+interface GuestsResponse {
+  success: boolean;
+  guests: GuestPlayerSummary[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPrevPage: boolean;
+  };
+  stats: {
+    totalGuests: number;
+    convertedGuests: number;
+    guestsWhoPlayed: number;
+    totalGames: number;
+    totalScore: number;
+    conversionRate: number;
+  };
+}
+
+const COUNTRY_FLAG_OFFSET = 0x1f1a5;
+function countryToFlag(code?: string | null): string {
+  if (!code || code.length !== 2) return '';
+  const upper = code.toUpperCase();
+  return String.fromCodePoint(
+    upper.charCodeAt(0) + COUNTRY_FLAG_OFFSET,
+    upper.charCodeAt(1) + COUNTRY_FLAG_OFFSET,
+  );
+}
+
+function formatRelative(dateString: string): string {
+  const d = new Date(dateString).getTime();
+  const diff = Date.now() - d;
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const days = Math.floor(h / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(dateString).toLocaleDateString();
+}
+
+function formatDuration(seconds: number): string {
+  if (!seconds) return '0s';
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  return `${hours}h ${mins % 60}m`;
+}
+
+export function GuestManager({ authToken }: { authToken: string }) {
+  const { t, language } = useLanguage();
+  const [data, setData] = useState<GuestsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [country, setCountry] = useState('');
+  const [utmSource, setUtmSource] = useState('');
+  const [converted, setConverted] = useState<'all' | 'yes' | 'no'>('all');
+  const [minGames, setMinGames] = useState('0');
+  const [sortBy, setSortBy] = useState<'last_activity_at' | 'first_visit_at' | 'total_games' | 'total_score'>('last_activity_at');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [page, setPage] = useState(1);
+  const pageSize = 25;
+
+  const fetchGuests = useCallback(async () => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams();
+      params.set('page', page.toString());
+      params.set('pageSize', pageSize.toString());
+      params.set('sortBy', sortBy);
+      params.set('sortOrder', sortOrder);
+      if (searchQuery.trim()) params.set('search', searchQuery.trim());
+      if (country.trim()) params.set('country', country.trim().toUpperCase());
+      if (utmSource.trim()) params.set('utmSource', utmSource.trim());
+      if (converted !== 'all') params.set('converted', converted);
+      if (minGames.trim() && Number(minGames) > 0) params.set('minGames', minGames.trim());
+
+      const response = await fetch(`/api/admin/guests?${params.toString()}`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      if (!response.ok) throw new Error('Failed to fetch guests');
+      const json: GuestsResponse = await response.json();
+      setData(json);
+    } catch (err) {
+      console.error('Error fetching guests:', err);
+      toast.error('Failed to load guest players');
+    } finally {
+      setLoading(false);
+    }
+  }, [authToken, page, sortBy, sortOrder, searchQuery, country, utmSource, converted, minGames]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      fetchGuests();
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [fetchGuests]);
+
+  // Reset to page 1 when filters change
+  const resetPageEffect = useMemo(
+    () => `${searchQuery}|${country}|${utmSource}|${converted}|${minGames}|${sortBy}|${sortOrder}`,
+    [searchQuery, country, utmSource, converted, minGames, sortBy, sortOrder],
+  );
+  useEffect(() => {
+    setPage(1);
+  }, [resetPageEffect]);
+
+  const guests = data?.guests || [];
+  const stats = data?.stats;
+  const total = data?.pagination?.totalCount || 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Stats summary */}
+      {stats && (
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+          <Card>
+            <CardContent className="p-4">
+              <div className="text-xs text-slate-400 uppercase">Guests</div>
+              <div className="text-2xl font-bold">{stats.totalGuests.toLocaleString()}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <div className="text-xs text-slate-400 uppercase">Played</div>
+              <div className="text-2xl font-bold text-blue-500">{stats.guestsWhoPlayed.toLocaleString()}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <div className="text-xs text-slate-400 uppercase">Games</div>
+              <div className="text-2xl font-bold">{stats.totalGames.toLocaleString()}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <div className="text-xs text-slate-400 uppercase">Converted</div>
+              <div className="text-2xl font-bold text-neo-lime">
+                {stats.convertedGuests.toLocaleString()}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <div className="text-xs text-slate-400 uppercase">Conv. Rate</div>
+              <div className="text-2xl font-bold text-amber-500">
+                {(stats.conversionRate * 100).toFixed(1)}%
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-3 bg-white dark:bg-slate-800 text-black dark:text-white p-3 rounded-lg shadow-xs">
+        <div className="col-span-2 md:col-span-2 relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <Input
+            placeholder="Search session ID, country, source…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Input
+          placeholder="Country (IL, US)"
+          value={country}
+          maxLength={3}
+          onChange={(e) => setCountry(e.target.value)}
+        />
+        <Input
+          placeholder="UTM source"
+          value={utmSource}
+          onChange={(e) => setUtmSource(e.target.value)}
+        />
+        <Select value={converted} onValueChange={(v) => setConverted(v as typeof converted)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Conversion" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="yes">Converted only</SelectItem>
+            <SelectItem value="no">Not converted</SelectItem>
+          </SelectContent>
+        </Select>
+        <Input
+          type="number"
+          min={0}
+          placeholder="Min games"
+          value={minGames}
+          onChange={(e) => setMinGames(e.target.value)}
+        />
+      </div>
+
+      {/* Sort */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-slate-400">Sort:</span>
+        <Select value={sortBy} onValueChange={(v) => setSortBy(v as typeof sortBy)}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="last_activity_at">Last activity</SelectItem>
+            <SelectItem value="first_visit_at">First visit</SelectItem>
+            <SelectItem value="total_games">Games played</SelectItem>
+            <SelectItem value="total_score">Total score</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => setSortOrder((p) => (p === 'asc' ? 'desc' : 'asc'))}
+          title={sortOrder === 'asc' ? 'Ascending' : 'Descending'}
+        >
+          {sortOrder === 'asc' ? '↑' : '↓'}
+        </Button>
+        <span className="ms-auto text-sm text-slate-500">{total.toLocaleString()} guests</span>
+      </div>
+
+      {/* List */}
+      {loading && guests.length === 0 ? (
+        <div className="flex justify-center py-12"><Loader size="md" /></div>
+      ) : guests.length === 0 ? (
+        <div className="text-center py-12 text-slate-500">No guest players found.</div>
+      ) : (
+        <div className="space-y-3">
+          {guests.map((g) => {
+            const flag = countryToFlag(g.country);
+            const isMobile = (g.device_type || '').toLowerCase().match(/mobile|phone|android|ios/);
+            const sessionShort = g.session_id.slice(0, 8);
+            return (
+              <Card key={g.session_id} className="hover:shadow-md transition-shadow">
+                <CardContent className="p-4">
+                  <div className="flex flex-col lg:flex-row gap-4 items-start lg:items-center justify-between">
+                    {/* Left: identity + acquisition */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Link
+                          href={`/${language}/admin/guests/${g.session_id}`}
+                          className="font-mono text-base font-bold hover:text-neo-cyan transition-colors"
+                        >
+                          {sessionShort}
+                        </Link>
+                        {g.converted ? (
+                          <span className="inline-flex items-center gap-1 text-xs bg-neo-lime/20 text-neo-lime px-2 py-0.5 rounded">
+                            <CheckCircle2 className="w-3 h-3" />
+                            Converted
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-xs bg-slate-600/30 text-slate-400 px-2 py-0.5 rounded">
+                            <XCircle className="w-3 h-3" />
+                            Guest
+                          </span>
+                        )}
+                        {flag && (
+                          <span className="text-sm" title={g.country ?? undefined}>
+                            {flag} {g.country}
+                          </span>
+                        )}
+                        {g.device_type && (
+                          <span
+                            className="inline-flex items-center gap-1 text-xs text-slate-500"
+                            title={`${g.device_type}${g.browser ? ` · ${g.browser}` : ''}`}
+                          >
+                            {isMobile ? <Smartphone className="w-3 h-3" /> : <Monitor className="w-3 h-3" />}
+                            {g.device_type}
+                            {g.browser && <span className="text-slate-600">· {g.browser}</span>}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500 mt-1.5">
+                        <span className="inline-flex items-center gap-1">
+                          <Clock className="w-3 h-3" />
+                          First visit {formatRelative(g.first_visit_at)}
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <Clock className="w-3 h-3" />
+                          Last seen {formatRelative(g.last_activity_at)}
+                        </span>
+                        {(g.utm_source || g.referrer) && (
+                          <span className="inline-flex items-center gap-1 max-w-[300px] truncate">
+                            <Globe className="w-3 h-3" />
+                            {g.utm_source ? (
+                              <span title={`utm_source=${g.utm_source}${g.utm_medium ? `, utm_medium=${g.utm_medium}` : ''}${g.utm_campaign ? `, utm_campaign=${g.utm_campaign}` : ''}`}>
+                                {g.utm_source}
+                                {g.utm_medium ? ` / ${g.utm_medium}` : ''}
+                              </span>
+                            ) : (
+                              <span title={g.referrer ?? undefined}>{g.referrer}</span>
+                            )}
+                          </span>
+                        )}
+                        {g.languages.length > 0 && (
+                          <span className="text-xs">{g.languages.join(', ')}</span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Right: stats */}
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-2 w-full lg:w-auto">
+                      <Stat label="Games" value={g.total_games} icon={<Gamepad2 className="w-3 h-3" />} />
+                      <Stat label="Score" value={g.total_score} highlight="text-blue-500" icon={<Trophy className="w-3 h-3" />} />
+                      <Stat label="Words" value={g.total_words} />
+                      <Stat label="Time" value={formatDuration(g.total_time_played)} icon={<Clock className="w-3 h-3" />} />
+                      {g.multiplayer_games > 0 && (
+                        <Stat label="MP" value={g.multiplayer_games} icon={<Gamepad2 className="w-3 h-3" />} />
+                      )}
+                      {g.word_hunt_games > 0 && (
+                        <Stat label="Hunt" value={g.word_hunt_games} icon={<Target className="w-3 h-3" />} />
+                      )}
+                      {g.daily_challenge_games > 0 && (
+                        <Stat label="Daily" value={g.daily_challenge_games} />
+                      )}
+                      {g.longest_word && (
+                        <Stat label="Longest" value={g.longest_word} highlight="text-amber-500" />
+                      )}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {total > pageSize && (
+        <div className="flex justify-between items-center bg-white dark:bg-slate-800 text-black dark:text-white p-4 rounded-lg shadow-xs">
+          <span className="text-sm text-slate-500">
+            Showing {(page - 1) * pageSize + 1}-{Math.min(page * pageSize, total)} of {total}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1 || loading}
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={!data?.pagination.hasNextPage || loading}
+            >
+              <ChevronRight className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  highlight,
+  icon,
+}: {
+  label: string;
+  value: string | number;
+  highlight?: string;
+  icon?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center sm:items-end">
+      <span className="text-xs text-slate-400 uppercase inline-flex items-center gap-1">
+        {icon}
+        {label}
+      </span>
+      <span className={cn('font-mono font-bold text-sm', highlight)}>{value}</span>
+    </div>
+  );
+}

--- a/fe-next/components/admin/sidebar/AdminBottomNav.tsx
+++ b/fe-next/components/admin/sidebar/AdminBottomNav.tsx
@@ -10,6 +10,7 @@ import {
   ShieldAlert,
   BookOpen,
   Users,
+  UserX,
   Settings,
   Gamepad2,
 } from 'lucide-react';
@@ -43,6 +44,7 @@ export function AdminBottomNav({ moderationCount = 0 }: AdminBottomNavProps) {
     { key: 'moderation', icon: ShieldAlert, label: t('admin.sidebar.moderation'), path: '/moderation', badge: moderationCount },
     { key: 'content', icon: BookOpen, label: t('admin.sidebar.content'), path: '/content' },
     { key: 'players', icon: Users, label: t('admin.sidebar.players'), path: '/players' },
+    { key: 'guests', icon: UserX, label: t('admin.sidebar.guests'), path: '/guests' },
     { key: 'system', icon: Settings, label: t('admin.sidebar.system'), path: '/system' },
     { key: 'word-craft', icon: Gamepad2, label: t('admin.sidebar.wordCraft'), path: '/word-craft' },
   ];

--- a/fe-next/components/admin/sidebar/AdminSidebar.tsx
+++ b/fe-next/components/admin/sidebar/AdminSidebar.tsx
@@ -9,6 +9,7 @@ import {
   ShieldAlert,
   BookOpen,
   Users,
+  UserX,
   Settings,
   Gamepad2,
 } from 'lucide-react';
@@ -36,6 +37,7 @@ export function AdminSidebar({ moderationCount = 0 }: AdminSidebarProps) {
     { key: 'moderation', labelKey: 'admin.sidebar.moderation', icon: ShieldAlert, path: '/moderation', badge: moderationCount },
     { key: 'content', labelKey: 'admin.sidebar.content', icon: BookOpen, path: '/content' },
     { key: 'players', labelKey: 'admin.sidebar.players', icon: Users, path: '/players' },
+    { key: 'guests', labelKey: 'admin.sidebar.guests', icon: UserX, path: '/guests' },
     { key: 'system', labelKey: 'admin.sidebar.system', icon: Settings, path: '/system' },
     { key: 'word-craft', labelKey: 'admin.sidebar.wordCraft', icon: Gamepad2, path: '/word-craft' },
   ];

--- a/fe-next/components/admin/today-games/components/GameRow.tsx
+++ b/fe-next/components/admin/today-games/components/GameRow.tsx
@@ -2,10 +2,30 @@
 
 import React from 'react';
 import { motion } from 'framer-motion';
-import { Clock, User, Crown, Gamepad2 } from 'lucide-react';
+import { Clock, User, Crown, Gamepad2, Smartphone, Monitor, Sparkles } from 'lucide-react';
 import type { UnifiedGame } from '../types';
 import { LANGUAGE_FLAGS, GAME_TYPE_ICONS, formatDuration, formatTime } from '../constants';
 import { PlayerAvatar } from './PlayerAvatar';
+
+const COUNTRY_FLAG_OFFSET = 0x1f1a5;
+function countryToFlag(code?: string | null): string {
+  if (!code || code.length !== 2) return '';
+  const upper = code.toUpperCase();
+  return String.fromCodePoint(
+    upper.charCodeAt(0) + COUNTRY_FLAG_OFFSET,
+    upper.charCodeAt(1) + COUNTRY_FLAG_OFFSET,
+  );
+}
+
+function formatReferrer(value?: string | null): string | null {
+  if (!value) return null;
+  if (!/^https?:\/\//i.test(value)) return value;
+  try {
+    return new URL(value).hostname.replace(/^www\./, '');
+  } catch {
+    return value;
+  }
+}
 
 interface GameRowProps {
   game: UnifiedGame;
@@ -40,6 +60,22 @@ export function GameRow({ game, t }: GameRowProps) {
     game.profiles?.username ||
     (game.is_guest ? t('admin.todayGames.guest') : 'Unknown');
 
+  const guestSessionShort = game.guest_session_id
+    ? game.guest_session_id.slice(0, 8)
+    : null;
+
+  const countryFlag = countryToFlag(game.country);
+  const acquisitionSource =
+    game.utm_source ||
+    formatReferrer(game.referrer_source) ||
+    (game.is_guest ? 'direct' : null);
+
+  const isMobile =
+    game.device_type?.toLowerCase().includes('mobile') ||
+    game.device_type?.toLowerCase().includes('phone') ||
+    game.device_type?.toLowerCase().includes('android') ||
+    game.device_type?.toLowerCase().includes('ios');
+
   return (
     <motion.tr
       layout
@@ -55,22 +91,63 @@ export function GameRow({ game, t }: GameRowProps) {
         </div>
       </td>
       <td className="px-2 sm:px-4 py-3">
-        <div className="flex items-center gap-2">
-          {game.is_guest ? (
-            <User className="w-4 h-4 text-slate-400" />
-          ) : game.placement === 1 ? (
-            <Crown className="w-4 h-4 text-neo-lime" />
-          ) : (
-            <PlayerAvatar
-              customAvatar={game.profiles?.avatar_config}
-              userId={game.player_id || undefined}
-            />
-          )}
-          <span className="text-sm text-neo-white truncate max-w-[120px]">{playerName}</span>
+        <div className="flex flex-col gap-0.5">
+          <div className="flex items-center gap-2">
+            {game.is_guest ? (
+              <User className="w-4 h-4 text-slate-400" />
+            ) : game.placement === 1 ? (
+              <Crown className="w-4 h-4 text-neo-lime" />
+            ) : (
+              <PlayerAvatar
+                customAvatar={game.profiles?.avatar_config}
+                userId={game.player_id || undefined}
+              />
+            )}
+            <span className="text-sm text-neo-white truncate max-w-[120px]">{playerName}</span>
+            {game.is_guest && (
+              <span className="text-xs bg-slate-600 text-slate-300 px-1.5 py-0.5 rounded">
+                {t('admin.todayGames.guest')}
+              </span>
+            )}
+            {game.is_first_game && (
+              <span
+                className="inline-flex items-center gap-1 text-xs bg-neo-lime/20 text-neo-lime px-1.5 py-0.5 rounded"
+                title={t('admin.todayGames.firstGame')}
+              >
+                <Sparkles className="w-3 h-3" />
+                {t('admin.todayGames.first')}
+              </span>
+            )}
+          </div>
           {game.is_guest && (
-            <span className="text-xs bg-slate-600 text-slate-300 px-1.5 py-0.5 rounded">
-              {t('admin.todayGames.guest')}
-            </span>
+            <div className="flex items-center gap-2 ms-6 text-[11px] text-slate-500">
+              {guestSessionShort && (
+                <span className="font-mono" title={game.guest_session_id ?? undefined}>
+                  {guestSessionShort}
+                </span>
+              )}
+              {countryFlag && (
+                <span title={game.country ?? undefined}>{countryFlag}</span>
+              )}
+              {game.device_type && (
+                <span
+                  className="inline-flex items-center gap-1"
+                  title={`${game.device_type}${game.browser ? ` · ${game.browser}` : ''}`}
+                >
+                  {isMobile ? (
+                    <Smartphone className="w-3 h-3" />
+                  ) : (
+                    <Monitor className="w-3 h-3" />
+                  )}
+                  {game.device_type}
+                </span>
+              )}
+              {acquisitionSource && (
+                <span className="truncate max-w-[120px]" title={acquisitionSource}>
+                  via {acquisitionSource}
+                </span>
+              )}
+            </div>
           )}
         </div>
       </td>

--- a/fe-next/components/admin/today-games/types.ts
+++ b/fe-next/components/admin/today-games/types.ts
@@ -23,9 +23,27 @@ export interface UnifiedGame {
   language: string;
   time_played: number;
   created_at: string;
+  completed_at?: string | null;
   profiles: GameProfile | null;
   drill_type?: string;
   drill_level?: number;
+  // Guest / acquisition metadata (only populated for guests)
+  difficulty?: string | null;
+  device_type?: string | null;
+  browser?: string | null;
+  country?: string | null;
+  referrer_source?: string | null;
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+  is_first_game?: boolean;
+  player_count?: number | null;
+  tokens_earned?: number;
+  tokens_spent?: number;
+  clues_used?: number;
+  life_gained?: number;
+  guest_first_visit_at?: string | null;
+  guest_last_visit_at?: string | null;
 }
 
 // API response structure

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -6700,6 +6700,7 @@ const en = {
       "moderation": "Moderation",
       "content": "Content",
       "players": "Players",
+      "guests": "Guests",
       "system": "System",
       "wordCraft": "WordCraft"
     },
@@ -6931,6 +6932,8 @@ const en = {
       "ranked": "Ranked",
       "casual": "Casual",
       "guest": "Guest",
+      "first": "First",
+      "firstGame": "First game from this guest",
       "noGames": "No games today yet",
       "noGamesHint": "Games will appear here as players start playing",
       "showing": "Showing",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -6636,6 +6636,7 @@ const es = {
       "moderation": "Moderación",
       "content": "Contenido",
       "players": "Jugadores",
+      "guests": "Invitados",
       "system": "Sistema",
       "wordCraft": "WordCraft"
     },
@@ -6726,6 +6727,8 @@ const es = {
       "ranked": "Clasificado",
       "casual": "Casual",
       "guest": "Invitado",
+      "first": "Primero",
+      "firstGame": "Primer juego de este invitado",
       "noGames": "Aún no hay juegos hoy",
       "noGamesHint": "Los juegos aparecerán aquí cuando los jugadores empiecen a jugar",
       "showing": "Mostrando",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -6557,6 +6557,7 @@ const he = {
       "moderation": "מודרציה",
       "content": "תוכן",
       "players": "שחקנים",
+      "guests": "אורחים",
       "system": "מערכת",
       "wordCraft": "וורדקראפט"
     },
@@ -6697,6 +6698,8 @@ const he = {
       "ranked": "מדורג",
       "casual": "רגיל",
       "guest": "אורח",
+      "first": "ראשון",
+      "firstGame": "המשחק הראשון של אורח זה",
       "noGames": "אין עדיין משחקים היום",
       "noGamesHint": "משחקים יופיעו כאן כשהשחקנים יתחילו לשחק",
       "showing": "מציג",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -6683,6 +6683,7 @@ const ja = {
       "moderation": "モデレーション",
       "content": "コンテンツ",
       "players": "プレイヤー",
+      "guests": "ゲスト",
       "system": "システム",
       "wordCraft": "ワードクラフト"
     },
@@ -6773,6 +6774,8 @@ const ja = {
       "ranked": "ランクマッチ",
       "casual": "カジュアル",
       "guest": "ゲスト",
+      "first": "初回",
+      "firstGame": "このゲストの初回プレイ",
       "noGames": "今日はまだゲームがありません",
       "noGamesHint": "プレイヤーがゲームを開始するとここに表示されます",
       "showing": "表示中",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -6594,6 +6594,7 @@ const sv = {
       "moderation": "Moderering",
       "content": "Innehåll",
       "players": "Spelare",
+      "guests": "Gäster",
       "system": "System",
       "wordCraft": "WordCraft"
     },
@@ -6684,6 +6685,8 @@ const sv = {
       "ranked": "Rankad",
       "casual": "Casual",
       "guest": "Gäst",
+      "first": "Första",
+      "firstGame": "Första spelet från denna gäst",
       "noGames": "Inga spel idag ännu",
       "noGamesHint": "Spel visas här när spelare börjar spela",
       "showing": "Visar",


### PR DESCRIPTION
## Summary

The admin dashboard was missing most of the data we already collect for guest (anonymous) players. Today's Games only showed the bare scoreline, and the Players page filtered to registered users only, so there was no way to see who guests were, where they came from, or what they did.

This PR exposes the data that was already in `game_sessions` and `guest_sessions` and adds a dedicated guest management view.

## What changed

### `/api/admin/game-logs` — richer guest rows
Guest rows now include `device_type`, `browser`, `country`, `referrer_source`, `utm_source/medium/campaign`, `is_first_game`, `completed_at`, `difficulty`, `player_count`, `tokens_earned/spent`, `clues_used`, and `life_gained`. The endpoint now joins `guest_sessions` to fill in acquisition metadata that isn't on the game row itself.

### Today's Games table — guest sub-line
Each guest row renders a sub-line under the player name showing:
- Short session id (first 8 chars)
- Country flag
- Device + browser (with mobile/desktop icon)
- Acquisition source (`utm_source`, falling back to referrer host, then `direct`)
- "First" badge when `is_first_game` is set

### New `/admin/guests` page
A dedicated guest management view at `/admin/guests`:
- Top-line stats: total guests, played, total games, converted, conversion rate
- Filters: country, utm source, conversion status, min games, search
- Sort by last activity / first visit / total games / total score
- Per-guest card with device, country, acquisition, languages, and per-game-type counts (multiplayer / word hunt / daily)

### New `/admin/guests/[sessionId]` detail page
Full per-guest history:
- Profile card with all UTM/referrer fields, device, conversion status (linked to player profile if converted)
- Per-game-type tables for `game_sessions`, `daily_word_hunt_attempts`, `daily_puzzle_attempts`

### New API endpoints
- `GET /api/admin/guests` — paginated list with aggregated stats across all three game tables
- `GET /api/admin/guests/[sessionId]` — full detail for one session

### Sidebar / bottom nav
New "Guests" entry between "Players" and "System".

### i18n
Sidebar label and `first/firstGame` strings added to en, he, sv, ja, es.

## Test plan

- [ ] Visit `/admin` and check Today's Games — guest rows show country flag, device, source
- [ ] Visit `/admin/guests` — list loads with stats card; verify filters (country, utm, conversion, min games)
- [ ] Click a guest → detail page shows profile + per-game-type tables
- [ ] If a guest converted, the "Converted" badge links to their player profile
- [ ] Run `vitest run app/api/admin/guests` — guests endpoint tests pass

https://claude.ai/code/session_01GP12vaWm41jLH3DqFyuh5L

---
_Generated by [Claude Code](https://claude.ai/code/session_01GP12vaWm41jLH3DqFyuh5L)_