### PR TITLE
fix(admin): use linked_at on guest detail page to fix build

### DIFF
--- a/fe-next/app/[locale]/admin/guests/[sessionId]/PageClient.tsx
+++ b/fe-next/app/[locale]/admin/guests/[sessionId]/PageClient.tsx
@@ -226,7 +226,7 @@ export default function GuestDetailPageClient() {
               <Card>
                 <CardContent className="p-6 space-y-4">
                   <div className="flex flex-wrap items-center gap-3">
-                    {guest.converted_at || guest.user_id ? (
+                    {guest.linked_at || guest.user_id ? (
                       <span className="inline-flex items-center gap-1 text-sm bg-neo-lime/20 text-neo-lime px-2 py-1 rounded">
                         <CheckCircle2 className="w-4 h-4" /> Converted
                         {guest.user_id && (


### PR DESCRIPTION
## Summary

Build broke after #419 was merged because the guest detail PageClient referenced `guest.converted_at` but the `GuestProfile` interface (and the underlying `guest_sessions` DB column) is named `linked_at`. The list summary endpoint exposes a derived `converted_at` field, but the per-guest detail endpoint returns the raw row.

This one-line fix uses `linked_at` to match the actual interface.

## Build error

```
./app/[locale]/admin/guests/[sessionId]/PageClient.tsx:229:28
Type error: Property 'converted_at' does not exist on type 'GuestProfile'.
```

## Test plan

- [ ] `npm run build` succeeds
- [ ] Visit a converted guest's detail page → "Converted" badge still shows

https://claude.ai/code/session_01GP12vaWm41jLH3DqFyuh5L

---
_Generated by [Claude Code](https://claude.ai/code/session_01GP12vaWm41jLH3DqFyuh5L)_