### PR TITLE
fix(blast/v2): FTUE coach marks no longer cover or block the board

### DIFF
--- a/fe-next/components/blast/v2/BlastBoard.tsx
+++ b/fe-next/components/blast/v2/BlastBoard.tsx
@@ -76,13 +76,19 @@ export function BlastBoard({
     [onPointerDown]
   );
 
+  const cols = level.columns.length;
+  // Scale tile size by column count so the board fills its container snugly
+  // regardless of grid width (3 cols = chunky tiles; 6 cols = compact).
+  const tileSize = `min(calc((100% - ${(cols - 1) * 8 + 24}px) / ${cols}), ${Math.round(88 - Math.max(0, cols - 4) * 6)}px)`;
+
   return (
     <div
       ref={boardRef}
       dir={dir}
       data-shake-key={invalidShakeKey}
       data-testid="blast-board"
-      className="relative flex items-end justify-center gap-2 p-4 touch-none"
+      className="relative mx-auto flex items-end justify-center gap-2 px-3 pb-3 pt-2 touch-none"
+      style={{ ['--blast-tile-size' as string]: tileSize }}
       onPointerUp={onPointerUp}
       onPointerMove={handleBoardPointerMove}
     >

--- a/fe-next/components/blast/v2/BlastFtueOverlay.tsx
+++ b/fe-next/components/blast/v2/BlastFtueOverlay.tsx
@@ -7,46 +7,49 @@ type Props = {
   onComplete: () => void;
   isVeteran?: boolean;
   onStepChange?: (step: number) => void;
+  selectionActive?: boolean;
+  wordsFoundCount?: number;
+  levelComplete?: boolean;
 };
 
 type FtueStep = 1 | 2 | 3 | 4 | 5 | 6;
 
-export function BlastFtueOverlay({ onComplete, isVeteran, onStepChange }: Props) {
+export function BlastFtueOverlay({
+  onComplete,
+  isVeteran,
+  onStepChange,
+  selectionActive = false,
+  wordsFoundCount = 0,
+  levelComplete = false,
+}: Props) {
   const { t } = useLanguage();
   const reducedMotion = useReducedMotion();
   const [step, setStep] = useState<FtueStep>(1);
-  const [skipTimeout, setSkipTimeout] = useState(false);
 
   useEffect(() => onStepChange?.(step), [step, onStepChange]);
 
-  const handleDragStart = () => {
-    if (step === 1) setStep(2);
-  };
+  // Step 2: advance when the user starts dragging on the board.
+  useEffect(() => {
+    if (step === 2 && selectionActive) setStep(3);
+  }, [step, selectionActive]);
 
-  const handleWordFound = () => {
-    if (step === 2) {
-      setStep(3);
-      setSkipTimeout(true);
-      const timeout = setTimeout(() => {
-        setStep(4);
-        setSkipTimeout(false);
-      }, 2000);
-      return;
-    }
-    if (step === 4) {
-      setStep(5);
-      return;
-    }
-    if (step === 5) {
-      setStep(6);
-    }
-  };
+  // Step 3 → 4: brief acknowledgement of cascade animation.
+  useEffect(() => {
+    if (step !== 3) return;
+    const id = setTimeout(() => setStep(4), 1800);
+    return () => clearTimeout(id);
+  }, [step]);
 
-  const handleLevelComplete = () => {
-    if (step === 6) {
-      onComplete();
-    }
-  };
+  // Step 4+: advance with words found.
+  useEffect(() => {
+    if (step === 4 && wordsFoundCount >= 1) setStep(5);
+    if (step === 5 && wordsFoundCount >= 2) setStep(6);
+  }, [step, wordsFoundCount]);
+
+  // Step 6: complete on level done.
+  useEffect(() => {
+    if (step === 6 && levelComplete) onComplete();
+  }, [step, levelComplete, onComplete]);
 
   if (isVeteran) {
     return (
@@ -78,146 +81,89 @@ export function BlastFtueOverlay({ onComplete, isVeteran, onStepChange }: Props)
     );
   }
 
+  // Step 1 is a full-screen modal: blocks the board, dismissed by tap.
+  // Steps 2–6 are coach marks at the top of the screen with pointer-events-none
+  // on the backdrop so the player can interact with the board underneath.
   return (
-    <AnimatePresence mode="wait">
+    <AnimatePresence>
       {step === 1 && (
         <motion.div
           key="step-1"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          onPointerDown={handleDragStart}
-          className="fixed inset-0 flex items-center justify-center bg-black/75 z-50"
+          onPointerDown={() => setStep(2)}
+          className="fixed inset-0 flex items-center justify-center bg-black/75 z-50 px-6"
         >
-          <div className="space-y-4 text-center">
-            <div className="text-white text-lg">
+          <div className="space-y-5 text-center max-w-sm">
+            <div className="text-white text-xl font-bold">
               {t('blast.tutorial.ftue.step1', 'Drag across letters to spell a word')}
             </div>
-            <svg className="w-12 h-12 mx-auto" viewBox="0 0 24 24">
-              <path d="M3 12h18M12 3v18" stroke="white" strokeWidth="2" />
+            <svg className="w-14 h-14 mx-auto" viewBox="0 0 24 24" fill="none">
+              <path d="M3 12h18M12 3v18" stroke="white" strokeWidth="2" strokeLinecap="round" />
             </svg>
+            <div className="text-white/70 text-sm">
+              {t('blast.tutorial.ftue.step1.cta', 'Tap to begin')}
+            </div>
           </div>
         </motion.div>
       )}
 
-      {step === 2 && (
+      {step >= 2 && step <= 6 && (
         <motion.div
-          key="step-2"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
+          key={`coach-${step}`}
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0 }}
-          className="fixed inset-0 flex items-center justify-center bg-black/75 z-50"
+          data-testid={`ftue-coach-step-${step}`}
+          className="pointer-events-none fixed inset-x-0 top-20 z-50 flex justify-center px-4"
         >
-          <div className="space-y-4 text-center text-white">
-            <div className="text-lg">
-              {t('blast.tutorial.ftue.step2', 'Try it: drag from C to T')}
-            </div>
-            {reducedMotion !== true && (
-              <motion.svg
-                className="w-16 h-16 mx-auto"
-                viewBox="0 0 100 100"
-                animate={{ opacity: [0.5, 1, 0.5] }}
-                transition={{ duration: 2, repeat: Infinity }}
-              >
-                <path d="M 20 50 Q 50 30, 80 50" stroke="white" strokeWidth="3" fill="none" />
-              </motion.svg>
+          <div className="pointer-events-auto bg-[#0b1530]/95 border-2 border-white/20 rounded-xl px-4 py-3 max-w-[20rem] text-center text-white shadow-lg space-y-1">
+            {step === 2 && (
+              <>
+                <div className="text-sm font-semibold">
+                  {t('blast.tutorial.ftue.step2', 'Try it: drag from C to T')}
+                </div>
+                <div className="text-xs text-white/70">
+                  {t('blast.tutorial.ftue.step2.hint', 'Letters must be adjacent')}
+                </div>
+              </>
             )}
-          </div>
-        </motion.div>
-      )}
-
-      {step === 3 && (
-        <motion.div
-          key="step-3"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          className="fixed inset-0 flex items-center justify-center bg-black/75 z-50"
-        >
-          <div className="space-y-4 text-center text-white">
-            <div className="text-lg">
-              {t('blast.tutorial.ftue.step3', 'Letters above fall to fill the space')}
-            </div>
-            <div className="text-xs opacity-70">
-              {reducedMotion !== true
-                ? t('blast.tutorial.ftue.step3.hint', 'Watch the animation')
-                : t('blast.tutorial.ftue.step3.hint', 'Letters fall down')}
-            </div>
-            {skipTimeout && (
-              <motion.div
-                animate={{ scale: [1, 1.1, 1] }}
-                transition={{ duration: 0.3 }}
-              >
-                ✓
-              </motion.div>
+            {step === 3 && (
+              <div className="text-sm font-semibold">
+                {t('blast.tutorial.ftue.step3', 'Letters above fall to fill the space')}
+              </div>
             )}
-          </div>
-        </motion.div>
-      )}
-
-      {step === 4 && (
-        <motion.div
-          key="step-4"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          className="fixed inset-0 flex items-center justify-center bg-black/75 z-50"
-        >
-          <div className="space-y-4 text-center text-white">
-            <div className="text-lg font-bold">
-              {t('blast.tutorial.ftue.step4', 'Find 3 ANIMAL words')}
-            </div>
-            <div className="flex justify-center gap-2">
-              <span className="text-2xl">●</span>
-              <span className="text-2xl opacity-30">○</span>
-              <span className="text-2xl opacity-30">○</span>
-            </div>
-          </div>
-        </motion.div>
-      )}
-
-      {step === 5 && (
-        <motion.div
-          key="step-5"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          className="fixed inset-0 flex items-center justify-center bg-black/75 z-50"
-        >
-          <div className="space-y-4 text-center text-white">
-            <div className="text-lg">
-              {t('blast.tutorial.ftue.step5', 'Or tap each letter, double-tap to confirm')}
-            </div>
-            {reducedMotion !== true && (
-              <motion.svg
-                className="w-16 h-16 mx-auto"
-                viewBox="0 0 100 100"
-                animate={{ scale: [1, 1.2, 1] }}
-                transition={{ duration: 0.8, repeat: Infinity }}
-              >
-                <circle cx="50" cy="50" r="20" fill="white" opacity="0.5" />
-              </motion.svg>
+            {step === 4 && (
+              <>
+                <div className="text-sm font-semibold">
+                  {t('blast.tutorial.ftue.step4', 'Find 3 ANIMAL words')}
+                </div>
+                <div className="flex justify-center gap-1 pt-1" aria-hidden>
+                  <span className="text-base">●</span>
+                  <span className="text-base opacity-30">○</span>
+                  <span className="text-base opacity-30">○</span>
+                </div>
+              </>
             )}
-          </div>
-        </motion.div>
-      )}
-
-      {step === 6 && (
-        <motion.div
-          key="step-6"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          onClick={handleLevelComplete}
-          className="fixed inset-0 flex items-center justify-center bg-black/75 z-50"
-        >
-          <div className="space-y-4 text-center text-white">
-            <div className="text-2xl font-bold">
-              {t('blast.tutorial.ftue.step6', 'Level 1! Watch your chest bar →')}
-            </div>
-            <div className="text-sm opacity-70">
-              {t('blast.tutorial.ftue.step6.hint', 'Tap to continue')}
-            </div>
+            {step === 5 && (
+              <div className="text-sm font-semibold">
+                {t('blast.tutorial.ftue.step5', 'Or tap each letter, double-tap to confirm')}
+              </div>
+            )}
+            {step === 6 && (
+              <div className="text-sm font-semibold">
+                {t('blast.tutorial.ftue.step6', 'Level 1! Watch your chest bar →')}
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={onComplete}
+              data-testid="ftue-skip"
+              className="mt-1 text-[11px] text-white/60 underline underline-offset-2 hover:text-white"
+            >
+              {t('blast.tutorial.ftue.skip', 'Skip tutorial')}
+            </button>
           </div>
         </motion.div>
       )}

--- a/fe-next/components/blast/v2/BlastFtueOverlay.tsx
+++ b/fe-next/components/blast/v2/BlastFtueOverlay.tsx
@@ -103,7 +103,7 @@ export function BlastFtueOverlay({
               <path d="M3 12h18M12 3v18" stroke="white" strokeWidth="2" strokeLinecap="round" />
             </svg>
             <div className="text-white/70 text-sm">
-              {t('blast.tutorial.ftue.step1.cta', 'Tap to begin')}
+              {t('blast.tutorial.ftue.step1Cta', 'Tap to begin')}
             </div>
           </div>
         </motion.div>
@@ -125,7 +125,7 @@ export function BlastFtueOverlay({
                   {t('blast.tutorial.ftue.step2', 'Try it: drag from C to T')}
                 </div>
                 <div className="text-xs text-white/70">
-                  {t('blast.tutorial.ftue.step2.hint', 'Letters must be adjacent')}
+                  {t('blast.tutorial.ftue.step2Hint', 'Letters must be adjacent')}
                 </div>
               </>
             )}

--- a/fe-next/components/blast/v2/BlastGame.tsx
+++ b/fe-next/components/blast/v2/BlastGame.tsx
@@ -199,7 +199,7 @@ export function BlastGame({
   }
 
   return (
-    <div className="min-h-screen bg-[#0b1530] text-white">
+    <div className="min-h-screen flex flex-col bg-[#0b1530] text-white">
       {tutorial.showFtueOverlay && (
         <BlastFtueOverlay
           onComplete={handleFtueComplete}
@@ -227,10 +227,13 @@ export function BlastGame({
           /* Plan 5 wires hints */
         }}
       />
-      <div className="relative flex items-center justify-center px-4 py-6 sm:py-10">
+      <div className="relative flex flex-1 items-center justify-center px-3 py-4 min-h-[60vh]">
         <BlastAtmosphereOverlay modeColor={modeColor} />
         <BlastFxOverlay />
-        <div className="w-full max-w-[560px]" style={{ containerType: 'inline-size' }}>
+        <div
+          className="relative w-full max-w-[460px]"
+          style={{ containerType: 'inline-size' }}
+        >
           <BlastBoard
             level={state.level}
             selection={state.selection}

--- a/fe-next/components/blast/v2/BlastGame.tsx
+++ b/fe-next/components/blast/v2/BlastGame.tsx
@@ -160,6 +160,15 @@ export function BlastGame({
     }
   }, [state.status, progressState.chestProgress, showChestModal]);
 
+  // Persist FTUE-completed flag when level finishes while overlay is still up
+  // (e.g. player completes the level before reaching step 6).
+  useEffect(() => {
+    if (state.status === 'levelComplete' && tutorial.showFtueOverlay) {
+      handleFtueComplete();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.status, tutorial.showFtueOverlay]);
+
   if (!introDismissed) {
     return <BlastLevelIntroCard level={level} onDismiss={() => setIntroDismissed(true)} />;
   }
@@ -192,7 +201,12 @@ export function BlastGame({
   return (
     <div className="min-h-screen bg-[#0b1530] text-white">
       {tutorial.showFtueOverlay && (
-        <BlastFtueOverlay onComplete={handleFtueComplete} isVeteran={isVeteranPlayer} />
+        <BlastFtueOverlay
+          onComplete={handleFtueComplete}
+          isVeteran={isVeteranPlayer}
+          selectionActive={state.selection.kind === 'active'}
+          wordsFoundCount={state.foundWords.size}
+        />
       )}
       {tutorial.showUnlockCard && (
         <BlastUnlockCard

--- a/fe-next/components/blast/v2/BlastHud.tsx
+++ b/fe-next/components/blast/v2/BlastHud.tsx
@@ -31,11 +31,19 @@ export function BlastHud({
 
   return (
     <>
-      <div className="flex items-center justify-between px-4 py-2 bg-[#0b1530] text-white">
-        <span data-testid="level-label">
+      <div className="flex items-center justify-between gap-3 px-4 py-3 bg-[#0b1530] text-white border-b border-white/10">
+        <span
+          data-testid="level-label"
+          className="text-sm font-bold uppercase tracking-wide opacity-90"
+        >
           {t('blast.level', `Level ${levelNumber}`, { n: String(levelNumber) })}
         </span>
-        <span data-testid="coin-counter">🪙 {coins}</span>
+        <span
+          data-testid="coin-counter"
+          className="text-sm font-semibold tabular-nums"
+        >
+          🪙 {coins}
+        </span>
         <BlastChestBadge
           chestNumber={chestNumber}
           progress={chestProgress}

--- a/fe-next/components/blast/v2/BlastTile.module.css
+++ b/fe-next/components/blast/v2/BlastTile.module.css
@@ -2,13 +2,13 @@
   position: relative;
   display: grid;
   place-items: center;
-  width: clamp(44px, 11cqi, 64px);
+  width: var(--blast-tile-size, clamp(48px, 18cqi, 88px));
   aspect-ratio: 1 / 1;
   border: 3px solid #0b1530;
-  border-radius: 12px;
+  border-radius: 14px;
   box-shadow: 4px 4px 0 0 #0b1530;
   font-weight: 800;
-  font-size: clamp(18px, 4.5cqi, 28px);
+  font-size: calc(var(--blast-tile-size, 64px) * 0.45);
   color: #0b1530;
   user-select: none;
   touch-action: none;

--- a/fe-next/components/blast/v2/__tests__/BlastFtueOverlay.test.tsx
+++ b/fe-next/components/blast/v2/__tests__/BlastFtueOverlay.test.tsx
@@ -2,88 +2,154 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BlastFtueOverlay } from '../BlastFtueOverlay';
 
-// Mock LanguageContext
 vi.mock('@/contexts/LanguageContext', () => ({
   useLanguage: () => ({
-    t: (key: string, fallback: string) => fallback,
+    t: (_key: string, fallback: string) => fallback,
   }),
 }));
 
 describe('BlastFtueOverlay', () => {
-  it('renders step 1 with arrow and text', () => {
-    const onComplete = vi.fn();
-    render(<BlastFtueOverlay onComplete={onComplete} isVeteran={false} />);
-
+  it('renders step 1 with intro text and dismiss CTA', () => {
+    render(<BlastFtueOverlay onComplete={vi.fn()} isVeteran={false} />);
     expect(screen.getByText('Drag across letters to spell a word')).toBeInTheDocument();
+    expect(screen.getByText('Tap to begin')).toBeInTheDocument();
   });
 
-  it('advances to step 2 on pointerdown', async () => {
-    const onComplete = vi.fn();
+  it('advances to step 2 (coach mark) on pointerdown', async () => {
     const onStepChange = vi.fn();
     render(
-      <BlastFtueOverlay onComplete={onComplete} isVeteran={false} onStepChange={onStepChange} />
+      <BlastFtueOverlay onComplete={vi.fn()} isVeteran={false} onStepChange={onStepChange} />
     );
 
-    const overlay = screen.getByText('Drag across letters to spell a word').closest('div');
-    expect(overlay).toBeInTheDocument();
-
-    if (overlay?.parentElement) {
-      fireEvent.pointerDown(overlay.parentElement);
-    }
+    fireEvent.pointerDown(screen.getByText('Drag across letters to spell a word'));
 
     await waitFor(() => {
       expect(screen.getByText('Try it: drag from C to T')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('ftue-coach-step-2')).toBeInTheDocument();
   });
 
-  it('shows veteran welcome message when isVeteran=true', () => {
-    const onComplete = vi.fn();
-    render(<BlastFtueOverlay onComplete={onComplete} isVeteran={true} />);
-
-    expect(screen.getByText('Welcome back!')).toBeInTheDocument();
-    expect(screen.getByText('Blast has been redesigned. Enjoy the new levels!')).toBeInTheDocument();
+  it('coach mark wrapper is pointer-events-none so the board stays interactive', async () => {
+    render(<BlastFtueOverlay onComplete={vi.fn()} isVeteran={false} />);
+    fireEvent.pointerDown(screen.getByText('Drag across letters to spell a word'));
+    const wrapper = await screen.findByTestId('ftue-coach-step-2');
+    expect(wrapper.className).toContain('pointer-events-none');
   });
 
-  it('calls onComplete when veteran dismisses', async () => {
+  it('advances step 2 → 3 when selectionActive becomes true', async () => {
+    const { rerender } = render(
+      <BlastFtueOverlay onComplete={vi.fn()} isVeteran={false} selectionActive={false} />
+    );
+    fireEvent.pointerDown(screen.getByText('Drag across letters to spell a word'));
+    await screen.findByText('Try it: drag from C to T');
+
+    rerender(<BlastFtueOverlay onComplete={vi.fn()} isVeteran={false} selectionActive={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Letters above fall to fill the space')).toBeInTheDocument();
+    });
+  });
+
+  it('advances step 4 → 5 → 6 as wordsFoundCount increases', async () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = render(
+        <BlastFtueOverlay onComplete={vi.fn()} isVeteran={false} selectionActive={true} />
+      );
+      fireEvent.pointerDown(screen.getByText('Drag across letters to spell a word'));
+      // selectionActive=true → step 3 (cascade hint), auto-advances after 1.8s
+      await waitFor(() =>
+        expect(screen.getByText('Letters above fall to fill the space')).toBeInTheDocument()
+      );
+      vi.advanceTimersByTime(2000);
+      await waitFor(() =>
+        expect(screen.getByText('Find 3 ANIMAL words')).toBeInTheDocument()
+      );
+
+      rerender(
+        <BlastFtueOverlay
+          onComplete={vi.fn()}
+          isVeteran={false}
+          selectionActive={true}
+          wordsFoundCount={1}
+        />
+      );
+      await waitFor(() =>
+        expect(
+          screen.getByText('Or tap each letter, double-tap to confirm')
+        ).toBeInTheDocument()
+      );
+
+      rerender(
+        <BlastFtueOverlay
+          onComplete={vi.fn()}
+          isVeteran={false}
+          selectionActive={true}
+          wordsFoundCount={2}
+        />
+      );
+      await waitFor(() =>
+        expect(screen.getByText('Level 1! Watch your chest bar →')).toBeInTheDocument()
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('calls onComplete at step 6 when levelComplete flips true', async () => {
+    vi.useFakeTimers();
     const onComplete = vi.fn();
-    render(<BlastFtueOverlay onComplete={onComplete} isVeteran={true} />);
+    try {
+      const { rerender } = render(
+        <BlastFtueOverlay
+          onComplete={onComplete}
+          isVeteran={false}
+          selectionActive={true}
+          wordsFoundCount={2}
+        />
+      );
+      fireEvent.pointerDown(screen.getByText('Drag across letters to spell a word'));
+      vi.advanceTimersByTime(2000);
+      await waitFor(() =>
+        expect(screen.getByText('Level 1! Watch your chest bar →')).toBeInTheDocument()
+      );
 
-    const button = screen.getByText("Let's go");
-    fireEvent.click(button);
+      rerender(
+        <BlastFtueOverlay
+          onComplete={onComplete}
+          isVeteran={false}
+          selectionActive={true}
+          wordsFoundCount={2}
+          levelComplete={true}
+        />
+      );
+      await waitFor(() => expect(onComplete).toHaveBeenCalled());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
+  it('skip button dismisses the tutorial', async () => {
+    const onComplete = vi.fn();
+    render(<BlastFtueOverlay onComplete={onComplete} isVeteran={false} />);
+    fireEvent.pointerDown(screen.getByText('Drag across letters to spell a word'));
+    const skip = await screen.findByTestId('ftue-skip');
+    fireEvent.click(skip);
     expect(onComplete).toHaveBeenCalled();
   });
 
-  it('auto-advances from step 3 after 2 seconds', async () => {
-    const onComplete = vi.fn();
-    const onStepChange = vi.fn();
-    render(
-      <BlastFtueOverlay onComplete={onComplete} isVeteran={false} onStepChange={onStepChange} />
-    );
-
-    // Advance to step 2
-    const overlay = screen.getByText('Drag across letters to spell a word').closest('div');
-    if (overlay?.parentElement) {
-      fireEvent.pointerDown(overlay.parentElement);
-    }
-
-    await waitFor(() => {
-      expect(screen.getByText('Try it: drag from C to T')).toBeInTheDocument();
-    });
-
-    // Simulate step progression (this would normally come from parent event)
-    // For this test, we verify the component structure is correct
-    expect(onStepChange).toHaveBeenCalled();
+  it('shows veteran welcome message when isVeteran=true', () => {
+    render(<BlastFtueOverlay onComplete={vi.fn()} isVeteran={true} />);
+    expect(screen.getByText('Welcome back!')).toBeInTheDocument();
+    expect(
+      screen.getByText('Blast has been redesigned. Enjoy the new levels!')
+    ).toBeInTheDocument();
   });
 
-  it('displays step 6 with level complete message', async () => {
+  it('calls onComplete when veteran dismisses', () => {
     const onComplete = vi.fn();
-    const { rerender } = render(
-      <BlastFtueOverlay onComplete={onComplete} isVeteran={false} />
-    );
-
-    // Note: In a real scenario, step progression would be controlled by parent
-    // This test verifies the component can render without errors
-    expect(screen.getByText('Drag across letters to spell a word')).toBeInTheDocument();
+    render(<BlastFtueOverlay onComplete={onComplete} isVeteran={true} />);
+    fireEvent.click(screen.getByText("Let's go"));
+    expect(onComplete).toHaveBeenCalled();
   });
 });

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -8910,6 +8910,24 @@ const en = {
     }
   },
   "blast": {
+    "tutorial": {
+      "ftue": {
+        "skip": "Skip tutorial",
+        "step1": "Drag across letters to spell a word",
+        "step1Cta": "Tap to begin",
+        "step2": "Try it: drag from C to T",
+        "step2Hint": "Letters must be adjacent",
+        "step3": "Letters above fall to fill the space",
+        "step4": "Find 3 ANIMAL words",
+        "step5": "Or tap each letter, double-tap to confirm",
+        "step6": "Level 1! Watch your chest bar →"
+      },
+      "veteran": {
+        "title": "Welcome back!",
+        "body": "Blast has been redesigned. Enjoy the new levels!",
+        "cta": "Let's go"
+      }
+    },
     "continueModal": {
       "title": "Don't stop now!",
       "body": "You're out of moves. Watch a quick ad to keep your run alive.",


### PR DESCRIPTION
## Summary

The Blast v2 FTUE was visually broken and functionally frozen — the
fullscreen `bg-black/75 z-50` overlay darkened the board to dark
olive (see screenshot), the instruction text sat right on top of the
tiles, and pointer events couldn't reach the board so the player
could not actually drag from C to T. The internal step-advance
handlers (`handleWordFound`, etc.) were defined but never invoked
from real gameplay, so the overlay stayed on step 2 forever.

This PR:
- **Step 1** keeps the modal intro with a `Tap to begin` CTA.
- **Steps 2–6** become a top-anchored coach-mark card with
  `pointer-events-none` on the backdrop and `pointer-events-auto`
  only on the card + Skip button, so the player can drag the tiles
  while the hint is visible.
- Drives step transitions from the actual game state via new
  `selectionActive` and `wordsFoundCount` props (selection start
  → step 3, words found → 5 → 6).
- Adds a **Skip tutorial** button visible in every step.
- Drops `AnimatePresence mode="wait"` — in jsdom the exit animation
  never resolves and the next step never mounts (broke the new
  state-machine tests).
- `BlastGame` passes the new props and persists `ftue_completed`
  even if the player finishes level 1 before reaching step 6 (the
  level-complete branch early-returns before the overlay renders,
  so a small `useEffect` handles that case).

## Test plan

- [x] `vitest components/blast/v2/__tests__/` — 14 files / 61 tests green
- [x] `BlastFtueOverlay.test.tsx` — 9 tests covering pointer-events-none
      coach marks, selection-driven step 2→3, word-count driven
      step 4→5→6, and Skip dismissal
- [x] `tsc --noEmit` — clean
- [x] `eslint` on the three changed files — clean
- [ ] Manual: launch Blast level 1, verify board is visible and
      interactive while the coach mark is shown at the top, drag
      C→A→T advances the FTUE, Skip exits the tutorial.


---
_Generated by [Claude Code](https://claude.ai/code/session_014jckPDmz7eJr86mcLkjM5B)_