### PR TITLE
fix(daily): swap primary CTA to back-to-leaderboard when other game is done

### DIFF
--- a/fe-next/components/daily/WordHuntResultsContent.tsx
+++ b/fe-next/components/daily/WordHuntResultsContent.tsx
@@ -196,6 +196,38 @@ export const WordHuntResultsContent: React.FC<WordHuntResultsContentProps> = ({
     </motion.div>
   );
 
+  // When the other game is already done, the primary CTA goes back to the
+  // Daily Hub (which surfaces the combined leaderboard) instead of nagging
+  // the player to "complete the other challenge".
+  const backToDailyCtaNode = wordWheelPlayed && (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.22, type: 'spring', stiffness: 300, damping: 26 }}
+    >
+      <Link
+        href={`/${language}/daily`}
+        data-testid="back-to-daily-link"
+        className="flex items-center justify-between gap-3 w-full p-5 rounded-neo border-3 border-neo-black bg-neo-cyan shadow-hard-lg hover:scale-[1.02] active:translate-x-px active:translate-y-px active:shadow-hard-pressed transition-all"
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex items-center justify-center w-12 h-12 rounded-neo border-2 border-neo-black bg-neo-navy shrink-0">
+            <Home className="w-7 h-7 text-neo-cyan" />
+          </div>
+          <div>
+            <span className="block font-neo-display font-black text-neo-black text-base leading-tight">
+              {t('wordHunt.results.backToDaily', 'Back to Daily Hub')}
+            </span>
+            <p className="text-neo-black/70 text-xs mt-0.5">
+              {t('wordHunt.results.backToDailyDesc', "See today's leaderboard")}
+            </p>
+          </div>
+        </div>
+        <ArrowRight className="w-6 h-6 text-neo-black shrink-0" />
+      </Link>
+    </motion.div>
+  );
+
   return (
   <div className="space-y-4">
     {/* Performance mascot — reacts to how many words the player found */}
@@ -281,8 +313,13 @@ export const WordHuntResultsContent: React.FC<WordHuntResultsContentProps> = ({
     {/* Daily Insight Cards — personalized analytics on challenge performance */}
     <DailyInsightStack mode="word_hunt" date={puzzleDate} />
 
-    {/* PRIMARY CROSS-PROMO (variant): Word Wheel CTA above leaderboard. */}
-    {crossPromoOrder === 'wheel-first' && wheelCtaNode}
+    {/* PRIMARY CTA above leaderboard.
+        - If the wheel is still to-do → variant-controlled wheel cross-promo.
+        - If the wheel is already done → back-to-daily (to see the leaderboard).
+        The back-to-daily card always sits above the leaderboard so the player
+        sees a clear, useful next step instead of a stale cross-promo. */}
+    {backToDailyCtaNode}
+    {!wordWheelPlayed && crossPromoOrder === 'wheel-first' && wheelCtaNode}
 
     {/* FAIL state: Reveal target word + watch ad */}
     {!result.solved && (
@@ -448,35 +485,7 @@ export const WordHuntResultsContent: React.FC<WordHuntResultsContentProps> = ({
       </motion.div>
     )}
 
-    {/* Back to Daily Hub — shown when both challenges complete */}
-    {wordWheelPlayed && (
-      <motion.div
-        initial={{ opacity: 0, y: 12 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.36, type: 'spring', stiffness: 300, damping: 26 }}
-      >
-        <Link
-          href={`/${language}/daily`}
-          data-testid="back-to-daily-link"
-          className="flex items-center justify-between gap-3 w-full p-5 rounded-neo border-3 border-neo-black bg-neo-cyan shadow-hard-lg hover:scale-[1.02] active:translate-x-px active:translate-y-px active:shadow-hard-pressed transition-all"
-        >
-          <div className="flex items-center gap-3">
-            <div className="flex items-center justify-center w-12 h-12 rounded-neo border-2 border-neo-black bg-neo-navy shrink-0">
-              <Home className="w-7 h-7 text-neo-cyan" />
-            </div>
-            <div>
-              <span className="block font-neo-display font-black text-neo-black text-base leading-tight">
-                {t('wordHunt.results.backToDaily', 'Back to Daily Hub')}
-              </span>
-              <p className="text-neo-black/70 text-xs mt-0.5">
-                {t('wordHunt.results.backToDailyDesc', 'See today\'s full results')}
-              </p>
-            </div>
-          </div>
-          <ArrowRight className="w-6 h-6 text-neo-black shrink-0" />
-        </Link>
-      </motion.div>
-    )}
+    {/* Back-to-daily CTA lives above the leaderboard now (see primary CTA block). */}
 
     {/* Witty facts — supplementary, below the fold */}
     {stats && (

--- a/fe-next/components/daily/WordWheelResults.tsx
+++ b/fe-next/components/daily/WordWheelResults.tsx
@@ -337,7 +337,7 @@ const WordWheelResults: React.FC<WordWheelResultsProps> = ({
                   {t('wordWheel.results.backToDaily', 'Back to Daily Hub')}
                 </span>
                 <p className="text-neo-black/70 text-xs mt-0.5">
-                  {t('wordWheel.results.backToDailyDesc', "See today's full results")}
+                  {t('wordWheel.results.backToDailyDesc', "See today's leaderboard")}
                 </p>
               </div>
             </div>

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -5696,7 +5696,7 @@ const en = {
       "dailyComplete": "Daily Challenge complete!",
       "dailyCompleteDesc": "Both games done. Come back tomorrow!",
       "backToDaily": "Back to Daily Hub",
-      "backToDailyDesc": "See today's full results",
+      "backToDailyDesc": "See today's leaderboard",
       "tapPlayerHint": "Tap a player to see what you missed"
     },
     "hub": {
@@ -5961,7 +5961,7 @@ const en = {
       "completeDailyTitle": "Finish today's challenge",
       "completeDailyDesc": "Play Word Hunt to complete your Daily Challenge",
       "backToDaily": "Back to Daily Hub",
-      "backToDailyDesc": "See today's full results",
+      "backToDailyDesc": "See today's leaderboard",
       "playerWordsTitle": "{{name}}'s path",
       "youMissedWords": "Words you missed",
       "tapPlayerHint": "Tap a player to see their path"

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -5632,7 +5632,7 @@ const es = {
       "dailyComplete": "¡Reto Diario completado!",
       "dailyCompleteDesc": "Ambos juegos hechos. ¡Vuelve mañana!",
       "backToDaily": "Volver al Reto Diario",
-      "backToDailyDesc": "Ver los resultados completos de hoy",
+      "backToDailyDesc": "Ver la tabla de clasificación de hoy",
       "tapPlayerHint": "Toca un jugador para ver lo que te perdiste"
     },
     "hub": {
@@ -5816,7 +5816,7 @@ const es = {
       "completeDailyTitle": "Termina el reto de hoy",
       "completeDailyDesc": "Juega Caza de Palabras para completar tu Reto Diario",
       "backToDaily": "Volver al Reto Diario",
-      "backToDailyDesc": "Ver los resultados completos de hoy",
+      "backToDailyDesc": "Ver la tabla de clasificación de hoy",
       "playerWordsTitle": "El camino de {{name}}",
       "youMissedWords": "Palabras que te perdiste",
       "tapPlayerHint": "Toca un jugador para ver su camino"

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -5590,7 +5590,7 @@ const he = {
       "dailyComplete": "האתגר היומי הושלם!",
       "dailyCompleteDesc": "שני המשחקים הושלמו. חזור מחר!",
       "backToDaily": "חזרה לאתגר היומי",
-      "backToDailyDesc": "ראה את התוצאות המלאות של היום",
+      "backToDailyDesc": "צפה בטבלת המובילים של היום",
       "tapPlayerHint": "לחץ על שחקן כדי לראות מה פספסת"
     },
     "hub": {
@@ -5837,7 +5837,7 @@ const he = {
       "completeDailyTitle": "סיים את האתגר היומי",
       "completeDailyDesc": "שחק בציד מילים כדי להשלים את האתגר היומי",
       "backToDaily": "חזרה לאתגר היומי",
-      "backToDailyDesc": "ראה את התוצאות המלאות של היום",
+      "backToDailyDesc": "צפה בטבלת המובילים של היום",
       "playerWordsTitle": "הנתיב של {{name}}",
       "youMissedWords": "מילים שהחמצת",
       "tapPlayerHint": "לחץ על שחקן כדי לראות את נתיבו"

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -5622,7 +5622,7 @@ const ja = {
       "dailyComplete": "デイリーチャレンジ達成！",
       "dailyCompleteDesc": "両方のゲーム完了。また明日！",
       "backToDaily": "デイリーハブに戻る",
-      "backToDailyDesc": "今日の全結果を見る",
+      "backToDailyDesc": "今日のリーダーボードを見る",
       "tapPlayerHint": "プレイヤーをタップして見逃した単語を確認"
     },
     "hub": {
@@ -5869,7 +5869,7 @@ const ja = {
       "completeDailyTitle": "今日のチャレンジを完了",
       "completeDailyDesc": "ワードハントをプレイしてデイリーチャレンジを達成",
       "backToDaily": "デイリーハブに戻る",
-      "backToDailyDesc": "今日の全結果を見る",
+      "backToDailyDesc": "今日のリーダーボードを見る",
       "playerWordsTitle": "{{name}}のルート",
       "youMissedWords": "見逃した単語",
       "tapPlayerHint": "プレイヤーをタップしてルートを確認"

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -5589,7 +5589,7 @@ const sv = {
       "dailyComplete": "Daglig utmaning klar!",
       "dailyCompleteDesc": "Båda spelen klara. Kom tillbaka imorgon!",
       "backToDaily": "Tillbaka till dagliga utmaningar",
-      "backToDailyDesc": "Se dagens fullständiga resultat",
+      "backToDailyDesc": "Se dagens topplista",
       "tapPlayerHint": "Tryck på en spelare för att se vad du missade"
     },
     "hub": {
@@ -5838,7 +5838,7 @@ const sv = {
       "completeDailyTitle": "Avsluta dagens utmaning",
       "completeDailyDesc": "Spela Ordjakt för att slutföra din dagliga utmaning",
       "backToDaily": "Tillbaka till dagliga utmaningar",
-      "backToDailyDesc": "Se dagens fullständiga resultat",
+      "backToDailyDesc": "Se dagens topplista",
       "playerWordsTitle": "{{name}}s väg",
       "youMissedWords": "Ord du missade",
       "tapPlayerHint": "Tryck på en spelare för att se deras väg"


### PR DESCRIPTION
## Summary

When a player finishes a Daily Challenge game and the other game is **already complete** for the day, the prominent "Finish today's challenge" cross-promo card is stale — there's nothing left to cross-promo to.

In `WordWheelResults` the back-to-hub CTA was already in the primary slot, but in `WordHuntResultsContent` it was buried far below the leaderboard, share section, signup card, and another cross-promo. This change makes the primary CTA above the leaderboard go back to the Daily Hub (where the combined leaderboard lives) whenever the other game is done — across both results screens — and updates the copy to advertise the leaderboard.

- `WordHuntResultsContent.tsx`: new `backToDailyCtaNode` rendered above the leaderboard when `wordWheelPlayed`. The buried duplicate further down is removed. Wheel cross-promo (and its A/B variant positioning) is untouched for the not-yet-played case.
- `WordWheelResults.tsx`: descriptor refreshed to mention the leaderboard.
- `translations/{en,he,es,sv,ja}.js`: `backToDailyDesc` updated to "See today's leaderboard" (and locale equivalents).

## Test plan
- [x] `WordHuntResultsContent.test.tsx` — back-to-daily link present when `hasPlayedWordWheelToday()` returns true; absent otherwise.
- [x] `WordHuntResultsContent.crossPromoExperiment.test.tsx` — wheel-CTA still respects the `wheel-first` / `leaderboard-first` A/B variant when the wheel is not yet played, and exposure fires once.
- [x] `WordWheelResults.backButton.test.tsx` — top back-arrow link still points at `/{lang}/daily`.
- [x] `WordWheelResults.crossPromoTranslation.test.tsx` — translations resolve cleanly.
- [x] `DailyWordHuntResults.{mascot,emojiCard,winCinematic}.test.tsx` — parent flows unaffected.
- [x] 29 tests pass (4 + 3 spec files; no regressions).
- [ ] Manual: play one of the two Daily games while the other is already complete; confirm the cyan "Back to Daily Hub / See today's leaderboard" card sits directly above the leaderboard instead of the purple/lime "Finish today's challenge" card.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mnz1vd3pZG3iArxmBuZ8fv)_