### PR TITLE
fix(daily): chest progress UX + leaderboard error state + remove streak widgets

### DIFF
--- a/fe-next/components/daily/DailyChallengeLanding.tsx
+++ b/fe-next/components/daily/DailyChallengeLanding.tsx
@@ -14,12 +14,8 @@ import type { Language } from '@/types';
 import type { PendingChest } from '@/hooks/useWeeklyChest';
 
 import { ScoreGauntletBanner } from './ScoreGauntletBanner';
-import { DailyRewardPreview } from './DailyRewardPreview';
-import { StreakFreezeIndicator } from './StreakFreezeIndicator';
-import WatchAdForFreezeButton from './WatchAdForFreezeButton';
 import { DailyMissionsHeader } from './landing/DailyMissionsHeader';
 import { QuestCard } from './landing/QuestCard';
-import { StreakCounter } from './landing/StreakCounter';
 import TabbedDailyLeaderboard from './TabbedDailyLeaderboard';
 import { ConfettiBackground } from './landing/ConfettiBackground';
 import { FloatingDecorations } from './landing/FloatingDecorations';
@@ -60,7 +56,6 @@ export function DailyChallengeLanding({
 
   // Word Wheel status from localStorage (no server endpoint for it yet)
   const [wordWheelStatus, setWordWheelStatus] = useState<'new' | 'played'>('new');
-  const [freezeCount, setFreezeCount] = useState(0);
   const [guestFingerprint, setGuestFingerprint] = useState<string | null>(null);
   // Defer Date.now()-derived value to client to avoid hydration mismatch (React #418)
   const [todayIso, setTodayIso] = useState<string>('');
@@ -80,35 +75,15 @@ export function DailyChallengeLanding({
         ? 'won'
         : 'lost';
 
-  const streak = dailyStatus.currentStreak;
-
   // Check Word Wheel status from localStorage
   const checkWordWheelStatus = () => {
     const wwPlayed = hasPlayedWordWheelToday(currentLanguage);
     setWordWheelStatus(wwPlayed ? 'played' : 'new');
   };
 
-  // Fetch streak freeze count (authed users only — guests have no server streak)
-  const fetchFreezeCount = async () => {
-    if (!user?.id) {
-      setFreezeCount(0);
-      return;
-    }
-    try {
-      const res = await fetch('/api/streak');
-      if (res.ok) {
-        const data = await res.json();
-        setFreezeCount(data.freezesAvailable ?? 0);
-      }
-    } catch {
-      // Freeze count is optional — fail silently
-    }
-  };
-
-  // Initial check + fetch
+  // Initial check
   useEffect(() => {
     checkWordWheelStatus();
-    fetchFreezeCount();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentLanguage, user?.id]);
 
@@ -118,7 +93,6 @@ export function DailyChallengeLanding({
       if (document.visibilityState === 'visible') {
         checkWordWheelStatus();
         dailyStatus.refresh();
-        fetchFreezeCount();
       }
     };
     document.addEventListener('visibilitychange', handleVisibilityChange);
@@ -392,18 +366,6 @@ export function DailyChallengeLanding({
       {claimedChest && (
         <WeeklyChestModal chest={claimedChest} onClose={() => setClaimedChest(null)} />
       )}
-
-      {/* Streak counter + freeze */}
-      <StreakCounter streak={streak} />
-      <StreakFreezeIndicator freezeCount={freezeCount} t={t} />
-      {streak > 0 && (
-        <div className="flex justify-center mt-2">
-          <WatchAdForFreezeButton t={t} surface="daily_freeze" />
-        </div>
-      )}
-      {/* Streak preview is auth-only — guests don't get streak tracking (storage.ts:205) */}
-      {/* Pass streak + 1: today's claim becomes day N+1, where streak = days already completed */}
-      {user && <DailyRewardPreview currentStreakDay={streak + 1} t={t} />}
 
       {/* Leaderboard Teaser — only render after client-side date hydration */}
       {todayIso && (

--- a/fe-next/components/daily/TabbedDailyLeaderboard.tsx
+++ b/fe-next/components/daily/TabbedDailyLeaderboard.tsx
@@ -640,7 +640,7 @@ const TabbedDailyLeaderboard: React.FC<TabbedDailyLeaderboardProps> = ({
               {scope === 'word-wheel' && <>🎡 {t('wordHunt.leaderboard.scopeWordWheel') || 'Word Wheel'}</>}
             </span>
           </h3>
-          {!isLoading && (
+          {!isLoading && !error && (
             <p className="text-xs sm:text-sm text-slate-600 dark:text-slate-400 font-medium truncate">
               {activeTab === 'today' && totalCount > 0 ? (
                 <>
@@ -664,9 +664,9 @@ const TabbedDailyLeaderboard: React.FC<TabbedDailyLeaderboardProps> = ({
                     </>
                   )}
                 </>
-              ) : (
+              ) : totalCount > 0 ? (
                 <>{totalCount} {totalCount === 1 ? t('daily.playerSingular') : t('daily.playersPlural')}</>
-              )}
+              ) : null}
             </p>
           )}
         </div>

--- a/fe-next/components/daily/WeeklyChestCard.tsx
+++ b/fe-next/components/daily/WeeklyChestCard.tsx
@@ -31,6 +31,14 @@ export default function WeeklyChestCard({ onChestClaimed }: Props) {
   } = useWeeklyChest()
   const chestRef = useRef<HTMLDivElement>(null)
   const cardRef = useRef<HTMLDivElement>(null)
+  const barRef = useRef<HTMLDivElement>(null)
+
+  // Defensive: callers may receive partial / error payloads. Always render integers.
+  const safeDays = Number.isFinite(daysCompleted)
+    ? Math.max(0, Math.min(7, Math.trunc(daysCompleted)))
+    : 0
+  const remaining = Math.max(0, 7 - safeDays)
+  const percent = Math.round((safeDays / 7) * 100)
 
   // Card entrance (one-shot)
   useEffect(() => {
@@ -47,6 +55,24 @@ export default function WeeklyChestCard({ onChestClaimed }: Props) {
       ease: 'back.out(1.4)',
     })
   }, [])
+
+  // Animate progress bar fill on data change
+  useEffect(() => {
+    if (!barRef.current) return
+    if (
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      barRef.current.style.width = `${percent}%`
+      return
+    }
+    const tween = gsap.to(barRef.current, {
+      width: `${percent}%`,
+      duration: 0.6,
+      ease: 'power2.out',
+    })
+    return () => { tween.kill() }
+  }, [percent])
 
   // Idle float; intensifies when claimable
   useEffect(() => {
@@ -104,6 +130,8 @@ export default function WeeklyChestCard({ onChestClaimed }: Props) {
           }}
         />
       )}
+
+      {/* Header: title + day counter pill */}
       <div className="flex items-center justify-between mb-3 relative">
         <div className="flex items-center gap-2">
           <Calendar className="w-4 h-4 text-neo-cream/60" />
@@ -111,45 +139,82 @@ export default function WeeklyChestCard({ onChestClaimed }: Props) {
             {t('daily.weeklyChest.title')}
           </span>
         </div>
-        <span className="text-xs text-neo-cream/50 font-bold">
-          {t('daily.weeklyChest.dayProgress').replace('{day}', String(daysCompleted))}
+        <span
+          className="text-[11px] font-black text-neo-navy bg-neo-yellow rounded-full px-2.5 py-0.5 border-2 border-neo-black shadow-hard-xs"
+          data-testid="chest-day-counter"
+        >
+          {safeDays}/7
         </span>
       </div>
 
-      <div className="flex items-center gap-3 relative">
-        {cycleStart && (
-          <ChestProgressDots
-            completedDates={completedDates}
-            cycleStart={cycleStart}
-          />
-        )}
-        <div ref={chestRef} className="ms-auto relative">
+      {/* Main row: chest + progress */}
+      <div className="flex items-center gap-4 relative">
+        <div ref={chestRef} className="relative shrink-0">
           <Image
             src={CHEST_IMG[tier]}
             alt={tierLabel}
             data-testid="chest-tier-thumb"
-            width={56}
-            height={56}
-            className="rounded-md border-2 border-neo-black shadow-hard-sm"
+            width={72}
+            height={72}
+            className="rounded-lg border-2 border-neo-black shadow-hard-sm"
             unoptimized
           />
           {isClaimable && (
             <Sparkles
               aria-hidden="true"
-              className="absolute -top-2 -end-2 w-4 h-4 text-neo-yellow drop-shadow"
+              className="absolute -top-2 -end-2 w-5 h-5 text-neo-yellow drop-shadow"
             />
           )}
         </div>
-      </div>
 
-      <p className="text-xs text-neo-cream/50 mt-2">
-        {isClaimable
-          ? t('daily.weeklyChest.claimReady')
-              .replace('{tier}', tierLabel)
-          : t('daily.weeklyChest.daysRemaining')
-              .replace('{n}', String(7 - daysCompleted))
-              .replace('{tier}', tierLabel)}
-      </p>
+        <div className="flex-1 min-w-0">
+          {/* Progress bar */}
+          <div
+            className="relative h-3 w-full rounded-full bg-neo-navy border-2 border-neo-black overflow-hidden"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={7}
+            aria-valuenow={safeDays}
+            aria-label={t('daily.weeklyChest.title')}
+            data-testid="chest-progress-bar"
+          >
+            <div
+              ref={barRef}
+              className="absolute inset-y-0 start-0 bg-gradient-to-r from-neo-lime via-neo-cyan to-neo-yellow"
+              style={{ width: '0%' }}
+            />
+          </div>
+
+          {/* Status line: X of 7 + days remaining */}
+          <p className="mt-2 text-xs text-neo-cream/70 font-bold">
+            <span className="text-neo-white">
+              {t('daily.weeklyChest.dayProgress').replace('{day}', String(safeDays))}
+            </span>
+            {!isClaimable && (
+              <span className="ms-2 text-neo-cream/50">
+                · {t('daily.weeklyChest.daysRemaining')
+                    .replace('{n}', String(remaining))
+                    .replace('{tier}', tierLabel)}
+              </span>
+            )}
+            {isClaimable && (
+              <span className="ms-2 text-neo-yellow">
+                · {t('daily.weeklyChest.claimReady').replace('{tier}', tierLabel)}
+              </span>
+            )}
+          </p>
+
+          {/* Day markers (kept as `chest-dots` testid for existing tests) */}
+          {cycleStart && (
+            <div className="mt-2">
+              <ChestProgressDots
+                completedDates={completedDates}
+                cycleStart={cycleStart}
+              />
+            </div>
+          )}
+        </div>
+      </div>
 
       <AnimatePresence>
         {isClaimable && (

--- a/fe-next/components/daily/__tests__/TabbedDailyLeaderboard.test.tsx
+++ b/fe-next/components/daily/__tests__/TabbedDailyLeaderboard.test.tsx
@@ -400,4 +400,31 @@ describe('TabbedDailyLeaderboard', () => {
       expect(screen.queryByText('Failed to load leaderboard')).not.toBeInTheDocument();
     });
   });
+
+  describe('header subtitle suppresses misleading counts on error', () => {
+    it('does NOT show "0 players" subtitle when the fetch fails', async () => {
+      (global.fetch as jest.Mock).mockImplementation(() =>
+        Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve('boom') })
+      );
+
+      const { default: TabbedDailyLeaderboard } = await import('../TabbedDailyLeaderboard');
+      const { container } = render(
+        <TabbedDailyLeaderboard
+          puzzleDate="2026-01-09"
+          language="en"
+          t={mockT}
+        />
+      );
+
+      // Wait for the error to render (proves loading is done)
+      expect(await screen.findByText('errors.failedToLoadLeaderboard')).toBeInTheDocument();
+
+      // The subtitle's "0 players" line must NOT appear when the load failed —
+      // showing both an error AND "0 players" looks broken (screenshot bug).
+      // mockT is identity, so the plural key leaks into the rendered text;
+      // when our fix lands the subtitle is hidden entirely on error.
+      expect(container.textContent || '').not.toContain('daily.playersPlural');
+      expect(container.textContent || '').not.toContain('daily.playerSingular');
+    });
+  });
 });

--- a/fe-next/components/daily/__tests__/WeeklyChestCard.test.tsx
+++ b/fe-next/components/daily/__tests__/WeeklyChestCard.test.tsx
@@ -117,4 +117,45 @@ describe('WeeklyChestCard', () => {
     const img = screen.getByTestId('chest-tier-thumb') as HTMLImageElement
     expect((img.getAttribute('src') || '')).toContain('chest-silver')
   })
+
+  it('renders a progress bar with the correct aria value', () => {
+    render(<WeeklyChestCard onChestClaimed={vi.fn()} />)
+    const bar = screen.getByTestId('chest-progress-bar')
+    expect(bar.getAttribute('aria-valuenow')).toBe('4')
+    expect(bar.getAttribute('aria-valuemax')).toBe('7')
+  })
+
+  it('shows the day counter pill as N/7', () => {
+    render(<WeeklyChestCard onChestClaimed={vi.fn()} />)
+    expect(screen.getByTestId('chest-day-counter').textContent).toBe('4/7')
+  })
+
+  it('never renders the literal string "undefined" or "NaN"', () => {
+    // Simulate a broken/error API response that leaks through the hook layer.
+    mockUseWeeklyChest.mockReturnValue({
+      loading: false,
+      daysCompleted: undefined as unknown as number,
+      completedDates: [],
+      cycleStart: '',
+      cycleNumber: 1,
+      isClaimable: false,
+      pendingChest: null,
+      claim: vi.fn(),
+      refresh: vi.fn(),
+    })
+    const { container } = render(<WeeklyChestCard onChestClaimed={vi.fn()} />)
+    expect(container.textContent || '').not.toMatch(/undefined|NaN/)
+    expect(screen.getByTestId('chest-day-counter').textContent).toBe('0/7')
+    expect(screen.getByTestId('chest-progress-bar').getAttribute('aria-valuenow')).toBe('0')
+  })
+
+  it('clamps daysCompleted above 7 to 7 so the bar never overflows', () => {
+    mockUseWeeklyChest.mockReturnValue({
+      ...defaultMockData,
+      daysCompleted: 42,
+    })
+    render(<WeeklyChestCard onChestClaimed={vi.fn()} />)
+    expect(screen.getByTestId('chest-day-counter').textContent).toBe('7/7')
+    expect(screen.getByTestId('chest-progress-bar').getAttribute('aria-valuenow')).toBe('7')
+  })
 })

--- a/fe-next/hooks/__tests__/useWeeklyChest.test.ts
+++ b/fe-next/hooks/__tests__/useWeeklyChest.test.ts
@@ -45,4 +45,41 @@ describe('useWeeklyChest', () => {
     const claimed = await result.current.claim()
     expect(claimed).toBeNull()
   })
+
+  it('returns safe defaults when API responds with an error payload', async () => {
+    global.fetch = makeFetch({ error: 'Unauthorized' })
+    const { result } = renderHook(() => useWeeklyChest())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.daysCompleted).toBe(0)
+    expect(result.current.completedDates).toEqual([])
+    expect(result.current.cycleStart).toBe('')
+    expect(result.current.isClaimable).toBe(false)
+    expect(result.current.pendingChest).toBeNull()
+  })
+
+  it('clamps daysCompleted to a finite number 0-7 even with junk values', async () => {
+    global.fetch = makeFetch({
+      daysCompleted: null,
+      completedDates: 'not-an-array',
+      cycleStart: undefined,
+      isClaimable: 'yes',
+      pendingChest: null,
+    })
+    const { result } = renderHook(() => useWeeklyChest())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(Number.isFinite(result.current.daysCompleted)).toBe(true)
+    expect(result.current.daysCompleted).toBe(0)
+    expect(Array.isArray(result.current.completedDates)).toBe(true)
+    expect(typeof result.current.cycleStart).toBe('string')
+    expect(result.current.isClaimable).toBe(false)
+  })
+
+  it('treats network failure as safe defaults (not undefined)', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('offline'))
+    const { result } = renderHook(() => useWeeklyChest())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.daysCompleted).toBe(0)
+    expect(result.current.completedDates).toEqual([])
+    expect(result.current.cycleStart).toBe('')
+  })
 })

--- a/fe-next/hooks/useWeeklyChest.ts
+++ b/fe-next/hooks/useWeeklyChest.ts
@@ -33,6 +33,27 @@ const DEFAULTS = {
   pendingChest: null as PendingChest | null,
 }
 
+// Coerce server payloads (or error responses) into the strict shape the UI expects.
+// Without this, an error response like `{ error: 'Unauthorized' }` would leak through
+// and render `undefined` / `NaN` in the chest copy.
+function normalizeStatus(json: unknown): typeof DEFAULTS {
+  const obj = (json && typeof json === 'object' ? json : {}) as Record<string, unknown>
+  const rawDays = Number(obj.daysCompleted)
+  const daysCompleted = Number.isFinite(rawDays)
+    ? Math.max(0, Math.min(7, Math.trunc(rawDays)))
+    : 0
+  const completedDates = Array.isArray(obj.completedDates)
+    ? (obj.completedDates.filter(d => typeof d === 'string') as string[])
+    : []
+  const cycleStart = typeof obj.cycleStart === 'string' ? obj.cycleStart : ''
+  const cycleNumber = Number.isFinite(Number(obj.cycleNumber)) ? Number(obj.cycleNumber) : 1
+  const isClaimable = obj.isClaimable === true
+  const pc = obj.pendingChest && typeof obj.pendingChest === 'object'
+    ? (obj.pendingChest as PendingChest)
+    : null
+  return { daysCompleted, completedDates, cycleStart, cycleNumber, isClaimable, pendingChest: pc }
+}
+
 export function useWeeklyChest(): WeeklyChestState {
   const [loading, setLoading] = useState(true)
   const [data, setData] = useState(DEFAULTS)
@@ -41,8 +62,8 @@ export function useWeeklyChest(): WeeklyChestState {
     setLoading(true)
     fetch('/api/daily/weekly-chest/status')
       .then(r => r.json())
-      .then(json => { setData(json); setLoading(false) })
-      .catch(() => setLoading(false))
+      .then(json => { setData(normalizeStatus(json)); setLoading(false) })
+      .catch(() => { setData(DEFAULTS); setLoading(false) })
   }, [])
 
   useEffect(() => { refresh() }, [refresh])


### PR DESCRIPTION
## Summary

Fixes the broken daily screen shown in the user's screenshot:
- "יום undefined מתוך 7" and "עוד NaN ימים לתיבת כסף!" in the weekly chest
- "0 שחקנים" rendered next to "לא הצלחנו לטעון את הטבלה" in the leaderboard
- A dense pile of streak / warrior-progress widgets between the chest and the leaderboard

## Changes

### Weekly chest (`WeeklyChestCard.tsx`, `useWeeklyChest.ts`)
- `useWeeklyChest` now runs every server payload through a single `normalizeStatus()` coercion. An error response like `{ error: 'Unauthorized' }` or a network rejection no longer overwrites the defaults — `daysCompleted` is always a finite integer clamped to `[0, 7]`, `completedDates` is always an array, etc.
- `WeeklyChestCard` redesigned to feel like progress:
  - Title row gains a bold `N/7` counter pill.
  - A 0–100% horizontal **progress bar** with `role="progressbar"` and proper aria values animates on data change.
  - Larger chest thumbnail (72×72) sits next to the bar.
  - Contextual status line shows day count + days-remaining-to-tier copy (or "ready" copy when claimable).
  - Local clamp inside the component so the UI cannot render `undefined` / `NaN` even if a future caller forgets the hook coercion.

### Daily landing (`DailyChallengeLanding.tsx`)
Removed the warrior/streak block beneath the chest:
- `StreakCounter`
- `StreakFreezeIndicator`
- `WatchAdForFreezeButton`
- `DailyRewardPreview`

…along with the `freezeCount` state and `/api/streak` fetch that only fed them. The chest is now the single progress block on the page.

### Leaderboard (`TabbedDailyLeaderboard.tsx`)
The header subtitle is now hidden whenever `error` is set, and the empty "0 players" line is suppressed even on the success path when there are no participants. Previously the header could read "0 שחקנים" while the content area also said "Failed to load the table" — looked broken.

## Test plan

- [x] `vitest run hooks/__tests__/useWeeklyChest.test.ts` — 7/7 passing, including 3 new tests for error payloads / junk values / network failure.
- [x] `vitest run components/daily/__tests__/WeeklyChestCard.test.tsx` — 11/11 passing, including new tests for the progress bar aria, the `N/7` counter, the never-`undefined`/`NaN` guarantee, and the clamp-above-7 behavior.
- [x] `vitest run components/daily/__tests__/TabbedDailyLeaderboard.test.tsx` — 9/9 passing, including a new test that the "0 players" subtitle does not appear when the fetch fails.
- [x] Full `components/daily/__tests__` + chest hook suite: **385/385 passing**.
- [x] `tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZP9SzTgPgjLR2SKU2MbLQ)_