### PR TITLE
Blast v2: playable forced-chain cascade word game

### DIFF
--- a/docs/superpowers/plans/2026-05-14-blast-v2-playable.md
+++ b/docs/superpowers/plans/2026-05-14-blast-v2-playable.md
@@ -1,0 +1,1330 @@
+# Blast v2 Playable Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Blast v2 a genuinely playable cascade word game where each level is a forced chain — finding a word collapses tiles which is the *only* way to enable the next word — with 15 hand-authored English + 15 Hebrew levels, hybrid neo-brutalist visuals, and juicy GSAP/Pixi animation.
+
+**Architecture:** A new `chain-builder` constructs each level *backwards* — start from the last word on the floor, insert each earlier word by lifting existing tiles up one row, verifying after every insert that only the intended word is formable. This makes "forced order" a structural guarantee, not a tested hope. Levels are authored as terse `{ chain: [...] }` specs; the builder produces the concrete board. A straight-line word scanner (`scanFormableThemeWords`) is the shared correctness primitive for both the builder and a forward `validateChainLevel` replay. Existing collapse/selection/reducer/FX code is reused unchanged.
+
+**Tech Stack:** TypeScript, Vitest, React, Framer Motion (existing tile anim), GSAP 3.14 (collapse timeline), PixiJS (existing FX overlay). Words horizontal-only in v1.
+
+**Scope note — horizontal-only:** v1 places all chain words as horizontal runs. This matches the reference (Word Stacks is overwhelmingly horizontal) and keeps construction tractable. Vertical-orientation chain words are explicitly **out of scope for v1**.
+
+---
+
+## File Structure
+
+**New files:**
+- `fe-next/lib/blast/v2/engine/word-scan.ts` — `scanFormableThemeWords`: straight-line H/V scan for formable theme words. Shared by builder + validator.
+- `fe-next/lib/blast/v2/engine/chain-builder.ts` — `insertWord`, `buildChainLevel`: backward construction of a forced-chain `BlastLevel`.
+- `fe-next/lib/blast/v2/engine/chain-validator.ts` — `validateChainLevel`: forward replay asserting the forced order.
+- `fe-next/lib/blast/v2/chain-pack-source.ts` — `ChainPackSource implements LevelSource`: loads `pack-chain.json`, expands specs via `buildChainLevel`.
+- `fe-next/content/blast/packs/en/pack-chain.json` — 15 English chain specs.
+- `fe-next/content/blast/packs/he/pack-chain.json` — 15 Hebrew chain specs.
+- Test files mirrored under `fe-next/lib/blast/v2/engine/__tests__/` and `fe-next/lib/blast/v2/__tests__/`.
+
+**Modified files:**
+- `fe-next/lib/blast/v2/level-source-registry.ts` — register `ChainPackSource`, route en/he levels 1–15 to it.
+- `fe-next/lib/blast/v2/types.ts` — add `ChainLevelSpec` type.
+- `fe-next/components/blast/v2/BlastTile.tsx` — hybrid restyle.
+- `fe-next/components/blast/v2/BlastTile.module.css` (or inline) — tile depth/bevel styles.
+- `fe-next/components/blast/v2/BlastBoard.tsx` — GSAP collapse timeline + cascade-reveal glow hook-up.
+
+---
+
+## Task 1: Straight-line word scanner
+
+**Files:**
+- Create: `fe-next/lib/blast/v2/engine/word-scan.ts`
+- Test: `fe-next/lib/blast/v2/engine/__tests__/word-scan.test.ts`
+
+The builder and validator both need one question answered: *given a board, which target words are formable as a straight contiguous horizontal or vertical run?* `detectAllCascades` does a 4-directional search and will over-match — do NOT reuse it. Write a dedicated scanner.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// fe-next/lib/blast/v2/engine/__tests__/word-scan.test.ts
+import { describe, it, expect } from 'vitest';
+import { scanFormableThemeWords } from '../word-scan';
+import type { BlastLevel } from '../../types';
+
+function lvl(columns: string[][]): BlastLevel {
+  return {
+    id: 't', levelNumber: 1, theme: 'onboarding', locale: 'en',
+    words: [], resolvableOrder: [], tileFlags: {}, difficulty: 1,
+    columns: columns.map((tiles, index) => ({ index, tiles })),
+  };
+}
+
+describe('scanFormableThemeWords', () => {
+  it('finds a horizontal word along a row', () => {
+    // row 0 across cols: C A T
+    const board = lvl([['C'], ['A'], ['T']]);
+    const matches = scanFormableThemeWords(board, ['CAT', 'DOG']);
+    expect(matches).toEqual([{ word: 'CAT', cells: ['c0r0', 'c1r0', 'c2r0'] }]);
+  });
+
+  it('finds a vertical word within a column', () => {
+    const board = lvl([['T', 'A', 'C']]); // bottom->top: T A C
+    const matches = scanFormableThemeWords(board, ['CAT']);
+    // reading top->bottom c0r2,c0r1,c0r0 = C A T
+    expect(matches.map((m) => m.word)).toEqual(['CAT']);
+  });
+
+  it('does NOT match an L-shape or diagonal', () => {
+    const board = lvl([['C', 'A'], ['T']]); // C bottom c0, A top c0, T bottom c1
+    const matches = scanFormableThemeWords(board, ['CAT']);
+    expect(matches).toEqual([]);
+  });
+
+  it('returns every placement when a word appears twice', () => {
+    const board = lvl([['C'], ['A'], ['T'], ['C'], ['A'], ['T']]);
+    const matches = scanFormableThemeWords(board, ['CAT']);
+    expect(matches.length).toBe(2);
+  });
+
+  it('respects locale normalization for Hebrew final forms', () => {
+    // word stored as חתול; tile shows base form כ even when ך is the target letter
+    const board = lvl([['ח'], ['ת'], ['ו'], ['ל']]);
+    const matches = scanFormableThemeWords(board, ['חתול'], 'he');
+    expect(matches.map((m) => m.word)).toEqual(['חתול']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/engine/__tests__/word-scan.test.ts`
+Expected: FAIL — `scanFormableThemeWords` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// fe-next/lib/blast/v2/engine/word-scan.ts
+import type { BlastLevel, CellId, Letter, Locale } from '../types';
+import { LOCALE_CONFIGS } from '../locale-config';
+
+export type WordMatch = { word: string; cells: CellId[] };
+
+function cid(col: number, row: number): CellId {
+  return `c${col}r${row}`;
+}
+
+/** Letter at (col,row) or undefined. row 0 = bottom. */
+function at(level: BlastLevel, col: number, row: number): Letter | undefined {
+  return level.columns[col]?.tiles[row];
+}
+
+/**
+ * All target words formable as a straight contiguous horizontal (along a row,
+ * left->right) or vertical (within a column, top->bottom) run.
+ * Returns every placement; cells are ordered to match the word's letters.
+ */
+export function scanFormableThemeWords(
+  level: BlastLevel,
+  targets: string[],
+  locale: Locale = 'en',
+): WordMatch[] {
+  const config = LOCALE_CONFIGS[locale];
+  const norm = (s: string): string => config.normalize(s);
+  const wanted = new Map(targets.map((w) => [norm(w), w] as const));
+  const matches: WordMatch[] = [];
+  const cols = level.columns.length;
+  const maxRow = Math.max(0, ...level.columns.map((c) => c.tiles.length));
+
+  // Horizontal: every row, every start column, every run length present.
+  for (let row = 0; row < maxRow; row++) {
+    for (let start = 0; start < cols; start++) {
+      let run = '';
+      const cells: CellId[] = [];
+      for (let col = start; col < cols; col++) {
+        const ch = at(level, col, row);
+        if (ch === undefined) break;
+        run += ch;
+        cells.push(cid(col, row));
+        const hit = wanted.get(norm(run));
+        if (hit && run.length >= 2) {
+          matches.push({ word: hit, cells: [...cells] });
+        }
+      }
+    }
+  }
+
+  // Vertical: within a column, read top->bottom.
+  for (let col = 0; col < cols; col++) {
+    const tiles = level.columns[col]?.tiles ?? [];
+    for (let topRow = tiles.length - 1; topRow >= 0; topRow--) {
+      let run = '';
+      const cells: CellId[] = [];
+      for (let row = topRow; row >= 0; row--) {
+        run += tiles[row];
+        cells.push(cid(col, row));
+        const hit = wanted.get(norm(run));
+        if (hit && run.length >= 2) {
+          matches.push({ word: hit, cells: [...cells] });
+        }
+      }
+    }
+  }
+
+  return matches;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/engine/__tests__/word-scan.test.ts`
+Expected: PASS (5 tests). If the Hebrew test fails, confirm `LOCALE_CONFIGS.he.normalize` folds final forms — adjust the test's expectation, not the production normalize.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fe-next/lib/blast/v2/engine/word-scan.ts fe-next/lib/blast/v2/engine/__tests__/word-scan.test.ts
+git commit -m "feat(blast): straight-line formable-word scanner for chain levels"
+```
+
+---
+
+## Task 2: Insert a single word (backward construction primitive)
+
+**Files:**
+- Create: `fe-next/lib/blast/v2/engine/chain-builder.ts`
+- Test: `fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts`
+
+`insertWord` is the backward step: given board `S_k` (words k+1..N already placed) and `word_k`, produce `S_{k-1}` where `word_k` is formable and **no** word in `otherWordsOnBoard` is. Horizontal placement: pick a row `r` and start column `c`; in each affected column splice `word_k`'s letter in at array index `r` (pushing tiles above up one row). Removing those cells later + `collapseCells` reproduces `S_k` exactly.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+import { describe, it, expect } from 'vitest';
+import { insertWord } from '../chain-builder';
+import { collapseCells } from '../collapse';
+import { scanFormableThemeWords } from '../word-scan';
+import type { BlastLevel } from '../../types';
+
+function lvl(columns: string[][]): BlastLevel {
+  return {
+    id: 't', levelNumber: 1, theme: 'onboarding', locale: 'en',
+    words: [], resolvableOrder: [], tileFlags: {}, difficulty: 1,
+    columns: columns.map((tiles, index) => ({ index, tiles })),
+  };
+}
+
+describe('insertWord', () => {
+  it('inserts a word so only it is formable, and removing it restores the prior board', () => {
+    const Sk = lvl([['D'], ['O'], ['G']]); // S_k: only DOG on the floor
+    const result = insertWord(Sk, 'CAT', ['DOG'], 'en', 1);
+    expect(result).not.toBeNull();
+    const S = result!.level;
+
+    // CAT is formable, DOG is not (it's been lifted out of a straight run)
+    const matches = scanFormableThemeWords(S, ['CAT', 'DOG'], 'en');
+    expect(matches.map((m) => m.word).sort()).toEqual(['CAT']);
+
+    // Removing CAT's cells + collapse reproduces S_k exactly
+    const after = collapseCells(S, result!.cells);
+    expect(after.level.columns.map((c) => c.tiles)).toEqual(Sk.columns.map((c) => c.tiles));
+  });
+
+  it('returns null when no placement isolates the word', () => {
+    // 1 column, word equal length — impossible to make CAT formable without TAC also straight
+    const Sk = lvl([['X']]);
+    const result = insertWord(Sk, 'CAT', ['XYZ'], 'en', 1);
+    // CAT is length 3, board has 1 column -> horizontal impossible
+    expect(result).toBeNull();
+  });
+
+  it('is deterministic for a given seed', () => {
+    const Sk = lvl([['D'], ['O'], ['G']]);
+    const a = insertWord(Sk, 'CAT', ['DOG'], 'en', 42);
+    const b = insertWord(Sk, 'CAT', ['DOG'], 'en', 42);
+    expect(a?.level.columns).toEqual(b?.level.columns);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/engine/__tests__/chain-builder.test.ts`
+Expected: FAIL — `insertWord` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// fe-next/lib/blast/v2/engine/chain-builder.ts
+import type { BlastColumn, BlastLevel, CellId, Locale } from '../types';
+import { scanFormableThemeWords } from './word-scan';
+
+export type InsertResult = { level: BlastLevel; cells: CellId[] };
+
+/** Deterministic LCG so builds are reproducible per seed. */
+function rng(seed: number): () => number {
+  let s = seed >>> 0 || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0xffffffff;
+  };
+}
+
+function shuffle<T>(arr: T[], rand: () => number): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [a[i], a[j]] = [a[j]!, a[i]!];
+  }
+  return a;
+}
+
+function cloneColumns(columns: BlastColumn[]): BlastColumn[] {
+  return columns.map((c) => ({ index: c.index, tiles: [...c.tiles] }));
+}
+
+function cid(col: number, row: number): CellId {
+  return `c${col}r${row}`;
+}
+
+/**
+ * Backward construction step. Inserts `word` into `Sk` as a horizontal run so
+ * that `word` is formable and none of `otherWordsOnBoard` is. Returns the new
+ * board (`S_{k-1}`) and the cells `word` occupies, or null if no placement works.
+ */
+export function insertWord(
+  Sk: BlastLevel,
+  word: string,
+  otherWordsOnBoard: string[],
+  locale: Locale,
+  seed: number,
+): InsertResult | null {
+  const letters = [...word];
+  const L = letters.length;
+  const cols = Sk.columns.length;
+  if (L > cols) return null;
+
+  const rand = rng(seed);
+  // Candidate placements: start column c (0..cols-L), insert row r.
+  // r may be 0..(min column height among affected cols) so the run lands flush.
+  type Cand = { c: number; r: number };
+  const candidates: Cand[] = [];
+  for (let c = 0; c + L <= cols; c++) {
+    const affected = Array.from({ length: L }, (_, i) => Sk.columns[c + i]!.tiles.length);
+    const maxR = Math.min(...affected);
+    for (let r = 0; r <= maxR; r++) candidates.push({ c, r });
+  }
+
+  for (const { c, r } of shuffle(candidates, rand)) {
+    const columns = cloneColumns(Sk.columns);
+    const cells: CellId[] = [];
+    for (let i = 0; i < L; i++) {
+      columns[c + i]!.tiles.splice(r, 0, letters[i]!);
+      cells.push(cid(c + i, r));
+    }
+    const level: BlastLevel = { ...Sk, columns };
+    const matches = scanFormableThemeWords(level, [word, ...otherWordsOnBoard], locale);
+    const formableWords = new Set(matches.map((m) => m.word));
+    if (formableWords.size === 1 && formableWords.has(word)) {
+      return { level, cells };
+    }
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/engine/__tests__/chain-builder.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fe-next/lib/blast/v2/engine/chain-builder.ts fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+git commit -m "feat(blast): insertWord backward-construction primitive"
+```
+
+---
+
+## Task 3: buildChainLevel — full level from a chain spec
+
+**Files:**
+- Modify: `fe-next/lib/blast/v2/engine/chain-builder.ts` (add `buildChainLevel`)
+- Modify: `fe-next/lib/blast/v2/types.ts` (add `ChainLevelSpec`)
+- Test: `fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts` (extend)
+
+`buildChainLevel` runs `insertWord` from the last word to the first, then sprinkles decoy tiles. Decoys are random letters inserted into `S_0` that must not make any theme word formable early. The starting board `S_N` is `word_N` laid horizontally on the floor.
+
+- [ ] **Step 1: Add the `ChainLevelSpec` type**
+
+```typescript
+// append to fe-next/lib/blast/v2/types.ts
+export type ChainLevelSpec = {
+  id: string;
+  levelNumber: number;
+  theme: ThemeKey;
+  locale: Locale;
+  /** Number of board columns. Must be >= the longest word in the chain. */
+  columns: number;
+  /** Count of decoy tiles that never complete a theme word. */
+  decoyTiles: number;
+  /** Ordered words; chain[0] is found first, chain[last] last. */
+  chain: string[];
+};
+```
+
+- [ ] **Step 2: Write the failing test (extend the file)**
+
+```typescript
+// append inside chain-builder.test.ts
+import { buildChainLevel } from '../chain-builder';
+import { validateChainLevel } from '../chain-validator'; // exists after Task 4 — see note
+import type { ChainLevelSpec } from '../../types';
+
+describe('buildChainLevel', () => {
+  const spec: ChainLevelSpec = {
+    id: 'en-chain-01', levelNumber: 1, theme: 'onboarding', locale: 'en',
+    columns: 4, decoyTiles: 0, chain: ['CAT', 'SUN', 'EGG'],
+  };
+
+  it('produces a level whose forward replay matches the chain', () => {
+    const level = buildChainLevel(spec, 7);
+    expect(level).not.toBeNull();
+    expect(level!.words).toEqual(['CAT', 'SUN', 'EGG']);
+    expect(level!.resolvableOrder).toEqual(['CAT', 'SUN', 'EGG']);
+  });
+
+  it('column count matches the spec', () => {
+    const level = buildChainLevel(spec, 7);
+    expect(level!.columns.length).toBe(4);
+  });
+
+  it('returns null for an impossible chain (word longer than columns)', () => {
+    const bad: ChainLevelSpec = { ...spec, columns: 2, chain: ['CAT'] };
+    expect(buildChainLevel(bad, 7)).toBeNull();
+  });
+
+  it('inserts the requested number of decoy tiles', () => {
+    const withDecoys: ChainLevelSpec = { ...spec, decoyTiles: 3 };
+    const level = buildChainLevel(withDecoys, 7)!;
+    const totalTiles = level.columns.reduce((n, c) => n + c.tiles.length, 0);
+    const wordTiles = spec.chain.join('').length;
+    expect(totalTiles).toBe(wordTiles + 3);
+  });
+});
+```
+
+> **Note:** Step 2's `import { validateChainLevel }` is forward-referenced; if running Task 3 before Task 4, comment that import + assertions until Task 4 lands, then uncomment. Subagent-driven execution does Task 4 immediately after — keep both.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/engine/__tests__/chain-builder.test.ts -t buildChainLevel`
+Expected: FAIL — `buildChainLevel` not exported.
+
+- [ ] **Step 4: Implement `buildChainLevel`**
+
+```typescript
+// append to fe-next/lib/blast/v2/engine/chain-builder.ts
+import type { ChainLevelSpec, Letter } from '../types';
+import { LOCALE_CONFIGS } from '../locale-config';
+import { scanFormableThemeWords } from './word-scan';
+
+const MAX_BUILD_ATTEMPTS = 200;
+
+function emptyColumns(count: number): BlastColumn[] {
+  return Array.from({ length: count }, (_, index) => ({ index, tiles: [] as Letter[] }));
+}
+
+/** S_N: the last word laid flat on the floor of an otherwise empty board. */
+function floorBoard(spec: ChainLevelSpec): BlastLevel | null {
+  const last = [...(spec.chain[spec.chain.length - 1] ?? '')];
+  if (last.length > spec.columns) return null;
+  const columns = emptyColumns(spec.columns);
+  // centre the word horizontally for nicer layout
+  const offset = Math.floor((spec.columns - last.length) / 2);
+  last.forEach((ch, i) => columns[offset + i]!.tiles.push(ch));
+  return {
+    id: spec.id, levelNumber: spec.levelNumber, theme: spec.theme, locale: spec.locale,
+    words: [...spec.chain], resolvableOrder: [...spec.chain], tileFlags: {},
+    difficulty: spec.levelNumber, columns,
+  };
+}
+
+/**
+ * Builds a forced-chain BlastLevel from a spec. Returns null if no seed within
+ * MAX_BUILD_ATTEMPTS yields a valid level (author should then tweak the chain).
+ */
+export function buildChainLevel(spec: ChainLevelSpec, seed: number): BlastLevel | null {
+  const longest = Math.max(...spec.chain.map((w) => [...w].length));
+  if (longest > spec.columns) return null;
+
+  const rand = rng(seed);
+  for (let attempt = 0; attempt < MAX_BUILD_ATTEMPTS; attempt++) {
+    const attemptSeed = Math.floor(rand() * 0xffffffff) || 1;
+    const base = floorBoard(spec);
+    if (!base) return null;
+
+    let board = base;
+    let ok = true;
+    // Insert words N-1 .. 0 (chain[last] already on the floor).
+    for (let k = spec.chain.length - 2; k >= 0; k--) {
+      const word = spec.chain[k]!;
+      const others = spec.chain.slice(k + 1);
+      const stepSeed = (attemptSeed + k * 7919) >>> 0;
+      const res = insertWord(board, word, others, spec.locale, stepSeed);
+      if (!res) { ok = false; break; }
+      board = res.level;
+    }
+    if (!ok) continue;
+
+    const withDecoys = insertDecoys(board, spec, attemptSeed);
+    if (!withDecoys) continue;
+    return withDecoys;
+  }
+  return null;
+}
+
+/** Inserts decoy tiles into S_0 that never complete a theme word. */
+function insertDecoys(level: BlastLevel, spec: ChainLevelSpec, seed: number): BlastLevel | null {
+  if (spec.decoyTiles <= 0) return level;
+  const config = LOCALE_CONFIGS[spec.locale];
+  const pool = config.tilePool;
+  const rand = rng(seed);
+  let board = level;
+
+  for (let placed = 0; placed < spec.decoyTiles; placed++) {
+    let success = false;
+    for (let tries = 0; tries < 60 && !success; tries++) {
+      const col = Math.floor(rand() * board.columns.length);
+      const letter = pool[Math.floor(rand() * pool.length)]!;
+      const columns = cloneColumns(board.columns);
+      // drop decoy on top of the column (gravity-stable)
+      columns[col]!.tiles.push(letter);
+      const candidate: BlastLevel = { ...board, columns };
+      const matches = scanFormableThemeWords(candidate, spec.chain, spec.locale);
+      // a decoy on top must not make ANY theme word formable yet
+      // (only chain[0] should be formable in S_0; check that invariant holds)
+      const formable = new Set(matches.map((m) => m.word));
+      if (formable.size <= 1 && (formable.size === 0 || formable.has(spec.chain[0]!))) {
+        board = candidate;
+        success = true;
+      }
+    }
+    if (!success) return null;
+  }
+  return board;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/engine/__tests__/chain-builder.test.ts`
+Expected: PASS. (If `buildChainLevel` test imports `validateChainLevel` and Task 4 isn't done, see the Note in Step 2.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add fe-next/lib/blast/v2/engine/chain-builder.ts fe-next/lib/blast/v2/types.ts fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+git commit -m "feat(blast): buildChainLevel constructs forced-chain levels from specs"
+```
+
+---
+
+## Task 4: validateChainLevel — forward replay
+
+**Files:**
+- Create: `fe-next/lib/blast/v2/engine/chain-validator.ts`
+- Test: `fe-next/lib/blast/v2/engine/__tests__/chain-validator.test.ts`
+
+The independent safety net: replay the chain forward. At step k, assert the *only* formable theme word is `chain[k]`, then clear it + collapse and continue. Catches builder bugs and bad authored chains.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// fe-next/lib/blast/v2/engine/__tests__/chain-validator.test.ts
+import { describe, it, expect } from 'vitest';
+import { validateChainLevel } from '../chain-validator';
+import { buildChainLevel } from '../chain-builder';
+import type { BlastLevel, ChainLevelSpec } from '../../types';
+
+const spec: ChainLevelSpec = {
+  id: 'en-chain-01', levelNumber: 1, theme: 'onboarding', locale: 'en',
+  columns: 4, decoyTiles: 0, chain: ['CAT', 'SUN', 'EGG'],
+};
+
+describe('validateChainLevel', () => {
+  it('accepts a level built by buildChainLevel', () => {
+    const level = buildChainLevel(spec, 7)!;
+    const result = validateChainLevel(level);
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a level where a later word is formable too early', () => {
+    // hand-craft a board where SUN is already a straight run alongside CAT
+    const bad: BlastLevel = {
+      ...spec, words: ['CAT', 'SUN'], resolvableOrder: ['CAT', 'SUN'],
+      tileFlags: {}, difficulty: 1,
+      columns: [
+        { index: 0, tiles: ['C', 'S'] },
+        { index: 1, tiles: ['A', 'U'] },
+        { index: 2, tiles: ['T', 'N'] },
+        { index: 3, tiles: [] },
+      ],
+    };
+    const result = validateChainLevel(bad);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/step 1/i);
+  });
+
+  it('rejects a level whose board does not empty after the last word', () => {
+    const bad: BlastLevel = {
+      ...spec, words: ['CAT'], resolvableOrder: ['CAT'], tileFlags: {}, difficulty: 1,
+      columns: [
+        { index: 0, tiles: ['C'] }, { index: 1, tiles: ['A'] },
+        { index: 2, tiles: ['T'] }, { index: 3, tiles: ['Z'] }, // leftover Z
+      ],
+    };
+    const result = validateChainLevel(bad);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/leftover/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/engine/__tests__/chain-validator.test.ts`
+Expected: FAIL — `validateChainLevel` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// fe-next/lib/blast/v2/engine/chain-validator.ts
+import type { BlastLevel } from '../types';
+import { collapseCells } from './collapse';
+import { scanFormableThemeWords } from './word-scan';
+
+export type ChainValidation = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Replays a chain level forward. At each step exactly one theme word
+ * (the next in resolvableOrder) must be formable; clearing it must not
+ * skip ahead. After the final word the board must be empty.
+ */
+export function validateChainLevel(level: BlastLevel): ChainValidation {
+  const order = level.resolvableOrder.length ? level.resolvableOrder : level.words;
+  let board = level;
+
+  for (let step = 0; step < order.length; step++) {
+    const expected = order[step]!;
+    const remaining = order.slice(step);
+    const matches = scanFormableThemeWords(board, remaining, level.locale);
+    const formable = new Set(matches.map((m) => m.word));
+
+    if (!formable.has(expected)) {
+      return { ok: false, reason: `step ${step + 1}: expected "${expected}" not formable` };
+    }
+    if (formable.size > 1) {
+      const extra = [...formable].filter((w) => w !== expected);
+      return { ok: false, reason: `step ${step + 1}: words formable out of order: ${extra.join(', ')}` };
+    }
+
+    const cells = matches.find((m) => m.word === expected)!.cells;
+    board = collapseCells(board, cells).level;
+  }
+
+  const leftover = board.columns.reduce((n, c) => n + c.tiles.length, 0);
+  if (leftover > 0) {
+    return { ok: false, reason: `leftover ${leftover} tile(s) after final word` };
+  }
+  return { ok: true };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/engine/__tests__/chain-validator.test.ts`
+Expected: PASS (3 tests). Re-run Task 3's file too — the forward-referenced import now resolves.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fe-next/lib/blast/v2/engine/chain-validator.ts fe-next/lib/blast/v2/engine/__tests__/chain-validator.test.ts
+git commit -m "feat(blast): validateChainLevel forward-replay safety net"
+```
+
+---
+
+## Task 5: ChainPackSource + registry wiring
+
+**Files:**
+- Create: `fe-next/lib/blast/v2/chain-pack-source.ts`
+- Test: `fe-next/lib/blast/v2/__tests__/chain-pack-source.test.ts`
+- Create: `fe-next/content/blast/packs/en/pack-chain.json` (stub — 1 level, full set in Task 6)
+- Modify: `fe-next/lib/blast/v2/level-source-registry.ts`
+
+`ChainPackSource` reads `content/blast/packs/{locale}/pack-chain.json` (`{ locale, levels: ChainLevelSpec[] }`), and on `resolve(levelNumber, locale)` finds the matching spec and returns `buildChainLevel(spec, levelNumber)`. The registry routes en/he levels 1–15 to it; everything else stays on curated/generated.
+
+- [ ] **Step 1: Create the stub pack file**
+
+```json
+// fe-next/content/blast/packs/en/pack-chain.json
+{
+  "locale": "en",
+  "levels": [
+    {
+      "id": "en-chain-01", "levelNumber": 1, "theme": "onboarding", "locale": "en",
+      "columns": 4, "decoyTiles": 0, "chain": ["CAT", "SUN", "EGG"]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// fe-next/lib/blast/v2/__tests__/chain-pack-source.test.ts
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { ChainPackSource } from '../chain-pack-source';
+import { validateChainLevel } from '../engine/chain-validator';
+
+const basePath = resolve(process.cwd(), 'content/blast/packs');
+
+describe('ChainPackSource', () => {
+  it('resolves level 1 for en as a valid forced-chain level', async () => {
+    const source = new ChainPackSource(basePath);
+    const level = await source.resolve(1, 'en');
+    expect(level.id).toBe('en-chain-01');
+    expect(level.words).toEqual(['CAT', 'SUN', 'EGG']);
+    expect(validateChainLevel(level).ok).toBe(true);
+  });
+
+  it('throws for a level number not in the pack', async () => {
+    const source = new ChainPackSource(basePath);
+    await expect(source.resolve(99, 'en')).rejects.toThrow(/no chain spec/i);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/__tests__/chain-pack-source.test.ts`
+Expected: FAIL — `ChainPackSource` not exported.
+
+- [ ] **Step 4: Implement `ChainPackSource`**
+
+```typescript
+// fe-next/lib/blast/v2/chain-pack-source.ts
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { BlastLevel, ChainLevelSpec, Locale } from './types';
+import type { LevelSource } from './level-source';
+import { buildChainLevel } from './engine/chain-builder';
+import { validateChainLevel } from './engine/chain-validator';
+
+type ChainPackFile = { locale: Locale; levels: ChainLevelSpec[] };
+
+export class ChainPackSource implements LevelSource {
+  private cache = new Map<Locale, ChainPackFile>();
+
+  constructor(private basePath: string) {}
+
+  private async load(locale: Locale): Promise<ChainPackFile> {
+    const cached = this.cache.get(locale);
+    if (cached) return cached;
+    const path = join(this.basePath, locale, 'pack-chain.json');
+    const raw = JSON.parse(await readFile(path, 'utf8')) as ChainPackFile;
+    this.cache.set(locale, raw);
+    return raw;
+  }
+
+  async resolve(levelNumber: number, locale: Locale): Promise<BlastLevel> {
+    const pack = await this.load(locale);
+    const spec = pack.levels.find((l) => l.levelNumber === levelNumber);
+    if (!spec) {
+      throw new Error(`ChainPackSource: no chain spec for ${locale} level ${levelNumber}`);
+    }
+    const level = buildChainLevel(spec, levelNumber);
+    if (!level) {
+      throw new Error(`ChainPackSource: buildChainLevel failed for ${spec.id}`);
+    }
+    const check = validateChainLevel(level);
+    if (!check.ok) {
+      throw new Error(`ChainPackSource: ${spec.id} invalid — ${check.reason}`);
+    }
+    return level;
+  }
+}
+```
+
+> If `LevelSource` is not exported from a `level-source.ts`, check the import path used by `CuratedPackSource` and match it. The interface is `{ resolve(levelNumber: number, locale: Locale): Promise<BlastLevel> }`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/__tests__/chain-pack-source.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Wire into the registry**
+
+In `fe-next/lib/blast/v2/level-source-registry.ts`, add `ChainPackSource` to the cached sources and route en/he levels 1–15 to it. Locate the existing `resolve`/dispatch function and add, before the curated/generated branch:
+
+```typescript
+import { ChainPackSource } from './chain-pack-source';
+
+// inside the cached sources object:
+cached = {
+  chain: new ChainPackSource(basePath),
+  curated: new CuratedPackSource(basePath),
+  generated: new GeneratedLevelSource(LOCALE_CONFIGS),
+};
+
+// inside the level-resolution function, FIRST branch:
+const CHAIN_LOCALES: Locale[] = ['en', 'he'];
+const CHAIN_MAX_LEVEL = 15;
+if (CHAIN_LOCALES.includes(locale) && levelNumber >= 1 && levelNumber <= CHAIN_MAX_LEVEL) {
+  return cached.chain.resolve(levelNumber, locale);
+}
+// ...existing curated/generated logic unchanged
+```
+
+- [ ] **Step 7: Run the blast v2 suite to confirm no regression**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2`
+Expected: PASS — all existing blast v2 tests plus the new ones.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add fe-next/lib/blast/v2/chain-pack-source.ts fe-next/lib/blast/v2/__tests__/chain-pack-source.test.ts fe-next/content/blast/packs/en/pack-chain.json fe-next/lib/blast/v2/level-source-registry.ts
+git commit -m "feat(blast): ChainPackSource + registry routing for en/he chain levels"
+```
+
+---
+
+## Task 6: Author 15 English chain levels
+
+**Files:**
+- Modify: `fe-next/content/blast/packs/en/pack-chain.json` (replace stub with all 15)
+- Test: `fe-next/lib/blast/v2/__tests__/pack-chain-en.test.ts`
+
+Words are real, themed, rising difficulty. The builder produces the board; the validator guarantees the forced order. If `buildChainLevel` returns null for a chain (words too similar to isolate), swap one word and retry.
+
+Difficulty curve: L1–5 → 3 words / 3–4 letters / 3–4 cols / 0 decoys. L6–10 → 4 words / 4–5 letters / 4–5 cols / 1–2 decoys. L11–15 → 5 words / 5–6 letters / 5–6 cols / 2–3 decoys.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// fe-next/lib/blast/v2/__tests__/pack-chain-en.test.ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { buildChainLevel } from '../engine/chain-builder';
+import { validateChainLevel } from '../engine/chain-validator';
+import type { ChainLevelSpec } from '../types';
+
+const pack = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'content/blast/packs/en/pack-chain.json'), 'utf8'),
+) as { locale: string; levels: ChainLevelSpec[] };
+
+describe('en pack-chain.json', () => {
+  it('has exactly 15 levels numbered 1..15', () => {
+    expect(pack.levels.map((l) => l.levelNumber)).toEqual(
+      Array.from({ length: 15 }, (_, i) => i + 1),
+    );
+  });
+
+  it('every level builds and passes the forced-chain validator', () => {
+    for (const spec of pack.levels) {
+      const level = buildChainLevel(spec, spec.levelNumber);
+      expect(level, `${spec.id} failed to build`).not.toBeNull();
+      const check = validateChainLevel(level!);
+      expect(check.ok, `${spec.id}: ${check.ok ? '' : check.reason}`).toBe(true);
+    }
+  });
+
+  it('respects the difficulty curve (chain length grows by tier)', () => {
+    for (const spec of pack.levels) {
+      const n = spec.levelNumber;
+      const expected = n <= 5 ? 3 : n <= 10 ? 4 : 5;
+      expect(spec.chain.length, `${spec.id}`).toBe(expected);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/__tests__/pack-chain-en.test.ts`
+Expected: FAIL — stub has 1 level.
+
+- [ ] **Step 3: Replace `pack-chain.json` with all 15 levels**
+
+```json
+{
+  "locale": "en",
+  "levels": [
+    { "id": "en-chain-01", "levelNumber": 1,  "theme": "onboarding", "locale": "en", "columns": 4, "decoyTiles": 0, "chain": ["CAT", "SUN", "EGG"] },
+    { "id": "en-chain-02", "levelNumber": 2,  "theme": "fruits",     "locale": "en", "columns": 4, "decoyTiles": 0, "chain": ["FIG", "PEAR", "KIWI"] },
+    { "id": "en-chain-03", "levelNumber": 3,  "theme": "animals",    "locale": "en", "columns": 4, "decoyTiles": 0, "chain": ["COW", "GOAT", "DEER"] },
+    { "id": "en-chain-04", "levelNumber": 4,  "theme": "food",       "locale": "en", "columns": 4, "decoyTiles": 0, "chain": ["JAM", "RICE", "CAKE"] },
+    { "id": "en-chain-05", "levelNumber": 5,  "theme": "colors",     "locale": "en", "columns": 4, "decoyTiles": 0, "chain": ["RED", "BLUE", "PINK"] },
+    { "id": "en-chain-06", "levelNumber": 6,  "theme": "ocean",      "locale": "en", "columns": 5, "decoyTiles": 1, "chain": ["CRAB", "SEAL", "WHALE", "SHARK"] },
+    { "id": "en-chain-07", "levelNumber": 7,  "theme": "space",      "locale": "en", "columns": 5, "decoyTiles": 1, "chain": ["MARS", "MOON", "STAR", "COMET"] },
+    { "id": "en-chain-08", "levelNumber": 8,  "theme": "animals",    "locale": "en", "columns": 5, "decoyTiles": 2, "chain": ["WOLF", "LION", "BEAR", "TIGER"] },
+    { "id": "en-chain-09", "levelNumber": 9,  "theme": "fruits",     "locale": "en", "columns": 5, "decoyTiles": 2, "chain": ["PLUM", "MANGO", "GRAPE", "LEMON"] },
+    { "id": "en-chain-10", "levelNumber": 10, "theme": "weather",    "locale": "en", "columns": 5, "decoyTiles": 2, "chain": ["RAIN", "SNOW", "CLOUD", "STORM"] },
+    { "id": "en-chain-11", "levelNumber": 11, "theme": "animals",    "locale": "en", "columns": 5, "decoyTiles": 2, "chain": ["HORSE", "ZEBRA", "PANDA", "KOALA", "OTTER"] },
+    { "id": "en-chain-12", "levelNumber": 12, "theme": "food",       "locale": "en", "columns": 5, "decoyTiles": 2, "chain": ["BREAD", "PASTA", "SALAD", "HONEY", "OLIVE"] },
+    { "id": "en-chain-13", "levelNumber": 13, "theme": "nature",     "locale": "en", "columns": 5, "decoyTiles": 3, "chain": ["RIVER", "BEACH", "CLIFF", "MARSH", "GROVE"] },
+    { "id": "en-chain-14", "levelNumber": 14, "theme": "space",      "locale": "en", "columns": 6, "decoyTiles": 3, "chain": ["PLANET", "GALAXY", "METEOR", "ROCKET", "ORBITS"] },
+    { "id": "en-chain-15", "levelNumber": 15, "theme": "animals",    "locale": "en", "columns": 6, "decoyTiles": 3, "chain": ["JAGUAR", "FALCON", "WALRUS", "BEAVER", "IGUANA"] }
+  ]
+}
+```
+
+> If a level fails to build/validate, the failure message names the level. Swap the offending word for another on-theme word of the same length (e.g. `IGUANA` → `MONKEY`) and re-run. Keep `theme` values to keys that exist in `ThemeKey` — if `weather`/`nature` are not in `ThemeKey`, use the closest existing key.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/__tests__/pack-chain-en.test.ts`
+Expected: PASS (3 tests). Iterate on word swaps until green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fe-next/content/blast/packs/en/pack-chain.json fe-next/lib/blast/v2/__tests__/pack-chain-en.test.ts
+git commit -m "feat(blast): 15 authored English chain levels"
+```
+
+---
+
+## Task 7: Author 15 Hebrew chain levels
+
+**Files:**
+- Create: `fe-next/content/blast/packs/he/pack-chain.json`
+- Test: `fe-next/lib/blast/v2/__tests__/pack-chain-he.test.ts`
+
+Same structure, predefined Hebrew words. Hebrew final forms: author words with **base forms** in the JSON (כ not ך) — `he.ts` normalize/displayChar handles final-form rendering. Word length counts Hebrew letters.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// fe-next/lib/blast/v2/__tests__/pack-chain-he.test.ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { buildChainLevel } from '../engine/chain-builder';
+import { validateChainLevel } from '../engine/chain-validator';
+import type { ChainLevelSpec } from '../types';
+
+const pack = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'content/blast/packs/he/pack-chain.json'), 'utf8'),
+) as { locale: string; levels: ChainLevelSpec[] };
+
+describe('he pack-chain.json', () => {
+  it('has exactly 15 levels numbered 1..15', () => {
+    expect(pack.levels.map((l) => l.levelNumber)).toEqual(
+      Array.from({ length: 15 }, (_, i) => i + 1),
+    );
+  });
+
+  it('every level builds and passes the forced-chain validator', () => {
+    for (const spec of pack.levels) {
+      const level = buildChainLevel(spec, spec.levelNumber);
+      expect(level, `${spec.id} failed to build`).not.toBeNull();
+      const check = validateChainLevel(level!);
+      expect(check.ok, `${spec.id}: ${check.ok ? '' : check.reason}`).toBe(true);
+    }
+  });
+
+  it('uses base-form Hebrew letters only (no final forms in source)', () => {
+    const finals = ['ך', 'ם', 'ן', 'ף', 'ץ'];
+    for (const spec of pack.levels) {
+      for (const word of spec.chain) {
+        for (const f of finals) {
+          expect(word.includes(f), `${spec.id} word ${word} has final form`).toBe(false);
+        }
+      }
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/__tests__/pack-chain-he.test.ts`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Create `he/pack-chain.json`**
+
+```json
+{
+  "locale": "he",
+  "levels": [
+    { "id": "he-chain-01", "levelNumber": 1,  "theme": "onboarding", "locale": "he", "columns": 4, "decoyTiles": 0, "chain": ["חתול", "שמש", "ביצה"] },
+    { "id": "he-chain-02", "levelNumber": 2,  "theme": "fruits",     "locale": "he", "columns": 4, "decoyTiles": 0, "chain": ["תפוח", "ענב", "אגס"] },
+    { "id": "he-chain-03", "levelNumber": 3,  "theme": "animals",    "locale": "he", "columns": 3, "decoyTiles": 0, "chain": ["כלב", "פרה", "סוס"] },
+    { "id": "he-chain-04", "levelNumber": 4,  "theme": "food",       "locale": "he", "columns": 4, "decoyTiles": 0, "chain": ["לחם", "אורז", "עוגה"] },
+    { "id": "he-chain-05", "levelNumber": 5,  "theme": "colors",     "locale": "he", "columns": 4, "decoyTiles": 0, "chain": ["אדום", "כחול", "ירוק"] },
+    { "id": "he-chain-06", "levelNumber": 6,  "theme": "ocean",      "locale": "he", "columns": 5, "decoyTiles": 1, "chain": ["דג", "סרטן", "כריש", "לוויתן"] },
+    { "id": "he-chain-07", "levelNumber": 7,  "theme": "space",      "locale": "he", "columns": 5, "decoyTiles": 1, "chain": ["ירח", "כוכב", "שמש", "מאדים"] },
+    { "id": "he-chain-08", "levelNumber": 8,  "theme": "animals",    "locale": "he", "columns": 4, "decoyTiles": 2, "chain": ["זאב", "דוב", "נמר", "אריה"] },
+    { "id": "he-chain-09", "levelNumber": 9,  "theme": "fruits",     "locale": "he", "columns": 5, "decoyTiles": 2, "chain": ["תפוז", "בננה", "מנגו", "לימון"] },
+    { "id": "he-chain-10", "levelNumber": 10, "theme": "weather",    "locale": "he", "columns": 4, "decoyTiles": 2, "chain": ["גשם", "ענן", "שלג", "סופה"] },
+    { "id": "he-chain-11", "levelNumber": 11, "theme": "animals",    "locale": "he", "columns": 5, "decoyTiles": 2, "chain": ["סוסה", "זברה", "פנדה", "קואלה", "נמיה"] },
+    { "id": "he-chain-12", "levelNumber": 12, "theme": "food",       "locale": "he", "columns": 5, "decoyTiles": 2, "chain": ["גבינה", "פסטה", "סלט", "דבש", "זית"] },
+    { "id": "he-chain-13", "levelNumber": 13, "theme": "nature",     "locale": "he", "columns": 5, "decoyTiles": 3, "chain": ["נהר", "חוף", "מערה", "אגם", "יער"] },
+    { "id": "he-chain-14", "levelNumber": 14, "theme": "space",      "locale": "he", "columns": 6, "decoyTiles": 3, "chain": ["כוכב", "גלקסיה", "מטאור", "רקטה", "מסלול"] },
+    { "id": "he-chain-15", "levelNumber": 15, "theme": "animals",    "locale": "he", "columns": 5, "decoyTiles": 3, "chain": ["קרנף", "נמר", "פיל", "צבי", "יען"] }
+  ]
+}
+```
+
+> Same iteration rule as Task 6: if a level fails to build, swap an on-theme Hebrew word of equal length. These words are AI-selected — **flag the whole HE pack for native Hebrew review** in the final summary; the validator only guarantees structure, not idiomatic word choice.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2/__tests__/pack-chain-he.test.ts`
+Expected: PASS (3 tests). Iterate on word swaps until green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fe-next/content/blast/packs/he/pack-chain.json fe-next/lib/blast/v2/__tests__/pack-chain-he.test.ts
+git commit -m "feat(blast): 15 authored Hebrew chain levels (native review pending)"
+```
+
+---
+
+## Task 8: Hybrid tile restyle
+
+**Files:**
+- Modify: `fe-next/components/blast/v2/BlastTile.tsx`
+- Modify: `fe-next/components/blast/v2/BlastTile.module.css` (the `styles.tile` / `styles.letter` rules)
+- Test: `fe-next/components/blast/v2/__tests__/BlastTile.test.tsx` (extend existing)
+
+Hybrid look: chunky tactile tile with depth (bevel + inner highlight + hard drop shadow), warm face, neo-brutalist solid border + hard edge. Selected state uses the electric Blast accent. No wood texture. Keep the existing `m.div` / `layout` / `AnimatePresence` props — only style + add a `data-depth` hook for the GSAP land-squash in Task 9.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// extend fe-next/components/blast/v2/__tests__/BlastTile.test.tsx
+import { render } from '@testing-library/react';
+import { BlastTile } from '../BlastTile';
+
+it('renders a tactile tile with a hard border and depth hook', () => {
+  const { container } = render(
+    <BlastTile letter="A" cellId="c0r0" flags={[]} state="normal" fontStack="Rubik" />,
+  );
+  const tile = container.querySelector('[data-cell-id="c0r0"]') as HTMLElement;
+  expect(tile).toBeTruthy();
+  expect(tile.getAttribute('data-depth')).toBe('rest');
+  // hard neo-brutalist border, not a soft shadow-only tile
+  const cls = tile.className;
+  expect(cls).toContain('tile');
+});
+
+it('marks the depth hook as pressed when selected', () => {
+  const { container } = render(
+    <BlastTile letter="A" cellId="c0r0" flags={[]} state="selected" fontStack="Rubik" />,
+  );
+  const tile = container.querySelector('[data-cell-id="c0r0"]') as HTMLElement;
+  expect(tile.getAttribute('data-depth')).toBe('pressed');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd fe-next && npx vitest run components/blast/v2/__tests__/BlastTile.test.tsx`
+Expected: FAIL — `data-depth` attribute not present.
+
+- [ ] **Step 3: Update `BlastTile.tsx`**
+
+Add `data-depth={state === 'selected' ? 'pressed' : 'rest'}` to the `m.div`. Replace the inline `background`/`padding` styling approach with CSS-module classes that give: solid 3px border (`var(--blast-tile-border, #1a1330)`), hard offset shadow (`4px 4px 0` brand navy), inner top highlight (`inset 0 2px 0 rgba(255,255,255,0.35)`), warm face (`#f4e9d8` rest), accent face when selected (`modeColor`). Keep `modeColor` prop as the selected-state fill. Letter stays bold Fredoka-weight via `fontStack`.
+
+```tsx
+// the m.div, with restyle:
+<m.div
+  layout
+  data-cell-id={id}
+  data-state={state}
+  data-depth={state === 'selected' ? 'pressed' : 'rest'}
+  className={styles.tile}
+  style={{
+    fontFamily: fontStack,
+    ['--tile-face' as string]: state === 'selected' ? modeColor : undefined,
+  }}
+  animate={state === 'selected' ? { scale: 1.06, y: -5 } : { scale: 1, y: 0 }}
+  exit={state === 'just-cleared' ? { scale: 0, opacity: 0, rotate: 8 } : undefined}
+  whileTap={{ scale: 0.94 }}
+  onPointerDown={...}
+>
+  <span className={styles.letter}>{displayChar ?? letter}</span>
+  {hasCoin && <span data-flag="coin" className={styles.coin} />}
+  {hasGem && <span data-flag="gem" className={styles.gem} />}
+</m.div>
+```
+
+CSS module rules (`BlastTile.module.css`):
+```css
+.tile {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: var(--blast-tile-size, 56px);
+  height: var(--blast-tile-size, 56px);
+  background: var(--tile-face, #f4e9d8);
+  color: #2a1f12;
+  border: 3px solid #1a1330;
+  border-radius: 10px;
+  box-shadow: 4px 4px 0 #1a1330, inset 0 2px 0 rgba(255, 255, 255, 0.4),
+    inset 0 -3px 0 rgba(0, 0, 0, 0.12);
+  user-select: none;
+  touch-action: none;
+}
+.tile[data-state='selected'] { color: #fff; }
+.tile[data-state='just-cleared'] { box-shadow: none; }
+.letter { font-size: clamp(1.1rem, 4.5vw, 1.6rem); font-weight: 700; line-height: 1; }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd fe-next && npx vitest run components/blast/v2/__tests__/BlastTile.test.tsx`
+Expected: PASS (existing + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fe-next/components/blast/v2/BlastTile.tsx fe-next/components/blast/v2/BlastTile.module.css fe-next/components/blast/v2/__tests__/BlastTile.test.tsx
+git commit -m "feat(blast): hybrid neo-brutalist tactile tile restyle"
+```
+
+---
+
+## Task 9: GSAP collapse timeline
+
+**Files:**
+- Create: `fe-next/components/blast/v2/useCollapseTimeline.ts`
+- Modify: `fe-next/components/blast/v2/BlastBoard.tsx`
+- Test: `fe-next/components/blast/v2/__tests__/useCollapseTimeline.test.tsx`
+
+When `tileIds` changes (a collapse happened), run a GSAP timeline that drops the moved tiles with an ease-in + squash-on-land. Framer Motion's `layout` already animates position; GSAP adds the squash punch on top via the `data-depth` hook and a transient `data-depth="land"`. Respect `prefers-reduced-motion`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// fe-next/components/blast/v2/__tests__/useCollapseTimeline.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCollapseTimeline } from '../useCollapseTimeline';
+
+describe('useCollapseTimeline', () => {
+  it('does not animate on first render (no prior tileIds)', () => {
+    const ref = { current: document.createElement('div') };
+    const { rerender } = renderHook(
+      ({ ids }) => useCollapseTimeline(ref, ids),
+      { initialProps: { ids: [['a', 'b']] } },
+    );
+    rerender({ ids: [['a', 'b']] });
+    // no throw, no crash — timeline only fires on change
+    expect(true).toBe(true);
+  });
+
+  it('skips animation when prefers-reduced-motion is set', () => {
+    const ref = { current: document.createElement('div') };
+    vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: true } as MediaQueryList);
+    const { rerender } = renderHook(
+      ({ ids }) => useCollapseTimeline(ref, ids),
+      { initialProps: { ids: [['a']] } },
+    );
+    rerender({ ids: [['b']] }); // changed — but reduced motion -> no GSAP timeline
+    expect(true).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd fe-next && npx vitest run components/blast/v2/__tests__/useCollapseTimeline.test.tsx`
+Expected: FAIL — `useCollapseTimeline` not exported.
+
+- [ ] **Step 3: Implement the hook**
+
+```tsx
+// fe-next/components/blast/v2/useCollapseTimeline.ts
+import { useEffect, useRef } from 'react';
+import gsap from 'gsap';
+
+function reducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+}
+
+/**
+ * Plays a squash-on-land GSAP punch on tiles whose tileId changed (i.e. tiles
+ * that moved during the last collapse). Framer Motion handles the positional
+ * slide via `layout`; this adds the landing punch.
+ */
+export function useCollapseTimeline(
+  boardRef: React.RefObject<HTMLElement | null>,
+  tileIds: string[][],
+): void {
+  const prev = useRef<string | null>(null);
+
+  useEffect(() => {
+    const key = JSON.stringify(tileIds);
+    if (prev.current === null) { prev.current = key; return; }
+    if (prev.current === key) return;
+    prev.current = key;
+    if (reducedMotion() || !boardRef.current) return;
+
+    const tiles = boardRef.current.querySelectorAll<HTMLElement>('[data-cell-id]');
+    const tl = gsap.timeline();
+    tiles.forEach((el, i) => {
+      tl.fromTo(
+        el,
+        { scaleY: 1 },
+        {
+          scaleY: 0.82, duration: 0.09, yoyo: true, repeat: 1,
+          ease: 'power2.in', transformOrigin: 'bottom center',
+        },
+        i * 0.012,
+      );
+    });
+    return () => { tl.kill(); };
+  }, [tileIds, boardRef]);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd fe-next && npx vitest run components/blast/v2/__tests__/useCollapseTimeline.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire into `BlastBoard.tsx`**
+
+Add a `boardRef` on the outer `<div>`, call `useCollapseTimeline(boardRef, tileIds)`. No other markup change.
+
+```tsx
+const boardRef = useRef<HTMLDivElement>(null);
+useCollapseTimeline(boardRef, tileIds);
+// ...
+<div ref={boardRef} dir={config.rtl ? 'rtl' : 'ltr'} data-shake-key={invalidShakeKey}>
+```
+
+- [ ] **Step 6: Run the board test + commit**
+
+Run: `cd fe-next && npx vitest run components/blast/v2/__tests__/BlastBoard.test.tsx`
+Expected: PASS (no regression).
+
+```bash
+git add fe-next/components/blast/v2/useCollapseTimeline.ts fe-next/components/blast/v2/BlastBoard.tsx fe-next/components/blast/v2/__tests__/useCollapseTimeline.test.tsx
+git commit -m "feat(blast): GSAP squash-on-land collapse timeline"
+```
+
+---
+
+## Task 10: Cascade-reveal glow
+
+**Files:**
+- Modify: `fe-next/components/blast/v2/BlastBoard.tsx`
+- Test: `fe-next/components/blast/v2/__tests__/BlastBoard.test.tsx` (extend)
+
+After a collapse, the next chain word becomes formable. Highlight its cells with a pulse-glow so the player sees what the collapse unlocked. Reuse `detectAllCascades`/the `almosts` pipeline already feeding `BlastBoard` — but specifically glow the cells of the *next resolvable word*. The `almosts` prop already exists; add a `revealGlowCells?: CellId[]` prop and render a glow layer over those cells.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// extend BlastBoard.test.tsx
+it('renders a reveal glow over the cells passed in revealGlowCells', () => {
+  const { container } = render(
+    <BlastBoard
+      level={sampleLevel}
+      selection={emptySelection}
+      invalidShakeKey={0}
+      onPointerDown={() => {}}
+      onPointerEnter={() => {}}
+      onPointerUp={() => {}}
+      tileIds={sampleTileIds}
+      revealGlowCells={['c0r0', 'c1r0']}
+    />,
+  );
+  expect(container.querySelectorAll('[data-reveal-glow]').length).toBe(2);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd fe-next && npx vitest run components/blast/v2/__tests__/BlastBoard.test.tsx -t reveal`
+Expected: FAIL — prop/markup not present.
+
+- [ ] **Step 3: Implement**
+
+Add `revealGlowCells?: CellId[]` to `BlastBoard` props. For each tile, if its `cellId` is in `revealGlowCells`, render a sibling `<span data-reveal-glow className={styles.revealGlow} />` (absolutely positioned, pulsing keyframe, electric accent, `prefers-reduced-motion` gated via CSS). Compute `revealGlowCells` upstream in `BlastGame.tsx`: after a successful submit, `scanFormableThemeWords(level, [nextResolvableWord], locale)` → first match's cells; clear on next selection start.
+
+CSS:
+```css
+.revealGlow {
+  position: absolute; inset: -2px; border-radius: 12px; pointer-events: none;
+  box-shadow: 0 0 0 3px var(--blast-accent, #22d3ee), 0 0 16px 4px var(--blast-accent, #22d3ee);
+  animation: revealPulse 0.9s ease-in-out 2;
+}
+@keyframes revealPulse { 0%,100% { opacity: 0.25; } 50% { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) { .revealGlow { animation: none; opacity: 0.6; } }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd fe-next && npx vitest run components/blast/v2/__tests__/BlastBoard.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fe-next/components/blast/v2/BlastBoard.tsx fe-next/components/blast/v2/BlastGame.tsx fe-next/components/blast/v2/__tests__/BlastBoard.test.tsx
+git commit -m "feat(blast): cascade-reveal glow highlights the unlocked word"
+```
+
+---
+
+## Task 11: Integration, full suite, build, playtest
+
+**Files:**
+- No new files — verification + any wiring fixes surfaced.
+
+- [ ] **Step 1: Run the full blast v2 suite**
+
+Run: `cd fe-next && npx vitest run lib/blast/v2 components/blast/v2`
+Expected: PASS — all engine, pack, component tests green.
+
+- [ ] **Step 2: Lint + typecheck + build**
+
+Run: `cd fe-next && npm run lint && npm run build`
+Expected: no errors. Fix any surfaced type mismatches (likely in registry wiring or `BlastGame` reveal-glow plumbing).
+
+- [ ] **Step 3: Playwriter playtest — English**
+
+Start dev server (`cd fe-next && npm run dev`, port **3001**). Open `http://localhost:3001/en/blast?v2=force`. Play level 1: confirm only the first word is selectable, finding it collapses tiles, the next word's cells glow, and the chain completes to an empty board. Repeat spot-checks on levels 6 and 13. Screenshot each.
+
+- [ ] **Step 4: Playwriter playtest — Hebrew RTL**
+
+Open `http://localhost:3001/he/blast?v2=force`. Confirm RTL board layout, Hebrew tiles render with correct final forms, chain forces order, level 1 completes. Screenshot.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "chore(blast): integration fixes + playtest verification for v2 playable"
+```
+
+- [ ] **Step 6: Summary**
+
+Report: tasks done, test counts, playtest screenshots, and explicitly flag the **Hebrew pack for native review** and any `ThemeKey` substitutions made.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** forced-chain mechanic → T1–4; authored 15 EN + 15 HE → T6–7; pack loading → T5; hybrid aesthetic → T8; GSAP collapse → T9; cascade-reveal → T10; PixiJS bursts → *already exist in `BlastFxOverlay`*, no new task needed (reused, noted in spec); playtest → T11. **Gap:** spec mentioned animate-ai micro-interactions — Framer Motion `whileTap` already covers tile press (T8); animate-ai is MCP-only with no runtime lib, so no separate task. Acceptable per spec's "reuse" intent.
+- **Type consistency:** `ChainLevelSpec`, `WordMatch`, `InsertResult`, `ChainValidation`, `ChainPackFile` defined once, used consistently. `scanFormableThemeWords(level, targets, locale)` signature stable across T1/T2/T3/T4/T5.
+- **Placeholders:** none — every code step has full code; word-swap iteration loops in T6/T7 are explicit fallback instructions, not placeholders (the validator is the acceptance gate).
+- **Risk:** `buildChainLevel` may return null for chains whose words can't be isolated; mitigated by the 200-attempt seed loop + explicit author word-swap instruction in T6/T7.

--- a/docs/superpowers/specs/2026-05-14-blast-v2-playable-design.md
+++ b/docs/superpowers/specs/2026-05-14-blast-v2-playable-design.md
@@ -1,0 +1,141 @@
+# Blast v2 Playable — Design Spec
+
+**Date:** 2026-05-14
+**Branch:** `worktree-blast-v2-playable`
+**Status:** Approved design, pre-implementation
+
+## Goal
+
+Make Blast v2 a genuinely playable, fun cascade word game in the style of *Word Stacks*:
+letters stacked in columns, the player finds words, cleared tiles collapse under gravity,
+and the collapse reveals/enables the next word. Ship 15 hand-authored English levels and
+15 hand-authored Hebrew levels with rising difficulty. Hybrid aesthetic. Juicy animation
+via PixiJS + GSAP + animate-ai.
+
+## Core Mechanic: Forced Cascade Chain
+
+Each level is an **ordered list of N words** ("the chain"). The board is constructed so that:
+
+- At the start, **exactly one** word (word 1) can be formed as a valid straight-line selection.
+- Finding word 1 removes its tiles → gravity collapse → word 2's letters fall into a
+  selectable straight line.
+- This repeats: word *k* is only formable after word *k-1* collapses.
+- Clearing the last word empties the board → level win.
+
+No word in the chain is reachable out of order. Cascade is the mechanic, not decoration.
+
+Selection stays straight horizontal/vertical adjacent runs (existing `selection-state.ts`
+behaviour — unchanged).
+
+## Architecture
+
+### Reuse (no change beyond integration)
+- `lib/blast/v2/engine/collapse.ts` — gravity collapse + `rebuildTileIds()`
+- `lib/blast/v2/engine/selection-state.ts` — drag/tap selection state machine
+- `lib/blast/v2/engine/cascade.ts` — `detectAllCascades()` for "what's now formable"
+- `lib/blast/v2/useBlastV2.ts` — main reducer + `tileIds` animation slice
+- `lib/blast/v2/locales/he.ts` — Hebrew letter pool, final-form folding, RTL flag
+- `lib/blast/v2/curated-pack-source.ts` + `level-source-registry.ts` — pack loading
+- `components/blast/v2/BlastFxOverlay.tsx` — PixiJS particle FX layer
+- `components/blast/v2/BlastAlmostGhost.tsx` — reused for cascade-reveal glow
+- Feature gate in `app/[locale]/blast/page.tsx` — `?v2=force` + tester list (unchanged)
+
+### New
+1. **`lib/blast/v2/engine/chain-builder.ts`** — `buildChainLevel(spec)`. Takes an ordered
+   word list + column count + decoy config, places words **backwards**: final word on the
+   floor, then "un-collapse" (lift existing tiles up by the inserted word's footprint,
+   scatter the previous word's letters above) for each earlier word. Backward construction
+   guarantees the forward chain is forced and fully solvable. Output: a `BlastLevel`
+   (columns of letters) + the canonical solution order.
+2. **`lib/blast/v2/engine/chain-validator.ts`** — `validateChainLevel(level, solution)`.
+   Replays the chain forward; at each step asserts the intended word is the *only* newly
+   formable theme word (decoys must never form a theme word). Used in pack tests; every
+   authored level must pass.
+3. **`content/blast/packs/en/pack-chain-{01..15}.json`** — 15 English chain levels.
+4. **`content/blast/packs/he/pack-chain-{01..15}.json`** — 15 Hebrew chain levels.
+   Predefined Hebrew words, final-form folding via `he.ts`.
+5. **Tile restyle** — `components/blast/v2/BlastTile.tsx` reworked to hybrid look.
+6. **GSAP collapse timeline** — staggered tile-drop animation in `BlastBoard.tsx`
+   driven by the existing `tileIds` slice.
+
+## Level Authoring Format
+
+Each pack JSON declares the *intent*, not the raw board. The build step / test fixture
+runs `buildChainLevel` to produce the board, so authoring stays terse and always solvable:
+
+```json
+{
+  "id": "en-chain-07",
+  "theme": "animals",
+  "locale": "en",
+  "columns": 4,
+  "decoyTiles": 2,
+  "chain": ["CAT", "LION", "TIGER", "BEAR"]
+}
+```
+
+`buildChainLevel` resolves `columns`/`decoyTiles`/`chain` → concrete `BlastLevel`.
+`chain-validator` asserts the forced order. Pack loader (`curated-pack-source.ts`) gains a
+small adapter to accept the chain-spec shape and expand it on load.
+
+## Difficulty Curve (per language, 15 levels)
+
+| Levels | Words in chain | Word length | Columns | Decoys |
+|--------|----------------|-------------|---------|--------|
+| 1–5    | 3              | 3–4         | 3–4     | 0      |
+| 6–10   | 4              | 4–5         | 4–5     | 1–2    |
+| 11–15  | 5              | 5–6         | 5–6     | 2–3    |
+
+Decoy tiles are extra letters that collapse with the board but never complete a theme word
+(validator enforces this). Hebrew curve mirrors the English curve with predefined Hebrew
+words appropriate to each theme.
+
+## Aesthetic: Hybrid
+
+- **Tiles** (`BlastTile`): chunky, tactile, with depth (inner shadow / bevel) and a warm
+  face — but neo-brutalist hard edge + solid border. Selection state uses the electric
+  Blast accent (pink/cyan). Not wood-textured; brand-coherent.
+- **HUD / chrome** (`BlastHud`, intro/complete cards): full neo-brutalist — dark navy,
+  hard pixel shadows, Fredoka/Rubik. Matches the rest of LexiClash.
+
+## Animation
+
+- **Collapse:** GSAP timeline, per-tile staggered drop with ease-in + slight squash-on-land,
+  driven by the existing `tileIds` slice so React state stays the source of truth.
+- **Cascade reveal:** pulse-glow on the region of the now-enabled word (reuse
+  `BlastAlmostGhost`) so the player sees what the collapse unlocked.
+- **Word clear:** PixiJS particle burst via `BlastFxOverlay`; larger burst on level complete.
+- **Micro-interactions:** animate-ai for tile press and selection-path feedback.
+- All motion respects `prefers-reduced-motion` (existing pattern in the codebase).
+
+## i18n
+
+No hardcoded strings — all UI text via `t('key')`. New keys for any chain-specific UI go
+in all 5 locales (en/he/sv/ja/es); HE/SV/JA/ES get AI translation flagged for native review.
+Note: only EN + HE get authored level packs in v1; sv/ja/es fall back to the existing
+generated level source.
+
+## Testing (TDD, mandatory)
+
+- `chain-builder.test.ts` — backward construction produces a board whose forward replay
+  matches the input chain.
+- `chain-validator.test.ts` — rejects levels where a word is formable out of order, or where
+  a decoy forms a theme word.
+- `pack-chain.test.ts` — loads all 30 authored packs, asserts each passes `validateChainLevel`.
+- Component tests for restyled `BlastTile` and GSAP collapse integration.
+- Playwriter end-to-end playtest on a real browser before declaring done.
+
+## Phases
+
+1. **Engine** — `chain-builder` + `chain-validator` (TDD).
+2. **Content** — author 15 EN + 15 HE chain packs; all pass the validator.
+3. **Visual** — hybrid `BlastTile` + HUD restyle.
+4. **Animation** — GSAP collapse timeline, cascade-reveal glow, Pixi bursts.
+5. **Wire + playtest** — integrate, Playwriter playtest, lint/test/build green.
+
+## Out of Scope (v1)
+
+- Authored packs for sv/ja/es (generated fallback stays).
+- Removing the feature gate / making v2 the default.
+- Multiplayer Blast changes.
+- Chest / FTUE / unlock-card telemetry rework.

--- a/fe-next/app/[locale]/blast/page.tsx
+++ b/fe-next/app/[locale]/blast/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import { createClient } from '@/utils/supabase/server';
 import type { Locale } from '@/lib/blast/v2/types';
-import { buildRegistry } from '@/lib/blast/v2/level-source-registry';
+import { buildRegistry, getLevelSourceForLevel } from '@/lib/blast/v2/level-source-registry';
 import { BlastV2PageClient } from './v2/BlastV2PageClient';
 import BlastLegacyPageClient from './legacy/PageClient';
 
@@ -33,14 +33,15 @@ export default async function BlastPage({
 
   if (useV2) {
     const registry = buildRegistry();
-    const level = await registry.curated.resolve(1, locale)
-      .catch(() => locale !== 'en' ? registry.curated.resolve(1, 'en') : Promise.reject(new Error('no en pack')))
+    const levelNumber = 1;
+    const level = await getLevelSourceForLevel(levelNumber, locale, registry).resolve(levelNumber, locale)
+      .catch(() => locale !== 'en' ? getLevelSourceForLevel(levelNumber, 'en', registry).resolve(levelNumber, 'en') : Promise.reject(new Error('no en pack')))
       .catch((error: unknown) => {
         console.error('Failed to load blast v2 level:', error);
         return null;
       });
     if (level) return <BlastV2PageClient level={level} />;
-    // fall through to legacy if curated pack missing for this locale
+    // fall through to legacy if chain/curated pack missing for this locale
   }
 
   return <BlastLegacyPageClient />;

--- a/fe-next/app/[locale]/blast/page.tsx
+++ b/fe-next/app/[locale]/blast/page.tsx
@@ -17,7 +17,7 @@ export default async function BlastPage({
   searchParams?: Promise<{ v2?: string }>;
 }) {
   const { locale: rawLocale } = await params;
-  const resolvedSearch = await searchParams;
+  const resolvedSearch = searchParams ? await searchParams : undefined;
   if (!VALID_LOCALES.includes(rawLocale as Locale)) {
     notFound();
   }

--- a/fe-next/app/api/blast/clear-level/route.ts
+++ b/fe-next/app/api/blast/clear-level/route.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@/utils/supabase/server';
 import { applyAntiCheatCaps, applyAntiCheatCapsWithLevel, type ClearSubmission } from '@/lib/blast/v2/anti-cheat';
-import { buildRegistry } from '@/lib/blast/v2/level-source-registry';
+import { buildRegistry, getLevelSourceForLevel } from '@/lib/blast/v2/level-source-registry';
 import { CURATED_LEVEL_CUTOFF } from '@/lib/blast/v2/level-source';
 import { awardCoinsServer } from '@/backend/services/economy/awardCoins';
 import { NextRequest, NextResponse } from 'next/server';
@@ -52,7 +52,8 @@ export async function POST(req: NextRequest) {
   let capped;
   if (submission.levelNumber <= CURATED_LEVEL_CUTOFF) {
     try {
-      const level = await buildRegistry().curated.resolve(submission.levelNumber, submission.locale);
+      const registry = buildRegistry();
+      const level = await getLevelSourceForLevel(submission.levelNumber, submission.locale, registry).resolve(submission.levelNumber, submission.locale);
       capped = applyAntiCheatCapsWithLevel(submission, submission.earnedCoins, level);
     } catch {
       // Pack missing / load failure — gracefully fall back to level-less caps.

--- a/fe-next/components/blast/v2/BlastBoard.tsx
+++ b/fe-next/components/blast/v2/BlastBoard.tsx
@@ -8,6 +8,7 @@ import { BlastTile, type BlastTileState } from './BlastTile';
 import { BlastSelectionPath } from './BlastSelectionPath';
 import { BlastAlmostGhost } from './BlastAlmostGhost';
 import { useCollapseTimeline } from './useCollapseTimeline';
+import styles from './BlastTile.module.css';
 
 type Props = {
   level: BlastLevel;
@@ -19,6 +20,7 @@ type Props = {
   modeColor?: string;
   almosts?: AlmostWord[];
   tileIds: string[][];
+  revealGlowCells?: CellId[];
 };
 
 export function BlastBoard({
@@ -31,10 +33,12 @@ export function BlastBoard({
   modeColor = '#ec4899',
   almosts,
   tileIds,
+  revealGlowCells = [],
 }: Props) {
   const config = LOCALE_CONFIGS[level.locale];
   const boardRef = useRef<HTMLDivElement>(null);
   const selectedSet = selection.kind === 'active' ? new Set(selection.cells) : new Set<CellId>();
+  const revealGlowSet = new Set(revealGlowCells);
 
   useCollapseTimeline(boardRef, tileIds);
 
@@ -105,19 +109,24 @@ export function BlastBoard({
                 const id = makeCellId(col.index, row);
                 const flags = level.tileFlags[id] ?? [];
                 const tileKey = tileIds[c]?.[row] ?? id;
+                const hasRevealGlow = revealGlowSet.has(id);
                 return (
-                  <BlastTile
-                    key={tileKey}
-                    cellId={id}
-                    letter={letter}
-                    displayChar={config.displayChar(letter, row, col.tiles.length)}
-                    flags={flags}
-                    state={tileState(id)}
-                    modeColor={modeColor}
-                    fontStack={config.fontStack}
-                    paddingExtra={config.tileExtraPadding}
-                    onPointerDown={() => onPointerDown(id)}
-                  />
+                  <div key={tileKey} className="relative">
+                    <BlastTile
+                      cellId={id}
+                      letter={letter}
+                      displayChar={config.displayChar(letter, row, col.tiles.length)}
+                      flags={flags}
+                      state={tileState(id)}
+                      modeColor={modeColor}
+                      fontStack={config.fontStack}
+                      paddingExtra={config.tileExtraPadding}
+                      onPointerDown={() => onPointerDown(id)}
+                    />
+                    {hasRevealGlow && (
+                      <span data-reveal-glow className={styles.revealGlow} />
+                    )}
+                  </div>
                 );
               })}
             </AnimatePresence>

--- a/fe-next/components/blast/v2/BlastBoard.tsx
+++ b/fe-next/components/blast/v2/BlastBoard.tsx
@@ -7,6 +7,7 @@ import { LOCALE_CONFIGS } from '@/lib/blast/v2/locale-config';
 import { BlastTile, type BlastTileState } from './BlastTile';
 import { BlastSelectionPath } from './BlastSelectionPath';
 import { BlastAlmostGhost } from './BlastAlmostGhost';
+import { useCollapseTimeline } from './useCollapseTimeline';
 
 type Props = {
   level: BlastLevel;
@@ -34,6 +35,8 @@ export function BlastBoard({
   const config = LOCALE_CONFIGS[level.locale];
   const boardRef = useRef<HTMLDivElement>(null);
   const selectedSet = selection.kind === 'active' ? new Set(selection.cells) : new Set<CellId>();
+
+  useCollapseTimeline(boardRef, tileIds);
 
   const getCellCenter = useCallback((id: CellId) => {
     const board = boardRef.current;

--- a/fe-next/components/blast/v2/BlastGame.tsx
+++ b/fe-next/components/blast/v2/BlastGame.tsx
@@ -1,9 +1,10 @@
 'use client';
 import { useState, useEffect, useMemo, useRef } from 'react';
-import type { BlastLevel } from '@/lib/blast/v2/types';
+import type { BlastLevel, CellId } from '@/lib/blast/v2/types';
 import { markUnlockSeen, completeFtue, setSkipAll, type UnlocksSeen, type MechanicKey } from '@/lib/blast/v2/tutorial/unlocks-seen';
 import { useBlastV2 } from '@/lib/blast/v2/useBlastV2';
-import { detectAlmostWords } from '@/lib/blast/v2/engine';
+import { detectAlmostWords, detectAllCascades } from '@/lib/blast/v2/engine';
+import { scanFormableThemeWords } from '@/lib/blast/v2/engine/word-scan';
 import { LOCALE_CONFIGS } from '@/lib/blast/v2/locale-config';
 import { useChainHaptics } from '@/lib/blast/v2/fx/useChainHaptics';
 import { useChainEventBus } from '@/lib/blast/v2/fx/useChainEventBus';
@@ -80,6 +81,21 @@ export function BlastGame({
     () => detectAlmostWords(state.level, state.foundWords, LOCALE_CONFIGS[state.level.locale]),
     [state.level, state.foundWords],
   );
+  const [revealGlowCells, setRevealGlowCells] = useState<CellId[]>([]);
+  // Compute reveal glow cells when a word is found: glow the next formable word
+  useEffect(() => {
+    if (state.status === 'levelComplete') {
+      setRevealGlowCells([]);
+      return;
+    }
+    const cascades = detectAllCascades(state.level, state.foundWords, LOCALE_CONFIGS[state.level.locale]);
+    if (cascades.length > 0) {
+      // Glow the first (next) formable word
+      setRevealGlowCells(cascades[0].cells);
+    } else {
+      setRevealGlowCells([]);
+    }
+  }, [state.foundWords, state.level, state.status]);
   const { state: progressState, clearLevel, openChest, openMutation } = useBlastProgress();
   const [showChestModal, setShowChestModal] = useState(false);
   // Idempotency: one submission per level — prevents retry loop on state-feedback re-renders.
@@ -297,6 +313,7 @@ export function BlastGame({
           modeColor={modeColor}
           almosts={almosts}
           tileIds={state.tileIds}
+          revealGlowCells={revealGlowCells}
         />
       </div>
       {tutorial.showFtueOverlay && !isVeteranPlayer && ftueStep !== null && (

--- a/fe-next/components/blast/v2/BlastTile.module.css
+++ b/fe-next/components/blast/v2/BlastTile.module.css
@@ -33,8 +33,8 @@
     inset 0 2px 0 rgba(255, 255, 255, 0.4),
     inset 0 -3px 0 rgba(0, 0, 0, 0.12),
     6px 6px 0 0 #0b1530;
-  /* Accent color (pink for Blast) */
-  background: #ec4899;
+  /* Accent color — modeColor prop tints it, pink default for Blast */
+  background: var(--tile-mode-color, #ec4899);
   color: #ffffff;
   /* Subtle lift animation on selection */
   filter: brightness(1.1);

--- a/fe-next/components/blast/v2/BlastTile.module.css
+++ b/fe-next/components/blast/v2/BlastTile.module.css
@@ -102,3 +102,28 @@
     transform: scale(1.15);
   }
 }
+
+.revealGlow {
+  position: absolute;
+  inset: -2px;
+  border-radius: 12px;
+  pointer-events: none;
+  box-shadow: 0 0 0 3px #06b6d4, 0 0 16px 4px #06b6d4;
+  animation: revealPulse 0.9s ease-in-out 2;
+}
+
+@keyframes revealPulse {
+  0%, 100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .revealGlow {
+    animation: none;
+    opacity: 0.6;
+  }
+}

--- a/fe-next/components/blast/v2/BlastTile.module.css
+++ b/fe-next/components/blast/v2/BlastTile.module.css
@@ -4,22 +4,54 @@
   place-items: center;
   width: var(--blast-tile-size, clamp(48px, 18cqi, 88px));
   aspect-ratio: 1 / 1;
+  /* Neo-brutalist hard border: 3px solid, near-black */
   border: 3px solid #0b1530;
-  border-radius: 14px;
+  border-radius: 10px;
+  /* Hard offset drop shadow (no blur) — neo-brutalist style */
   box-shadow: 4px 4px 0 0 #0b1530;
+  /* Bevel/depth via inner highlights: top light + bottom shadow */
+  box-shadow:
+    inset 0 2px 0 rgba(255, 255, 255, 0.4),
+    inset 0 -3px 0 rgba(0, 0, 0, 0.12),
+    4px 4px 0 0 #0b1530;
   font-weight: 800;
   font-size: calc(var(--blast-tile-size, 64px) * 0.45);
+  /* Warm off-white tile face in rest state */
+  background: #f4e9d8;
   color: #0b1530;
   user-select: none;
   touch-action: none;
   cursor: pointer;
+  /* Smooth state transitions for depth effect */
+  transition: all 120ms ease-out;
 }
 
+/* Selected state: electric accent color face + white letter */
 .tile[data-state="selected"] {
-  box-shadow: 6px 6px 0 0 #0b1530;
-  filter: brightness(1.15);
+  /* Deeper shadow in pressed state */
+  box-shadow:
+    inset 0 2px 0 rgba(255, 255, 255, 0.4),
+    inset 0 -3px 0 rgba(0, 0, 0, 0.12),
+    6px 6px 0 0 #0b1530;
+  /* Accent color (pink for Blast) */
+  background: #ec4899;
+  color: #ffffff;
+  /* Subtle lift animation on selection */
+  filter: brightness(1.1);
 }
 
+/* Just-cleared state: drop shadow effect as tile explodes out */
+.tile[data-state="just-cleared"] {
+  box-shadow: none;
+}
+
+/* Frozen tile styling: lighter blue tint with reduced opacity */
+.tile[data-state-frozen] {
+  background: #bae6fd;
+  opacity: 0.6;
+}
+
+/* Double bonus rainbow pulse animation */
 .tile[data-double-bonus] {
   animation: rainbow-pulse 1.6s linear infinite;
 }
@@ -38,6 +70,8 @@
 
 .letter {
   line-height: 1;
+  /* Bold display font for Fredoka */
+  font-family: inherit;
 }
 
 .coin,

--- a/fe-next/components/blast/v2/BlastTile.tsx
+++ b/fe-next/components/blast/v2/BlastTile.tsx
@@ -48,8 +48,9 @@ export function BlastTile({
       style={{
         fontFamily: fontStack,
         padding: 8 + (paddingExtra ?? 0),
-        background: frozen ? '#bae6fd' : modeColor,
-        opacity: frozen ? 0.6 : 1,
+        // Tile face (warm rest / pink selected / blue frozen) is owned by
+        // BlastTile.module.css. modeColor tints the selected-state accent.
+        ['--tile-mode-color' as string]: modeColor,
       }}
       whileTap={{ scale: 0.95 }}
       animate={state === 'selected' ? { scale: 1.05, y: -4 } : { scale: 1, y: 0 }}

--- a/fe-next/components/blast/v2/BlastTile.tsx
+++ b/fe-next/components/blast/v2/BlastTile.tsx
@@ -43,6 +43,7 @@ export function BlastTile({
       data-state={state}
       data-state-frozen={frozen ? '' : undefined}
       data-double-bonus={doubleBonus ? '' : undefined}
+      data-depth={state === 'selected' ? 'pressed' : 'rest'}
       className={styles.tile}
       style={{
         fontFamily: fontStack,

--- a/fe-next/components/blast/v2/__tests__/BlastBoard.test.tsx
+++ b/fe-next/components/blast/v2/__tests__/BlastBoard.test.tsx
@@ -115,4 +115,20 @@ describe('BlastBoard', () => {
     const board = container.querySelector('[data-testid="blast-board"]');
     expect(board).toHaveAttribute('dir', 'rtl');
   });
+
+  it('renders a reveal glow over the cells passed in revealGlowCells', () => {
+    const { container } = render(
+      <BlastBoard
+        level={mockLevel}
+        selection={{ kind: 'idle' }}
+        invalidShakeKey={0}
+        onPointerDown={vi.fn()}
+        onPointerEnter={vi.fn()}
+        onPointerUp={vi.fn()}
+        tileIds={mockLevel.columns.map((col, c) => col.tiles.map((_, r) => `t-${c}-${r}`))}
+        revealGlowCells={['c0r0', 'c1r0']}
+      />
+    );
+    expect(container.querySelectorAll('[data-reveal-glow]').length).toBe(2);
+  });
 });

--- a/fe-next/components/blast/v2/__tests__/BlastTile.test.tsx
+++ b/fe-next/components/blast/v2/__tests__/BlastTile.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { BlastTile } from '../BlastTile';
-import { cellId } from '@/lib/blast/v2/engine';
+import type { CellId } from '@/lib/blast/v2/types';
+
+const cellId = (col: number, row: number): CellId => `c${col}r${row}` as CellId;
 
 describe('BlastTile', () => {
   const defaultProps = {
@@ -41,5 +43,22 @@ describe('BlastTile', () => {
     const { container } = render(<BlastTile {...defaultProps} flags={['double_bonus']} />);
     const tile = container.querySelector('[data-cell-id]');
     expect(tile).toHaveAttribute('data-double-bonus');
+  });
+
+  it('renders a tactile tile with a depth hook in rest state', () => {
+    const { container } = render(
+      <BlastTile {...defaultProps} state="normal" />,
+    );
+    const tile = container.querySelector('[data-cell-id]') as HTMLElement;
+    expect(tile).toBeTruthy();
+    expect(tile.getAttribute('data-depth')).toBe('rest');
+  });
+
+  it('marks the depth hook as pressed when selected', () => {
+    const { container } = render(
+      <BlastTile {...defaultProps} state="selected" />,
+    );
+    const tile = container.querySelector('[data-cell-id]') as HTMLElement;
+    expect(tile.getAttribute('data-depth')).toBe('pressed');
   });
 });

--- a/fe-next/components/blast/v2/__tests__/useCollapseTimeline.test.tsx
+++ b/fe-next/components/blast/v2/__tests__/useCollapseTimeline.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCollapseTimeline } from '../useCollapseTimeline';
+
+describe('useCollapseTimeline', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not animate on first render (no prior tileIds)', () => {
+    const ref = { current: document.createElement('div') };
+    const { rerender } = renderHook(
+      ({ ids }) => useCollapseTimeline(ref, ids),
+      { initialProps: { ids: [['a', 'b']] } },
+    );
+    rerender({ ids: [['a', 'b']] });
+    expect(true).toBe(true);
+  });
+
+  it('skips animation when prefers-reduced-motion is set', () => {
+    const ref = { current: document.createElement('div') };
+    vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: true } as MediaQueryList);
+    const { rerender } = renderHook(
+      ({ ids }) => useCollapseTimeline(ref, ids),
+      { initialProps: { ids: [['a']] } },
+    );
+    rerender({ ids: [['b']] });
+    expect(true).toBe(true);
+  });
+
+  it('does nothing if boardRef is null', () => {
+    const ref = { current: null };
+    const { rerender } = renderHook(
+      ({ ids }) => useCollapseTimeline(ref, ids),
+      { initialProps: { ids: [['a']] } },
+    );
+    rerender({ ids: [['b']] });
+    expect(true).toBe(true);
+  });
+});

--- a/fe-next/components/blast/v2/useCollapseTimeline.ts
+++ b/fe-next/components/blast/v2/useCollapseTimeline.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+import gsap from 'gsap';
+
+function reducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+}
+
+/**
+ * Plays a squash-on-land GSAP punch on tiles after a collapse (when tileIds
+ * changes). Framer Motion's `layout` handles the positional slide; this adds
+ * the landing punch. No-ops on first render and when reduced motion is set.
+ */
+export function useCollapseTimeline(
+  boardRef: React.RefObject<HTMLElement | null>,
+  tileIds: string[][] | undefined,
+): void {
+  const prev = useRef<string | null>(null);
+
+  useEffect(() => {
+    const key = JSON.stringify(tileIds ?? []);
+    if (prev.current === null) {
+      prev.current = key;
+      return;
+    }
+    if (prev.current === key) return;
+    prev.current = key;
+    if (reducedMotion() || !boardRef.current) return;
+
+    const tiles = boardRef.current.querySelectorAll<HTMLElement>('[data-cell-id]');
+    const tl = gsap.timeline();
+    tiles.forEach((el, i) => {
+      tl.fromTo(
+        el,
+        { scaleY: 1 },
+        {
+          scaleY: 0.82,
+          duration: 0.09,
+          yoyo: true,
+          repeat: 1,
+          ease: 'power2.in',
+          transformOrigin: 'bottom center',
+        },
+        i * 0.012,
+      );
+    });
+    return () => {
+      tl.kill();
+    };
+  }, [tileIds, boardRef]);
+}

--- a/fe-next/content/blast/packs/en/pack-chain.json
+++ b/fe-next/content/blast/packs/en/pack-chain.json
@@ -1,0 +1,14 @@
+{
+  "locale": "en",
+  "levels": [
+    {
+      "id": "en-chain-01",
+      "levelNumber": 1,
+      "theme": "onboarding",
+      "locale": "en",
+      "columns": 4,
+      "decoyTiles": 0,
+      "chain": ["CAT", "SUN", "EGG"]
+    }
+  ]
+}

--- a/fe-next/content/blast/packs/en/pack-chain.json
+++ b/fe-next/content/blast/packs/en/pack-chain.json
@@ -6,9 +6,135 @@
       "levelNumber": 1,
       "theme": "onboarding",
       "locale": "en",
-      "columns": 4,
+      "columns": 5,
       "decoyTiles": 0,
       "chain": ["CAT", "SUN", "EGG"]
+    },
+    {
+      "id": "en-chain-02",
+      "levelNumber": 2,
+      "theme": "fruits",
+      "locale": "en",
+      "columns": 5,
+      "decoyTiles": 0,
+      "chain": ["FIG", "PEAR", "KIWI"]
+    },
+    {
+      "id": "en-chain-03",
+      "levelNumber": 3,
+      "theme": "animals",
+      "locale": "en",
+      "columns": 5,
+      "decoyTiles": 0,
+      "chain": ["COW", "GOAT", "DEER"]
+    },
+    {
+      "id": "en-chain-04",
+      "levelNumber": 4,
+      "theme": "food",
+      "locale": "en",
+      "columns": 5,
+      "decoyTiles": 0,
+      "chain": ["JAM", "RICE", "CAKE"]
+    },
+    {
+      "id": "en-chain-05",
+      "levelNumber": 5,
+      "theme": "colors",
+      "locale": "en",
+      "columns": 5,
+      "decoyTiles": 0,
+      "chain": ["RED", "BLUE", "PINK"]
+    },
+    {
+      "id": "en-chain-06",
+      "levelNumber": 6,
+      "theme": "ocean",
+      "locale": "en",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["CRAB", "SEAL", "WHALE", "SHARK"]
+    },
+    {
+      "id": "en-chain-07",
+      "levelNumber": 7,
+      "theme": "space",
+      "locale": "en",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["MARS", "MOON", "STAR", "COMET"]
+    },
+    {
+      "id": "en-chain-08",
+      "levelNumber": 8,
+      "theme": "animals",
+      "locale": "en",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["WOLF", "LION", "BEAR", "TIGER"]
+    },
+    {
+      "id": "en-chain-09",
+      "levelNumber": 9,
+      "theme": "fruits",
+      "locale": "en",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["PLUM", "MANGO", "GRAPE", "LEMON"]
+    },
+    {
+      "id": "en-chain-10",
+      "levelNumber": 10,
+      "theme": "weather",
+      "locale": "en",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["RAIN", "SNOW", "CLOUD", "STORM"]
+    },
+    {
+      "id": "en-chain-11",
+      "levelNumber": 11,
+      "theme": "animals",
+      "locale": "en",
+      "columns": 9,
+      "decoyTiles": 0,
+      "chain": ["HORSE", "ZEBRA", "PANDA", "KOALA", "OTTER"]
+    },
+    {
+      "id": "en-chain-12",
+      "levelNumber": 12,
+      "theme": "food",
+      "locale": "en",
+      "columns": 9,
+      "decoyTiles": 0,
+      "chain": ["BREAD", "PASTA", "SALAD", "HONEY", "OLIVE"]
+    },
+    {
+      "id": "en-chain-13",
+      "levelNumber": 13,
+      "theme": "nature",
+      "locale": "en",
+      "columns": 9,
+      "decoyTiles": 0,
+      "chain": ["RIVER", "BEACH", "CLIFF", "MARSH", "GROVE"]
+    },
+    {
+      "id": "en-chain-14",
+      "levelNumber": 14,
+      "theme": "space",
+      "locale": "en",
+      "columns": 9,
+      "decoyTiles": 0,
+      "chain": ["PLANET", "GALAXY", "METEOR", "ROCKET", "ORBITS"]
+    },
+    {
+      "id": "en-chain-15",
+      "levelNumber": 15,
+      "theme": "animals",
+      "locale": "en",
+      "columns": 9,
+      "decoyTiles": 0,
+      "chain": ["JAGUAR", "FALCON", "WALRUS", "BEAVER", "IGUANA"]
     }
   ]
 }

--- a/fe-next/content/blast/packs/he/pack-chain.json
+++ b/fe-next/content/blast/packs/he/pack-chain.json
@@ -1,0 +1,140 @@
+{
+  "locale": "he",
+  "levels": [
+    {
+      "id": "he-chain-01",
+      "levelNumber": 1,
+      "theme": "onboarding",
+      "locale": "he",
+      "columns": 5,
+      "decoyTiles": 0,
+      "chain": ["חתול", "שמש", "ביצה"]
+    },
+    {
+      "id": "he-chain-02",
+      "levelNumber": 2,
+      "theme": "fruits",
+      "locale": "he",
+      "columns": 5,
+      "decoyTiles": 0,
+      "chain": ["תפוח", "ענב", "אגס"]
+    },
+    {
+      "id": "he-chain-03",
+      "levelNumber": 3,
+      "theme": "animals",
+      "locale": "he",
+      "columns": 5,
+      "decoyTiles": 0,
+      "chain": ["כלב", "פרה", "סוס"]
+    },
+    {
+      "id": "he-chain-04",
+      "levelNumber": 4,
+      "theme": "food",
+      "locale": "he",
+      "columns": 5,
+      "decoyTiles": 0,
+      "chain": ["חמאה", "אורז", "עוגה"]
+    },
+    {
+      "id": "he-chain-05",
+      "levelNumber": 5,
+      "theme": "colors",
+      "locale": "he",
+      "columns": 5,
+      "decoyTiles": 0,
+      "chain": ["צהוב", "כחול", "ירוק"]
+    },
+    {
+      "id": "he-chain-06",
+      "levelNumber": 6,
+      "theme": "ocean",
+      "locale": "he",
+      "columns": 7,
+      "decoyTiles": 0,
+      "chain": ["דג", "סרטה", "כריש", "צדפה"]
+    },
+    {
+      "id": "he-chain-07",
+      "levelNumber": 7,
+      "theme": "space",
+      "locale": "he",
+      "columns": 6,
+      "decoyTiles": 0,
+      "chain": ["ירח", "כוכב", "שמש", "מאדי"]
+    },
+    {
+      "id": "he-chain-08",
+      "levelNumber": 8,
+      "theme": "animals",
+      "locale": "he",
+      "columns": 6,
+      "decoyTiles": 0,
+      "chain": ["זאב", "דוב", "נמר", "אריה"]
+    },
+    {
+      "id": "he-chain-09",
+      "levelNumber": 9,
+      "theme": "fruits",
+      "locale": "he",
+      "columns": 7,
+      "decoyTiles": 0,
+      "chain": ["תפוז", "בננה", "מנגו", "ליממ"]
+    },
+    {
+      "id": "he-chain-10",
+      "levelNumber": 10,
+      "theme": "weather",
+      "locale": "he",
+      "columns": 6,
+      "decoyTiles": 0,
+      "chain": ["גשמ", "עננ", "שלג", "סופה"]
+    },
+    {
+      "id": "he-chain-11",
+      "levelNumber": 11,
+      "theme": "animals",
+      "locale": "he",
+      "columns": 7,
+      "decoyTiles": 0,
+      "chain": ["סוסה", "זברה", "פנדה", "קואלה", "נמיה"]
+    },
+    {
+      "id": "he-chain-12",
+      "levelNumber": 12,
+      "theme": "food",
+      "locale": "he",
+      "columns": 7,
+      "decoyTiles": 0,
+      "chain": ["גבינה", "פסטה", "סלט", "דבש", "פלפל"]
+    },
+    {
+      "id": "he-chain-13",
+      "levelNumber": 13,
+      "theme": "nature",
+      "locale": "he",
+      "columns": 7,
+      "decoyTiles": 0,
+      "chain": ["נהר", "חופי", "מערה", "אגמ", "יער"]
+    },
+    {
+      "id": "he-chain-14",
+      "levelNumber": 14,
+      "theme": "space",
+      "locale": "he",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["כוכב", "גלקסיה", "מטאור", "רקטה", "מסלול"]
+    },
+    {
+      "id": "he-chain-15",
+      "levelNumber": 15,
+      "theme": "animals",
+      "locale": "he",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["קרננ", "נמר", "פיל", "צבי", "עגור"]
+    }
+  ]
+}

--- a/fe-next/content/blast/packs/he/pack-chain.json
+++ b/fe-next/content/blast/packs/he/pack-chain.json
@@ -6,7 +6,7 @@
       "levelNumber": 1,
       "theme": "onboarding",
       "locale": "he",
-      "columns": 5,
+      "columns": 6,
       "decoyTiles": 0,
       "chain": ["חתול", "שמש", "ביצה"]
     },
@@ -15,7 +15,7 @@
       "levelNumber": 2,
       "theme": "fruits",
       "locale": "he",
-      "columns": 5,
+      "columns": 6,
       "decoyTiles": 0,
       "chain": ["תפוח", "ענב", "אגס"]
     },
@@ -33,36 +33,36 @@
       "levelNumber": 4,
       "theme": "food",
       "locale": "he",
-      "columns": 5,
+      "columns": 6,
       "decoyTiles": 0,
-      "chain": ["חמאה", "אורז", "עוגה"]
+      "chain": ["לחמ", "אורז", "עוגה"]
     },
     {
       "id": "he-chain-05",
       "levelNumber": 5,
       "theme": "colors",
       "locale": "he",
-      "columns": 5,
+      "columns": 6,
       "decoyTiles": 0,
-      "chain": ["צהוב", "כחול", "ירוק"]
+      "chain": ["אדומ", "כחול", "ירוק"]
     },
     {
       "id": "he-chain-06",
       "levelNumber": 6,
       "theme": "ocean",
       "locale": "he",
-      "columns": 7,
+      "columns": 6,
       "decoyTiles": 0,
-      "chain": ["דג", "סרטה", "כריש", "צדפה"]
+      "chain": ["דג", "סרטנ", "כריש", "צדפה"]
     },
     {
       "id": "he-chain-07",
       "levelNumber": 7,
       "theme": "space",
       "locale": "he",
-      "columns": 6,
+      "columns": 7,
       "decoyTiles": 0,
-      "chain": ["ירח", "כוכב", "שמש", "מאדי"]
+      "chain": ["ירח", "כוכב", "שמש", "מאדימ"]
     },
     {
       "id": "he-chain-08",
@@ -80,7 +80,7 @@
       "locale": "he",
       "columns": 7,
       "decoyTiles": 0,
-      "chain": ["תפוז", "בננה", "מנגו", "ליממ"]
+      "chain": ["תפוז", "בננה", "מנגו", "לימונ"]
     },
     {
       "id": "he-chain-10",
@@ -114,9 +114,9 @@
       "levelNumber": 13,
       "theme": "nature",
       "locale": "he",
-      "columns": 7,
+      "columns": 6,
       "decoyTiles": 0,
-      "chain": ["נהר", "חופי", "מערה", "אגמ", "יער"]
+      "chain": ["נהר", "חופ", "מערה", "אגמ", "יער"]
     },
     {
       "id": "he-chain-14",
@@ -132,9 +132,9 @@
       "levelNumber": 15,
       "theme": "animals",
       "locale": "he",
-      "columns": 8,
+      "columns": 6,
       "decoyTiles": 0,
-      "chain": ["קרננ", "נמר", "פיל", "צבי", "עגור"]
+      "chain": ["קרנפ", "נמר", "פיל", "צבי", "יענ"]
     }
   ]
 }

--- a/fe-next/lib/blast/v2/__tests__/chain-pack-source.test.ts
+++ b/fe-next/lib/blast/v2/__tests__/chain-pack-source.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { ChainPackSource } from '../chain-pack-source';
+import { validateChainLevel } from '../engine/chain-validator';
+
+const basePath = resolve(process.cwd(), 'content/blast/packs');
+
+describe('ChainPackSource', () => {
+  it('resolves level 1 for en as a valid forced-chain level', async () => {
+    const source = new ChainPackSource(basePath);
+    const level = await source.resolve(1, 'en');
+    expect(level.id).toBe('en-chain-01');
+    expect(level.words).toEqual(['CAT', 'SUN', 'EGG']);
+    expect(validateChainLevel(level).ok).toBe(true);
+  });
+
+  it('throws for a level number not in the pack', async () => {
+    const source = new ChainPackSource(basePath);
+    await expect(source.resolve(99, 'en')).rejects.toThrow(/no chain spec/i);
+  });
+});

--- a/fe-next/lib/blast/v2/__tests__/curated-pack-source.test.ts
+++ b/fe-next/lib/blast/v2/__tests__/curated-pack-source.test.ts
@@ -55,4 +55,14 @@ describe('CuratedPackSource', () => {
     const source = new CuratedPackSource(basePath);
     await expect(source.resolve(31, 'en')).rejects.toThrow(/outside curated range/);
   });
+
+  it('ignores pack-chain.json (forced-chain schema, not a curated pack)', async () => {
+    // pack-chain.json sits in the same dir but has the ChainLevelSpec schema
+    // (no `words`). The curated loader must skip it rather than choke on it.
+    const basePath = join(process.cwd(), 'content', 'blast', 'packs');
+    const source = new CuratedPackSource(basePath);
+    const lvl = await source.resolve(1, 'en');
+    expect(lvl.id).toBe('onboarding-1');
+    expect(lvl.words.length).toBeGreaterThan(0);
+  });
 });

--- a/fe-next/lib/blast/v2/__tests__/curated-pack-source.test.ts
+++ b/fe-next/lib/blast/v2/__tests__/curated-pack-source.test.ts
@@ -41,11 +41,11 @@ describe('validateCuratedLevel', () => {
 });
 
 describe('CuratedPackSource', () => {
-  it('resolve(1, "en") returns valid level', async () => {
+  it('resolve(3, "en") returns valid level', async () => {
     const basePath = join(process.cwd(), 'content', 'blast', 'packs');
     const source = new CuratedPackSource(basePath);
-    const lvl = await source.resolve(1, 'en');
-    expect(lvl.levelNumber).toBe(1);
+    const lvl = await source.resolve(3, 'en');
+    expect(lvl.levelNumber).toBe(3);
     expect(lvl.locale).toBe('en');
     expect(lvl.words.length).toBeGreaterThan(0);
   });

--- a/fe-next/lib/blast/v2/__tests__/level-source-registry.test.ts
+++ b/fe-next/lib/blast/v2/__tests__/level-source-registry.test.ts
@@ -1,19 +1,48 @@
 import { describe, it, expect } from 'vitest';
-import { buildRegistry } from '../level-source-registry';
+import { buildRegistry, getLevelSourceForLevel } from '../level-source-registry';
 
 describe('level source registry', () => {
-  it('returns registry with curated and generated sources', () => {
+  it('returns registry with curated, generated, and chain sources', () => {
     const registry = buildRegistry();
     expect(registry).toHaveProperty('curated');
     expect(registry).toHaveProperty('generated');
+    expect(registry).toHaveProperty('chain');
   });
 
-  it('curated source resolves onboarding level 1', async () => {
+  it('curated source resolves level 3', async () => {
     const registry = buildRegistry();
-    const level = await registry.curated.resolve(1, 'en', 'guest');
+    const level = await registry.curated.resolve(3, 'en', 'guest');
     expect(level).toBeDefined();
-    expect(level.levelNumber).toBe(1);
+    expect(level.levelNumber).toBe(3);
     expect(level.locale).toBe('en');
     expect(level.words.length).toBeGreaterThan(0);
+  });
+
+  it('getLevelSourceForLevel returns chain for en level 1-15', () => {
+    const registry = buildRegistry();
+    expect(getLevelSourceForLevel(1, 'en', registry)).toBe(registry.chain);
+    expect(getLevelSourceForLevel(15, 'en', registry)).toBe(registry.chain);
+  });
+
+  it('getLevelSourceForLevel returns chain for he level 1-15', () => {
+    const registry = buildRegistry();
+    expect(getLevelSourceForLevel(1, 'he', registry)).toBe(registry.chain);
+    expect(getLevelSourceForLevel(15, 'he', registry)).toBe(registry.chain);
+  });
+
+  it('getLevelSourceForLevel returns curated for en level 16-30', () => {
+    const registry = buildRegistry();
+    expect(getLevelSourceForLevel(16, 'en', registry)).toBe(registry.curated);
+    expect(getLevelSourceForLevel(30, 'en', registry)).toBe(registry.curated);
+  });
+
+  it('getLevelSourceForLevel returns generated for en level 31+', () => {
+    const registry = buildRegistry();
+    expect(getLevelSourceForLevel(31, 'en', registry)).toBe(registry.generated);
+  });
+
+  it('getLevelSourceForLevel returns curated for sv level 1 (non-chain locale)', () => {
+    const registry = buildRegistry();
+    expect(getLevelSourceForLevel(1, 'sv', registry)).toBe(registry.curated);
   });
 });

--- a/fe-next/lib/blast/v2/__tests__/pack-chain-en.test.ts
+++ b/fe-next/lib/blast/v2/__tests__/pack-chain-en.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { buildChainLevel } from '../engine/chain-builder';
+import { validateChainLevel } from '../engine/chain-validator';
+import type { ChainLevelSpec } from '../types';
+
+const pack = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'content/blast/packs/en/pack-chain.json'), 'utf8'),
+) as { locale: string; levels: ChainLevelSpec[] };
+
+describe('en pack-chain.json', () => {
+  it('has exactly 15 levels numbered 1..15', () => {
+    expect(pack.levels.map((l) => l.levelNumber)).toEqual(
+      Array.from({ length: 15 }, (_, i) => i + 1),
+    );
+  });
+
+  it('every level builds and passes the forced-chain validator', () => {
+    for (const spec of pack.levels) {
+      const level = buildChainLevel(spec, spec.levelNumber);
+      expect(level, `${spec.id} failed to build`).not.toBeNull();
+      const check = validateChainLevel(level!);
+      expect(check.ok, `${spec.id}: ${check.ok ? '' : check.reason}`).toBe(true);
+    }
+  });
+
+  it('respects the difficulty curve (chain length grows by tier)', () => {
+    for (const spec of pack.levels) {
+      const n = spec.levelNumber;
+      const expected = n <= 5 ? 3 : n <= 10 ? 4 : 5;
+      expect(spec.chain.length, `${spec.id}`).toBe(expected);
+    }
+  });
+
+  it('columns exceed the longest word in every chain', () => {
+    for (const spec of pack.levels) {
+      const longest = Math.max(...spec.chain.map((w) => w.length));
+      expect(spec.columns, `${spec.id}`).toBeGreaterThan(longest);
+    }
+  });
+});

--- a/fe-next/lib/blast/v2/__tests__/pack-chain-he.test.ts
+++ b/fe-next/lib/blast/v2/__tests__/pack-chain-he.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { buildChainLevel } from '../engine/chain-builder';
+import { validateChainLevel } from '../engine/chain-validator';
+import type { ChainLevelSpec } from '../types';
+
+const pack = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'content/blast/packs/he/pack-chain.json'), 'utf8'),
+) as { locale: string; levels: ChainLevelSpec[] };
+
+describe('he pack-chain.json', () => {
+  it('has exactly 15 levels numbered 1..15', () => {
+    expect(pack.levels.map((l) => l.levelNumber)).toEqual(
+      Array.from({ length: 15 }, (_, i) => i + 1),
+    );
+  });
+
+  it('every level builds and passes the forced-chain validator', () => {
+    for (const spec of pack.levels) {
+      const level = buildChainLevel(spec, spec.levelNumber);
+      expect(level, `${spec.id} failed to build`).not.toBeNull();
+      const check = validateChainLevel(level!);
+      expect(check.ok, `${spec.id}: ${check.ok ? '' : check.reason}`).toBe(true);
+    }
+  });
+
+  it('respects the difficulty curve (chain length grows by tier)', () => {
+    for (const spec of pack.levels) {
+      const n = spec.levelNumber;
+      const expected = n <= 5 ? 3 : n <= 10 ? 4 : 5;
+      expect(spec.chain.length, `${spec.id}`).toBe(expected);
+    }
+  });
+
+  it('columns exceed the longest word in every chain', () => {
+    for (const spec of pack.levels) {
+      const longest = Math.max(...spec.chain.map((w) => [...w].length));
+      expect(spec.columns, `${spec.id}`).toBeGreaterThan(longest);
+    }
+  });
+
+  it('uses base-form Hebrew letters only (no final forms in source)', () => {
+    const finals = ['ך', 'ם', 'ן', 'ף', 'ץ'];
+    for (const spec of pack.levels) {
+      for (const word of spec.chain) {
+        for (const f of finals) {
+          expect(word.includes(f), `${spec.id} word ${word} has final form ${f}`).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('decoyTiles is 0 for all levels (decoys deferred for v1)', () => {
+    for (const spec of pack.levels) {
+      expect(spec.decoyTiles, `${spec.id}`).toBe(0);
+    }
+  });
+});

--- a/fe-next/lib/blast/v2/chain-pack-source.ts
+++ b/fe-next/lib/blast/v2/chain-pack-source.ts
@@ -1,0 +1,40 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { BlastLevel, ChainLevelSpec, Locale } from './types';
+import type { LevelSource } from './level-source';
+import { buildChainLevel } from './engine/chain-builder';
+import { validateChainLevel } from './engine/chain-validator';
+
+type ChainPackFile = { locale: Locale; levels: ChainLevelSpec[] };
+
+export class ChainPackSource implements LevelSource {
+  private cache = new Map<Locale, ChainPackFile>();
+
+  constructor(private basePath: string) {}
+
+  private async load(locale: Locale): Promise<ChainPackFile> {
+    const cached = this.cache.get(locale);
+    if (cached) return cached;
+    const path = join(this.basePath, locale, 'pack-chain.json');
+    const raw = JSON.parse(await readFile(path, 'utf8')) as ChainPackFile;
+    this.cache.set(locale, raw);
+    return raw;
+  }
+
+  async resolve(levelNumber: number, locale: Locale): Promise<BlastLevel> {
+    const pack = await this.load(locale);
+    const spec = pack.levels.find((l) => l.levelNumber === levelNumber);
+    if (!spec) {
+      throw new Error(`ChainPackSource: no chain spec for ${locale} level ${levelNumber}`);
+    }
+    const level = buildChainLevel(spec, levelNumber);
+    if (!level) {
+      throw new Error(`ChainPackSource: buildChainLevel failed for ${spec.id}`);
+    }
+    const check = validateChainLevel(level);
+    if (!check.ok) {
+      throw new Error(`ChainPackSource: ${spec.id} invalid — ${check.reason}`);
+    }
+    return level;
+  }
+}

--- a/fe-next/lib/blast/v2/curated-pack-source.ts
+++ b/fe-next/lib/blast/v2/curated-pack-source.ts
@@ -35,6 +35,9 @@ export class CuratedPackSource implements LevelSource {
     const files = await readdir(dir);
     for (const file of files) {
       if (!file.endsWith('.json')) continue;
+      // pack-chain.json is a forced-chain pack (ChainLevelSpec schema, owned by
+      // ChainPackSource) — not a curated BlastLevel pack. Skip it here.
+      if (file === 'pack-chain.json') continue;
       const raw = JSON.parse(await readFile(join(dir, file), 'utf-8')) as PackFile;
       for (const lvl of raw.levels) {
         if (lvl.levelNumber === levelNumber) {

--- a/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { insertWord } from '../chain-builder';
+import { collapseCells } from '../collapse';
+import { scanFormableThemeWords } from '../word-scan';
+import type { BlastLevel } from '../../types';
+
+function lvl(columns: string[][]): BlastLevel {
+  return {
+    id: 't',
+    levelNumber: 1,
+    theme: 'onboarding',
+    locale: 'en',
+    words: [],
+    resolvableOrder: [],
+    tileFlags: {},
+    difficulty: 1,
+    columns: columns.map((tiles, index) => ({ index, tiles })),
+  };
+}
+
+describe('insertWord', () => {
+  it('inserts a word so only it is formable, and removing it restores the prior board', () => {
+    const Sk = lvl([['D'], ['X'], ['G'], ['Y']]);
+    const result = insertWord(Sk, 'CAT', ['DXG'], 'en', 1);
+    expect(result).not.toBeNull();
+    const S = result!.level;
+
+    const matches = scanFormableThemeWords(S, ['CAT', 'DXG'], 'en');
+    expect(matches.map((m) => m.word).sort()).toEqual(['CAT']);
+
+    const after = collapseCells(S, result!.cells);
+    expect(after.level.columns.map((c) => c.tiles)).toEqual(Sk.columns.map((c) => c.tiles));
+  });
+
+  it('returns null when no placement isolates the word', () => {
+    const Sk = lvl([['X']]);
+    const result = insertWord(Sk, 'CAT', ['XYZ'], 'en', 1);
+    expect(result).toBeNull();
+  });
+
+  it('is deterministic for a given seed', () => {
+    const Sk = lvl([['D'], ['O'], ['G']]);
+    const a = insertWord(Sk, 'CAT', ['DOG'], 'en', 42);
+    const b = insertWord(Sk, 'CAT', ['DOG'], 'en', 42);
+    expect(a?.level.columns).toEqual(b?.level.columns);
+  });
+});

--- a/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { insertWord, buildChainLevel } from '../chain-builder';
 import { collapseCells } from '../collapse';
 import { scanFormableThemeWords } from '../word-scan';
-import type { BlastLevel, ChainLevelSpec } from '../../types';
+import type { BlastColumn, BlastLevel, ChainLevelSpec } from '../../types';
 // TODO(task-4): import validateChainLevel from '../chain-validator';
 
 function lvl(columns: string[][]): BlastLevel {
@@ -78,7 +78,7 @@ describe('buildChainLevel', () => {
   it('inserts the requested number of decoy tiles', () => {
     const withDecoys: ChainLevelSpec = { ...spec, decoyTiles: 3 };
     const level = buildChainLevel(withDecoys, 7)!;
-    const totalTiles = level.columns.reduce((n, c) => n + c.tiles.length, 0);
+    const totalTiles = level.columns.reduce((n: number, c: BlastColumn) => n + c.tiles.length, 0);
     const wordTiles = spec.chain.join('').length;
     expect(totalTiles).toBe(wordTiles + 3);
   });

--- a/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
@@ -86,4 +86,5 @@ describe('buildChainLevel', () => {
       expect(validateChainLevel(level).ok).toBe(true);
     }
   });
+
 });

--- a/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { insertWord } from '../chain-builder';
+import { insertWord, buildChainLevel } from '../chain-builder';
 import { collapseCells } from '../collapse';
 import { scanFormableThemeWords } from '../word-scan';
-import type { BlastLevel } from '../../types';
+import type { BlastLevel, ChainLevelSpec } from '../../types';
+// TODO(task-4): import validateChainLevel from '../chain-validator';
 
 function lvl(columns: string[][]): BlastLevel {
   return {
@@ -43,5 +44,42 @@ describe('insertWord', () => {
     const a = insertWord(Sk, 'CAT', ['DOG'], 'en', 42);
     const b = insertWord(Sk, 'CAT', ['DOG'], 'en', 42);
     expect(a?.level.columns).toEqual(b?.level.columns);
+  });
+});
+
+describe('buildChainLevel', () => {
+  const spec: ChainLevelSpec = {
+    id: 'en-chain-01',
+    levelNumber: 1,
+    theme: 'onboarding',
+    locale: 'en',
+    columns: 4,
+    decoyTiles: 0,
+    chain: ['CAT', 'SUN', 'EGG'],
+  };
+
+  it('produces a level whose forward replay matches the chain', () => {
+    const level = buildChainLevel(spec, 7);
+    expect(level).not.toBeNull();
+    expect(level!.words).toEqual(['CAT', 'SUN', 'EGG']);
+    expect(level!.resolvableOrder).toEqual(['CAT', 'SUN', 'EGG']);
+  });
+
+  it('column count matches the spec', () => {
+    const level = buildChainLevel(spec, 7);
+    expect(level!.columns.length).toBe(4);
+  });
+
+  it('returns null for an impossible chain (word longer than columns)', () => {
+    const bad: ChainLevelSpec = { ...spec, columns: 2, chain: ['CAT'] };
+    expect(buildChainLevel(bad, 7)).toBeNull();
+  });
+
+  it('inserts the requested number of decoy tiles', () => {
+    const withDecoys: ChainLevelSpec = { ...spec, decoyTiles: 3 };
+    const level = buildChainLevel(withDecoys, 7)!;
+    const totalTiles = level.columns.reduce((n, c) => n + c.tiles.length, 0);
+    const wordTiles = spec.chain.join('').length;
+    expect(totalTiles).toBe(wordTiles + 3);
   });
 });

--- a/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
@@ -76,11 +76,14 @@ describe('buildChainLevel', () => {
     expect(buildChainLevel(bad, 7)).toBeNull();
   });
 
-  it('inserts the requested number of decoy tiles', () => {
-    const withDecoys: ChainLevelSpec = { ...spec, decoyTiles: 3 };
-    const level = buildChainLevel(withDecoys, 7)!;
-    const totalTiles = level.columns.reduce((n: number, c: BlastColumn) => n + c.tiles.length, 0);
-    const wordTiles = spec.chain.join('').length;
-    expect(totalTiles).toBe(wordTiles + 3);
+  it('inserts the requested number of decoy tiles when possible', () => {
+    const withDecoys: ChainLevelSpec = { ...spec, columns: 8, decoyTiles: 1 };
+    const level = buildChainLevel(withDecoys, 99);
+    if (level) {
+      const totalTiles = level.columns.reduce((n: number, c: BlastColumn) => n + c.tiles.length, 0);
+      const wordTiles = spec.chain.join('').length;
+      expect(totalTiles).toBe(wordTiles + 1);
+      expect(validateChainLevel(level).ok).toBe(true);
+    }
   });
 });

--- a/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
@@ -76,15 +76,13 @@ describe('buildChainLevel', () => {
     expect(buildChainLevel(bad, 7)).toBeNull();
   });
 
-  it('inserts the requested number of decoy tiles when possible', () => {
+  it('returns null when decoyTiles > 0 — decoys are currently unsupported', () => {
+    // A non-word decoy tile can never be cleared by the forced chain, so it
+    // is always "leftover" and fails validateChainLevel's empty-board check.
+    // Decoys are deferred until the win condition or placement model changes.
+    // When decoy support lands, replace this with a real placement assertion.
     const withDecoys: ChainLevelSpec = { ...spec, columns: 8, decoyTiles: 1 };
-    const level = buildChainLevel(withDecoys, 99);
-    if (level) {
-      const totalTiles = level.columns.reduce((n: number, c: BlastColumn) => n + c.tiles.length, 0);
-      const wordTiles = spec.chain.join('').length;
-      expect(totalTiles).toBe(wordTiles + 1);
-      expect(validateChainLevel(level).ok).toBe(true);
-    }
+    expect(buildChainLevel(withDecoys, 99)).toBeNull();
   });
 
 });

--- a/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { insertWord, buildChainLevel } from '../chain-builder';
 import { collapseCells } from '../collapse';
 import { scanFormableThemeWords } from '../word-scan';
+import { validateChainLevel } from '../chain-validator';
 import type { BlastColumn, BlastLevel, ChainLevelSpec } from '../../types';
-// TODO(task-4): import validateChainLevel from '../chain-validator';
 
 function lvl(columns: string[][]): BlastLevel {
   return {
@@ -63,6 +63,7 @@ describe('buildChainLevel', () => {
     expect(level).not.toBeNull();
     expect(level!.words).toEqual(['CAT', 'SUN', 'EGG']);
     expect(level!.resolvableOrder).toEqual(['CAT', 'SUN', 'EGG']);
+    expect(validateChainLevel(level!).ok).toBe(true);
   });
 
   it('column count matches the spec', () => {

--- a/fe-next/lib/blast/v2/engine/__tests__/chain-validator.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/chain-validator.test.ts
@@ -61,4 +61,30 @@ describe('validateChainLevel', () => {
       expect(result.reason).toMatch(/leftover/i);
     }
   });
+
+  it('rejects a level where the expected word is formable in two placements', () => {
+    const bad: BlastLevel = {
+      id: 'en-chain-dup',
+      levelNumber: 1,
+      theme: 'onboarding',
+      locale: 'en',
+      words: ['CAT'],
+      resolvableOrder: ['CAT'],
+      tileFlags: {},
+      difficulty: 1,
+      columns: [
+        { index: 0, tiles: ['C'] },
+        { index: 1, tiles: ['A'] },
+        { index: 2, tiles: ['T'] },
+        { index: 3, tiles: ['C'] },
+        { index: 4, tiles: ['A'] },
+        { index: 5, tiles: ['T'] },
+      ],
+    };
+    const result = validateChainLevel(bad);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/multiple placements/i);
+    }
+  });
 });

--- a/fe-next/lib/blast/v2/engine/__tests__/chain-validator.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/chain-validator.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { validateChainLevel } from '../chain-validator';
+import { buildChainLevel } from '../chain-builder';
+import type { BlastLevel, ChainLevelSpec } from '../../types';
+
+const spec: ChainLevelSpec = {
+  id: 'en-chain-01',
+  levelNumber: 1,
+  theme: 'onboarding',
+  locale: 'en',
+  columns: 4,
+  decoyTiles: 0,
+  chain: ['CAT', 'SUN', 'EGG'],
+};
+
+describe('validateChainLevel', () => {
+  it('accepts a level built by buildChainLevel', () => {
+    const level = buildChainLevel(spec, 7)!;
+    const result = validateChainLevel(level);
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a level where a later word is formable too early', () => {
+    const bad: BlastLevel = {
+      ...spec,
+      words: ['CAT', 'SUN'],
+      resolvableOrder: ['CAT', 'SUN'],
+      tileFlags: {},
+      difficulty: 1,
+      columns: [
+        { index: 0, tiles: ['C', 'S'] },
+        { index: 1, tiles: ['A', 'U'] },
+        { index: 2, tiles: ['T', 'N'] },
+        { index: 3, tiles: [] },
+      ],
+    };
+    const result = validateChainLevel(bad);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/step 1/i);
+    }
+  });
+
+  it('rejects a level whose board does not empty after the last word', () => {
+    const bad: BlastLevel = {
+      ...spec,
+      words: ['CAT'],
+      resolvableOrder: ['CAT'],
+      tileFlags: {},
+      difficulty: 1,
+      columns: [
+        { index: 0, tiles: ['C'] },
+        { index: 1, tiles: ['A'] },
+        { index: 2, tiles: ['T'] },
+        { index: 3, tiles: ['Z'] },
+      ],
+    };
+    const result = validateChainLevel(bad);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/leftover/i);
+    }
+  });
+});

--- a/fe-next/lib/blast/v2/engine/__tests__/word-scan.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/word-scan.test.ts
@@ -39,6 +39,10 @@ describe('scanFormableThemeWords', () => {
     const board = lvl([['C'], ['A'], ['T'], ['C'], ['A'], ['T']]);
     const matches = scanFormableThemeWords(board, ['CAT']);
     expect(matches.length).toBe(2);
+    expect(matches.map((m) => m.cells)).toEqual([
+      ['c0r0', 'c1r0', 'c2r0'],
+      ['c3r0', 'c4r0', 'c5r0'],
+    ]);
   });
 
   it('respects locale normalization for Hebrew final forms', () => {

--- a/fe-next/lib/blast/v2/engine/__tests__/word-scan.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/word-scan.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { scanFormableThemeWords } from '../word-scan';
+import type { BlastLevel } from '../../types';
+
+function lvl(columns: string[][], locale: string = 'en'): BlastLevel {
+  return {
+    id: 't',
+    levelNumber: 1,
+    theme: 'onboarding',
+    locale: locale as any,
+    words: [],
+    resolvableOrder: [],
+    tileFlags: {},
+    difficulty: 1,
+    columns: columns.map((tiles, index) => ({ index, tiles })),
+  };
+}
+
+describe('scanFormableThemeWords', () => {
+  it('finds a horizontal word along a row', () => {
+    const board = lvl([['C'], ['A'], ['T']]);
+    const matches = scanFormableThemeWords(board, ['CAT']);
+    expect(matches).toEqual([{ word: 'CAT', cells: ['c0r0', 'c1r0', 'c2r0'] }]);
+  });
+
+  it('finds a vertical word within a column', () => {
+    const board = lvl([['T', 'A', 'C']]); // bottom->top: T A C
+    const matches = scanFormableThemeWords(board, ['CAT']);
+    expect(matches.map((m) => m.word)).toEqual(['CAT']);
+  });
+
+  it('does NOT match an L-shape or diagonal', () => {
+    const board = lvl([['C', 'A'], ['T']]);
+    const matches = scanFormableThemeWords(board, ['CAT']);
+    expect(matches).toEqual([]);
+  });
+
+  it('returns every placement when a word appears twice', () => {
+    const board = lvl([['C'], ['A'], ['T'], ['C'], ['A'], ['T']]);
+    const matches = scanFormableThemeWords(board, ['CAT']);
+    expect(matches.length).toBe(2);
+  });
+
+  it('respects locale normalization for Hebrew final forms', () => {
+    const board = lvl([['ח'], ['ת'], ['ו'], ['ל']], 'he');
+    const matches = scanFormableThemeWords(board, ['חתול']);
+    expect(matches.map((m) => m.word)).toEqual(['חתול']);
+  });
+});

--- a/fe-next/lib/blast/v2/engine/chain-builder.ts
+++ b/fe-next/lib/blast/v2/engine/chain-builder.ts
@@ -1,6 +1,7 @@
 import type { BlastColumn, BlastLevel, CellId, ChainLevelSpec, Letter, Locale } from '../types';
 import { cellId } from './cell-id';
 import { scanFormableThemeWords } from './word-scan';
+import { validateChainLevel } from './chain-validator';
 import { LOCALE_CONFIGS } from '../locale-config';
 
 export type InsertResult = { level: BlastLevel; cells: CellId[] };
@@ -84,7 +85,7 @@ export function insertWord(
   return null;
 }
 
-const MAX_BUILD_ATTEMPTS = 200;
+const MAX_BUILD_ATTEMPTS = 500;
 
 function emptyColumns(count: number): BlastColumn[] {
   return Array.from({ length: count }, (_, index) => ({ index, tiles: [] as Letter[] }));
@@ -149,7 +150,9 @@ export function buildChainLevel(spec: ChainLevelSpec, seed: number): BlastLevel 
 }
 
 /**
- * Inserts decoy tiles into S_0 that never complete a theme word.
+ * Inserts decoy tiles into S_0 that preserve the chain's validity.
+ * Uses the ground truth: a decoy is valid iff validateChainLevel still passes.
+ * This is the only guarantee that the chain can be replayed correctly.
  */
 function insertDecoys(level: BlastLevel, spec: ChainLevelSpec, seed: number): BlastLevel | null {
   if (spec.decoyTiles <= 0) return level;
@@ -160,19 +163,22 @@ function insertDecoys(level: BlastLevel, spec: ChainLevelSpec, seed: number): Bl
 
   for (let placed = 0; placed < spec.decoyTiles; placed++) {
     let success = false;
-    for (let tries = 0; tries < 60 && !success; tries++) {
+    // Higher try limit since validation is expensive but accurate
+    for (let tries = 0; tries < 100 && !success; tries++) {
       const col = Math.floor(rand() * board.columns.length);
       const letter = pool[Math.floor(rand() * pool.length)]!;
-      const columns = cloneColumns(board.columns);
-      columns[col]!.tiles.push(letter);
-      const candidate: BlastLevel = { ...board, columns };
-      const matches = scanFormableThemeWords(candidate, spec.chain, spec.locale);
-      const formable = new Set(matches.map((m) => m.word));
-      if (formable.size <= 1 && (formable.size === 0 || formable.has(spec.chain[0]!))) {
+      const testColumns = cloneColumns(board.columns);
+      testColumns[col]!.tiles.push(letter);
+      const candidate: BlastLevel = { ...board, columns: testColumns };
+
+      // Ground truth: the level must still validate
+      const validation = validateChainLevel(candidate);
+      if (validation.ok) {
         board = candidate;
         success = true;
       }
     }
+
     if (!success) return null;
   }
   return board;

--- a/fe-next/lib/blast/v2/engine/chain-builder.ts
+++ b/fe-next/lib/blast/v2/engine/chain-builder.ts
@@ -150,36 +150,27 @@ export function buildChainLevel(spec: ChainLevelSpec, seed: number): BlastLevel 
 }
 
 /**
- * Inserts decoy tiles into S_0 that preserve the chain's validity.
- * Uses the ground truth: a decoy is valid iff validateChainLevel still passes.
- * This is the only guarantee that the chain can be replayed correctly.
+ * Inserts decoy tiles into a level that preserve the chain's validity.
+ *
+ * CURRENT LIMITATION: Decoys cannot be reliably placed because the validator
+ * requires the board to fully empty after all chain words are removed. Any decoy
+ * tile that doesn't fall into a position captured by a word removal becomes
+ * leftover and fails validation.
+ *
+ * For small, sparse chains, random placement occasionally succeeds by luck.
+ * For dense chains (4-5 words on 9 columns), the probability of a random tile
+ * landing in a captured position is near-zero, making placement computationally
+ * infeasible.
+ *
+ * WORKAROUND: Keep decoyTiles at 0 for all authored packs. Future improvements
+ * could:
+ * - Modify the validator to allow decoys if they're guaranteed to be cleared
+ * - Use graph analysis to identify which positions will be cleared and only
+ *   place decoys there
+ * - Relax the validator to allow non-empty boards (game-design choice)
  */
 function insertDecoys(level: BlastLevel, spec: ChainLevelSpec, seed: number): BlastLevel | null {
   if (spec.decoyTiles <= 0) return level;
-  const config = LOCALE_CONFIGS[spec.locale];
-  const pool = config.tilePool;
-  const rand = rng(seed);
-  let board = level;
-
-  for (let placed = 0; placed < spec.decoyTiles; placed++) {
-    let success = false;
-    // Higher try limit since validation is expensive but accurate
-    for (let tries = 0; tries < 100 && !success; tries++) {
-      const col = Math.floor(rand() * board.columns.length);
-      const letter = pool[Math.floor(rand() * pool.length)]!;
-      const testColumns = cloneColumns(board.columns);
-      testColumns[col]!.tiles.push(letter);
-      const candidate: BlastLevel = { ...board, columns: testColumns };
-
-      // Ground truth: the level must still validate
-      const validation = validateChainLevel(candidate);
-      if (validation.ok) {
-        board = candidate;
-        success = true;
-      }
-    }
-
-    if (!success) return null;
-  }
-  return board;
+  // For now, decoys cannot be placed reliably. Return null.
+  return null;
 }

--- a/fe-next/lib/blast/v2/engine/chain-builder.ts
+++ b/fe-next/lib/blast/v2/engine/chain-builder.ts
@@ -1,6 +1,7 @@
-import type { BlastColumn, BlastLevel, CellId, Locale } from '../types';
+import type { BlastColumn, BlastLevel, CellId, ChainLevelSpec, Letter, Locale } from '../types';
 import { cellId } from './cell-id';
 import { scanFormableThemeWords } from './word-scan';
+import { LOCALE_CONFIGS } from '../locale-config';
 
 export type InsertResult = { level: BlastLevel; cells: CellId[] };
 
@@ -81,4 +82,98 @@ export function insertWord(
   }
 
   return null;
+}
+
+const MAX_BUILD_ATTEMPTS = 200;
+
+function emptyColumns(count: number): BlastColumn[] {
+  return Array.from({ length: count }, (_, index) => ({ index, tiles: [] as Letter[] }));
+}
+
+/**
+ * S_N: the last word laid flat on the floor of an otherwise empty board.
+ */
+function floorBoard(spec: ChainLevelSpec): BlastLevel | null {
+  const last = [...(spec.chain[spec.chain.length - 1] ?? '')];
+  if (last.length > spec.columns) return null;
+  const columns = emptyColumns(spec.columns);
+  const offset = Math.floor((spec.columns - last.length) / 2);
+  last.forEach((ch, i) => columns[offset + i]!.tiles.push(ch));
+  return {
+    id: spec.id,
+    levelNumber: spec.levelNumber,
+    theme: spec.theme,
+    locale: spec.locale,
+    words: [...spec.chain],
+    resolvableOrder: [...spec.chain],
+    tileFlags: {},
+    difficulty: spec.levelNumber,
+    columns,
+  };
+}
+
+/**
+ * Builds a forced-chain BlastLevel from a spec. Returns null if no seed within
+ * MAX_BUILD_ATTEMPTS yields a valid level (author should then tweak the chain).
+ */
+export function buildChainLevel(spec: ChainLevelSpec, seed: number): BlastLevel | null {
+  const longest = Math.max(...spec.chain.map((w) => [...w].length));
+  if (longest > spec.columns) return null;
+
+  const rand = rng(seed);
+  for (let attempt = 0; attempt < MAX_BUILD_ATTEMPTS; attempt++) {
+    const attemptSeed = Math.floor(rand() * 0xffffffff) || 1;
+    const base = floorBoard(spec);
+    if (!base) return null;
+
+    let board = base;
+    let ok = true;
+    for (let k = spec.chain.length - 2; k >= 0; k--) {
+      const word = spec.chain[k]!;
+      const others = spec.chain.slice(k + 1);
+      const stepSeed = (attemptSeed + k * 7919) >>> 0;
+      const res = insertWord(board, word, others, spec.locale, stepSeed);
+      if (!res) {
+        ok = false;
+        break;
+      }
+      board = res.level;
+    }
+    if (!ok) continue;
+
+    const withDecoys = insertDecoys(board, spec, attemptSeed);
+    if (!withDecoys) continue;
+    return withDecoys;
+  }
+  return null;
+}
+
+/**
+ * Inserts decoy tiles into S_0 that never complete a theme word.
+ */
+function insertDecoys(level: BlastLevel, spec: ChainLevelSpec, seed: number): BlastLevel | null {
+  if (spec.decoyTiles <= 0) return level;
+  const config = LOCALE_CONFIGS[spec.locale];
+  const pool = config.tilePool;
+  const rand = rng(seed);
+  let board = level;
+
+  for (let placed = 0; placed < spec.decoyTiles; placed++) {
+    let success = false;
+    for (let tries = 0; tries < 60 && !success; tries++) {
+      const col = Math.floor(rand() * board.columns.length);
+      const letter = pool[Math.floor(rand() * pool.length)]!;
+      const columns = cloneColumns(board.columns);
+      columns[col]!.tiles.push(letter);
+      const candidate: BlastLevel = { ...board, columns };
+      const matches = scanFormableThemeWords(candidate, spec.chain, spec.locale);
+      const formable = new Set(matches.map((m) => m.word));
+      if (formable.size <= 1 && (formable.size === 0 || formable.has(spec.chain[0]!))) {
+        board = candidate;
+        success = true;
+      }
+    }
+    if (!success) return null;
+  }
+  return board;
 }

--- a/fe-next/lib/blast/v2/engine/chain-builder.ts
+++ b/fe-next/lib/blast/v2/engine/chain-builder.ts
@@ -1,0 +1,84 @@
+import type { BlastColumn, BlastLevel, CellId, Locale } from '../types';
+import { cellId } from './cell-id';
+import { scanFormableThemeWords } from './word-scan';
+
+export type InsertResult = { level: BlastLevel; cells: CellId[] };
+
+/** Deterministic LCG so builds are reproducible per seed. */
+function rng(seed: number): () => number {
+  let s = seed >>> 0 || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0xffffffff;
+  };
+}
+
+function shuffle<T>(arr: T[], rand: () => number): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [a[i], a[j]!] = [a[j]!, a[i]!];
+  }
+  return a;
+}
+
+function cloneColumns(columns: BlastColumn[]): BlastColumn[] {
+  return columns.map((c) => ({ index: c.index, tiles: [...c.tiles] }));
+}
+
+/**
+ * Backward construction step. Inserts `word` into `Sk` as a horizontal run so
+ * that `word` is formable and none of `otherWordsOnBoard` is. Returns the new
+ * board (`S_{k-1}`) and the cells `word` occupies, or null if no placement works.
+ */
+export function insertWord(
+  Sk: BlastLevel,
+  word: string,
+  otherWordsOnBoard: string[],
+  locale: Locale,
+  seed: number,
+): InsertResult | null {
+  const letters = [...word];
+  const L = letters.length;
+  const cols = Sk.columns.length;
+  if (L > cols) return null;
+
+  const rand = rng(seed);
+  type Cand = { c: number; r: number };
+  const candidates: Cand[] = [];
+
+  // Generate all valid placements: starting column c, row r such that
+  // the word fits horizontally and row r is a valid insertion point.
+  for (let c = 0; c + L <= cols; c++) {
+    const affected = Array.from({ length: L }, (_, i) => Sk.columns[c + i]!.tiles.length);
+    const maxR = Math.min(...affected);
+    for (let r = 0; r <= maxR; r++) {
+      candidates.push({ c, r });
+    }
+  }
+
+  // Randomize candidate order for reproducibility via seed.
+  const shuffled = shuffle(candidates, rand);
+
+  for (const { c, r } of shuffled) {
+    const columns = cloneColumns(Sk.columns);
+    const cells: CellId[] = [];
+
+    // Insert each letter at row r in its respective column.
+    for (let i = 0; i < L; i++) {
+      columns[c + i]!.tiles.splice(r, 0, letters[i]!);
+      cells.push(cellId(c + i, r));
+    }
+
+    const level: BlastLevel = { ...Sk, columns };
+    const matches = scanFormableThemeWords(level, [word, ...otherWordsOnBoard], locale);
+    const formableWords = new Set(matches.map((m) => m.word));
+
+    // Success: only `word` is formable.
+    if (formableWords.size === 1 && formableWords.has(word)) {
+      return { level, cells };
+    }
+  }
+
+  return null;
+}

--- a/fe-next/lib/blast/v2/engine/chain-validator.ts
+++ b/fe-next/lib/blast/v2/engine/chain-validator.ts
@@ -1,0 +1,45 @@
+import type { BlastLevel, BlastColumn } from '../types';
+import { collapseCells } from './collapse';
+import { scanFormableThemeWords } from './word-scan';
+
+export type ChainValidation = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Replays a chain level forward. At each step exactly one theme word
+ * (the next in resolvableOrder) must be formable; clearing it must not
+ * skip ahead. After the final word the board must be empty.
+ */
+export function validateChainLevel(level: BlastLevel): ChainValidation {
+  const order = level.resolvableOrder.length ? level.resolvableOrder : level.words;
+  let board = level;
+
+  for (let step = 0; step < order.length; step++) {
+    const expected = order[step]!;
+    const remaining = order.slice(step);
+    const matches = scanFormableThemeWords(board, remaining, level.locale);
+    const formable = new Set(matches.map((m) => m.word));
+
+    if (!formable.has(expected)) {
+      return { ok: false, reason: `step ${step + 1}: expected "${expected}" not formable` };
+    }
+    if (formable.size > 1) {
+      const extra = [...formable].filter((w) => w !== expected);
+      return {
+        ok: false,
+        reason: `step ${step + 1}: words formable out of order: ${extra.join(', ')}`,
+      };
+    }
+
+    const cells = matches.find((m) => m.word === expected)!.cells;
+    board = collapseCells(board, cells).level;
+  }
+
+  const leftover = board.columns.reduce(
+    (n: number, c: BlastColumn) => n + c.tiles.length,
+    0,
+  );
+  if (leftover > 0) {
+    return { ok: false, reason: `leftover ${leftover} tile(s) after final word` };
+  }
+  return { ok: true };
+}

--- a/fe-next/lib/blast/v2/engine/chain-validator.ts
+++ b/fe-next/lib/blast/v2/engine/chain-validator.ts
@@ -15,6 +15,8 @@ export function validateChainLevel(level: BlastLevel): ChainValidation {
 
   for (let step = 0; step < order.length; step++) {
     const expected = order[step]!;
+    // Include all remaining words in the scan so we catch any future chain word
+    // becoming formable out of order (which is an error).
     const remaining = order.slice(step);
     const matches = scanFormableThemeWords(board, remaining, level.locale);
     const formable = new Set(matches.map((m) => m.word));
@@ -30,7 +32,17 @@ export function validateChainLevel(level: BlastLevel): ChainValidation {
       };
     }
 
-    const cells = matches.find((m) => m.word === expected)!.cells;
+    // Reject if the expected word is formable in multiple placements—
+    // the step would be ambiguous, breaking the strict forced-chain constraint.
+    const placements = matches.filter((m) => m.word === expected);
+    if (placements.length > 1) {
+      return {
+        ok: false,
+        reason: `step ${step + 1}: word "${expected}" formable in multiple placements`,
+      };
+    }
+
+    const cells = placements[0]!.cells;
     board = collapseCells(board, cells).level;
   }
 

--- a/fe-next/lib/blast/v2/engine/word-scan.ts
+++ b/fe-next/lib/blast/v2/engine/word-scan.ts
@@ -1,0 +1,72 @@
+import type { BlastLevel, CellId, Locale } from '../types';
+import { LOCALE_CONFIGS } from '../locale-config';
+import { cellId } from './cell-id';
+
+export type WordMatch = { word: string; cells: CellId[] };
+
+function at(level: BlastLevel, col: number, row: number): string | undefined {
+  return level.columns[col]?.tiles[row];
+}
+
+/**
+ * Scan a Blast level to find which target words are formable as straight-line runs.
+ * A word match requires a contiguous horizontal (within a row, left→right) or
+ * vertical (within a column, bottom→top) sequence of tiles.
+ *
+ * Matches are returned in the order they are found (row-major for horizontal,
+ * then column-major for vertical).
+ *
+ * Normalization (e.g. Hebrew final forms) is applied per locale.
+ */
+export function scanFormableThemeWords(
+  level: BlastLevel,
+  targets: string[],
+  locale: Locale = 'en',
+): WordMatch[] {
+  const config = LOCALE_CONFIGS[locale];
+  const norm = (s: string): string => config.normalize(s);
+
+  // Map normalized target words to their original form for output
+  const wanted = new Map(targets.map((w) => [norm(w), w] as const));
+  const matches: WordMatch[] = [];
+
+  const cols = level.columns.length;
+  const maxRow = Math.max(0, ...level.columns.map((c) => c.tiles.length));
+
+  // Scan horizontal runs: for each row, check each starting column
+  for (let row = 0; row < maxRow; row++) {
+    for (let start = 0; start < cols; start++) {
+      let run = '';
+      const cells: CellId[] = [];
+      for (let col = start; col < cols; col++) {
+        const ch = at(level, col, row);
+        if (ch === undefined) break;
+        run += ch;
+        cells.push(cellId(col, row));
+        const hit = wanted.get(norm(run));
+        if (hit && run.length >= 2) {
+          matches.push({ word: hit, cells: [...cells] });
+        }
+      }
+    }
+  }
+
+  // Scan vertical runs: for each column, check each starting row (from top down)
+  for (let col = 0; col < cols; col++) {
+    const tiles = level.columns[col]?.tiles ?? [];
+    for (let topRow = tiles.length - 1; topRow >= 0; topRow--) {
+      let run = '';
+      const cells: CellId[] = [];
+      for (let row = topRow; row >= 0; row--) {
+        run += tiles[row];
+        cells.push(cellId(col, row));
+        const hit = wanted.get(norm(run));
+        if (hit && run.length >= 2) {
+          matches.push({ word: hit, cells: [...cells] });
+        }
+      }
+    }
+  }
+
+  return matches;
+}

--- a/fe-next/lib/blast/v2/level-source-registry.ts
+++ b/fe-next/lib/blast/v2/level-source-registry.ts
@@ -1,8 +1,13 @@
 import { CuratedPackSource } from './curated-pack-source';
 import { GeneratedLevelSource } from './generator';
+import { ChainPackSource } from './chain-pack-source';
 import { LOCALE_CONFIGS } from './locale-config';
-import type { LevelSourceRegistry } from './level-source';
+import type { LevelSourceRegistry, LevelSource } from './level-source';
+import type { Locale } from './types';
 import { resolve } from 'node:path';
+
+const CHAIN_LOCALES: Locale[] = ['en', 'he'];
+const CHAIN_MAX_LEVEL = 15;
 
 let cached: LevelSourceRegistry | null = null;
 
@@ -12,6 +17,22 @@ export function buildRegistry(): LevelSourceRegistry {
   cached = {
     curated: new CuratedPackSource(basePath),
     generated: new GeneratedLevelSource(LOCALE_CONFIGS),
+    chain: new ChainPackSource(basePath),
   };
   return cached;
+}
+
+/**
+ * Resolve the appropriate source for a given level number and locale.
+ * Priority: chain (1-15 for en/he) → curated → generated.
+ */
+export function getLevelSourceForLevel(
+  levelNumber: number,
+  locale: Locale,
+  registry: LevelSourceRegistry,
+): LevelSource {
+  if (CHAIN_LOCALES.includes(locale) && levelNumber >= 1 && levelNumber <= CHAIN_MAX_LEVEL) {
+    return registry.chain;
+  }
+  return levelNumber <= 30 ? registry.curated : registry.generated;
 }

--- a/fe-next/lib/blast/v2/level-source.ts
+++ b/fe-next/lib/blast/v2/level-source.ts
@@ -4,7 +4,7 @@ export interface LevelSource {
   resolve(levelNumber: number, locale: Locale, userIdBucket?: string): Promise<BlastLevel>;
 }
 
-export type LevelSourceRegistry = { curated: LevelSource; generated: LevelSource };
+export type LevelSourceRegistry = { curated: LevelSource; generated: LevelSource; chain: LevelSource };
 
 export const CURATED_LEVEL_CUTOFF = 30;
 

--- a/fe-next/lib/blast/v2/types.ts
+++ b/fe-next/lib/blast/v2/types.ts
@@ -34,6 +34,19 @@ export type BlastLevel = {
   interestingnessScore?: number;
 };
 
+export type ChainLevelSpec = {
+  id: string;
+  levelNumber: number;
+  theme: ThemeKey;
+  locale: Locale;
+  /** Number of board columns. Must be >= the longest word in the chain. */
+  columns: number;
+  /** Count of decoy tiles that never complete a theme word. */
+  decoyTiles: number;
+  /** Ordered words; chain[0] is found first, chain[last] last. */
+  chain: string[];
+};
+
 export type MechanicSet = {
   coinOverlay: boolean;
   reverseSelection: boolean;


### PR DESCRIPTION
## Summary
Rebuilds Blast v2 as a playable forced-chain cascade word game (Word Stacks style). Each level is an ordered word list; the board is constructed so each word is **only** formable after the previous word's tiles collapse — verified playable end-to-end in a real browser (EN level 1 played CAT→SUN→EGG to an empty board, cascade-reveal glow firing at each step).

- **Engine** (`lib/blast/v2/engine/`): `word-scan` (straight-line word finder), `chain-builder` (backward construction — builds each level from the solved state so forced order is structurally guaranteed), `chain-validator` (forward-replay safety net).
- **Content**: 15 English + 15 Hebrew hand-authored chain levels, rising difficulty (3→4→5 words), every level passes `validateChainLevel`. New `ChainPackSource` wired into the level registry (en/he 1–15).
- **Feel**: hybrid neo-brutalist tile restyle (warm tactile face, hard border + offset shadow, bevel), GSAP squash-on-land collapse, electric cascade-reveal glow.
- 441/441 Blast v2 tests green; production build clean.

Spec + plan: `docs/superpowers/{specs,plans}/2026-05-14-blast-v2-playable*`. Gated behind `?v2=force` / tester list.

## Known gaps (tracked, not blockers)
- **Decoy tiles deferred** — ships at `decoyTiles: 0`. Reliable placement on dense boards needs a board-model change.
- **Hebrew pack needs native-speaker review** — words are AI-selected, structurally validated only.

## Test plan
- [x] `npx vitest run --config vitest.config.ts lib/blast/v2 components/blast/v2` — 441/441
- [x] `npm run build` — clean
- [x] Browser playtest EN: forced chain plays through to empty board
- [x] Browser playtest HE: RTL board renders, chain plays
- [ ] Native Hebrew review of the 15 HE levels
- [ ] Decoy tiles (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)