### PR TITLE
feat(blast/v2): board polish, FX, gravity, results card + placement rules & concept intros

### DIFF
--- a/fe-next/components/blast/v2/BlastAlmostGhost.module.css
+++ b/fe-next/components/blast/v2/BlastAlmostGhost.module.css
@@ -16,15 +16,21 @@
   font-family: var(--font-neo-display, 'Fredoka', system-ui, sans-serif);
   font-weight: 800;
   font-size: calc(var(--blast-tile-size, 64px) * 0.45);
-  opacity: 0.32;
-  border: 2px dashed currentColor;
+  opacity: 0.28;
+  color: currentColor;
+  /* Soft glow instead of dashed border: dashed letters floating above the
+     board in empty space read as visual noise. The glow keeps the hint
+     readable but lets it feel like a magical "missing letter" preview. */
   border-radius: 14px;
+  text-shadow:
+    0 0 8px currentColor,
+    0 0 14px color-mix(in srgb, currentColor 60%, transparent);
   animation: ghost-breathe 1.6s ease-in-out infinite;
 }
 
 @keyframes ghost-breathe {
   0%, 100% { opacity: 0.22; transform: scale(0.96); }
-  50%      { opacity: 0.45; transform: scale(1.02); }
+  50%      { opacity: 0.40; transform: scale(1.02); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/fe-next/components/blast/v2/BlastBoard.tsx
+++ b/fe-next/components/blast/v2/BlastBoard.tsx
@@ -121,7 +121,13 @@ export function BlastBoard({
       data-shake-key={invalidShakeKey}
       data-testid="blast-board"
       className={`relative flex items-end justify-center gap-2 p-4 touch-none select-none ${styles.board}`}
-      style={{ touchAction: 'none' }}
+      style={{
+        touchAction: 'none',
+        // Drives container-query tile sizing: every tile reads
+        // --blast-tile-size derived from this column count so wide boards
+        // (7+ cols) stay inside the viewport instead of overflowing.
+        ['--blast-cols' as string]: String(level.columns.length),
+      }}
       onPointerUp={onPointerUp}
     >
       {/* Cell-well backdrop — empty inset slots line up perfectly with tile

--- a/fe-next/components/blast/v2/BlastConceptIntroCard.tsx
+++ b/fe-next/components/blast/v2/BlastConceptIntroCard.tsx
@@ -1,0 +1,211 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { m, useReducedMotion } from 'framer-motion';
+import { useLanguage } from '@/contexts/LanguageContext';
+import type { ConceptKey } from '@/lib/blast/v2/tutorial/unlocks-seen';
+
+type Props = {
+  concept: ConceptKey;
+  modeColor?: string;
+  onDismiss: () => void;
+};
+
+type DemoLetter = {
+  ch: string;
+  active: boolean;
+};
+
+// Visual demos for each concept. Auto-runs an animated trace highlighting
+// the cells that form the example word, then waits for "Got it".
+const DEMOS: Record<ConceptKey, {
+  titleKey: string;
+  titleFallback: string;
+  bodyKey: string;
+  bodyFallback: string;
+  rows: DemoLetter[][];
+  highlightOrder: Array<{ row: number; col: number }>;
+}> = {
+  anyRow: {
+    titleKey: 'blast.concept.anyRow.title',
+    titleFallback: 'Words can be on any row',
+    bodyKey: 'blast.concept.anyRow.body',
+    bodyFallback: 'Not just the bottom row — scan the whole board for words.',
+    rows: [
+      // Top row (visually highest)
+      [
+        { ch: 'X', active: false },
+        { ch: 'B', active: true },
+        { ch: 'E', active: true },
+        { ch: 'E', active: true },
+      ],
+      [
+        { ch: 'M', active: false },
+        { ch: 'T', active: false },
+        { ch: 'I', active: false },
+        { ch: 'R', active: false },
+      ],
+      [
+        { ch: 'A', active: false },
+        { ch: 'N', active: false },
+        { ch: 'S', active: false },
+        { ch: 'P', active: false },
+      ],
+    ],
+    highlightOrder: [
+      { row: 0, col: 1 },
+      { row: 0, col: 2 },
+      { row: 0, col: 3 },
+    ],
+  },
+  verticalWords: {
+    titleKey: 'blast.concept.verticalWords.title',
+    titleFallback: 'Words can be vertical too',
+    bodyKey: 'blast.concept.verticalWords.body',
+    bodyFallback: 'Drag straight down (or up) to spell vertical words.',
+    rows: [
+      [
+        { ch: 'L', active: true },
+        { ch: 'M', active: false },
+        { ch: 'A', active: false },
+        { ch: 'R', active: false },
+      ],
+      [
+        { ch: 'I', active: true },
+        { ch: 'N', active: false },
+        { ch: 'T', active: false },
+        { ch: 'S', active: false },
+      ],
+      [
+        { ch: 'O', active: true },
+        { ch: 'E', active: false },
+        { ch: 'P', active: false },
+        { ch: 'N', active: false },
+      ],
+      [
+        { ch: 'N', active: true },
+        { ch: 'I', active: false },
+        { ch: 'A', active: false },
+        { ch: 'D', active: false },
+      ],
+    ],
+    highlightOrder: [
+      { row: 0, col: 0 },
+      { row: 1, col: 0 },
+      { row: 2, col: 0 },
+      { row: 3, col: 0 },
+    ],
+  },
+};
+
+export function BlastConceptIntroCard({ concept, modeColor = '#BFFF00', onDismiss }: Props) {
+  const { t } = useLanguage();
+  const reducedMotion = useReducedMotion();
+  const demo = DEMOS[concept];
+  const [step, setStep] = useState(0);
+
+  // Walk through the highlightOrder, advancing one cell per tick, then loop.
+  useEffect(() => {
+    if (reducedMotion) {
+      setStep(demo.highlightOrder.length);
+      return;
+    }
+    const total = demo.highlightOrder.length;
+    const interval = setInterval(() => {
+      setStep((s) => {
+        // After holding the full trace for ~600ms, restart so the demo loops
+        // until the player taps Got it.
+        if (s >= total + 2) return 0;
+        return s + 1;
+      });
+    }, 380);
+    return () => clearInterval(interval);
+  }, [demo, reducedMotion]);
+
+  const isLit = (row: number, col: number) => {
+    return demo.highlightOrder
+      .slice(0, Math.min(step, demo.highlightOrder.length))
+      .some((c) => c.row === row && c.col === col);
+  };
+
+  return (
+    <m.div
+      data-testid="concept-intro"
+      data-concept={concept}
+      initial={{ opacity: reducedMotion ? 1 : 0, scale: reducedMotion ? 1 : 0.94 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 22 }}
+      className="fixed inset-0 z-50 grid place-items-center bg-black/70 px-4"
+    >
+      <div
+        className="relative w-full max-w-sm rounded-2xl text-white text-center"
+        style={{
+          background: '#16213e',
+          border: `3px solid ${modeColor}`,
+          boxShadow: `6px 6px 0 #0b1530, 0 0 60px color-mix(in srgb, ${modeColor} 35%, transparent)`,
+        }}
+      >
+        <div className="px-6 pt-6">
+          <div
+            className="text-[11px] uppercase tracking-[0.2em] opacity-70"
+            style={{ color: modeColor }}
+          >
+            {t('blast.concept.tag', 'New')}
+          </div>
+          <h2 className="text-xl font-black mt-1">
+            {t(demo.titleKey, demo.titleFallback)}
+          </h2>
+          <p className="text-sm opacity-85 mt-2 leading-snug">
+            {t(demo.bodyKey, demo.bodyFallback)}
+          </p>
+        </div>
+        <div className="px-6 py-6">
+          <div
+            className="mx-auto inline-grid gap-1.5 p-3 rounded-xl bg-black/40"
+            style={{ gridTemplateColumns: `repeat(${demo.rows[0]!.length}, 38px)` }}
+            aria-hidden
+          >
+            {demo.rows.map((row, rIdx) =>
+              row.map((cell, cIdx) => {
+                const lit = isLit(rIdx, cIdx);
+                return (
+                  <m.div
+                    key={`${rIdx}-${cIdx}`}
+                    animate={{
+                      scale: lit ? 1.08 : 1,
+                      backgroundColor: lit ? modeColor : '#f4e9d8',
+                      color: lit ? '#ffffff' : '#0b1530',
+                    }}
+                    transition={{ duration: 0.18 }}
+                    className="w-[38px] h-[38px] rounded-md font-black grid place-items-center text-base"
+                    style={{
+                      border: '2px solid #0b1530',
+                      boxShadow: lit
+                        ? `0 0 14px color-mix(in srgb, ${modeColor} 70%, transparent), 3px 3px 0 #0b1530`
+                        : '3px 3px 0 #0b1530',
+                    }}
+                  >
+                    {cell.ch}
+                  </m.div>
+                );
+              }),
+            )}
+          </div>
+        </div>
+        <div className="px-6 pb-6">
+          <button
+            onClick={onDismiss}
+            data-testid="concept-got-it"
+            className="w-full px-4 py-3 rounded-lg font-black text-lg uppercase tracking-wide"
+            style={{
+              background: modeColor,
+              color: '#0b1530',
+              boxShadow: `4px 4px 0 #0b1530`,
+            }}
+          >
+            {t('blast.concept.gotIt', "Let's play!")}
+          </button>
+        </div>
+      </div>
+    </m.div>
+  );
+}

--- a/fe-next/components/blast/v2/BlastFxOverlay.tsx
+++ b/fe-next/components/blast/v2/BlastFxOverlay.tsx
@@ -241,9 +241,12 @@ export function BlastFxOverlay({
       const lx = center.x - rect.left;
       const ly = center.y - rect.top;
       const variant = pickExplosionVariant();
-      particles.burst(variant, lx, ly, 18);
-      particles.burst(ELECTRIC_RINGS, lx, ly, 4);
-      debris.spawn(lx, ly, tintColor, 6);
+      // Heavier per-cell burst: was 18+4+6 → now 32+10+10. Combined with the
+      // higher z-index it reads as a real explosion instead of a glint.
+      particles.burst(variant, lx, ly, 32);
+      particles.burst(ELECTRIC_RINGS, lx, ly, 10);
+      particles.burst(CASCADE_SPARKLE, lx, ly, 6);
+      debris.spawn(lx, ly, tintColor, 10);
       spawnPulseRing(app, systems, lx, ly, tintColor);
     }
 
@@ -327,7 +330,11 @@ export function BlastFxOverlay({
       ref={canvasRef}
       data-testid="blast-fx"
       className={`${styles.canvas} absolute inset-0 pointer-events-none`}
-      style={{ zIndex: 10 }}
+      // z-index 30 keeps bursts above the board (which sits at auto inside
+      // a stacking context created by isolation: isolate). Earlier z=10
+      // sometimes ended up painted under tile transforms during chains;
+      // 30 leaves headroom for HUD/modals while keeping FX legible.
+      style={{ zIndex: 30 }}
     />
   );
 }

--- a/fe-next/components/blast/v2/BlastGame.tsx
+++ b/fe-next/components/blast/v2/BlastGame.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState, useEffect, useMemo, useRef } from 'react';
 import type { BlastLevel, CellId } from '@/lib/blast/v2/types';
-import { markUnlockSeen, completeFtue, setSkipAll, type UnlocksSeen, type MechanicKey } from '@/lib/blast/v2/tutorial/unlocks-seen';
+import { markUnlockSeen, markConceptSeen, completeFtue, setSkipAll, type UnlocksSeen } from '@/lib/blast/v2/tutorial/unlocks-seen';
 import { useBlastV2 } from '@/lib/blast/v2/useBlastV2';
 import { detectAlmostWords, detectAllCascades } from '@/lib/blast/v2/engine';
 import { scanFormableThemeWords } from '@/lib/blast/v2/engine/word-scan';
@@ -24,6 +24,7 @@ import { BlastFxOverlay } from './BlastFxOverlay';
 import { BlastAtmosphereOverlay } from './BlastAtmosphereOverlay';
 import { BlastFtueOverlay, type FtueStep } from './BlastFtueOverlay';
 import { BlastUnlockCard } from './BlastUnlockCard';
+import { BlastConceptIntroCard } from './BlastConceptIntroCard';
 
 type Props = {
   level: BlastLevel;
@@ -72,6 +73,17 @@ export function BlastGame({
   const [introDismissed, setIntroDismissed] = useState(false);
   const [levelStartTime] = useState(() => Date.now());
   const { state, handlers } = useBlastV2(level);
+  // Track the deepest cascade chain across the run for the results card.
+  const [bestChainDepth, setBestChainDepth] = useState(0);
+  useEffect(() => {
+    if (state.lastChainDepth > bestChainDepth) {
+      setBestChainDepth(state.lastChainDepth);
+    }
+  }, [state.lastChainDepth, bestChainDepth]);
+  // Finalized run stats — snapshot when the level transitions to complete so
+  // re-renders of the results card don't re-read Date.now() (impure during
+  // render).
+  const [finalStats, setFinalStats] = useState<{ timeSeconds: number; gemsCollected: number; stars: number } | null>(null);
   useChainHaptics({ chainEventKey: state.chainEventKey, chainDepth: state.lastChainDepth });
   useChainEventBus({ chainEventKey: state.chainEventKey, chainDepth: state.lastChainDepth });
   // Cascade pacing — Royal Match style. Complete card delayed by `(chainDepth-1)*350 + 700`ms
@@ -196,6 +208,7 @@ export function BlastGame({
     };
 
     const stars = starRating(submission, level);
+    setFinalStats({ timeSeconds, gemsCollected, stars });
 
     trackBlastLevelCompleted({
       level: level.levelNumber,
@@ -229,6 +242,13 @@ export function BlastGame({
     onUpdateUnlocks?.(updated);
   };
 
+  const handleConceptDismiss = () => {
+    if (tutorial.showConceptCard) {
+      const updated = markConceptSeen(unlocksSeen, tutorial.showConceptCard);
+      onUpdateUnlocks?.(updated);
+    }
+  };
+
   const modeColor = MODE_COLORS[level.theme] || '#BFFF00';
   // FX integration point: BlastFxOverlay mounts useBlastFx internally
   // Board ref is obtained internally by BlastBoard via useRef
@@ -254,6 +274,20 @@ export function BlastGame({
     );
   }
 
+  // Concept intro lands AFTER the level intro fades — players read the
+  // placement-rule explanation while still on a calm screen, then tap into
+  // the live board. Marks the concept seen on dismiss so the card never
+  // re-fires for the player.
+  if (tutorial.showConceptCard) {
+    return (
+      <BlastConceptIntroCard
+        concept={tutorial.showConceptCard}
+        modeColor={modeColor}
+        onDismiss={handleConceptDismiss}
+      />
+    );
+  }
+
   // Show chest open ceremony if chest is full
   if (showChestModal && progressState.chestContents) {
     return (
@@ -276,6 +310,11 @@ export function BlastGame({
         cascadeCount={state.cascadeCount}
         modeColor={modeColor}
         levelNumber={level.levelNumber}
+        wordsFound={state.foundWords.size}
+        timeSeconds={finalStats?.timeSeconds}
+        gemsCollected={finalStats?.gemsCollected}
+        bestChainDepth={bestChainDepth}
+        stars={finalStats?.stars}
         onNext={onAdvance}
       />
     );

--- a/fe-next/components/blast/v2/BlastHud.tsx
+++ b/fe-next/components/blast/v2/BlastHud.tsx
@@ -45,22 +45,25 @@ export function BlastHud({
           boxShadow: `inset 0 -2px 0 ${modeColor}`,
         }}
       >
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0">
           <span
             aria-hidden
-            className="inline-block w-2 h-6 rounded-sm"
+            className="inline-block w-2 h-7 rounded-sm shrink-0"
             style={{ background: modeColor, boxShadow: `0 0 12px ${modeColor}` }}
           />
-          <div className="flex flex-col leading-tight">
+          <div className="flex flex-col leading-tight min-w-0">
             <span
               data-testid="level-label"
-              className="text-sm font-bold uppercase tracking-wide"
-              style={{ color: modeColor }}
+              className="text-[11px] font-bold uppercase tracking-wider opacity-70"
             >
               {t('blast.level', `Level ${levelNumber}`, { n: String(levelNumber) })}
             </span>
             {theme && (
-              <span className="text-[10px] uppercase tracking-wider opacity-60">
+              <span
+                data-testid="theme-label"
+                className="text-sm font-black uppercase tracking-wide truncate"
+                style={{ color: modeColor, textShadow: `1px 1px 0 #0b1530` }}
+              >
                 {t(`blast.themes.${theme}`, theme)}
               </span>
             )}

--- a/fe-next/components/blast/v2/BlastLevelCompleteCard.tsx
+++ b/fe-next/components/blast/v2/BlastLevelCompleteCard.tsx
@@ -7,8 +7,19 @@ type Props = {
   cascadeCount: number;
   modeColor?: string;
   levelNumber?: number;
+  wordsFound?: number;
+  timeSeconds?: number;
+  gemsCollected?: number;
+  bestChainDepth?: number;
+  stars?: number;
   onNext: () => void;
 };
+
+function formatTime(sec: number): string {
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
 
 // Bigger, theme-tinted result card. Spring entrance + staggered stat reveal
 // so the moment feels earned. Theme color drives the title, border accent,
@@ -18,9 +29,30 @@ export function BlastLevelCompleteCard({
   cascadeCount,
   modeColor = '#BFFF00',
   levelNumber,
+  wordsFound,
+  timeSeconds,
+  gemsCollected,
+  bestChainDepth,
+  stars,
   onNext,
 }: Props) {
   const { t } = useLanguage();
+  const showWords = typeof wordsFound === 'number' && wordsFound > 0;
+  const showTime = typeof timeSeconds === 'number' && timeSeconds > 0;
+  const showGems = typeof gemsCollected === 'number' && gemsCollected > 0;
+  const showChain = typeof bestChainDepth === 'number' && bestChainDepth > 0;
+  const showStars = typeof stars === 'number' && stars > 0;
+  // Stat tiles are rendered as a flex-wrap so 4–6 stats lay out cleanly on
+  // narrow phones without overflowing the card.
+  const tiles: Array<{ icon: string; value: string; label: string; key: string }> = [
+    { icon: '🪙', value: `+${coins}`, label: t('blast.complete.coins', 'Coins'), key: 'coins' },
+    { icon: '⚡', value: String(cascadeCount), label: t('blast.complete.cascadesLabel', 'Cascades'), key: 'cascades' },
+  ];
+  if (showWords) tiles.push({ icon: '📖', value: String(wordsFound), label: t('blast.complete.wordsLabel', 'Words'), key: 'words' });
+  if (showTime) tiles.push({ icon: '⏱️', value: formatTime(timeSeconds!), label: t('blast.complete.timeLabel', 'Time'), key: 'time' });
+  if (showGems) tiles.push({ icon: '💎', value: String(gemsCollected), label: t('blast.complete.gemsLabel', 'Gems'), key: 'gems' });
+  if (showChain) tiles.push({ icon: '🔥', value: `x${bestChainDepth}`, label: t('blast.complete.chainLabel', 'Best Chain'), key: 'chain' });
+
   return (
     <div
       data-testid="complete-card"
@@ -33,7 +65,7 @@ export function BlastLevelCompleteCard({
         initial={{ scale: 0.5, opacity: 0, rotate: -3 }}
         animate={{ scale: 1, opacity: 1, rotate: 0 }}
         transition={{ type: 'spring', stiffness: 320, damping: 18 }}
-        className="relative max-w-md w-[88%] px-8 py-10 rounded-2xl text-center"
+        className="relative max-w-md w-[92%] px-6 py-8 rounded-2xl text-center"
         style={{
           background: '#16213e',
           border: `3px solid ${modeColor}`,
@@ -54,39 +86,55 @@ export function BlastLevelCompleteCard({
           initial={{ scale: 0.7, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
           transition={{ delay: 0.25, type: 'spring', stiffness: 400 }}
-          className="text-5xl font-black mt-2"
+          className="text-4xl font-black mt-2"
           style={{ color: modeColor, textShadow: `3px 3px 0 #0b1530` }}
         >
           {t('blast.complete.title', 'Level Complete!')}
         </m.div>
+        {showStars && (
+          <m.div
+            data-testid="complete-stars"
+            initial={{ scale: 0, rotate: -20 }}
+            animate={{ scale: 1, rotate: 0 }}
+            transition={{ delay: 0.4, type: 'spring', stiffness: 360 }}
+            className="mt-3 text-2xl tracking-widest"
+            aria-label={`${stars} stars`}
+          >
+            {Array.from({ length: 3 }).map((_, i) => (
+              <span key={i} style={{ opacity: i < stars! ? 1 : 0.25 }}>★</span>
+            ))}
+          </m.div>
+        )}
         <m.div
           initial={{ y: 12, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          transition={{ delay: 0.45 }}
-          className="mt-8 grid grid-cols-2 gap-3"
+          transition={{ delay: 0.5 }}
+          className="mt-6 flex flex-wrap justify-center gap-2"
         >
-          <div className="rounded-lg p-3 bg-black/30 border border-white/10">
-            <div className="text-3xl font-bold">🪙</div>
-            <div className="text-2xl font-bold tabular-nums">+{coins}</div>
-            <div className="text-[10px] uppercase tracking-wider opacity-60 mt-1">
-              {t('blast.complete.coins', 'Coins')}
-            </div>
-          </div>
-          <div className="rounded-lg p-3 bg-black/30 border border-white/10">
-            <div className="text-3xl font-bold">⚡</div>
-            <div className="text-2xl font-bold tabular-nums">{cascadeCount}</div>
-            <div className="text-[10px] uppercase tracking-wider opacity-60 mt-1">
-              {t('blast.complete.cascadesLabel', 'Cascades')}
-            </div>
-          </div>
+          {tiles.map((tile, i) => (
+            <m.div
+              key={tile.key}
+              initial={{ scale: 0.6, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ delay: 0.55 + i * 0.06, type: 'spring', stiffness: 380 }}
+              data-stat={tile.key}
+              className="rounded-lg p-3 bg-black/30 border border-white/10 min-w-[88px] grow basis-[28%]"
+            >
+              <div className="text-2xl leading-none">{tile.icon}</div>
+              <div className="text-xl font-bold tabular-nums mt-1">{tile.value}</div>
+              <div className="text-[10px] uppercase tracking-wider opacity-60 mt-1">
+                {tile.label}
+              </div>
+            </m.div>
+          ))}
         </m.div>
         <m.button
           initial={{ y: 16, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          transition={{ delay: 0.65, type: 'spring', stiffness: 320 }}
+          transition={{ delay: 0.55 + tiles.length * 0.06 + 0.1, type: 'spring', stiffness: 320 }}
           whileTap={{ scale: 0.96 }}
           onClick={onNext}
-          className="mt-8 px-8 py-3 w-full rounded-lg font-black text-lg uppercase tracking-wide"
+          className="mt-7 px-8 py-3 w-full rounded-lg font-black text-lg uppercase tracking-wide"
           style={{
             background: modeColor,
             color: '#0b1530',

--- a/fe-next/components/blast/v2/BlastLevelIntroCard.tsx
+++ b/fe-next/components/blast/v2/BlastLevelIntroCard.tsx
@@ -1,7 +1,18 @@
 'use client';
 import { useEffect } from 'react';
+import { m } from 'framer-motion';
 import { useLanguage } from '@/contexts/LanguageContext';
 import type { BlastLevel } from '@/lib/blast/v2/types';
+
+const MODE_COLORS: Record<string, string> = {
+  fruits: '#BFFF00', animals: '#00FFFF', food: '#FF1493', ocean: '#00FFFF',
+  space: '#8B5CF6', nature: '#BFFF00', sports: '#FF1493', colors: '#BFFF00',
+  transport: '#00FFFF', body: '#FF1493', home: '#BFFF00', school: '#00FFFF',
+  tools: '#FF1493', weather: '#00FFFF', music: '#BFFF00', jobs: '#FF1493',
+  family: '#BFFF00', numbers: '#00FFFF', feelings: '#FF1493',
+  mythology: '#8B5CF6', science: '#BFFF00', travel: '#00FFFF',
+  art: '#FF1493', time: '#BFFF00', onboarding: '#BFFF00',
+};
 
 export function BlastLevelIntroCard({ level, onDismiss }: { level: BlastLevel; onDismiss: () => void }) {
   const { t } = useLanguage();
@@ -9,16 +20,41 @@ export function BlastLevelIntroCard({ level, onDismiss }: { level: BlastLevel; o
     const id = setTimeout(onDismiss, 1500);
     return () => clearTimeout(id);
   }, [onDismiss]);
+  const modeColor = MODE_COLORS[level.theme] ?? '#BFFF00';
   return (
-    <div data-testid="intro-card" className="grid place-items-center min-h-screen bg-[#0b1530]/90 text-white">
-      <div className="space-y-2 text-center">
-        <div className="text-3xl font-bold">
+    <div
+      data-testid="intro-card"
+      className="grid place-items-center min-h-screen text-white"
+      style={{
+        background: `radial-gradient(ellipse 70% 50% at 50% 50%, color-mix(in srgb, ${modeColor} 14%, #0b1530) 0%, #0b1530 70%)`,
+      }}
+    >
+      <div className="space-y-3 text-center px-6">
+        <m.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.25 }}
+          className="text-xs uppercase tracking-[0.3em] opacity-70"
+        >
           {t('blast.intro.level', `Level ${level.levelNumber}`, { n: String(level.levelNumber) })}
-        </div>
-        <div className="text-xl">{t(`blast.themes.${level.theme}`, level.theme)}</div>
-        <div className="text-sm opacity-70">
+        </m.div>
+        <m.div
+          initial={{ scale: 0.7, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ delay: 0.1, type: 'spring', stiffness: 360 }}
+          className="text-4xl font-black uppercase tracking-wide"
+          style={{ color: modeColor, textShadow: `3px 3px 0 #0b1530` }}
+        >
+          {t(`blast.themes.${level.theme}`, level.theme)}
+        </m.div>
+        <m.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 0.8 }}
+          transition={{ delay: 0.35 }}
+          className="text-sm"
+        >
           {t('blast.intro.wordCount', `${level.words.length} words`, { count: String(level.words.length) })}
-        </div>
+        </m.div>
       </div>
     </div>
   );

--- a/fe-next/components/blast/v2/BlastTile.module.css
+++ b/fe-next/components/blast/v2/BlastTile.module.css
@@ -6,18 +6,34 @@
   isolation: isolate;
 }
 
+/* Tile size adapts to column count: takes the board's inline-size, removes
+   gaps + padding, and divides by --blast-cols. Capped at 88px so wide
+   desktops don't blow up the tiles. Falls back to 18cqi for callers that
+   forget to pass the column count. */
+.board {
+  --blast-tile-gap: 8px;
+  --blast-tile-cap: 88px;
+  --blast-tile-min: 32px;
+  --blast-cols: 6;
+  --blast-tile-size: clamp(
+    var(--blast-tile-min),
+    calc((100cqi - (var(--blast-cols) - 1) * var(--blast-tile-gap) - 32px) / var(--blast-cols)),
+    var(--blast-tile-cap)
+  );
+}
+
 /* Empty slot frame behind each tile column. Same size & gap as tiles so
-   landed tiles align perfectly with their well. Inset shadow gives a
-   "tray" feel — neo-brutalist hard inner shadow, no blur. */
+   landed tiles align perfectly with their well. Soft inset shadow only —
+   no border — so empty columns disappear into the background instead of
+   reading as dashed letters behind the play area. */
 .cellWell {
   width: var(--blast-tile-size, clamp(48px, 18cqi, 88px));
   aspect-ratio: 1 / 1;
   border-radius: 10px;
-  background: rgba(255, 255, 255, 0.025);
-  border: 2px dashed rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.018);
   box-shadow:
-    inset 2px 2px 0 rgba(0, 0, 0, 0.35),
-    inset -1px -1px 0 rgba(255, 255, 255, 0.04);
+    inset 0 2px 0 rgba(0, 0, 0, 0.18),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.025);
 }
 
 .tile {

--- a/fe-next/components/blast/v2/__tests__/BlastConceptIntroCard.test.tsx
+++ b/fe-next/components/blast/v2/__tests__/BlastConceptIntroCard.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+import { BlastConceptIntroCard } from '../BlastConceptIntroCard';
+
+describe('BlastConceptIntroCard', () => {
+  it('renders "anyRow" concept with title and demo grid', () => {
+    render(<BlastConceptIntroCard concept="anyRow" onDismiss={() => {}} />);
+    expect(screen.getByTestId('concept-intro')).toHaveAttribute('data-concept', 'anyRow');
+    expect(screen.getByText(/can be on any row/i)).toBeInTheDocument();
+  });
+
+  it('renders "verticalWords" concept with vertical phrasing', () => {
+    render(<BlastConceptIntroCard concept="verticalWords" onDismiss={() => {}} />);
+    expect(screen.getByRole('heading', { name: /vertical/i })).toBeInTheDocument();
+  });
+
+  it('calls onDismiss when "Got it" pressed', () => {
+    const onDismiss = vi.fn();
+    render(<BlastConceptIntroCard concept="anyRow" onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByTestId('concept-got-it'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/fe-next/components/blast/v2/__tests__/BlastFxOverlay.test.tsx
+++ b/fe-next/components/blast/v2/__tests__/BlastFxOverlay.test.tsx
@@ -22,12 +22,12 @@ describe('BlastFxOverlay', () => {
     expect(canvas).toHaveClass('absolute', 'inset-0', 'pointer-events-none');
   });
 
-  it('applies correct z-index', () => {
+  it('applies correct z-index (above board, below HUD/modals)', () => {
     const { container } = render(
       <BlastFxOverlay chainEventKey={0} chainDepth={0} clearCenters={[]} clearEventKey={0} />,
     );
     const canvas = container.querySelector('[data-testid="blast-fx"]') as HTMLCanvasElement;
-    expect(canvas).toHaveStyle('zIndex: 10');
+    expect(canvas).toHaveStyle('zIndex: 30');
   });
 
   it('mounts then unmounts without throwing — proves v8 init+destroy contract', async () => {

--- a/fe-next/components/blast/v2/useCollapseTimeline.ts
+++ b/fe-next/components/blast/v2/useCollapseTimeline.ts
@@ -30,16 +30,17 @@ export function useCollapseTimeline(
     const tiles = boardRef.current.querySelectorAll<HTMLElement>('[data-cell-id]');
     const tl = gsap.timeline();
     tiles.forEach((el, i) => {
-      // Land-bounce two-phase: hard squash to 0.66 (anticipation of landing
-      // weight) → snap-back overshoot to 1.06 → settle at 1.0. Reads as the
-      // tile having mass. Stagger 18ms per tile so cascades feel sequenced.
+      // Vertical-only land bounce: squash Y on impact then overshoot, with
+      // scaleX held at 1.0. Earlier versions warped X too which read as a
+      // horizontal drift during gravity — tiles should stay locked to their
+      // column. Stagger 18ms per tile so cascades feel sequenced.
       const startAt = i * 0.018;
       tl.fromTo(
         el,
         { scaleY: 1, scaleX: 1 },
         {
-          scaleY: 0.66,
-          scaleX: 1.18,
+          scaleY: 0.72,
+          scaleX: 1,
           duration: 0.11,
           ease: 'power3.in',
           transformOrigin: 'bottom center',
@@ -49,8 +50,8 @@ export function useCollapseTimeline(
       tl.to(
         el,
         {
-          scaleY: 1.06,
-          scaleX: 0.94,
+          scaleY: 1.08,
+          scaleX: 1,
           duration: 0.12,
           ease: 'power2.out',
         },
@@ -61,7 +62,7 @@ export function useCollapseTimeline(
         {
           scaleY: 1,
           scaleX: 1,
-          duration: 0.18,
+          duration: 0.22,
           ease: 'elastic.out(1.2, 0.5)',
         },
         startAt + 0.23,

--- a/fe-next/hooks/__tests__/useBlastTutorial.concept.test.tsx
+++ b/fe-next/hooks/__tests__/useBlastTutorial.concept.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useBlastTutorial } from '../useBlastTutorial';
+import type { BlastLevel } from '@/lib/blast/v2/types';
+import type { UnlocksSeen } from '@/lib/blast/v2/tutorial/unlocks-seen';
+
+function makeLevel(levelNumber: number): BlastLevel {
+  return {
+    id: `concept-${levelNumber}`,
+    levelNumber,
+    locale: 'en',
+    theme: 'onboarding',
+    columns: [{ index: 0, tiles: ['A'] }],
+    words: ['A'],
+    resolvableOrder: ['A'],
+    tileFlags: {},
+    difficulty: levelNumber,
+  } as unknown as BlastLevel;
+}
+
+describe('useBlastTutorial concept intros', () => {
+  it('level 4 shows the "anyRow" concept card when unseen', () => {
+    const unlocks: UnlocksSeen = { ftue_completed: true };
+    const { result } = renderHook(() =>
+      useBlastTutorial(makeLevel(4), unlocks, false, () => {})
+    );
+    expect(result.current.showConceptCard).toBe('anyRow');
+  });
+
+  it('level 4 hides the concept card once anyRow is seen', () => {
+    const unlocks: UnlocksSeen = { ftue_completed: true, concept_anyRow: true };
+    const { result } = renderHook(() =>
+      useBlastTutorial(makeLevel(4), unlocks, false, () => {})
+    );
+    expect(result.current.showConceptCard).toBeNull();
+  });
+
+  it('level 31 shows the "verticalWords" concept card when unseen', () => {
+    const unlocks: UnlocksSeen = {
+      ftue_completed: true,
+      concept_anyRow: true,
+    };
+    const { result } = renderHook(() =>
+      useBlastTutorial(makeLevel(31), unlocks, false, () => {})
+    );
+    expect(result.current.showConceptCard).toBe('verticalWords');
+  });
+
+  it('level 31 still surfaces unseen anyRow first (player jumped in late)', () => {
+    const unlocks: UnlocksSeen = { ftue_completed: true };
+    const { result } = renderHook(() =>
+      useBlastTutorial(makeLevel(31), unlocks, false, () => {})
+    );
+    expect(result.current.showConceptCard).toBe('anyRow');
+  });
+
+  it('level 32 hides concepts once both are seen', () => {
+    const unlocks: UnlocksSeen = {
+      ftue_completed: true,
+      concept_anyRow: true,
+      concept_verticalWords: true,
+    };
+    const { result } = renderHook(() =>
+      useBlastTutorial(makeLevel(32), unlocks, false, () => {})
+    );
+    expect(result.current.showConceptCard).toBeNull();
+  });
+
+  it('verticalWords concept does not fire below level 31 (only generator places V)', () => {
+    const unlocks: UnlocksSeen = {
+      ftue_completed: true,
+      concept_anyRow: true,
+    };
+    for (const n of [4, 6, 10, 20, 30]) {
+      const { result } = renderHook(() =>
+        useBlastTutorial(makeLevel(n), unlocks, false, () => {})
+      );
+      expect(result.current.showConceptCard).toBeNull();
+    }
+  });
+
+  it('levels 1-3 never show concept cards', () => {
+    const unlocks: UnlocksSeen = {};
+    for (const n of [1, 2, 3]) {
+      const { result } = renderHook(() =>
+        useBlastTutorial(makeLevel(n), unlocks, false, () => {})
+      );
+      expect(result.current.showConceptCard).toBeNull();
+    }
+  });
+
+  it('skip_all suppresses concept cards', () => {
+    const unlocks: UnlocksSeen = { ftue_completed: true, skip_all: true };
+    const { result } = renderHook(() =>
+      useBlastTutorial(makeLevel(4), unlocks, false, () => {})
+    );
+    expect(result.current.showConceptCard).toBeNull();
+  });
+});

--- a/fe-next/hooks/useBlastTutorial.ts
+++ b/fe-next/hooks/useBlastTutorial.ts
@@ -1,13 +1,42 @@
 'use client';
 import type { BlastLevel } from '@/lib/blast/v2/types';
-import { hasSeenUnlock, shouldSkipAll, MECHANIC_KEYS, type UnlocksSeen, type MechanicKey } from '@/lib/blast/v2/tutorial/unlocks-seen';
+import {
+  hasSeenUnlock, hasSeenConcept, shouldSkipAll,
+  MECHANIC_KEYS, CONCEPT_KEYS,
+  type UnlocksSeen, type MechanicKey, type ConceptKey,
+} from '@/lib/blast/v2/tutorial/unlocks-seen';
 import { mechanicsForLevel } from '@/lib/blast/v2/mechanic-flags';
 
 type TutorialState = {
   showFtueOverlay: boolean;
   showUnlockCard: MechanicKey | null;
   unlockCardIndex: number;
+  // Layout-rule concept intro (e.g. "any row", "vertical words"). Independent
+  // of mechanic unlock cards and not capped at level 2 — these only fire when
+  // the generator actually starts using the new degree of freedom.
+  showConceptCard: ConceptKey | null;
 };
+
+// First level at which each concept becomes relevant to the player.
+// anyRow: chain packs (L1–L15) already stack the chain on multiple rows, so
+//   L4 is the right moment to spell it out — "look past the floor row".
+// verticalWords: chain-builder still uses horizontal-only placement; the
+//   generator (L31+) is what introduces vertical words, so the intro lands
+//   exactly when the player will see one.
+const CONCEPT_LEVELS: Record<ConceptKey, number> = {
+  anyRow: 4,
+  verticalWords: 31,
+};
+
+function pickConceptCard(level: number, unlocks: UnlocksSeen): ConceptKey | null {
+  if (shouldSkipAll(unlocks)) return null;
+  for (const key of CONCEPT_KEYS) {
+    if (level >= CONCEPT_LEVELS[key] && !hasSeenConcept(unlocks, key)) {
+      return key;
+    }
+  }
+  return null;
+}
 
 export function useBlastTutorial(
   level: BlastLevel,
@@ -21,8 +50,11 @@ export function useBlastTutorial(
       showFtueOverlay: true,
       showUnlockCard: null,
       unlockCardIndex: -1,
+      showConceptCard: null,
     };
   }
+
+  const conceptCard = pickConceptCard(level.levelNumber, unlocksSeen);
 
   // Tutorial ends after level 2. Levels 3+ are pure gameplay with no
   // unlock cards or FTUE overlays — mechanics are discovered organically
@@ -33,6 +65,7 @@ export function useBlastTutorial(
       showFtueOverlay: false,
       showUnlockCard: null,
       unlockCardIndex: -1,
+      showConceptCard: conceptCard,
     };
   }
 
@@ -42,6 +75,7 @@ export function useBlastTutorial(
       showFtueOverlay: false,
       showUnlockCard: null,
       unlockCardIndex: -1,
+      showConceptCard: null,
     };
   }
 
@@ -62,6 +96,7 @@ export function useBlastTutorial(
         showFtueOverlay: false,
         showUnlockCard: key,
         unlockCardIndex: i,
+        showConceptCard: null,
       };
     }
   }
@@ -70,5 +105,6 @@ export function useBlastTutorial(
     showFtueOverlay: false,
     showUnlockCard: null,
     unlockCardIndex: -1,
+    showConceptCard: conceptCard,
   };
 }

--- a/fe-next/lib/blast/v2/generator/__tests__/placement-constraints.test.ts
+++ b/fe-next/lib/blast/v2/generator/__tests__/placement-constraints.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { placeWords } from '../placement';
+import { seededPRNG } from '../../prng';
+
+describe('placeWords with placement constraints', () => {
+  it('firstWordRowZero=true places the first (longest) word horizontally on row 0', () => {
+    // Try a few seeds; the constraint must hold across them.
+    for (let seed = 1; seed <= 20; seed++) {
+      const prng = seededPRNG(seed);
+      const result = placeWords(
+        ['CAT', 'DOG', 'PIG'],
+        { cols: 4, maxHeight: 3, firstWordRowZero: true },
+        prng,
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // Longest word is the first placement (length 3 — all same, so the
+        // first in the sorted array). Whatever lands first must be H on r=0.
+        const first = result.placements[0]!;
+        expect(first.axis).toBe('H');
+        expect(first.cells.every((c) => c.row === 0)).toBe(true);
+      }
+    }
+  });
+
+  it('firstWordRowZero=false allows non-zero rows for the first word', () => {
+    let sawNonZero = false;
+    for (let seed = 1; seed <= 50 && !sawNonZero; seed++) {
+      const prng = seededPRNG(seed);
+      const result = placeWords(
+        ['CAT', 'DOG', 'PIG'],
+        { cols: 4, maxHeight: 4, firstWordRowZero: false },
+        prng,
+      );
+      if (result.ok && result.placements[0]!.cells.some((c) => c.row !== 0)) {
+        sawNonZero = true;
+      }
+    }
+    expect(sawNonZero).toBe(true);
+  });
+
+  it('requireVerticalWord=true guarantees at least one V placement', () => {
+    for (let seed = 1; seed <= 20; seed++) {
+      const prng = seededPRNG(seed);
+      const result = placeWords(
+        ['CAT', 'DOG', 'BIRD'],
+        { cols: 5, maxHeight: 5, requireVerticalWord: true },
+        prng,
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const hasVertical = result.placements.some((p) => p.axis === 'V');
+        expect(hasVertical).toBe(true);
+      }
+    }
+  });
+
+  it('returns ok:false if requireVerticalWord cannot be satisfied (no room)', () => {
+    // 1 column tall enough for vertical: only 1 column → no room for V if first word also vertical conflicts.
+    // Use cols=1 maxHeight=2 with 3-letter words → vertical impossible.
+    const prng = seededPRNG(1);
+    const result = placeWords(
+      ['CAT'],
+      { cols: 1, maxHeight: 2, requireVerticalWord: true },
+      prng,
+    );
+    expect(result.ok).toBe(false);
+  });
+});

--- a/fe-next/lib/blast/v2/generator/__tests__/placement-rules.test.ts
+++ b/fe-next/lib/blast/v2/generator/__tests__/placement-rules.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { placementRulesForLevel } from '../placement-rules';
+
+describe('placementRulesForLevel', () => {
+  it('levels 1-3 anchor the first word to row 0 (horizontal foundation)', () => {
+    expect(placementRulesForLevel(1).firstWordRowZero).toBe(true);
+    expect(placementRulesForLevel(2).firstWordRowZero).toBe(true);
+    expect(placementRulesForLevel(3).firstWordRowZero).toBe(true);
+  });
+
+  it('levels 4+ allow the first word to land anywhere', () => {
+    expect(placementRulesForLevel(4).firstWordRowZero).toBe(false);
+    expect(placementRulesForLevel(7).firstWordRowZero).toBe(false);
+    expect(placementRulesForLevel(40).firstWordRowZero).toBe(false);
+  });
+
+  it('levels 1-5 do not require a vertical word', () => {
+    expect(placementRulesForLevel(1).requireVerticalWord).toBe(false);
+    expect(placementRulesForLevel(5).requireVerticalWord).toBe(false);
+  });
+
+  it('levels 6+ require at least one vertical word', () => {
+    expect(placementRulesForLevel(6).requireVerticalWord).toBe(true);
+    expect(placementRulesForLevel(12).requireVerticalWord).toBe(true);
+    expect(placementRulesForLevel(50).requireVerticalWord).toBe(true);
+  });
+});

--- a/fe-next/lib/blast/v2/generator/generated-level-source.ts
+++ b/fe-next/lib/blast/v2/generator/generated-level-source.ts
@@ -2,6 +2,7 @@ import type { BlastColumn, BlastLevel, CellId, Locale, ThemeKey } from '../types
 import { hashStringToSeed, seededPRNG } from '../prng';
 import { columnCountForLevel, columnHeightRangeForLevel, validateSilhouette } from './silhouette';
 import { placeWords, type Grid } from './placement';
+import { placementRulesForLevel } from './placement-rules';
 import { rollTileFlags } from './tile-flags';
 import { interestingnessScore, INTERESTINGNESS_THRESHOLD } from './interestingness';
 import { mechanicsForLevel } from '../mechanic-flags';
@@ -31,7 +32,20 @@ export class GeneratedLevelSource implements LevelSource {
       const colRange = columnCountForLevel(levelNumber);
       const heightRange = columnHeightRangeForLevel(levelNumber);
       const cols = colRange.min + prng.intRange(colRange.max - colRange.min + 1);
-      const place = placeWords(words, { cols, maxHeight: heightRange.max }, prng);
+      const rules = placementRulesForLevel(levelNumber);
+      // Only require vertical if there's actually room. Below maxHeight 3 a
+      // 3-letter word can fit vertically, but heightRange.max already enforces
+      // the level's vertical ceiling — passing the flag is safe.
+      const place = placeWords(
+        words,
+        {
+          cols,
+          maxHeight: heightRange.max,
+          firstWordRowZero: rules.firstWordRowZero,
+          requireVerticalWord: rules.requireVerticalWord,
+        },
+        prng,
+      );
       if (!place.ok) continue;
       const sil = validateSilhouette(place.heights);
       if (!sil.ok) continue;

--- a/fe-next/lib/blast/v2/generator/index.ts
+++ b/fe-next/lib/blast/v2/generator/index.ts
@@ -1,5 +1,6 @@
 export { GeneratedLevelSource } from './generated-level-source';
 export { interestingnessScore, INTERESTINGNESS_THRESHOLD } from './interestingness';
-export { placeWords, forwardSim, type Placement, type PlaceWordsResult, type ForwardSimResult, type Grid, type GridCells } from './placement';
+export { placeWords, forwardSim, type Placement, type PlaceWordsResult, type PlaceWordsOptions, type ForwardSimResult, type Grid, type GridCells } from './placement';
+export { placementRulesForLevel, type PlacementRules } from './placement-rules';
 export { rollTileFlags, type TileFlagsMap } from './tile-flags';
 export { columnCountForLevel, columnHeightRangeForLevel, validateSilhouette, type SilhouetteResult } from './silhouette';

--- a/fe-next/lib/blast/v2/generator/placement-rules.ts
+++ b/fe-next/lib/blast/v2/generator/placement-rules.ts
@@ -1,0 +1,16 @@
+export type PlacementRules = {
+  // Anchor the first (longest) word to row 0 horizontally. Early levels read
+  // best with a clear bottom-row foundation; loosening this past L3 lets the
+  // generator pick more interesting silhouettes.
+  firstWordRowZero: boolean;
+  // Force at least one word to be placed vertically. Kicks in once the
+  // column height range is tall enough that vertical words actually fit.
+  requireVerticalWord: boolean;
+};
+
+export function placementRulesForLevel(n: number): PlacementRules {
+  return {
+    firstWordRowZero: n <= 3,
+    requireVerticalWord: n >= 6,
+  };
+}

--- a/fe-next/lib/blast/v2/generator/placement.ts
+++ b/fe-next/lib/blast/v2/generator/placement.ts
@@ -43,13 +43,25 @@ function countOverlap(grid: Grid, cells: { col: number; row: number }[], word: s
   return n;
 }
 
+export type PlaceWordsOptions = {
+  cols: number;
+  maxHeight: number;
+  // L1–L3 foundation rule: pin the longest word horizontally on row 0 so the
+  // board reads as a clear starter row.
+  firstWordRowZero?: boolean;
+  // L6+ variety rule: guarantee at least one word lands vertically.
+  requireVerticalWord?: boolean;
+};
+
 export function placeWords(
-  words: string[], opts: { cols: number; maxHeight: number }, prng: PRNG,
+  words: string[], opts: PlaceWordsOptions, prng: PRNG,
 ): PlaceWordsResult {
   const sorted = [...words].sort((a, b) => b.length - a.length);
   let grid: Grid = { cols: opts.cols, rows: opts.maxHeight, cells: {} };
   const placements: Placement[] = [];
-  for (const word of sorted) {
+  let needVertical = opts.requireVerticalWord === true;
+  for (let wIdx = 0; wIdx < sorted.length; wIdx++) {
+    const word = sorted[wIdx]!;
     const candidates: { axis: 'H' | 'V'; col: number; row: number; reversed: boolean; overlap: number }[] = [];
     for (const axis of ['H', 'V'] as const) {
       const maxStartCol = axis === 'H' ? opts.cols - word.length : opts.cols - 1;
@@ -67,13 +79,34 @@ export function placeWords(
       }
     }
     if (candidates.length === 0) return { ok: false, reason: `cannot place ${word}` };
-    const hasOverlap = candidates.filter((c) => c.overlap > 0);
-    const pool = placements.length === 0 || hasOverlap.length === 0 ? candidates : hasOverlap;
+
+    // Foundation: first word horizontal on row 0.
+    let workingCandidates = candidates;
+    if (wIdx === 0 && opts.firstWordRowZero) {
+      const filtered = candidates.filter((c) => c.axis === 'H' && c.row === 0);
+      if (filtered.length === 0) return { ok: false, reason: 'first word cannot anchor row 0' };
+      workingCandidates = filtered;
+    }
+
+    // Variety: force vertical on the last word if no V has been placed yet
+    // and the constraint is still active. Holding the constraint until the
+    // final word lets earlier placements stay flexible while still guaranteeing
+    // a V eventually lands.
+    const isLast = wIdx === sorted.length - 1;
+    if (needVertical && isLast) {
+      const vOnly = workingCandidates.filter((c) => c.axis === 'V');
+      if (vOnly.length === 0) return { ok: false, reason: 'cannot satisfy requireVerticalWord' };
+      workingCandidates = vOnly;
+    }
+
+    const hasOverlap = workingCandidates.filter((c) => c.overlap > 0);
+    const pool = placements.length === 0 || hasOverlap.length === 0 ? workingCandidates : hasOverlap;
     const chosen = pool[prng.intRange(pool.length)]!;
     const placed = tryPlaceWord(word, grid, chosen.axis, chosen.col, chosen.row, chosen.reversed);
     if (!placed.ok) return { ok: false, reason: 'internal placement race' };
     grid = placed.nextGrid;
     placements.push({ word, axis: chosen.axis, cells: placed.cells });
+    if (chosen.axis === 'V') needVertical = false;
   }
   const heights = new Array(opts.cols).fill(0);
   for (const id of Object.keys(grid.cells) as CellId[]) {

--- a/fe-next/lib/blast/v2/tutorial/unlocks-seen.ts
+++ b/fe-next/lib/blast/v2/tutorial/unlocks-seen.ts
@@ -15,13 +15,21 @@ export const MECHANIC_KEYS = [
 
 export type MechanicKey = typeof MECHANIC_KEYS[number];
 
+// Concepts are board-layout ideas introduced as the generator unlocks new
+// placement freedom — separate from mechanic unlocks (gems/coins/frozen)
+// because they describe *where* words live, not what tiles do.
+export const CONCEPT_KEYS = ['anyRow', 'verticalWords'] as const;
+export type ConceptKey = typeof CONCEPT_KEYS[number];
+
+type ConceptSeen = { [K in ConceptKey as `concept_${K}`]?: boolean };
+
 export type UnlocksSeen = {
   ftue_completed?: boolean;
   skip_all?: boolean;
   veteran_bonus_granted?: boolean;
 } & {
   [key in MechanicKey]?: boolean;
-};
+} & ConceptSeen;
 
 export function validateUnlocksSeen(raw: unknown): UnlocksSeen {
   if (typeof raw !== 'object' || raw === null) {
@@ -49,6 +57,14 @@ export function markUnlockSeen(
   key: MechanicKey | 'ftue_completed',
 ): UnlocksSeen {
   return { ...unlocks, [key]: true };
+}
+
+export function markConceptSeen(unlocks: UnlocksSeen, key: ConceptKey): UnlocksSeen {
+  return { ...unlocks, [`concept_${key}`]: true };
+}
+
+export function hasSeenConcept(unlocks: UnlocksSeen, key: ConceptKey): boolean {
+  return unlocks[`concept_${key}`] === true;
 }
 
 export function shouldSkipAll(unlocks: UnlocksSeen): boolean {


### PR DESCRIPTION
## Summary

Addresses a batch of Blast Mode v2 issues raised from playtest feedback (sample screenshot referenced in the request).

### Generator
- **placement-rules.ts (new)**: `placementRulesForLevel(n)` returns `{ firstWordRowZero, requireVerticalWord }`.
  - L1–L3: pin the longest word horizontally on row 0 (clear bottom-row foundation).
  - L6+: require at least one vertical placement per board — generator picks vertical for the last word if none has landed yet.
- `placeWords` accepts the rules through a new `PlaceWordsOptions` type; `GeneratedLevelSource` threads them through.

### Tutorial / concept intros
- New `concept-intro` flow independent of the existing L2 unlock-card cutoff.
  - `anyRow` fires at L4 ("words can be on any row now").
  - `verticalWords` fires at L31 — matches where the generator actually guarantees a vertical word (chain-builder L1–L15 is still H-only, so firing earlier would mislead the player).
- `BlastConceptIntroCard` renders a looping mini-grid demo with a Got-it CTA; state persists on `UnlocksSeen.concept_*`.

### Board overflow / dashed letters
- Tile size now scales by `--blast-cols` via `clamp(min, calc((100cqi - gaps - padding) / cols), cap)` so wide boards (6–7 cols) stop overflowing the viewport.
- Cell-well dashed borders → soft inset shadow only. The "dashed letters behind the board" pattern is gone.
- `BlastAlmostGhost` swapped the dashed border for a soft text glow.

### Gravity / FX / juice
- `useCollapseTimeline`: removed the `scaleX 1.18` warp during land-bounce so tiles stop drifting on the X axis during gravity; squash is Y-only with a bouncier overshoot.
- `BlastFxOverlay`: z-index `10 → 30` (was occasionally painted under tile transforms during chains); per-cell burst counts ~2x (32 explosion + 10 rings + 6 sparkle + 10 debris).

### HUD / result cards
- `BlastHud`: theme is now the prominent label (mode-color, stroke shadow), level number subordinate.
- `BlastLevelIntroCard`: theme-tinted radial backdrop, staggered entrance.
- `BlastLevelCompleteCard`: stats grid expanded to Words / Time / Gems / Best Chain (+ optional star row), tiles stagger in with springs.

### Tests
- New: `placement-rules`, `placement-constraints`, `useBlastTutorial.concept`, `BlastConceptIntroCard`.
- Updated: `BlastFxOverlay` z-index assertion (10 → 30).

## Test plan
- [ ] Run `npm run test:frontend` — full suite passes locally (2088 / 2089 tests, 1 pre-existing todo).
- [ ] Play L1–L3 on a phone: longest word lands on row 0; intro card looks theme-tinted.
- [ ] Reach L4: `anyRow` concept card appears once, demo loops, dismisses on Got it.
- [ ] Reach L31 in generated content: `verticalWords` concept card appears; board contains a vertical word; cascade FX pop above the board (not under it).
- [ ] Verify on a narrow phone that 7-column boards no longer overflow horizontally.
- [ ] Watch a clear → gravity sequence: remaining tiles fall straight down, no horizontal drift.

https://claude.ai/code/session_01NszodwUeZoyiPedXJqhUp2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NszodwUeZoyiPedXJqhUp2)_