### PR TITLE
feat(blast/v2): fix board sizing, scroll, gravity + vertical word generation

### DIFF
--- a/fe-next/components/blast/v2/BlastBoard.tsx
+++ b/fe-next/components/blast/v2/BlastBoard.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRef, useCallback, useEffect } from 'react';
+import { useRef, useCallback, useEffect, useMemo } from 'react';
 import { LayoutGroup, AnimatePresence, m } from 'framer-motion';
 import type { BlastLevel, CellId } from '@/lib/blast/v2/types';
 import { cellId as makeCellId, type SelectionState, type AlmostWord } from '@/lib/blast/v2/engine';
@@ -22,6 +22,12 @@ type Props = {
   tileIds: string[][];
   revealGlowCells?: CellId[];
   onCommitSelection?: (centers: Array<{ x: number; y: number }>) => void;
+  /**
+   * Stable count of cellWell rows to render per column. Anchored at the
+   * level's initial max row height so the play area doesn't shrink as
+   * tiles are cleared — board stays visually consistent.
+   */
+  boardRows: number;
 };
 
 export function BlastBoard({
@@ -36,6 +42,7 @@ export function BlastBoard({
   tileIds,
   revealGlowCells = [],
   onCommitSelection,
+  boardRows,
 }: Props) {
   const config = LOCALE_CONFIGS[level.locale];
   const boardRef = useRef<HTMLDivElement>(null);
@@ -114,28 +121,40 @@ export function BlastBoard({
     };
   }, [isDragging, onPointerEnter, onPointerUp, selection, onCommitSelection, getCellViewportCenter]);
 
+  // Cellwell row count: anchored at the level's tallest column at start so
+  // the board doesn't shrink as words clear. min(boardRows, current max) so
+  // we never shrink BELOW current tile heights either.
+  const visualRows = useMemo(() => {
+    const currentMax = Math.max(1, ...level.columns.map((c) => c.tiles.length));
+    return Math.max(boardRows, currentMax);
+  }, [boardRows, level.columns]);
+
   return (
     <div
       ref={boardRef}
       dir={dir}
       data-shake-key={invalidShakeKey}
       data-testid="blast-board"
-      className={`relative flex items-end justify-center gap-2 p-4 touch-none select-none ${styles.board}`}
+      data-board-rows={visualRows}
+      className={`relative flex items-end justify-center gap-2 p-4 touch-none select-none w-full h-full ${styles.board}`}
       style={{
         touchAction: 'none',
         // Drives container-query tile sizing: every tile reads
-        // --blast-tile-size derived from this column count so wide boards
-        // (7+ cols) stay inside the viewport instead of overflowing.
+        // --blast-tile-size derived from both column AND row counts so the
+        // board fills the available box on both axes (no more 3:1 wide-short
+        // strip when only 2 rows remain).
         ['--blast-cols' as string]: String(level.columns.length),
+        ['--blast-rows' as string]: String(visualRows),
       }}
       onPointerUp={onPointerUp}
     >
-      {/* Cell-well backdrop — empty inset slots line up perfectly with tile
-          positions. Reads as a real game board, not floating stickers. */}
+      {/* Cell-well backdrop — empty inset slots line up with tile positions.
+          Renders a FIXED `visualRows` wells per column so the board stays the
+          same size as tiles are cleared (Royal-Match style stable playfield). */}
       <div aria-hidden className="absolute inset-0 flex items-end justify-center gap-2 p-4 pointer-events-none">
         {level.columns.map((col) => (
           <div key={`well-${col.index}`} className="flex flex-col-reverse gap-2">
-            {col.tiles.map((_, row) => (
+            {Array.from({ length: visualRows }).map((_, row) => (
               <div key={`well-${col.index}-${row}`} className={styles.cellWell} />
             ))}
           </div>
@@ -153,13 +172,20 @@ export function BlastBoard({
                 // Framer's LayoutGroup tracks the keyed child — promoting
                 // this wrapper to <m.div layout> is what makes tiles SLIDE
                 // into their new positions after a collapse (gravity).
+                // `layout="position"` locks size animation off; only x/y
+                // animate, so tiles never inflate horizontally as a side
+                // effect of size measurement and the visual axis stays Y.
                 return (
                   <m.div
                     key={tileKey}
-                    layout
-                    // Bouncier spring: lower stiffness + damping → overshoot
-                    // on land so tiles "settle" instead of snapping into place.
-                    transition={{ type: 'spring', stiffness: 420, damping: 22, mass: 1.05, restDelta: 0.5 }}
+                    layout="position"
+                    // Tighter, punchier spring tuned for fall-from-above:
+                    // higher stiffness gives a snappier accelerate-then-land,
+                    // bumped mass + slightly lower damping keeps a small
+                    // overshoot so the landing reads as a "thump" rather than
+                    // a soft glide. Pairs with the squash timeline in
+                    // useCollapseTimeline for the secondary bounce.
+                    transition={{ type: 'spring', stiffness: 560, damping: 20, mass: 1.2, restDelta: 0.4 }}
                     className="relative"
                   >
                     <BlastTile

--- a/fe-next/components/blast/v2/BlastGame.tsx
+++ b/fe-next/components/blast/v2/BlastGame.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { useHideNavigation } from '@/contexts/NavigationContext';
 import type { BlastLevel, CellId } from '@/lib/blast/v2/types';
 import { markUnlockSeen, markConceptSeen, completeFtue, setSkipAll, type UnlocksSeen } from '@/lib/blast/v2/tutorial/unlocks-seen';
 import { useBlastV2 } from '@/lib/blast/v2/useBlastV2';
@@ -73,6 +74,19 @@ export function BlastGame({
   const [introDismissed, setIntroDismissed] = useState(false);
   const [levelStartTime] = useState(() => Date.now());
   const { state, handlers } = useBlastV2(level);
+  // Hide the global bottom nav while the board is mounted — without this the
+  // HUD + board + bottom nav exceed 100dvh on phones and force a page scroll.
+  const setIsInGame = useHideNavigation();
+  useEffect(() => {
+    setIsInGame(true);
+    return () => setIsInGame(false);
+  }, [setIsInGame]);
+  // Initial board height — anchors the visual row count so the playfield
+  // doesn't shrink after the first clear. Captured ONCE per level mount.
+  const initialBoardRows = useMemo(
+    () => Math.max(1, ...level.columns.map((c) => c.tiles.length)),
+    [level],
+  );
   // Track the deepest cascade chain across the run for the results card.
   const [bestChainDepth, setBestChainDepth] = useState(0);
   useEffect(() => {
@@ -321,7 +335,7 @@ export function BlastGame({
   }
 
   return (
-    <div className="flex flex-col min-h-dvh bg-[#0b1530] text-white">
+    <div className="flex flex-col h-dvh overflow-hidden bg-[#0b1530] text-white">
       {tutorial.showUnlockCard && (
         <BlastUnlockCard
           mechanic={tutorial.showUnlockCard}
@@ -343,7 +357,7 @@ export function BlastGame({
           /* Plan 5 wires hints */
         }}
       />
-      <div className="relative flex-1 flex items-end justify-center pb-[max(1rem,env(safe-area-inset-bottom))]">
+      <div className="relative flex-1 min-h-0 flex items-stretch justify-center pb-[max(0.5rem,env(safe-area-inset-bottom))] px-2">
         <BlastAtmosphereOverlay modeColor={modeColor} />
         <BlastFxOverlay
           chainEventKey={state.chainEventKey}
@@ -353,12 +367,12 @@ export function BlastGame({
           modeColor={modeColor}
         />
         <BlastChainSoundListener />
-        {/* Container-typed stage: caps board width so phones, tablets, and
-            wide desktops all get a centered, balanced playfield. `cqi` units
-            in BlastTile sizing measure THIS box, not the viewport. */}
+        {/* Size-typed stage: drives container-query tile sizing on BOTH axes.
+            Caps width on tablets/desktops; fills available height on phones.
+            Tile size = min(width-fit, height-fit) so a 6-col / 2-row board
+            no longer collapses to a thin strip at the bottom of the screen. */}
         <div
-          className="relative w-full max-w-[min(96vw,520px)] mx-auto flex items-end justify-center"
-          style={{ containerType: 'inline-size', aspectRatio: `${level.columns.length} / ${Math.max(...level.columns.map(c => c.tiles.length))}` }}
+          className="relative w-full max-w-[min(96vw,520px)] h-full mx-auto flex items-stretch justify-center"
         >
         <BlastBoard
           level={state.level}
@@ -371,6 +385,7 @@ export function BlastGame({
           almosts={almosts}
           tileIds={state.tileIds}
           revealGlowCells={revealGlowCells}
+          boardRows={initialBoardRows}
           onCommitSelection={(centers) => {
             clearCentersRef.current = centers;
           }}

--- a/fe-next/components/blast/v2/BlastTile.module.css
+++ b/fe-next/components/blast/v2/BlastTile.module.css
@@ -1,23 +1,31 @@
 /* Board wrapper — sets up container query context for tile sizing and
-   draws a faint frame around the playing field. */
+   draws a faint frame around the playing field. The wrapping flex parent
+   uses `containerType: size` so both width (cqi) and height (cqb) drive
+   tile sizing — boards stay big regardless of how few rows are filled. */
 .board {
-  container-type: inline-size;
+  container-type: size;
   border-radius: 18px;
   isolation: isolate;
 }
 
-/* Tile size adapts to column count: takes the board's inline-size, removes
-   gaps + padding, and divides by --blast-cols. Capped at 88px so wide
-   desktops don't blow up the tiles. Falls back to 18cqi for callers that
-   forget to pass the column count. */
+/* Tile size adapts to BOTH column count AND row count by taking the smaller
+   of width-fit and height-fit. Without the height constraint, a 6-col board
+   with only 2 rows of tiles produced a 3:1 ratio that pinned tiles to ~30px
+   on phones with most of the play area wasted. min(cqi, cqb) lets the board
+   fill its allotted box and pump tile size up to ~88px on tall phones.
+   Falls back to 18cqi for callers that forget to pass column/row counts. */
 .board {
   --blast-tile-gap: 8px;
   --blast-tile-cap: 88px;
   --blast-tile-min: 32px;
   --blast-cols: 6;
+  --blast-rows: 6;
   --blast-tile-size: clamp(
     var(--blast-tile-min),
-    calc((100cqi - (var(--blast-cols) - 1) * var(--blast-tile-gap) - 32px) / var(--blast-cols)),
+    min(
+      calc((100cqi - (var(--blast-cols) - 1) * var(--blast-tile-gap) - 32px) / var(--blast-cols)),
+      calc((100cqb - (var(--blast-rows) - 1) * var(--blast-tile-gap) - 32px) / var(--blast-rows))
+    ),
     var(--blast-tile-cap)
   );
 }

--- a/fe-next/components/blast/v2/__tests__/BlastBoard.pointermove.test.tsx
+++ b/fe-next/components/blast/v2/__tests__/BlastBoard.pointermove.test.tsx
@@ -36,6 +36,7 @@ describe('BlastBoard pointer-move drag selection', () => {
         onPointerEnter={onPointerEnter}
         onPointerUp={vi.fn()}
         tileIds={mockLevel.columns.map((col, c) => col.tiles.map((_, r) => `t-${c}-${r}`))}
+        boardRows={3}
       />
     );
 
@@ -64,6 +65,7 @@ describe('BlastBoard pointer-move drag selection', () => {
         onPointerEnter={onPointerEnter}
         onPointerUp={vi.fn()}
         tileIds={mockLevel.columns.map((col, c) => col.tiles.map((_, r) => `t-${c}-${r}`))}
+        boardRows={3}
       />
     );
 
@@ -91,6 +93,7 @@ describe('BlastBoard pointer-move drag selection', () => {
         onPointerEnter={onPointerEnter}
         onPointerUp={vi.fn()}
         tileIds={mockLevel.columns.map((col, c) => col.tiles.map((_, r) => `t-${c}-${r}`))}
+        boardRows={3}
       />
     );
 
@@ -117,6 +120,7 @@ describe('BlastBoard pointer-move drag selection', () => {
         onPointerEnter={onPointerEnter}
         onPointerUp={vi.fn()}
         tileIds={mockLevel.columns.map((col, c) => col.tiles.map((_, r) => `t-${c}-${r}`))}
+        boardRows={3}
       />
     );
 

--- a/fe-next/components/blast/v2/__tests__/BlastBoard.test.tsx
+++ b/fe-next/components/blast/v2/__tests__/BlastBoard.test.tsx
@@ -32,6 +32,7 @@ describe('BlastBoard', () => {
         onPointerEnter={vi.fn()}
         onPointerUp={vi.fn()}
         tileIds={mockLevel.columns.map((col, c) => col.tiles.map((_, r) => `t-${c}-${r}`))}
+        boardRows={3}
       />
     );
     expect(container.querySelector('[data-cell-id="c0r0"]')).toBeInTheDocument();

--- a/fe-next/components/blast/v2/__tests__/BlastGame.test.tsx
+++ b/fe-next/components/blast/v2/__tests__/BlastGame.test.tsx
@@ -16,6 +16,12 @@ vi.mock('@/contexts/LanguageContext', () => ({
     t: (key: string, fallback: string) => fallback,
   }),
 }));
+// NavigationContext gates the global bottom-nav hide; BlastGame calls it on
+// mount/unmount. Tests don't ship a provider, so stub the hook.
+vi.mock('@/contexts/NavigationContext', () => ({
+  useHideNavigation: () => vi.fn(),
+  useNavigation: () => ({ isInGame: false, setIsInGame: vi.fn(), activeTab: 'home', setActiveTab: vi.fn() }),
+}));
 
 import { BlastGame } from '../BlastGame';
 

--- a/fe-next/components/blast/v2/useCollapseTimeline.ts
+++ b/fe-next/components/blast/v2/useCollapseTimeline.ts
@@ -30,19 +30,20 @@ export function useCollapseTimeline(
     const tiles = boardRef.current.querySelectorAll<HTMLElement>('[data-cell-id]');
     const tl = gsap.timeline();
     tiles.forEach((el, i) => {
-      // Vertical-only land bounce: squash Y on impact then overshoot, with
-      // scaleX held at 1.0. Earlier versions warped X too which read as a
-      // horizontal drift during gravity — tiles should stay locked to their
-      // column. Stagger 18ms per tile so cascades feel sequenced.
-      const startAt = i * 0.018;
+      // Vertical-only land thump: deeper squash → stronger overshoot → elastic
+      // settle. scaleX is held at 1.0 throughout — earlier versions warped X
+      // too which read as horizontal drift during gravity. Tiles must stay
+      // locked to their column. Stagger 22ms per tile so cascades feel
+      // sequenced like Royal Match's drop cadence.
+      const startAt = i * 0.022;
       tl.fromTo(
         el,
         { scaleY: 1, scaleX: 1 },
         {
-          scaleY: 0.72,
+          scaleY: 0.62,
           scaleX: 1,
-          duration: 0.11,
-          ease: 'power3.in',
+          duration: 0.1,
+          ease: 'power4.in',
           transformOrigin: 'bottom center',
         },
         startAt,
@@ -50,20 +51,20 @@ export function useCollapseTimeline(
       tl.to(
         el,
         {
-          scaleY: 1.08,
+          scaleY: 1.14,
           scaleX: 1,
-          duration: 0.12,
+          duration: 0.13,
           ease: 'power2.out',
         },
-        startAt + 0.11,
+        startAt + 0.1,
       );
       tl.to(
         el,
         {
           scaleY: 1,
           scaleX: 1,
-          duration: 0.22,
-          ease: 'elastic.out(1.2, 0.5)',
+          duration: 0.28,
+          ease: 'elastic.out(1.4, 0.45)',
         },
         startAt + 0.23,
       );

--- a/fe-next/lib/blast/v2/chain-pack-source.ts
+++ b/fe-next/lib/blast/v2/chain-pack-source.ts
@@ -2,13 +2,16 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { BlastLevel, ChainLevelSpec, Locale } from './types';
 import type { LevelSource } from './level-source';
-import { buildChainLevel } from './engine/chain-builder';
+import { buildChainLevel, type ExtraWordCheck } from './engine/chain-builder';
 import { validateChainLevel } from './engine/chain-validator';
+import { LOCALE_CONFIGS } from './locale-config';
+import { getBlastCommonWords } from './engine/common-words';
 
 type ChainPackFile = { locale: Locale; levels: ChainLevelSpec[] };
 
 export class ChainPackSource implements LevelSource {
   private cache = new Map<Locale, ChainPackFile>();
+  private extraCheckCache = new Map<Locale, ExtraWordCheck>();
 
   constructor(private basePath: string) {}
 
@@ -21,13 +24,32 @@ export class ChainPackSource implements LevelSource {
     return raw;
   }
 
+  // Common-word screen: rejects placements (horizontal OR vertical) that
+  // create a dictionary word outside the authored chain. Without this the
+  // newly-enabled vertical insertion produces incidental commons like "GEAR".
+  private async getExtraWordCheck(locale: Locale): Promise<ExtraWordCheck | undefined> {
+    const cached = this.extraCheckCache.get(locale);
+    if (cached) return cached;
+    try {
+      const isCommon = await getBlastCommonWords(locale);
+      const minLength = LOCALE_CONFIGS[locale].wordLengthRange.min;
+      const check: ExtraWordCheck = { isCommon, minLength };
+      this.extraCheckCache.set(locale, check);
+      return check;
+    } catch {
+      // Common-words list optional — skip the screen when missing.
+      return undefined;
+    }
+  }
+
   async resolve(levelNumber: number, locale: Locale): Promise<BlastLevel> {
     const pack = await this.load(locale);
     const spec = pack.levels.find((l) => l.levelNumber === levelNumber);
     if (!spec) {
       throw new Error(`ChainPackSource: no chain spec for ${locale} level ${levelNumber}`);
     }
-    const level = buildChainLevel(spec, levelNumber);
+    const extraCheck = await this.getExtraWordCheck(locale);
+    const level = buildChainLevel(spec, levelNumber, extraCheck);
     if (!level) {
       throw new Error(`ChainPackSource: buildChainLevel failed for ${spec.id}`);
     }

--- a/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
+++ b/fe-next/lib/blast/v2/engine/__tests__/chain-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { insertWord, buildChainLevel } from '../chain-builder';
+import { insertWord, insertWordVertical, buildChainLevel } from '../chain-builder';
 import { collapseCells } from '../collapse';
 import { scanFormableThemeWords } from '../word-scan';
 import { validateChainLevel } from '../chain-validator';
@@ -47,6 +47,43 @@ describe('insertWord', () => {
   });
 });
 
+describe('insertWordVertical', () => {
+  it('inserts the word as a single-column vertical run so only it is formable', () => {
+    // Two single-tile columns leave room for a 3-tall vertical insert in
+    // either column. Letters must be placed so reading TOP-DOWN spells the word
+    // (engine word-scan reads vertical runs top-down).
+    const Sk = lvl([['Z'], ['Q']]);
+    const result = insertWordVertical(Sk, 'CAT', ['ZQ'], 'en', 1);
+    expect(result).not.toBeNull();
+    const S = result!.level;
+
+    const matches = scanFormableThemeWords(S, ['CAT', 'ZQ'], 'en');
+    expect(matches.map((m) => m.word).sort()).toEqual(['CAT']);
+
+    // All 3 inserted cells share a single column.
+    const cols = new Set(result!.cells.map((c) => c.match(/^c(\d+)r/)![1]));
+    expect(cols.size).toBe(1);
+
+    // Removing those cells must restore the prior board.
+    const after = collapseCells(S, result!.cells);
+    expect(after.level.columns.map((c) => c.tiles)).toEqual(Sk.columns.map((c) => c.tiles));
+  });
+
+  it('returns null when the word is longer than the available vertical headroom', () => {
+    // Board is 1-col but a 3-letter word needs 3 stacked cells; should still fit
+    // since headroom is unbounded. With 0 cols the word never fits.
+    const Sk = lvl([]);
+    expect(insertWordVertical(Sk, 'CAT', [], 'en', 1)).toBeNull();
+  });
+
+  it('is deterministic for a given seed', () => {
+    const Sk = lvl([['D'], ['O'], ['G']]);
+    const a = insertWordVertical(Sk, 'CAT', ['DOG'], 'en', 42);
+    const b = insertWordVertical(Sk, 'CAT', ['DOG'], 'en', 42);
+    expect(a?.level.columns).toEqual(b?.level.columns);
+  });
+});
+
 describe('buildChainLevel', () => {
   const spec: ChainLevelSpec = {
     id: 'en-chain-01',
@@ -83,6 +120,39 @@ describe('buildChainLevel', () => {
     // When decoy support lands, replace this with a real placement assertion.
     const withDecoys: ChainLevelSpec = { ...spec, columns: 8, decoyTiles: 1 };
     expect(buildChainLevel(withDecoys, 99)).toBeNull();
+  });
+
+  it('produces at least one vertical placement across many seeds (chain not all horizontal)', () => {
+    // With horizontal+vertical insertion both available, sweep seeds; at least
+    // one resulting level must contain a column whose tiles spell one of the
+    // chain words top-down — the only way that happens is a vertical insert,
+    // since horizontal stacking puts only one letter from each word per column.
+    const verticalSpec: ChainLevelSpec = {
+      id: 'en-chain-vert-test',
+      levelNumber: 1,
+      theme: 'onboarding',
+      locale: 'en',
+      columns: 6,
+      decoyTiles: 0,
+      chain: ['CAT', 'SUN', 'EGG'],
+    };
+    let sawVerticalWord = false;
+    for (let seed = 1; seed <= 80; seed++) {
+      const level = buildChainLevel(verticalSpec, seed);
+      if (!level) continue;
+      for (const col of level.columns) {
+        for (const w of verticalSpec.chain) {
+          const L = w.length;
+          for (let r = 0; r + L <= col.tiles.length; r++) {
+            // word-scan reads vertical runs top-down: tiles[r+L-1]..tiles[r].
+            const topDown = col.tiles.slice(r, r + L).reverse().join('');
+            if (topDown === w) sawVerticalWord = true;
+          }
+        }
+      }
+      if (sawVerticalWord) break;
+    }
+    expect(sawVerticalWord).toBe(true);
   });
 
 });

--- a/fe-next/lib/blast/v2/engine/chain-builder.ts
+++ b/fe-next/lib/blast/v2/engine/chain-builder.ts
@@ -2,9 +2,26 @@ import type { BlastColumn, BlastLevel, CellId, ChainLevelSpec, Letter, Locale } 
 import { cellId } from './cell-id';
 import { scanFormableThemeWords } from './word-scan';
 import { validateChainLevel } from './chain-validator';
+import { findExtraWords } from './extra-word-check';
 import { LOCALE_CONFIGS } from '../locale-config';
 
 export type InsertResult = { level: BlastLevel; cells: CellId[] };
+
+/**
+ * Optional extra-word screen. When provided, a placement is rejected if it
+ * introduces a board-formable common word that isn't part of the chain.
+ * Lets vertical insertion live alongside the existing common-word audit
+ * without forcing the author to babysit dictionary collisions.
+ */
+export type ExtraWordCheck = {
+  isCommon: (word: string) => boolean;
+  minLength: number;
+};
+
+function passesExtraWordCheck(level: BlastLevel, check: ExtraWordCheck | undefined): boolean {
+  if (!check) return true;
+  return findExtraWords(level, check.isCommon, check.minLength).length === 0;
+}
 
 /** Deterministic LCG so builds are reproducible per seed. */
 function rng(seed: number): () => number {
@@ -39,6 +56,7 @@ export function insertWord(
   otherWordsOnBoard: string[],
   locale: Locale,
   seed: number,
+  extraWordCheck?: ExtraWordCheck,
 ): InsertResult | null {
   const letters = [...word];
   const L = letters.length;
@@ -76,8 +94,87 @@ export function insertWord(
     const matches = scanFormableThemeWords(level, [word, ...otherWordsOnBoard], locale);
     const formableWords = new Set(matches.map((m) => m.word));
 
-    // Success: only `word` is formable.
-    if (formableWords.size === 1 && formableWords.has(word)) {
+    // Success: only `word` is formable AND no unintended common words appear.
+    if (
+      formableWords.size === 1 &&
+      formableWords.has(word) &&
+      passesExtraWordCheck(level, extraWordCheck)
+    ) {
+      return { level, cells };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Backward construction step — vertical variant. Inserts `word` as a single
+ * vertical run inside one column, such that scanning the column top-down
+ * yields `word`. Returns the new board and the cells (bottom-to-top) the
+ * word occupies, or null if no placement isolates the word.
+ *
+ * Why "reversed when written into tiles": word-scan reads vertical runs
+ * top-down (highest row first). To form "CAT" reading top→down we must have
+ * tiles[r+2]='C', tiles[r+1]='A', tiles[r]='T' — i.e., the letters are
+ * inserted at row r in REVERSE order so the bottom tile is the last letter.
+ */
+export function insertWordVertical(
+  Sk: BlastLevel,
+  word: string,
+  otherWordsOnBoard: string[],
+  locale: Locale,
+  seed: number,
+  extraWordCheck?: ExtraWordCheck,
+): InsertResult | null {
+  const letters = [...word];
+  const L = letters.length;
+  const cols = Sk.columns.length;
+  if (cols === 0 || L < 2) return null;
+
+  const rand = rng(seed);
+  type Cand = { c: number; r: number };
+  const candidates: Cand[] = [];
+
+  // Vertical placements: pick a column c, then a row r where the L-letter
+  // word will sit. Any r from 0 (bottom) up to current column height is valid
+  // (splice shifts existing tiles up). r=0 stacks the word ON TOP of the
+  // existing column tiles only if we splice at index `col.tiles.length`; so
+  // we enumerate r in [0, col.tiles.length] inclusive.
+  for (let c = 0; c < cols; c++) {
+    const h = Sk.columns[c]!.tiles.length;
+    for (let r = 0; r <= h; r++) {
+      candidates.push({ c, r });
+    }
+  }
+
+  const shuffled = shuffle(candidates, rand);
+
+  for (const { c, r } of shuffled) {
+    const columns = cloneColumns(Sk.columns);
+    const cells: CellId[] = [];
+
+    // Insert letters in FORWARD order. Each splice(r, 0, ch) pushes the
+    // previous letter up, so after L splices tiles[r]=last letter, …,
+    // tiles[r+L-1]=first letter. word-scan reads vertical runs top-down
+    // (highest row first), which then yields the forward word.
+    for (let i = 0; i < L; i++) {
+      columns[c]!.tiles.splice(r, 0, letters[i]!);
+    }
+    // Emit cells in bottom-to-top order (row r, r+1, … r+L-1) — engine
+    // convention is row 0 = bottom; consumers expect ascending rows.
+    for (let i = 0; i < L; i++) {
+      cells.push(cellId(c, r + i));
+    }
+
+    const level: BlastLevel = { ...Sk, columns };
+    const matches = scanFormableThemeWords(level, [word, ...otherWordsOnBoard], locale);
+    const formableWords = new Set(matches.map((m) => m.word));
+
+    if (
+      formableWords.size === 1 &&
+      formableWords.has(word) &&
+      passesExtraWordCheck(level, extraWordCheck)
+    ) {
       return { level, cells };
     }
   }
@@ -117,7 +214,11 @@ function floorBoard(spec: ChainLevelSpec): BlastLevel | null {
  * Builds a forced-chain BlastLevel from a spec. Returns null if no seed within
  * MAX_BUILD_ATTEMPTS yields a valid level (author should then tweak the chain).
  */
-export function buildChainLevel(spec: ChainLevelSpec, seed: number): BlastLevel | null {
+export function buildChainLevel(
+  spec: ChainLevelSpec,
+  seed: number,
+  extraWordCheck?: ExtraWordCheck,
+): BlastLevel | null {
   const longest = Math.max(...spec.chain.map((w) => [...w].length));
   if (longest > spec.columns) return null;
 
@@ -129,11 +230,22 @@ export function buildChainLevel(spec: ChainLevelSpec, seed: number): BlastLevel 
 
     let board = base;
     let ok = true;
+    // Coin-flip per step to pick orientation; fall back to the other axis if
+    // the chosen one can't isolate the word. This produces visually mixed
+    // levels — some words land as rows, others stack as columns — instead of
+    // every board being a flat horizontal scroll.
+    const orientRand = rng(attemptSeed ^ 0xa5a5a5a5);
     for (let k = spec.chain.length - 2; k >= 0; k--) {
       const word = spec.chain[k]!;
       const others = spec.chain.slice(k + 1);
       const stepSeed = (attemptSeed + k * 7919) >>> 0;
-      const res = insertWord(board, word, others, spec.locale, stepSeed);
+      const preferVertical = orientRand() < 0.5;
+      const first = preferVertical
+        ? insertWordVertical(board, word, others, spec.locale, stepSeed, extraWordCheck)
+        : insertWord(board, word, others, spec.locale, stepSeed, extraWordCheck);
+      const res = first ?? (preferVertical
+        ? insertWord(board, word, others, spec.locale, stepSeed, extraWordCheck)
+        : insertWordVertical(board, word, others, spec.locale, stepSeed, extraWordCheck));
       if (!res) {
         ok = false;
         break;


### PR DESCRIPTION
## Summary

Addresses the playtest report on Blast V2: tiles tiny, board too tall (page scrolls), gravity/cascade lacks juice, levels never use vertical clears, and gravity feels off.

- **Scroll + sizing**: `BlastGame` hides the global bottom nav via `useHideNavigation` and switches `min-h-dvh` → `h-dvh` + `overflow-hidden`. The brittle `aspectRatio: cols/maxRows` wrapper (which pinned a 6-col / 2-row board to a 3:1 strip) is dropped for a flex-stretch container that fills the available height.
- **Tile sizing**: `BlastTile.module.css` switches to `container-type: size` and computes `--blast-tile-size` as `min(width-fit, height-fit)` — tiles now scale up on tall phones instead of being pinned by the narrower axis.
- **Stable visual board**: `BlastBoard` takes a `boardRows` prop and renders that many `cellWell`s per column so the playfield doesn't shrink as words clear. Anchored at the level's initial max-row count, captured once per mount (Royal-Match-style stable field).
- **Gravity x-axis lock + juice**: column tile wrapper uses `layout="position"` (animates x/y only, never size, so tiles stay locked to their column). Punchier spring (`stiffness: 560`, `mass: 1.2`) for a snappier fall + small overshoot. `useCollapseTimeline` tightens the squash/overshoot/elastic beats and bumps stagger to 22ms.
- **Vertical word placement**: new `insertWordVertical` inserts a chain word as a single-column run (top-down read = forward word). `buildChainLevel` coin-flips orientation per chain step and falls back to the other axis when one fails — levels now mix horizontal and vertical runs instead of every board being a flat row.
- **Common-word screen**: optional `ExtraWordCheck` threads through `insertWord` / `insertWordVertical` / `buildChainLevel`; `ChainPackSource` wires the locale's common-words list so vertical placements that accidentally spell a dictionary word (e.g. `GEAR`) are rejected.

## Test plan
- [x] `chain-builder.test.ts`: new `insertWordVertical` (isolation + determinism) and a sweep that proves `buildChainLevel` produces at least one vertical run across many seeds.
- [x] `BlastBoard.test.tsx` + `BlastBoard.pointermove.test.tsx`: pass new `boardRows` prop.
- [x] `BlastGame.test.tsx`: mocks `NavigationContext` for the new `useHideNavigation` call.
- [x] Full vitest suite: 2077 passed (1 pre-existing todo).
- [x] `tsc --noEmit` clean.
- [x] `next build --experimental-build-mode=compile` clean.
- [ ] Manual phone smoke: HE level 5, confirm no page scroll, tiles fill more of the board height, gravity drop visibly bounces, at least one level shows a vertical run.

https://claude.ai/code/session_01ANuisFRzwEoW4S4o2C8Suw

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANuisFRzwEoW4S4o2C8Suw)_