### PR TITLE
fix(mp-results): single countdown, parallax/reveals, golden tiles, less confetti

### DIFF
--- a/fe-next/backend/handlers/gameLifecycleHandler.ts
+++ b/fe-next/backend/handlers/gameLifecycleHandler.ts
@@ -451,6 +451,7 @@ function registerGameLifecycleHandlers(io: Server, socket: Socket): void {
           wordHuntEliminatedPlayers: game.wordHuntState.eliminatedPlayers || [],
           wordHuntPlayerLives: game.wordHuntState.playerLives || {},
         } : {}),
+        ...(game.goldenLetters?.length ? { goldenLetters: game.goldenLetters } : {}),
       });
     } else if (game.gameState === 'finished') {
       // Reconnecting to a finished game — resend results so the player sees the results screen

--- a/fe-next/backend/handlers/gameStartHandler.ts
+++ b/fe-next/backend/handlers/gameStartHandler.ts
@@ -117,9 +117,11 @@ function buildStartGamePayload(
     payload.wordHuntPlayerLives = game?.wordHuntState?.playerLives ?? {};
   }
 
-  if (game?.goldenLetters?.length) {
-    payload.goldenLetters = game.goldenLetters;
-  }
+  // Always include goldenLetters (even as []) on the fresh startGame payload so
+  // the client can distinguish "no goldens this round" from "reconnect with
+  // missing field". Reconnect / late-join / recovery emits add the field only
+  // when populated and the client treats omitted as "don't touch".
+  payload.goldenLetters = game?.goldenLetters ?? [];
 
   if (isRetry) {
     payload.retry = true;

--- a/fe-next/backend/handlers/playerReconnectHandler.ts
+++ b/fe-next/backend/handlers/playerReconnectHandler.ts
@@ -262,6 +262,11 @@ function handleReconnection(io: Server, socket: Socket, game: GameState, gameCod
       reconnectPayload.wordHuntPlayerLives = game.wordHuntState.playerLives || {};
     }
 
+    // Replay golden letters so star tiles aren't lost on reconnect.
+    if (game.goldenLetters?.length) {
+      reconnectPayload.goldenLetters = game.goldenLetters;
+    }
+
     socket.emit('startGame', reconnectPayload);
 
     // Send current leaderboard and player's achievements so UI is fully restored
@@ -326,6 +331,11 @@ function handleLateJoin(socket: Socket, game: GameState, gameCode: string, usern
     lateJoinPayload.wordHuntTargetLength = game.wordHuntState.targetWordLength ?? 0;
     lateJoinPayload.wordHuntEliminatedPlayers = game.wordHuntState.eliminatedPlayers || [];
     lateJoinPayload.wordHuntPlayerLives = game.wordHuntState.playerLives || {};
+  }
+
+  // Include golden letters for late joiners so they see the star tiles too.
+  if (game.goldenLetters?.length) {
+    lateJoinPayload.goldenLetters = game.goldenLetters;
   }
 
   socket.emit('startGame', lateJoinPayload);

--- a/fe-next/components/__tests__/ResultsPage.ranking.test.tsx
+++ b/fe-next/components/__tests__/ResultsPage.ranking.test.tsx
@@ -47,21 +47,37 @@ vi.mock('@/hooks/useMobileLandscape', () => ({
   useMobileLandscape: () => false,
 }));
 
-vi.mock('framer-motion', () => ({
-  m: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...props}>{children}</div>
-    ),
-    button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <button {...props}>{children}</button>
-    ),
-    span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <span {...props}>{children}</span>
-    ),
-  },
-  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
-  useReducedMotion: () => false,
-}));
+vi.mock('framer-motion', () => {
+  const motionValueStub = () => ({
+    set: vi.fn(),
+    get: () => 0,
+    on: () => () => {},
+    onChange: () => () => {},
+  });
+  return {
+    m: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...props}>{children}</div>
+      ),
+      button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <button {...props}>{children}</button>
+      ),
+      span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <span {...props}>{children}</span>
+      ),
+    },
+    AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+    useReducedMotion: () => false,
+    useScroll: () => ({
+      scrollX: motionValueStub(),
+      scrollY: motionValueStub(),
+      scrollXProgress: motionValueStub(),
+      scrollYProgress: motionValueStub(),
+    }),
+    useTransform: () => motionValueStub(),
+    useMotionValue: motionValueStub,
+  };
+});
 
 vi.mock('canvas-confetti', () => ({
   __esModule: true,

--- a/fe-next/components/game/InGameScreen.tsx
+++ b/fe-next/components/game/InGameScreen.tsx
@@ -336,8 +336,13 @@ const InGameScreen = memo<InGameScreenProps>(function InGameScreen({
   useEffect(() => {
     if (!socket) return;
 
-    const handleGoldenLetters = (data: { goldenLetters?: Array<{ row: number; col: number }> }) => {
-      setGoldenLetters(data.goldenLetters ?? []);
+    const handleGoldenLetters = (data: { goldenLetters?: Array<{ row: number; col: number }>; reconnect?: boolean }) => {
+      // Only update when the payload explicitly carries goldenLetters. Reconnect /
+      // late-join startGame emits omit the field, which previously clobbered the
+      // existing golden tiles (stars vanished mid-game after a re-render).
+      if (data.goldenLetters !== undefined) {
+        setGoldenLetters(data.goldenLetters);
+      }
     };
 
     const handleRoundEventWarning = (data: { eventType: string }) => {
@@ -409,10 +414,11 @@ const InGameScreen = memo<InGameScreenProps>(function InGameScreen({
     };
   }, [socket]);
 
-  // Clear golden letters when game resets
-  useEffect(() => {
-    if (!gameActive) setGoldenLetters([]);
-  }, [gameActive]);
+  // Golden letters are now driven entirely by the server's startGame payload
+  // (which always includes the field, even as []). Don't pre-emptively clear
+  // when gameActive flickers — a transient false would wipe the tiles and the
+  // next round's payload re-broadcast is the only place that could restore
+  // them, which doesn't happen mid-round.
 
   // Ref to hold detected combo type from path (blast multiplayer)
   const comboTypeRef = useRef<string | null>(null);

--- a/fe-next/components/multiplayer/MultiplayerInGameView.tsx
+++ b/fe-next/components/multiplayer/MultiplayerInGameView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { memo, useCallback, useState } from 'react';
+import React, { memo, useCallback, useDeferredValue, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import type { Socket } from 'socket.io-client';
 import { Button } from '../ui/button';
@@ -254,16 +254,19 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
   // Desktop shell routing (standard mode only)
   const shellEnabled = useDesktopShellEnabled();
 
-  // Opponent word feed
+  // Opponent word feed. Defer the array + memoize the mapped shape so socket
+  // bursts of opponent words don't allocate a fresh insight array each render
+  // (which broke memo on every consumer downstream — esp. during local drag).
   const { feedItems: opponentFeedItems } = useOpponentWordFeed({ socket, currentPlayerName: username });
-  const opponentInsightWords = opponentFeedItems.map(item => ({
+  const deferredOpponentFeedItems = useDeferredValue(opponentFeedItems);
+  const opponentInsightWords = useMemo(() => deferredOpponentFeedItems.map(item => ({
     wordLength: item.wordLength,
     firstLetter: item.firstLetter,
     lastLetter: item.lastLetter,
     score: item.score,
     ts: item.timestamp,
     byUsername: item.playerName,
-  }));
+  })), [deferredOpponentFeedItems]);
 
   // Effective grid (player may have shufflingGrid fallback)
   const effectiveGrid = letterGrid || shufflingGrid || null;

--- a/fe-next/components/results/ResultsHeroSection.tsx
+++ b/fe-next/components/results/ResultsHeroSection.tsx
@@ -130,11 +130,13 @@ const ResultsHeroSection = memo<ResultsHeroSectionProps>(
     const accent = getAccent(rank);
     const isEliminated = isWordHunt && wordHuntStatus === 'eliminated';
 
-    // Cascading confetti burst for winner (rank 1)
+    // Cascading confetti burst for winner (rank 1) — short & restrained.
+    // Prior 2.5s cascade overlapped the podium reveal animations and felt
+    // overwhelming on repeated MP wins.
     useEffect(() => {
       if (rank !== 1 || reducedMotion) return;
       const timer = setTimeout(() => {
-        cancelConfettiRef.current = fireFirstWinConfetti(2500);
+        cancelConfettiRef.current = fireFirstWinConfetti(1200);
       }, 800);
       return () => {
         clearTimeout(timer);

--- a/fe-next/components/results/ResultsScrollEffects.tsx
+++ b/fe-next/components/results/ResultsScrollEffects.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import React, { useRef, type ReactNode } from 'react';
+import { m, useScroll, useTransform, useReducedMotion, type MotionStyle } from 'framer-motion';
+
+interface ParallaxBackdropProps {
+  /** Scroll container ref. Required — the page uses an inner scrollable, not window. */
+  scrollRef: React.RefObject<HTMLElement | null>;
+  /** Translation amplitude (px) the inner layer drifts as the page scrolls. */
+  intensity?: number;
+}
+
+/**
+ * Subtle dual-layer parallax backdrop pinned behind the results content.
+ *
+ * Sits absolutely inside the page chrome and tracks the inner scroll container
+ * (the MP results layout uses overflow-y inside; window scroll wouldn't catch
+ * anything). Two layers drift at different rates so depth reads without
+ * overwhelming the foreground. Disabled when reduced-motion is requested.
+ */
+export const ResultsParallaxBackdrop: React.FC<ParallaxBackdropProps> = ({
+  scrollRef,
+  intensity = 80,
+}) => {
+  const reducedMotion = useReducedMotion();
+  const { scrollY } = useScroll({ container: scrollRef as React.RefObject<HTMLElement> });
+
+  // Back layer drifts slowly; front layer drifts faster + slight opposite hue.
+  const backY = useTransform(scrollY, [0, 600], [0, -intensity * 0.5]);
+  const frontY = useTransform(scrollY, [0, 600], [0, -intensity]);
+  const auraScale = useTransform(scrollY, [0, 400], [1, 1.08]);
+
+  if (reducedMotion) return null;
+
+  const backStyle: MotionStyle = {
+    y: backY,
+    background:
+      'radial-gradient(circle at 50% 30%, rgba(0,255,255,0.10) 0%, transparent 55%)',
+  };
+  const frontStyle: MotionStyle = {
+    y: frontY,
+    scale: auraScale,
+    background:
+      'radial-gradient(circle at 30% 60%, rgba(255,20,147,0.08) 0%, transparent 50%), radial-gradient(circle at 80% 40%, rgba(191,255,0,0.06) 0%, transparent 50%)',
+  };
+
+  return (
+    <div className="absolute inset-0 pointer-events-none overflow-hidden z-0" aria-hidden="true">
+      <m.div className="absolute inset-0" style={backStyle} />
+      <m.div className="absolute inset-0" style={frontStyle} />
+    </div>
+  );
+};
+
+interface SectionRevealProps {
+  children: ReactNode;
+  /** Order in the scroll flow — used to vary stagger delay/parallax direction. */
+  index?: number;
+  className?: string;
+  /** Disable the parallax Y drift on this section (default keeps a subtle drift). */
+  flat?: boolean;
+}
+
+/**
+ * Wraps a results section with a one-shot scroll-triggered reveal and a very
+ * subtle parallax drift. Sections fade + lift on enter and gently translate as
+ * the user keeps scrolling, giving the page depth without per-section work at
+ * each callsite.
+ */
+export const ResultsSectionReveal: React.FC<SectionRevealProps> = ({
+  children,
+  index = 0,
+  className,
+  flat = false,
+}) => {
+  const reducedMotion = useReducedMotion();
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Alternate parallax direction so adjacent sections don't drift in lockstep.
+  const direction = index % 2 === 0 ? 1 : -1;
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ['start end', 'end start'],
+  });
+  const driftRange = flat ? 0 : 14;
+  const y = useTransform(scrollYProgress, [0, 1], [driftRange * direction, -driftRange * direction]);
+
+  if (reducedMotion) {
+    return <div ref={ref} className={className}>{children}</div>;
+  }
+
+  return (
+    <m.div
+      ref={ref}
+      className={className}
+      initial={{ opacity: 0, y: 24 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.2, margin: '0px 0px -10% 0px' }}
+      transition={{ type: 'spring', stiffness: 140, damping: 22, mass: 0.6 }}
+      style={flat ? undefined : { y }}
+    >
+      {children}
+    </m.div>
+  );
+};
+
+export default ResultsSectionReveal;

--- a/fe-next/components/views/ResultsPage.tsx
+++ b/fe-next/components/views/ResultsPage.tsx
@@ -19,7 +19,9 @@ import { useResultsSocketEvents } from '@/components/results/useResultsSocketEve
 import { useResultsData } from '@/hooks/useResultsData';
 import { useResultsSideEffects } from '@/hooks/useResultsSideEffects';
 import { useHideNavigation } from '@/contexts/NavigationContext';
+import { useIsDesktop } from '@/hooks/useMediaQuery';
 import { useMultiplayerSignupNudge } from '@/hooks/useMultiplayerSignupNudge';
+import { ResultsParallaxBackdrop, ResultsSectionReveal } from '@/components/results/ResultsScrollEffects';
 import { FloatingReaction } from '@/components/game/QuickReactions';
 import { useQuickReactions } from '@/hooks/useQuickReactions';
 
@@ -100,7 +102,7 @@ function DesktopResultsLayout({
   userId,
   matchScore,
 }: DesktopResultsLayoutProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
   const [showScrollIndicator, setShowScrollIndicator] = useState(false);
 
   useEffect(() => {
@@ -127,27 +129,28 @@ function DesktopResultsLayout({
     <div className="hidden md:flex md:flex-col md:flex-1 md:min-h-0 relative">
       <div
         ref={scrollRef}
-        className="flex-1 min-h-0 overflow-y-auto overscroll-contain scrollable-area p-4 medium-short:p-2 desktop-medium-short:p-3 xl:p-6 pb-32 medium-short:pb-24"
+        className="flex-1 min-h-0 overflow-y-auto overscroll-contain scrollable-area p-4 medium-short:p-2 desktop-medium-short:p-3 xl:p-6 pb-32 medium-short:pb-24 relative"
         style={{ WebkitOverflowScrolling: 'touch' }}
       >
+        <ResultsParallaxBackdrop scrollRef={scrollRef} intensity={110} />
         {/* Top Bar with Exit Button */}
-        <div className="w-full max-w-5xl mx-auto flex items-center justify-end mb-4">
+        <div className="w-full max-w-5xl mx-auto flex items-center justify-end mb-4 relative z-10">
           <ExitRoomButton onClick={handleExitRoom} label={exitLabel || ''} />
         </div>
 
         {/* Wheel-rush hero scene takes the top slot for that mode; the
             standard cinematic block follows beneath for podium + ranks. */}
         {resolvedGameMode === 'wheel-rush' && Object.keys(wheelRushPlayerStats).length > 0 && (
-          <div className="w-full max-w-3xl mx-auto mb-6">
+          <ResultsSectionReveal index={0} flat className="w-full max-w-3xl mx-auto mb-6 relative z-10">
             <WheelRushResultsScene
               playerStats={wheelRushPlayerStats}
               currentUsername={currentUsername}
             />
-          </div>
+          </ResultsSectionReveal>
         )}
 
         {/* Full-width cinematic area: Hero + Podium + Consolation */}
-        <div className="w-full max-w-5xl mx-auto">
+        <ResultsSectionReveal index={1} flat className="w-full max-w-5xl mx-auto relative z-10">
           <ResultsMainContent
             {...mainContentProps}
             hideInlineCta={!!gameCode && !isBotsOnlyGame}
@@ -159,47 +162,54 @@ function DesktopResultsLayout({
               <GlobalRankBadge userId={userId} matchScore={matchScore} />
             </div>
           ) : null}
-        </div>
+        </ResultsSectionReveal>
 
         {/* Two-column area below the cinematic hero */}
-        <div className="w-full max-w-5xl mx-auto mt-6 medium-short:mt-3 desktop-medium-short:mt-4 grid grid-cols-1 lg:grid-cols-2 gap-6 medium-short:gap-3 desktop-medium-short:gap-4">
+        <div className="w-full max-w-5xl mx-auto mt-6 medium-short:mt-3 desktop-medium-short:mt-4 grid grid-cols-1 lg:grid-cols-2 gap-6 medium-short:gap-3 desktop-medium-short:gap-4 relative z-10">
           {/* LEFT: Game mode summary + social + engagement */}
           <div className="space-y-4">
             {resolvedGameMode === 'word-hunt' && wordHuntResultsData && (
-              <WordHuntResultsSummary {...wordHuntResultsData} />
+              <ResultsSectionReveal index={2}>
+                <WordHuntResultsSummary {...wordHuntResultsData} />
+              </ResultsSectionReveal>
             )}
             {resolvedGameMode === 'blast' && Object.keys(blastPlayerStats).length > 0 && (
-              <BlastResultsScene
-                playerStats={blastPlayerStats}
-                scores={blastResultScores}
-                currentUsername={currentUsername}
-              />
+              <ResultsSectionReveal index={2}>
+                <BlastResultsScene
+                  playerStats={blastPlayerStats}
+                  scores={blastResultScores}
+                  currentUsername={currentUsername}
+                />
+              </ResultsSectionReveal>
             )}
             {/* Wheel-rush summary already rendered as the hero scene above
                 this layout's two-column grid. No secondary card needed. */}
             {/* Add-friend affordance now lives inline on each player tile (Podium + ConsolationRows). */}
             {/* D1 retention CTA — outcome-aware Daily Challenge invite. Renders on CG too
                 (PostGameEngagement self-hides on CG; this one stays). */}
-            <DailyChallengeInvite isWinner={isCurrentUserWinner} />
-            <PostGameEngagement />
-            {postGameWordReview}
+            <ResultsSectionReveal index={4}>
+              <DailyChallengeInvite isWinner={isCurrentUserWinner} />
+            </ResultsSectionReveal>
+            <ResultsSectionReveal index={6}>
+              <PostGameEngagement />
+            </ResultsSectionReveal>
+            {postGameWordReview && (
+              <ResultsSectionReveal index={8}>
+                {postGameWordReview}
+              </ResultsSectionReveal>
+            )}
           </div>
 
           {/* RIGHT: Other players expanded + achievements */}
-          <m.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2, type: 'spring', stiffness: 120, damping: 20 }}
-            className="space-y-4"
-          >
+          <ResultsSectionReveal index={3} className="space-y-4">
             <ResultsDetailsContent {...detailsContentProps} />
-          </m.div>
+          </ResultsSectionReveal>
         </div>
 
         {/* CrazyGames banner ad — shown after results content */}
-        <div className="w-full max-w-5xl mx-auto mt-6">
+        <ResultsSectionReveal index={9} flat className="w-full max-w-5xl mx-auto mt-6 relative z-10">
           <CrazyGamesBanner size="728x90" />
-        </div>
+        </ResultsSectionReveal>
       </div>
 
       {/* Scroll indicator — subtle bouncing chevron at bottom */}
@@ -241,6 +251,15 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, gameCode, onRetu
   }, [setIsInGame]);
 
   const router = useRouter();
+
+  // Render exactly one StickyReadyBar — mobile fixed bar OR desktop fixed bar.
+  // Previously both were always mounted (hidden via Tailwind), so two countdown
+  // intervals ran in parallel and could each fire onStartGame/onMarkReady.
+  const isDesktopViewport = useIsDesktop();
+
+  // Mobile inner scroll container — drives the parallax backdrop & section
+  // reveals (window scroll is locked here; everything pages inside this div).
+  const mobileScrollRef = useRef<HTMLDivElement>(null);
 
   // Classroom lesson data from sessionStorage (set by ClassroomGameLobby)
   const lessonGameData = useMemo(() => {
@@ -911,37 +930,53 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, gameCode, onRetu
       </div>
 
       {/* MOBILE VIEW — single scroll, no tabs */}
-      <div className="md:hidden flex flex-col flex-1 min-h-0">
+      <div className="md:hidden flex flex-col flex-1 min-h-0 relative">
         {/* Exit-only header — podium already renders the 'matchResults' label */}
-        <div className="shrink-0 w-full flex items-center justify-end px-2 py-2">
+        <div className="shrink-0 w-full flex items-center justify-end px-2 py-2 relative z-10">
           <ExitRoomButton onClick={handleExitRoom} label="" className="w-11 h-11 min-w-[44px] min-h-[44px] p-0" />
         </div>
 
         {/* Scrollable content — everything in one flow */}
         <div
-          className="flex-1 min-h-0 overflow-y-auto overscroll-contain scrollable-area px-2 pb-36 medium-short:pb-24 bg-neo-navy"
+          ref={mobileScrollRef}
+          className="flex-1 min-h-0 overflow-y-auto overscroll-contain scrollable-area px-2 pb-36 medium-short:pb-24 bg-neo-navy relative"
           style={{ overscrollBehavior: 'contain', WebkitOverflowScrolling: 'touch' }}
         >
-          <div className="max-w-lg mx-auto space-y-6 medium-short:space-y-3">
-            {renderResultsTab()}
+          <ResultsParallaxBackdrop scrollRef={mobileScrollRef} />
+          <div className="max-w-lg mx-auto space-y-6 medium-short:space-y-3 relative z-10">
+            <ResultsSectionReveal index={0} flat>
+              {renderResultsTab()}
+            </ResultsSectionReveal>
             {/* Global rank badge — mobile, sub-podium */}
             {user?.id ? (
-              <div className="flex justify-center">
-                <GlobalRankBadge userId={user.id} matchScore={currentPlayerData?.score ?? 0} />
-              </div>
+              <ResultsSectionReveal index={1}>
+                <div className="flex justify-center">
+                  <GlobalRankBadge userId={user.id} matchScore={currentPlayerData?.score ?? 0} />
+                </div>
+              </ResultsSectionReveal>
             ) : null}
             {/* D1 retention CTA — Daily Challenge invite */}
-            <DailyChallengeInvite isWinner={isCurrentUserWinner} />
+            <ResultsSectionReveal index={2}>
+              <DailyChallengeInvite isWinner={isCurrentUserWinner} />
+            </ResultsSectionReveal>
             {/* CrazyGames banner ad — mobile size between results and details */}
-            <CrazyGamesBanner size="320x50" />
+            <ResultsSectionReveal index={3} flat>
+              <CrazyGamesBanner size="320x50" />
+            </ResultsSectionReveal>
             {/* Other players' details (inline, no tab switch needed) */}
-            {renderDetailsTab()}
-            {postGameWordReviewNode}
+            <ResultsSectionReveal index={4}>
+              {renderDetailsTab()}
+            </ResultsSectionReveal>
+            {postGameWordReviewNode && (
+              <ResultsSectionReveal index={5}>
+                {postGameWordReviewNode}
+              </ResultsSectionReveal>
+            )}
           </div>
         </div>
 
         {/* Floating bottom bar — always-visible sticky CTA */}
-        {gameCode && onReturnToRoom && (
+        {gameCode && onReturnToRoom && !isDesktopViewport && (
           <div className="shrink-0 fixed bottom-[var(--admob-banner-height,0px)] inset-x-0 z-50 text-neo-cream">
             <m.div
               initial={{ y: 60, opacity: 0 }}
@@ -995,8 +1030,8 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, gameCode, onRetu
       />
 
       {/* DESKTOP Sticky Ready Bar — pinned to bottom on md+ screens */}
-      {gameCode && onReturnToRoom && (
-        <div className="hidden md:block fixed bottom-[var(--admob-banner-height,0px)] inset-x-0 z-50 bg-neo-navy text-neo-cream border-t-4 border-neo-black safe-area-pb">
+      {gameCode && onReturnToRoom && isDesktopViewport && (
+        <div className="fixed bottom-[var(--admob-banner-height,0px)] inset-x-0 z-50 bg-neo-navy text-neo-cream border-t-4 border-neo-black safe-area-pb">
           <div className="max-w-6xl mx-auto px-4 py-2.5">
             <StickyReadyBar
               isHost={isHost}

--- a/fe-next/hooks/useFirstWinCelebration.ts
+++ b/fe-next/hooks/useFirstWinCelebration.ts
@@ -47,8 +47,10 @@ export function useFirstWinCelebration({
 
     addCoins(FIRST_WIN_BONUS, 'First Win Bonus');
 
-    // Epic confetti burst using centralized utility
-    fireFirstWinConfetti(4000);
+    // First-win burst — keep it celebratory but short. Was 4000ms; long
+    // cascades stacked with the hero section's 1.2s burst into a wall of
+    // particles for the only-once-per-lifetime first-MP-win event.
+    fireFirstWinConfetti(2200);
 
     // Trigger haptic feedback
     hapticGameWin();

--- a/fe-next/utils/confettiUtils.ts
+++ b/fe-next/utils/confettiUtils.ts
@@ -398,7 +398,7 @@ export function fireStreakConfetti(): void {
  * Neo-brutalist style with chunky particles and bold colors
  * @returns Cancel function to stop the animation (call on unmount)
  */
-export function fireFirstWinConfetti(durationMs: number = 2500): () => void {
+export function fireFirstWinConfetti(durationMs: number = 1500): () => void {
   const colors = NEO_BRUTALIST_COLORS;
   const end = Date.now() + durationMs;
   let rafId: number | null = null;
@@ -409,47 +409,48 @@ export function fireFirstWinConfetti(durationMs: number = 2500): () => void {
     if (cancelled) return;
     frameCount++;
 
-    // Only fire every 3rd frame to reduce particle count
-    if (frameCount % 3 === 0) {
+    // Side bursts every 6th frame — was every 3rd. Cuts particle drizzle in half
+    // without losing the cascading-from-the-corners shape.
+    if (frameCount % 6 === 0) {
       // Left side burst
       fireConfetti({
-        particleCount: 2, // Reduced from 5
+        particleCount: 1,
         angle: 60,
         spread: 50,
         origin: { x: 0, y: 0.6 },
         colors,
         startVelocity: 55,
         gravity: 1.0,
-        ticks: 180,
-        scalar: 1.3,
+        ticks: 160,
+        scalar: 1.2,
       });
 
       // Right side burst
       fireConfetti({
-        particleCount: 2, // Reduced from 5
+        particleCount: 1,
         angle: 120,
         spread: 50,
         origin: { x: 1, y: 0.6 },
         colors,
         startVelocity: 55,
         gravity: 1.0,
-        ticks: 180,
-        scalar: 1.3,
+        ticks: 160,
+        scalar: 1.2,
       });
     }
 
-    // Center burst occasionally
-    if (Math.random() > 0.85) {
+    // Center burst rare-ish punctuation only — was Math.random()>0.85.
+    if (Math.random() > 0.95) {
       fireConfetti({
-        particleCount: 6, // Reduced from 12
+        particleCount: 3,
         angle: 90,
         spread: 100,
         origin: { x: 0.5, y: 0.5 },
         colors,
         startVelocity: 40,
         gravity: 0.8,
-        ticks: 140,
-        scalar: 1.5,
+        ticks: 120,
+        scalar: 1.4,
       });
     }
 


### PR DESCRIPTION
## Summary

Bundles five MP-results / in-game issues into one pass:

- **Two MP results countdowns** — mobile and desktop `StickyReadyBar` were both mounted (only hidden via Tailwind), so two `setInterval`s ticked in parallel and could each fire `onStartGame`/`onMarkReady`. Now exactly one mounts based on `useIsDesktop()`.
- **Scroll animations + parallax on MP results page** — new `ResultsScrollEffects` exposes a dual-layer scroll-tracked parallax backdrop and a reusable `ResultsSectionReveal` (`whileInView` + subtle alternating Y-drift). Wired into both mobile and desktop layouts; respects `prefers-reduced-motion`.
- **Golden ("star") tiles vanished mid-game in MP classic** — reconnect / late-join / recovery emits sent `startGame` payloads without a `goldenLetters` field; the client did `data.goldenLetters ?? []` and wiped state. Backend now includes `goldenLetters` in those payloads when present and always sends an explicit array on fresh starts; client only updates when the field is defined. Removed the `gameActive=false → []` clear that could also nuke state on a transient flicker.
- **Still too much confetti on the winner podium** — `fireFirstWinConfetti` runs at every 6th frame (vs 3rd), with single-particle side bursts and rarer center punctuation. Winner hero burst trimmed 2.5s → 1.2s; first-MP-win celebration trimmed 4s → 2.2s.
- **Drag stutter — remaining unmemoized changes** — followup to `ba7483d`. `opponentInsightWords` was a fresh array allocation per render straight off a socket-driven hook, breaking memo on every consumer. Now routes through `useDeferredValue` + `useMemo` so local drag input stays high-priority during opponent-word bursts.

## Test plan

- [x] `npx vitest run --config vitest.config.ts components/results` → 49 files, 373 tests green
- [x] `npx vitest run --config vitest.config.ts components/game components/grid components/multiplayer` → 77 files, 619 tests green
- [x] `npx vitest run --config vitest.config.ts components/multiplayer/__tests__` → 26 files, 209 tests green
- [x] `npx vitest run --config vitest.config.ts hooks` → 333 files, 3523 tests green
- [x] `npx vitest run --config backend/vitest.config.ts handlers/__tests__/playerReconnectHandler handlers/__tests__/gameStartHandler handlers/__tests__/gameLifecycleHandler` → 6 files, 94 tests green
- [x] `npx tsc --noEmit --skipLibCheck` → clean
- [x] `npx eslint` on every touched file → clean
- [ ] Manual: rematch from MP results once — confirm exactly one countdown shows + only one start fires
- [ ] Manual: win an MP match — confirm confetti reads as a quick celebratory burst, not a 4s downpour
- [ ] Manual: drop network for 2-3s during MP classic with golden tiles — confirm stars persist through the reconnect
- [ ] Manual: scroll the MP results page on mobile — confirm sections fade-in on view and parallax backdrop drifts

https://claude.ai/code/session_01EpnutN2uaVcKq387CHgXB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpnutN2uaVcKq387CHgXB7)_