### PR TITLE
feat(blast/v2): 30 levels, softer gravity, RGB shockwave, SVG result icons, fix sideways fall

### DIFF
--- a/fe-next/components/blast/v2/BlastBoard.tsx
+++ b/fe-next/components/blast/v2/BlastBoard.tsx
@@ -162,7 +162,11 @@ export function BlastBoard({
       </div>
       <LayoutGroup>
         {level.columns.map((col, c) => (
-          <div key={col.index} className="flex flex-col-reverse gap-2 relative" data-col={col.index}>
+          <div
+            key={col.index}
+            className={`flex flex-col-reverse gap-2 relative ${styles.tileColumn}`}
+            data-col={col.index}
+          >
             <AnimatePresence>
               {col.tiles.map((letter, row) => {
                 const id = makeCellId(col.index, row);

--- a/fe-next/components/blast/v2/BlastFxOverlay.tsx
+++ b/fe-next/components/blast/v2/BlastFxOverlay.tsx
@@ -83,6 +83,68 @@ async function spawnPulseRing(
   entry.raf = requestAnimationFrame(step);
 }
 
+// Chromatic shockwave wrap — three concentric rings in cyan/magenta/yellow
+// staggered ~50ms apart with slight scale offsets. Reads as a glitch/sci-fi
+// shockwave around the cleared cell, distinct from the solid pulse ring.
+// Spawned in addition to the pulse ring on word found.
+async function spawnShockwaveWrap(
+  app: import('pixi.js').Application,
+  systems: { rings: Array<{ g: import('pixi.js').Graphics; raf: number }> },
+  cx: number,
+  cy: number,
+) {
+  if (typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return;
+  if (systems.rings.length >= MAX_RINGS) return;
+  const PIXI = await import('pixi.js');
+  // RGB-split shockwave: cyan slightly behind, yellow middle, magenta leading.
+  const layers: Array<{ color: number; delayMs: number; scaleStart: number; width: number }> = [
+    { color: 0x00ffff, delayMs: 0,   scaleStart: 0.35, width: 4 },
+    { color: 0xffe135, delayMs: 60,  scaleStart: 0.32, width: 3 },
+    { color: 0xff1493, delayMs: 120, scaleStart: 0.28, width: 3 },
+  ];
+  const t0 = performance.now();
+  const baseRadius = Math.min(app.screen.width, app.screen.height) * 0.13;
+  for (const layer of layers) {
+    if (systems.rings.length >= MAX_RINGS) return;
+    const g = new PIXI.Graphics();
+    g.circle(0, 0, baseRadius).stroke({ color: layer.color, width: layer.width, alpha: 0.95 });
+    g.x = cx;
+    g.y = cy;
+    g.scale.set(layer.scaleStart);
+    g.alpha = 0;
+    app.stage.addChild(g);
+
+    const duration = 460;
+    const entry = { g, raf: 0 };
+    systems.rings.push(entry);
+    const step = () => {
+      if (g.destroyed) return;
+      const now = performance.now();
+      const localT = now - t0 - layer.delayMs;
+      if (localT < 0) {
+        entry.raf = requestAnimationFrame(step);
+        return;
+      }
+      const t = Math.min(localT / duration, 1);
+      // ease-out cubic, expanding from scaleStart to 2.2
+      const ease = 1 - Math.pow(1 - t, 3);
+      g.scale.set(layer.scaleStart + ease * (2.2 - layer.scaleStart));
+      // fade in fast, hold, then fade out
+      g.alpha = t < 0.18 ? (t / 0.18) * 0.95 : 0.95 * (1 - (t - 0.18) / 0.82);
+      if (t >= 1) {
+        try { app.stage.removeChild(g); } catch { /* ok */ }
+        g.destroy();
+        const idx = systems.rings.indexOf(entry);
+        if (idx >= 0) systems.rings.splice(idx, 1);
+        return;
+      }
+      entry.raf = requestAnimationFrame(step);
+    };
+    entry.raf = requestAnimationFrame(step);
+  }
+}
+
 // Horizontal luminous bar sweeping top→bottom — cinematic on big clears / chains.
 async function spawnLightSweep(
   app: import('pixi.js').Application,
@@ -248,6 +310,12 @@ export function BlastFxOverlay({
       particles.burst(CASCADE_SPARKLE, lx, ly, 6);
       debris.spawn(lx, ly, tintColor, 10);
       spawnPulseRing(app, systems, lx, ly, tintColor);
+      // RGB-split shockwave wrap on word found — extra polish over the solid
+      // pulse ring. Only fire on the FIRST cell of a clear group to avoid
+      // saturating the rings pool when long words pop many tiles at once.
+      if (center === clearCenters[0]) {
+        spawnShockwaveWrap(app, systems, lx, ly);
+      }
     }
 
     // Screen flash + shake scale with clear size. Bumped one tier across the

--- a/fe-next/components/blast/v2/BlastLevelCompleteCard.tsx
+++ b/fe-next/components/blast/v2/BlastLevelCompleteCard.tsx
@@ -1,4 +1,5 @@
 'use client';
+import type * as React from 'react';
 import { m } from 'framer-motion';
 import { useLanguage } from '@/contexts/LanguageContext';
 
@@ -21,6 +22,80 @@ function formatTime(sec: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
+// Inline SVG icons — sized via currentColor so the tile's accent tint drives
+// stroke/fill. 24px viewBox, stroke 2px throughout for a unified weight that
+// the previous emoji-icons set (🪙⚡📖⏱️💎🔥) lacked. Each icon is a single
+// component so the stat tile renders identically across themes/locales.
+type IconProps = { className?: string };
+
+function CoinIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}
+      strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M9 9.5c.5-1 1.6-1.5 3-1.5s2.5.7 2.5 1.8c0 2.2-5 1.5-5 4 0 1.1 1.1 1.8 2.5 1.8s2.5-.5 3-1.5" />
+      <path d="M12 6v2M12 16v2" />
+    </svg>
+  );
+}
+
+function BoltIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden>
+      <path d="M13 2 4 13.5h6L9 22l11-13.5h-6L13 2z" />
+    </svg>
+  );
+}
+
+function BookIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}
+      strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden>
+      <path d="M4 5a2 2 0 0 1 2-2h12v18H6a2 2 0 0 1-2-2V5z" />
+      <path d="M8 7h6M8 11h6" />
+    </svg>
+  );
+}
+
+function ClockIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}
+      strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 2" />
+    </svg>
+  );
+}
+
+function GemIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden>
+      <path d="M6 3h12l3 6-9 12L3 9l3-6z" opacity="0.95" />
+      <path d="M6 3l3 6h6l3-6" stroke="rgba(0,0,0,0.35)" strokeWidth={1.2} fill="none" />
+      <path d="M9 9l3 12 3-12" stroke="rgba(0,0,0,0.35)" strokeWidth={1.2} fill="none" />
+    </svg>
+  );
+}
+
+function FlameIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden>
+      <path d="M12 2c2 4 6 5 6 10a6 6 0 1 1-12 0c0-3 2-5 3-7 1 2 2 2 3 0z" />
+    </svg>
+  );
+}
+
+function StarIcon({ className, filled }: IconProps & { filled: boolean }) {
+  return (
+    <svg viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} stroke="currentColor"
+      strokeWidth={1.8} strokeLinejoin="round" className={className} aria-hidden>
+      <path d="m12 2 3 6.5 7 .9-5 4.9 1.3 7L12 17.8 5.7 21.3 7 14.4 2 9.4l7-.9L12 2z" />
+    </svg>
+  );
+}
+
+type TileDef = { key: string; Icon: (p: IconProps) => React.ReactElement; value: string; label: string };
+
 // Bigger, theme-tinted result card. Spring entrance + staggered stat reveal
 // so the moment feels earned. Theme color drives the title, border accent,
 // and the primary CTA — keeping each mode visually distinct.
@@ -42,16 +117,15 @@ export function BlastLevelCompleteCard({
   const showGems = typeof gemsCollected === 'number' && gemsCollected > 0;
   const showChain = typeof bestChainDepth === 'number' && bestChainDepth > 0;
   const showStars = typeof stars === 'number' && stars > 0;
-  // Stat tiles are rendered as a flex-wrap so 4–6 stats lay out cleanly on
-  // narrow phones without overflowing the card.
-  const tiles: Array<{ icon: string; value: string; label: string; key: string }> = [
-    { icon: '🪙', value: `+${coins}`, label: t('blast.complete.coins', 'Coins'), key: 'coins' },
-    { icon: '⚡', value: String(cascadeCount), label: t('blast.complete.cascadesLabel', 'Cascades'), key: 'cascades' },
+
+  const tiles: TileDef[] = [
+    { key: 'coins', Icon: CoinIcon, value: `+${coins}`, label: t('blast.complete.coins', 'Coins') },
+    { key: 'cascades', Icon: BoltIcon, value: String(cascadeCount), label: t('blast.complete.cascadesLabel', 'Cascades') },
   ];
-  if (showWords) tiles.push({ icon: '📖', value: String(wordsFound), label: t('blast.complete.wordsLabel', 'Words'), key: 'words' });
-  if (showTime) tiles.push({ icon: '⏱️', value: formatTime(timeSeconds!), label: t('blast.complete.timeLabel', 'Time'), key: 'time' });
-  if (showGems) tiles.push({ icon: '💎', value: String(gemsCollected), label: t('blast.complete.gemsLabel', 'Gems'), key: 'gems' });
-  if (showChain) tiles.push({ icon: '🔥', value: `x${bestChainDepth}`, label: t('blast.complete.chainLabel', 'Best Chain'), key: 'chain' });
+  if (showWords) tiles.push({ key: 'words', Icon: BookIcon, value: String(wordsFound), label: t('blast.complete.wordsLabel', 'Words') });
+  if (showTime) tiles.push({ key: 'time', Icon: ClockIcon, value: formatTime(timeSeconds!), label: t('blast.complete.timeLabel', 'Time') });
+  if (showGems) tiles.push({ key: 'gems', Icon: GemIcon, value: String(gemsCollected), label: t('blast.complete.gemsLabel', 'Gems') });
+  if (showChain) tiles.push({ key: 'chain', Icon: FlameIcon, value: `x${bestChainDepth}`, label: t('blast.complete.chainLabel', 'Best Chain') });
 
   return (
     <div
@@ -97,11 +171,19 @@ export function BlastLevelCompleteCard({
             initial={{ scale: 0, rotate: -20 }}
             animate={{ scale: 1, rotate: 0 }}
             transition={{ delay: 0.4, type: 'spring', stiffness: 360 }}
-            className="mt-3 text-2xl tracking-widest"
+            className="mt-3 flex justify-center gap-1.5"
             aria-label={`${stars} stars`}
+            style={{ color: modeColor }}
           >
             {Array.from({ length: 3 }).map((_, i) => (
-              <span key={i} style={{ opacity: i < stars! ? 1 : 0.25 }}>★</span>
+              <span
+                key={i}
+                data-star-index={i}
+                data-star-filled={i < stars!}
+                style={{ opacity: i < stars! ? 1 : 0.28 }}
+              >
+                <StarIcon className="w-7 h-7" filled={i < stars!} />
+              </span>
             ))}
           </m.div>
         )}
@@ -109,7 +191,7 @@ export function BlastLevelCompleteCard({
           initial={{ y: 12, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
           transition={{ delay: 0.5 }}
-          className="mt-6 flex flex-wrap justify-center gap-2"
+          className="mt-6 grid grid-cols-3 gap-2"
         >
           {tiles.map((tile, i) => (
             <m.div
@@ -118,11 +200,22 @@ export function BlastLevelCompleteCard({
               animate={{ scale: 1, opacity: 1 }}
               transition={{ delay: 0.55 + i * 0.06, type: 'spring', stiffness: 380 }}
               data-stat={tile.key}
-              className="rounded-lg p-3 bg-black/30 border border-white/10 min-w-[88px] grow basis-[28%]"
+              className="rounded-xl p-3 flex flex-col items-center"
+              style={{
+                background: `linear-gradient(180deg, color-mix(in srgb, ${modeColor} 14%, #0b1530) 0%, #0b1530 100%)`,
+                border: `1px solid color-mix(in srgb, ${modeColor} 35%, transparent)`,
+                boxShadow: `inset 0 1px 0 rgba(255,255,255,0.08), 2px 2px 0 rgba(0,0,0,0.35)`,
+              }}
             >
-              <div className="text-2xl leading-none">{tile.icon}</div>
-              <div className="text-xl font-bold tabular-nums mt-1">{tile.value}</div>
-              <div className="text-[10px] uppercase tracking-wider opacity-60 mt-1">
+              <div
+                data-stat-icon
+                className="w-7 h-7 flex items-center justify-center"
+                style={{ color: modeColor }}
+              >
+                <tile.Icon className="w-7 h-7" />
+              </div>
+              <div className="text-xl font-bold tabular-nums mt-1.5">{tile.value}</div>
+              <div className="text-[10px] uppercase tracking-wider opacity-65 mt-0.5">
                 {tile.label}
               </div>
             </m.div>

--- a/fe-next/components/blast/v2/BlastTile.module.css
+++ b/fe-next/components/blast/v2/BlastTile.module.css
@@ -44,6 +44,15 @@
     inset 0 -1px 0 rgba(255, 255, 255, 0.025);
 }
 
+/* Column wrapper for live tiles — must hold a fixed width matching the well
+   beneath, otherwise an emptied column collapses to 0px and `justify-center`
+   shifts the remaining columns horizontally mid-fall. That sideways shift
+   is what made tiles read as "falling down AND to the side" during gravity. */
+.tileColumn {
+  width: var(--blast-tile-size, clamp(48px, 18cqi, 88px));
+  flex: 0 0 var(--blast-tile-size, clamp(48px, 18cqi, 88px));
+}
+
 .tile {
   position: relative;
   display: grid;

--- a/fe-next/components/blast/v2/useCollapseTimeline.ts
+++ b/fe-next/components/blast/v2/useCollapseTimeline.ts
@@ -30,20 +30,20 @@ export function useCollapseTimeline(
     const tiles = boardRef.current.querySelectorAll<HTMLElement>('[data-cell-id]');
     const tl = gsap.timeline();
     tiles.forEach((el, i) => {
-      // Vertical-only land thump: deeper squash → stronger overshoot → elastic
-      // settle. scaleX is held at 1.0 throughout — earlier versions warped X
-      // too which read as horizontal drift during gravity. Tiles must stay
-      // locked to their column. Stagger 22ms per tile so cascades feel
-      // sequenced like Royal Match's drop cadence.
-      const startAt = i * 0.022;
+      // Vertical-only land thump — toned down per playtest feedback that the
+      // previous (0.62 squash → 1.14 overshoot → elastic settle) felt over-
+      // animated and "jelly". Softer values keep the impact readable without
+      // the bouncy elastic tail. scaleX held at 1.0 so tiles stay column-
+      // locked. Stagger 18ms per tile keeps the cascade cadence.
+      const startAt = i * 0.018;
       tl.fromTo(
         el,
         { scaleY: 1, scaleX: 1 },
         {
-          scaleY: 0.62,
+          scaleY: 0.86,
           scaleX: 1,
-          duration: 0.1,
-          ease: 'power4.in',
+          duration: 0.08,
+          ease: 'power3.in',
           transformOrigin: 'bottom center',
         },
         startAt,
@@ -51,22 +51,22 @@ export function useCollapseTimeline(
       tl.to(
         el,
         {
-          scaleY: 1.14,
+          scaleY: 1.04,
           scaleX: 1,
-          duration: 0.13,
+          duration: 0.1,
           ease: 'power2.out',
         },
-        startAt + 0.1,
+        startAt + 0.08,
       );
       tl.to(
         el,
         {
           scaleY: 1,
           scaleX: 1,
-          duration: 0.28,
-          ease: 'elastic.out(1.4, 0.45)',
+          duration: 0.18,
+          ease: 'back.out(1.4)',
         },
-        startAt + 0.23,
+        startAt + 0.18,
       );
     });
     return () => {

--- a/fe-next/content/blast/packs/en/pack-chain.json
+++ b/fe-next/content/blast/packs/en/pack-chain.json
@@ -135,6 +135,141 @@
       "columns": 9,
       "decoyTiles": 0,
       "chain": ["JAGUAR", "FALCON", "WALRUS", "BEAVER", "IGUANA"]
+    },
+    {
+      "id": "en-chain-16",
+      "levelNumber": 16,
+      "theme": "ocean",
+      "locale": "en",
+      "columns": 11,
+      "decoyTiles": 0,
+      "chain": ["WAVE", "REEF", "CORAL", "SHARK", "WHALE", "PEARL"]
+    },
+    {
+      "id": "en-chain-17",
+      "levelNumber": 17,
+      "theme": "nature",
+      "locale": "en",
+      "columns": 11,
+      "decoyTiles": 0,
+      "chain": ["TREE", "LEAF", "ROCK", "RIVER", "STONE", "FOREST"]
+    },
+    {
+      "id": "en-chain-18",
+      "levelNumber": 18,
+      "theme": "weather",
+      "locale": "en",
+      "columns": 11,
+      "decoyTiles": 0,
+      "chain": ["RAIN", "WIND", "SNOW", "CLOUD", "STORM", "FROST"]
+    },
+    {
+      "id": "en-chain-19",
+      "levelNumber": 19,
+      "theme": "fruits",
+      "locale": "en",
+      "columns": 11,
+      "decoyTiles": 0,
+      "chain": ["PLUM", "PEAR", "MANGO", "LEMON", "GRAPE", "PEACH"]
+    },
+    {
+      "id": "en-chain-20",
+      "levelNumber": 20,
+      "theme": "food",
+      "locale": "en",
+      "columns": 11,
+      "decoyTiles": 0,
+      "chain": ["RICE", "SOUP", "PASTA", "BREAD", "OLIVE", "BUTTER"]
+    },
+    {
+      "id": "en-chain-21",
+      "levelNumber": 21,
+      "theme": "animals",
+      "locale": "en",
+      "columns": 13,
+      "decoyTiles": 0,
+      "chain": ["WOLF", "BEAR", "LION", "HORSE", "TIGER", "ZEBRA", "RHINO"]
+    },
+    {
+      "id": "en-chain-22",
+      "levelNumber": 22,
+      "theme": "home",
+      "locale": "en",
+      "columns": 13,
+      "decoyTiles": 0,
+      "chain": ["DOOR", "BED", "ROOM", "CHAIR", "TABLE", "HOUSE", "WINDOW"]
+    },
+    {
+      "id": "en-chain-23",
+      "levelNumber": 23,
+      "theme": "school",
+      "locale": "en",
+      "columns": 13,
+      "decoyTiles": 0,
+      "chain": ["PEN", "DESK", "BOOK", "RULER", "PAPER", "CHALK", "PENCIL"]
+    },
+    {
+      "id": "en-chain-24",
+      "levelNumber": 24,
+      "theme": "space",
+      "locale": "en",
+      "columns": 13,
+      "decoyTiles": 0,
+      "chain": ["STAR", "MOON", "COMET", "ORBIT", "PLANET", "GALAXY", "NEBULA"]
+    },
+    {
+      "id": "en-chain-25",
+      "levelNumber": 25,
+      "theme": "transport",
+      "locale": "en",
+      "columns": 13,
+      "decoyTiles": 0,
+      "chain": ["CAR", "BIKE", "TRAIN", "PLANE", "TRUCK", "BOAT", "ROCKET"]
+    },
+    {
+      "id": "en-chain-26",
+      "levelNumber": 26,
+      "theme": "fruits",
+      "locale": "en",
+      "columns": 15,
+      "decoyTiles": 0,
+      "chain": ["FIG", "PEAR", "KIWI", "PLUM", "GRAPE", "MANGO", "LEMON", "ORANGE"]
+    },
+    {
+      "id": "en-chain-27",
+      "levelNumber": 27,
+      "theme": "ocean",
+      "locale": "en",
+      "columns": 15,
+      "decoyTiles": 0,
+      "chain": ["FISH", "REEF", "WAVE", "SHELL", "SHARK", "WHALE", "CORAL", "OCTOPUS"]
+    },
+    {
+      "id": "en-chain-28",
+      "levelNumber": 28,
+      "theme": "mythology",
+      "locale": "en",
+      "columns": 15,
+      "decoyTiles": 0,
+      "chain": ["ELF", "OGRE", "TROLL", "GIANT", "FAIRY", "GNOME", "DRAGON", "WIZARD"]
+    },
+    {
+      "id": "en-chain-29",
+      "levelNumber": 29,
+      "theme": "music",
+      "locale": "en",
+      "columns": 15,
+      "decoyTiles": 0,
+      "chain": ["DRUM", "SONG", "BAND", "FLUTE", "PIANO", "ORGAN", "GUITAR", "VIOLIN"]
+    },
+    {
+      "id": "en-chain-30",
+      "levelNumber": 30,
+      "theme": "science",
+      "locale": "en",
+      "columns": 15,
+      "decoyTiles": 0,
+      "chain": ["ATOM", "CELL", "BONE", "NERVE", "BRAIN", "BLOOD", "ENERGY", "GRAVITY"]
     }
   ]
 }

--- a/fe-next/content/blast/packs/he/pack-chain.json
+++ b/fe-next/content/blast/packs/he/pack-chain.json
@@ -135,6 +135,141 @@
       "columns": 6,
       "decoyTiles": 0,
       "chain": ["קרנפ", "נמר", "פיל", "צבי", "יענ"]
+    },
+    {
+      "id": "he-chain-16",
+      "levelNumber": 16,
+      "theme": "ocean",
+      "locale": "he",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["דג", "גל", "צדפ", "שונית", "כריש", "צלילה"]
+    },
+    {
+      "id": "he-chain-17",
+      "levelNumber": 17,
+      "theme": "nature",
+      "locale": "he",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["עצ", "עלה", "סלע", "נהר", "אגמ", "מערה"]
+    },
+    {
+      "id": "he-chain-18",
+      "levelNumber": 18,
+      "theme": "weather",
+      "locale": "he",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["גשמ", "רוח", "שלג", "עננ", "ברד", "סופה"]
+    },
+    {
+      "id": "he-chain-19",
+      "levelNumber": 19,
+      "theme": "fruits",
+      "locale": "he",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["תפוז", "ענב", "אגס", "מנגו", "בננה", "אפרסק"]
+    },
+    {
+      "id": "he-chain-20",
+      "levelNumber": 20,
+      "theme": "food",
+      "locale": "he",
+      "columns": 8,
+      "decoyTiles": 0,
+      "chain": ["אורז", "סלט", "פסטה", "עוגה", "לחמ", "גבינה"]
+    },
+    {
+      "id": "he-chain-21",
+      "levelNumber": 21,
+      "theme": "animals",
+      "locale": "he",
+      "columns": 10,
+      "decoyTiles": 0,
+      "chain": ["דוב", "זאב", "פיל", "נמר", "סוס", "אריה", "קרנפ"]
+    },
+    {
+      "id": "he-chain-22",
+      "levelNumber": 22,
+      "theme": "home",
+      "locale": "he",
+      "columns": 10,
+      "decoyTiles": 0,
+      "chain": ["דלת", "חדר", "כסא", "מיטה", "שולח", "ארונ", "מטבח"]
+    },
+    {
+      "id": "he-chain-23",
+      "levelNumber": 23,
+      "theme": "school",
+      "locale": "he",
+      "columns": 10,
+      "decoyTiles": 0,
+      "chain": ["ספר", "עט", "כיתה", "מורה", "תיק", "לוח", "תלמיד"]
+    },
+    {
+      "id": "he-chain-24",
+      "levelNumber": 24,
+      "theme": "space",
+      "locale": "he",
+      "columns": 10,
+      "decoyTiles": 0,
+      "chain": ["כוכב", "ירח", "שמש", "רקטה", "מאדימ", "גלקסיה", "מסלול"]
+    },
+    {
+      "id": "he-chain-25",
+      "levelNumber": 25,
+      "theme": "transport",
+      "locale": "he",
+      "columns": 10,
+      "decoyTiles": 0,
+      "chain": ["מכונית", "אופניימ", "רכבת", "מטוס", "סירה", "אוטובוס", "אוניה"]
+    },
+    {
+      "id": "he-chain-26",
+      "levelNumber": 26,
+      "theme": "fruits",
+      "locale": "he",
+      "columns": 12,
+      "decoyTiles": 0,
+      "chain": ["תפוח", "ענב", "אגס", "מנגו", "תפוז", "לימונ", "בננה", "אננס"]
+    },
+    {
+      "id": "he-chain-27",
+      "levelNumber": 27,
+      "theme": "ocean",
+      "locale": "he",
+      "columns": 12,
+      "decoyTiles": 0,
+      "chain": ["דג", "גל", "סרטנ", "צדפ", "כריש", "לוויתנ", "תמנונ", "אלמוג"]
+    },
+    {
+      "id": "he-chain-28",
+      "levelNumber": 28,
+      "theme": "mythology",
+      "locale": "he",
+      "columns": 12,
+      "decoyTiles": 0,
+      "chain": ["ענק", "פרא", "שד", "ננס", "פיה", "טרול", "דרקונ", "קוסמ"]
+    },
+    {
+      "id": "he-chain-29",
+      "levelNumber": 29,
+      "theme": "music",
+      "locale": "he",
+      "columns": 12,
+      "decoyTiles": 0,
+      "chain": ["תופ", "שיר", "להקה", "חליל", "כינור", "גיטרה", "פסנתר", "תזמורת"]
+    },
+    {
+      "id": "he-chain-30",
+      "levelNumber": 30,
+      "theme": "science",
+      "locale": "he",
+      "columns": 12,
+      "decoyTiles": 0,
+      "chain": ["אטומ", "תא", "עצמ", "מוח", "דמ", "גנ", "אנרגיה", "כבידה"]
     }
   ]
 }

--- a/fe-next/lib/blast/v2/__tests__/level-source-registry.test.ts
+++ b/fe-next/lib/blast/v2/__tests__/level-source-registry.test.ts
@@ -18,22 +18,18 @@ describe('level source registry', () => {
     expect(level.words.length).toBeGreaterThan(0);
   });
 
-  it('getLevelSourceForLevel returns chain for en level 1-15', () => {
+  it('getLevelSourceForLevel returns chain for en level 1-30', () => {
     const registry = buildRegistry();
     expect(getLevelSourceForLevel(1, 'en', registry)).toBe(registry.chain);
     expect(getLevelSourceForLevel(15, 'en', registry)).toBe(registry.chain);
+    expect(getLevelSourceForLevel(30, 'en', registry)).toBe(registry.chain);
   });
 
-  it('getLevelSourceForLevel returns chain for he level 1-15', () => {
+  it('getLevelSourceForLevel returns chain for he level 1-30', () => {
     const registry = buildRegistry();
     expect(getLevelSourceForLevel(1, 'he', registry)).toBe(registry.chain);
     expect(getLevelSourceForLevel(15, 'he', registry)).toBe(registry.chain);
-  });
-
-  it('getLevelSourceForLevel returns curated for en level 16-30', () => {
-    const registry = buildRegistry();
-    expect(getLevelSourceForLevel(16, 'en', registry)).toBe(registry.curated);
-    expect(getLevelSourceForLevel(30, 'en', registry)).toBe(registry.curated);
+    expect(getLevelSourceForLevel(30, 'he', registry)).toBe(registry.chain);
   });
 
   it('getLevelSourceForLevel returns generated for en level 31+', () => {

--- a/fe-next/lib/blast/v2/__tests__/pack-chain-en.test.ts
+++ b/fe-next/lib/blast/v2/__tests__/pack-chain-en.test.ts
@@ -9,10 +9,23 @@ const pack = JSON.parse(
   readFileSync(resolve(process.cwd(), 'content/blast/packs/en/pack-chain.json'), 'utf8'),
 ) as { locale: string; levels: ChainLevelSpec[] };
 
+// Difficulty curve — each 5-level tier bumps the chain length so progression
+// stays readable. Tiers 1–3 (3/4/5-word chains) are the original onboarding
+// arc; tiers 4–6 (6/7/8-word chains) extend the curated content from 15 → 30
+// levels before the generator takes over.
+function expectedChainLength(n: number): number {
+  if (n <= 5) return 3;
+  if (n <= 10) return 4;
+  if (n <= 15) return 5;
+  if (n <= 20) return 6;
+  if (n <= 25) return 7;
+  return 8;
+}
+
 describe('en pack-chain.json', () => {
-  it('has exactly 15 levels numbered 1..15', () => {
+  it('has exactly 30 levels numbered 1..30', () => {
     expect(pack.levels.map((l) => l.levelNumber)).toEqual(
-      Array.from({ length: 15 }, (_, i) => i + 1),
+      Array.from({ length: 30 }, (_, i) => i + 1),
     );
   });
 
@@ -27,9 +40,7 @@ describe('en pack-chain.json', () => {
 
   it('respects the difficulty curve (chain length grows by tier)', () => {
     for (const spec of pack.levels) {
-      const n = spec.levelNumber;
-      const expected = n <= 5 ? 3 : n <= 10 ? 4 : 5;
-      expect(spec.chain.length, `${spec.id}`).toBe(expected);
+      expect(spec.chain.length, `${spec.id}`).toBe(expectedChainLength(spec.levelNumber));
     }
   });
 

--- a/fe-next/lib/blast/v2/__tests__/pack-chain-he.test.ts
+++ b/fe-next/lib/blast/v2/__tests__/pack-chain-he.test.ts
@@ -9,10 +9,20 @@ const pack = JSON.parse(
   readFileSync(resolve(process.cwd(), 'content/blast/packs/he/pack-chain.json'), 'utf8'),
 ) as { locale: string; levels: ChainLevelSpec[] };
 
+// Mirror the en curve: tiers 4–6 extend the curated content to level 30.
+function expectedChainLength(n: number): number {
+  if (n <= 5) return 3;
+  if (n <= 10) return 4;
+  if (n <= 15) return 5;
+  if (n <= 20) return 6;
+  if (n <= 25) return 7;
+  return 8;
+}
+
 describe('he pack-chain.json', () => {
-  it('has exactly 15 levels numbered 1..15', () => {
+  it('has exactly 30 levels numbered 1..30', () => {
     expect(pack.levels.map((l) => l.levelNumber)).toEqual(
-      Array.from({ length: 15 }, (_, i) => i + 1),
+      Array.from({ length: 30 }, (_, i) => i + 1),
     );
   });
 
@@ -27,9 +37,7 @@ describe('he pack-chain.json', () => {
 
   it('respects the difficulty curve (chain length grows by tier)', () => {
     for (const spec of pack.levels) {
-      const n = spec.levelNumber;
-      const expected = n <= 5 ? 3 : n <= 10 ? 4 : 5;
-      expect(spec.chain.length, `${spec.id}`).toBe(expected);
+      expect(spec.chain.length, `${spec.id}`).toBe(expectedChainLength(spec.levelNumber));
     }
   });
 

--- a/fe-next/lib/blast/v2/level-source-registry.ts
+++ b/fe-next/lib/blast/v2/level-source-registry.ts
@@ -7,7 +7,7 @@ import type { Locale } from './types';
 import { resolve } from 'node:path';
 
 const CHAIN_LOCALES: Locale[] = ['en', 'he'];
-const CHAIN_MAX_LEVEL = 15;
+const CHAIN_MAX_LEVEL = 30;
 
 let cached: LevelSourceRegistry | null = null;
 


### PR DESCRIPTION
## Summary

Five fixes to Blast Mode v2 based on playtest feedback:

- **More levels** — pack-chain extended from 15 → 30 for en + he. Adds three new difficulty tiers (6/7/8-word chains at L16–20 / 21–25 / 26–30) before the procedural generator takes over. `CHAIN_MAX_LEVEL` bumped to 30 and tests updated to assert the new curve.
- **Softer gravity** — `useCollapseTimeline` reduced: squash 0.62 → 0.86, overshoot 1.14 → 1.04, `elastic.out(1.4, 0.45)` → `back.out(1.4)`. The bouncy "jelly" tail is gone; the impact still reads.
- **Shockwave-wrap FX on word found** — new chromatic 3-ring shockwave (cyan / yellow / magenta, ~50ms stagger, ease-out cubic) added to `BlastFxOverlay`. Fires once per word (on the first cleared cell) alongside the existing pulse ring. Respects `prefers-reduced-motion` and the 12-ring pool cap.
- **Result card polish** — `BlastLevelCompleteCard` now uses inline SVG icons (coin, bolt, book, clock, gem, flame, star) instead of emoji. Stat tiles get a gradient background tinted by `modeColor`, 3-column grid layout, mode-color accents throughout.
- **Sideways-fall fix** — emptied tile columns used to collapse to 0 px, which then let `justify-center` shift the remaining columns horizontally during gravity, making tiles read as falling diagonally. Each column wrapper is now pinned to `--blast-tile-size`, so the board width stays stable through clears.

## Test plan

- [x] `vitest` lib/blast/v2 — 60 files / 396 tests pass
- [x] `vitest` components/blast/v2 — 19 files / 87 tests pass
- [x] Updated assertions in `pack-chain-en.test.ts`, `pack-chain-he.test.ts`, `level-source-registry.test.ts`
- [x] `tsc --noEmit` clean
- [ ] Manual: play L16+ end-to-end, watch the shockwave on each word, verify columns hold their position through a multi-clear cascade, check the result card on phones with 2–6 stat tiles

https://claude.ai/code/session_01LMLsymydsbzxNcaS9xeApo

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMLsymydsbzxNcaS9xeApo)_