### PR TITLE
SEO: daily meta tag improvements (2026-05-16)

### DIFF
--- a/docs/seo-daily/2026-05-16.md
+++ b/docs/seo-daily/2026-05-16.md
@@ -1,0 +1,132 @@
+# SEO Daily Report — 2026-05-16
+
+**Data range:** 2026-04-17 → 2026-05-14 (28 days, GSC 2-day lag)
+**Bing:** API returned empty response — likely regional network block. Section skipped.
+
+---
+
+## Headline Metrics
+
+### Google (28d)
+| Metric | Value |
+|---|---|
+| Total Clicks | 49 |
+| Total Impressions | 1,652 |
+| Avg CTR | 2.97% |
+| Avg Position | 11.3 |
+
+### Google 7d vs Prior 7d
+| Metric | Last 7d | Prior 7d | Delta |
+|---|---|---|---|
+| Clicks | 15 | 25 | -10 (-40.0%) |
+| Impressions | 313 | 1,058 | -745 (-70.4%) |
+
+> **Warning:** Impressions dropped 70% week-over-week. Likely a GSC data lag artifact (prior-7d window ended 2026-05-07, data may be incomplete near the 2-day lag boundary). Monitor next 48h before treating as a ranking drop.
+
+---
+
+## CTR Opportunities (Google) — Underperforming by ≥30% vs Expected CTR
+
+| # | Query | Page | Pos | Impr | Actual CTR | Expected CTR | Gap | Suggested Fix |
+|---|---|---|---|---|---|---|---|---|
+| 1 | scrabble online español | /es/juego-de-palabras-multijugador | 8.7 | 167 | 0.0% | 2.0% | +2.0pp | **FIXED** — title rewrite (see PR) |
+| 2 | scrabble online svenska | /sv/swedish-multiplayer-word-game | 9.3 | 137 | 0.0% | 1.5% | +1.5pp | **FIXED** — title rewrite (see PR) |
+| 3 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.4 | 102 | 0.0% | 2.0% | +2.0pp | Inherits ES page title fix |
+| 4 | jugar scrabble gratis | /es/juego-de-palabras-multijugador | 9.2 | 68 | 0.0% | 1.5% | +1.5pp | Inherits ES page title fix |
+| 5 | scrabble en linea | /es/juego-de-palabras-multijugador | 9.4 | 67 | 0.0% | 1.5% | +1.5pp | Inherits ES page title fix |
+| 6 | scrabble svenska online | /sv/swedish-multiplayer-word-game | 5.9 | 59 | 0.0% | 4.0% | +4.0pp | Inherits SV page title fix |
+| 7 | scrabble en español online | /es/juego-de-palabras-multijugador | 8.1 | 58 | 0.0% | 2.0% | +2.0pp | Inherits ES page title fix |
+| 8 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 7.3 | 54 | 0.0% | 2.5% | +2.5pp | Inherits ES page title fix |
+| 9 | scrabble online gratis | /es/juego-de-palabras-multijugador | 9.0 | 45 | 0.0% | 1.5% | +1.5pp | Add "gratis" earlier in title/desc |
+| 10 | scrabble español online | /es/juego-de-palabras-multijugador | 9.1 | 43 | 0.0% | 1.5% | +1.5pp | Inherits ES page title fix |
+
+> Note: GSC query-level clicks round to 0 for sub-1 click counts. Page-level CTR for /es/ is 1.13% (12 clicks / 1,066 impr), confirming some traffic exists. CTR opportunity is real but smaller in absolute terms.
+
+---
+
+## Rank-Up Opportunities (pos 8–20, impr ≥ 50)
+
+| # | Query | Page | Pos | Impr | Clicks | Suggested Action |
+|---|---|---|---|---|---|---|
+| 1 | scrabble online español | /es/juego-de-palabras-multijugador | 8.7 | 167 | 0 | Add "scrabble online español" as H2; expand FAQ with direct Q: "¿Cómo jugar Scrabble online en español gratis?" |
+| 2 | scrabble online svenska | /sv/swedish-multiplayer-word-game | 9.3 | 137 | 0 | Add internal links from blog posts to SV page; add Swedish-language H2 with "scrabble online svenska" phrase |
+| 3 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.4 | 102 | 0 | Expand body content with "Cómo jugar Scrabble online" section (HowTo schema already present, strengthen it) |
+| 4 | jugar scrabble gratis | /es/juego-de-palabras-multijugador | 9.2 | 68 | 0 | Add "gratis" more prominently in hero H2/subheading |
+| 5 | scrabble en linea | /es/juego-de-palabras-multijugador | 9.4 | 67 | 0 | Include exact phrase "scrabble en línea" in a paragraph or FAQ answer |
+| 6 | scrabble en español online | /es/juego-de-palabras-multijugador | 8.1 | 58 | 0 | Already covered by ES page fix |
+
+---
+
+## Bing Parity Gaps
+
+**Bing API returned empty (network issue in execution environment). Cannot assess Bing performance.**
+Recommended action: Run `curl "https://ssl.bing.com/webmaster/api.svc/json/GetQueryStats?siteUrl=https://lexiclash.live/&apikey=c13df4f2164643cabd986b652269b1c5"` from a non-restricted network.
+
+---
+
+## Rising / Falling Queries (Last 7d vs Prior 7d)
+
+### Rising (>30% impression increase)
+| Query | Prior 7d | Last 7d | Delta | Page | Action |
+|---|---|---|---|---|---|
+| scrabble svenska online | 7 | 51 | +629% | /sv/swedish-multiplayer-word-game | Capitalize — SV page fix shipped today |
+| best free browser word games 2025 2026 | 5 | 18 | +260% | /en/best-online-word-games | Title shortened today to match query |
+| most popular online word games 2025 2026 | 8 | 25 | +212% | /en/best-online-word-games | Already on this page; add H2 with this phrase |
+| best free browser word games 2026 | 7 | 19 | +171% | /en/best-online-word-games | Title fix today targets this exactly |
+| scrabble online svenska | 39 | 73 | +87% | /sv/swedish-multiplayer-word-game | SV page fix shipped today |
+
+### Falling (>30% impression drop)
+| Query | Prior 7d | Last 7d | Delta | Notes |
+|---|---|---|---|---|
+| juego de palabras netflix | 31 | 1 | -97% | Blog post /es/blog/netflix-word-game-2026-rise may be losing freshness |
+| juego palabras netflix | 15 | 2 | -87% | Same post — update publish date or add 2026 update section |
+| juegos de palabras online multijugador | 5 | 3 | -40% | Small absolute numbers; monitor |
+
+---
+
+## GEO / AI Visibility Recommendations
+
+These queries look like question-intent or comparison searches that AI overviews and LLM citation sources (Perplexity, ChatGPT) prefer as structured FAQ content:
+
+| Query | Current Schema | Gap | Draft Q&A for FAQPage |
+|---|---|---|---|
+| most popular online word games 2025 2026 | ItemList + Article on /en/best-online-word-games | Needs explicit FAQ Q&A block | **Q:** What are the most popular online word games in 2025–2026? **A:** The top online word games in 2025–2026 are LexiClash, Wordle, NYT Connections, NYT Strands, NYT Spelling Bee, Words With Friends, Scrabble GO, Wordscapes, and Semantle. LexiClash is the only one with real-time multiplayer and zero install required. |
+| best free browser word games 2026 | FAQPage on /en/best-online-word-games | Already has FAQ — confirm exact phrase appears in an answer | **Q:** What are the best free browser word games in 2026? **A:** The best free browser word games in 2026 with no download or install are LexiClash (real-time multiplayer, 8 modes), Wordle (daily puzzle), NYT Connections, and Semantle. All run in any browser. |
+| juego de palabras netflix | Blog post — no FAQ schema | Add FAQPage schema to /es/blog/netflix-word-game-2026-rise | **Q:** ¿Hay un juego de palabras en Netflix? **A:** Netflix lanzó "Trivia Quest" pero no tiene un juego de palabras tipo Scrabble. LexiClash es la alternativa más popular que funciona en TV mediante Chromecast con el teléfono como mando. |
+| scrabble en linea | FAQPage on /es/ page | Confirm FAQ answer uses exact phrase "scrabble en línea" | **Q:** ¿Cómo jugar Scrabble en línea gratis? **A:** Con LexiClash puedes jugar Scrabble en línea gratis y sin registro: crea una sala, comparte el enlace con amigos y empieza en segundos. |
+
+---
+
+## Meta Tag Changes (PR #seo/daily-2026-05-16)
+
+### Fix 1 — /es/juego-de-palabras-multijugador
+| | Before | After |
+|---|---|---|
+| Title | Scrabble Online en Español Gratis — Sin Registro \| LexiClash (60 chars) | Scrabble en Español Online Gratis \| Multijugador — LexiClash (60 chars) |
+| Description | Juega scrabble online en español gratis, sin registro ni descarga. Crea sala, invita amigos por enlace y compite en tiempo real. ¡Empieza en segundos! (150 chars) | Juega scrabble online en español gratis y sin registro. Crea una sala, comparte el enlace y compite en tiempo real — 10,000+ palabras, gratis siempre. (150 chars) |
+| Rationale | "Multijugador" added as the clearest product differentiator; word order puts "en Español" earlier (closer to the query phrase); description adds "10,000+ palabras" trust signal | |
+| Expected impact | Covers 7 queries (167+102+68+67+58+54+43 = 559 impressions). At 1% CTR uplift → +5–6 clicks/month | |
+
+### Fix 2 — /sv/swedish-multiplayer-word-game
+| | Before | After |
+|---|---|---|
+| Title | Scrabble Online Svenska Gratis — Spela Multiplayer \| LexiClash (62 chars — OVER limit) | Scrabble Online Svenska Gratis \| Utan Konto — LexiClash (55 chars) |
+| Description | Spela scrabble online på svenska gratis, utan registrering. Skapa rum, bjud in med länk och tävla i realtid med vänner. 10 000+ ord. Börja nu! (142 chars) | Spela Scrabble online på svenska gratis utan konto. Skapa ett rum, bjud in vänner med länk och tävla i realtid. 10 000+ ord. Starta nu! (136 chars) |
+| Rationale | Title was 2 chars over the 60-char display limit (risk of truncation). "Utan Konto" (no account) is more casual/compelling than "Spela Multiplayer". "Starta nu" > "Börja nu" as CTA. | |
+| Expected impact | Covers "scrabble online svenska" (137 impr) + "scrabble svenska online" (59 impr, +629% rising). At 1% CTR uplift → +2 clicks/month, growing fast. | |
+
+### Fix 3 — /en/best-online-word-games
+| | Before | After |
+|---|---|---|
+| Title | Best Free Browser Word Games 2026 — 9 Honest Picks (No Download) (65 chars — OVER limit) | Best Free Browser Word Games 2026 — 9 Honest Picks (51 chars) |
+| Description | Best free browser word games of 2026 — honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, Semantle, LexiClash. Pros, cons & which to pick in 2 minutes. (179 chars — OVER limit) | Honestly ranked: Wordle, NYT Connections, Strands, LexiClash & 5 more. Free, no download, no install. Find the right word game in 2 minutes. (141 chars) |
+| Rationale | Title was 5 chars over limit — Google truncates with "...". Description was 24 chars over 155-char limit. Trimmed both; rising query "best free browser word games 2026" now exactly matches title. | |
+| Expected impact | Page has 658 impressions at 0.46% CTR. Fixing truncation + tightening desc could push CTR to 0.8–1.0% → +2–4 clicks/month on this page alone. | |
+
+---
+
+## Today's Actions
+
+- **Shipped:** Title + description fix for 3 pages via PR `seo/daily-2026-05-16`. Covers ~900 impressions across 10 CTR-opportunity queries.
+- **Monitor:** 70% impression drop in last-7d window — verify in 48h once GSC data settles. If real, investigate index coverage or manual action.
+- **Next priority:** Add "scrabble en línea" and "jugar scrabble gratis" as explicit H2 phrases on /es/ page; update /es/blog/netflix-word-game-2026-rise with fresh 2026 content to recover falling impressions (-97%).

--- a/fe-next/app/[locale]/best-online-word-games/page.tsx
+++ b/fe-next/app/[locale]/best-online-word-games/page.tsx
@@ -15,8 +15,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const canonicalUrl = `${BASE_URL}/en/best-online-word-games`;
 
   return {
-    title: 'Best Free Browser Word Games 2026 — 9 Honest Picks (No Download)',
-    description: 'Best free browser word games of 2026 — honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, Semantle, LexiClash. Pros, cons & which to pick in 2 minutes.',
+    title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',
+    description: 'Honestly ranked: Wordle, NYT Connections, Strands, LexiClash & 5 more. Free, no download, no install. Find the right word game in 2 minutes.',
     keywords: 'best free browser word games 2026, best word games 2026, best online word games 2025 2026, most popular online word games 2025 2026, free word games online, nyt connections, nyt strands, spelling bee game, semantle, wordle alternatives, multiplayer word games, word games with friends, word puzzle games online, word games no download, connections game',
     openGraph: {
       title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -24,11 +24,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
-    description: 'Juega scrabble online en español gratis, sin registro ni descarga. Crea sala, invita amigos por enlace y compite en tiempo real. ¡Empieza en segundos!',
+    title: 'Scrabble en Español Online Gratis | Multijugador — LexiClash',
+    description: 'Juega scrabble online en español gratis y sin registro. Crea una sala, comparte el enlace y compite en tiempo real — 10,000+ palabras, gratis siempre.',
     keywords: 'cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
+      title: 'Scrabble en Español Online Gratis | Multijugador — LexiClash',
       description: 'Juega scrabble online en español con amigos en tiempo real. Crea sala, invita por enlace. 100% gratis, sin descargas.',
       locale: 'es_ES',
       type: 'website',
@@ -44,7 +44,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
+      title: 'Scrabble en Español Online Gratis | Multijugador — LexiClash',
       description: 'Juega scrabble online en español con amigos. Sala con enlace, tiempo real, sin registro. ¡100% gratis!',
       images: [`${BASE_URL}/og-image-es.webp`],
     },

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -15,11 +15,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
-    description: 'Spela scrabble online på svenska gratis, utan registrering. Skapa rum, bjud in med länk och tävla i realtid med vänner. 10 000+ ord. Börja nu!',
+    title: 'Scrabble Online Svenska Gratis | Utan Konto — LexiClash',
+    description: 'Spela Scrabble online på svenska gratis utan konto. Skapa ett rum, bjud in vänner med länk och tävla i realtid. 10 000+ ord. Starta nu!',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid',
     openGraph: {
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis | Utan Konto — LexiClash',
       description: 'Spela scrabble online på svenska med vänner i realtid. Skapa rum, bjud in med länk. Gratis, ingen registrering.',
       locale: 'sv_SE',
       type: 'website',
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis | Utan Konto — LexiClash',
       description: 'Spela scrabble online på svenska: skapa rum, bjud in med länk, tävla i realtid. Gratis, ingen registrering.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },


### PR DESCRIPTION
## SEO Daily Meta Tag Improvements — 2026-05-16

Fixes 3 pages identified from 28-day GSC data (2026-04-17 → 2026-05-14). All changes are title/description only — no body content rewrite.

---

### Fix 1 — `/es/juego-de-palabras-multijugador`
**Queries covered:** scrabble online español (167 impr), jugar scrabble online (102), jugar scrabble gratis (68), scrabble en linea (67), scrabble en español online (58), jugar scrabble en español gratis (54), scrabble español online (43) — **~559 total impressions, all at 0% click-through**

| | Before | After |
|---|---|---|
| **Title** | `Scrabble Online en Español Gratis — Sin Registro \| LexiClash` (60 chars) | `Scrabble en Español Online Gratis \| Multijugador — LexiClash` (60 chars) |
| **Description** | `Juega scrabble online en español gratis, sin registro ni descarga. Crea sala, invita amigos por enlace y compite en tiempo real. ¡Empieza en segundos!` (150 chars) | `Juega scrabble online en español gratis y sin registro. Crea una sala, comparte el enlace y compite en tiempo real — 10,000+ palabras, gratis siempre.` (150 chars) |

**Why:** "Multijugador" is the clearest product differentiator; "en Español" moved earlier to match dominant query phrase; "10,000+ palabras" adds a trust signal competitors lack.
**Expected CTR uplift:** ~5–6 additional clicks/month across 7 queries.

---

### Fix 2 — `/sv/swedish-multiplayer-word-game`
**Queries covered:** scrabble online svenska (137 impr, +87% rising), scrabble svenska online (59 impr, **+629% rising**)

| | Before | After |
|---|---|---|
| **Title** | `Scrabble Online Svenska Gratis — Spela Multiplayer \| LexiClash` **(62 chars — over 60-char limit)** | `Scrabble Online Svenska Gratis \| Utan Konto — LexiClash` (55 chars) |
| **Description** | `Spela scrabble online på svenska gratis, utan registrering. Skapa rum, bjud in med länk och tävla i realtid med vänner. 10 000+ ord. Börja nu!` (142 chars) | `Spela Scrabble online på svenska gratis utan konto. Skapa ett rum, bjud in vänner med länk och tävla i realtid. 10 000+ ord. Starta nu!` (136 chars) |

**Why:** Title was 2 chars over limit (Google truncates with "..."). "Utan Konto" is more conversational than "Spela Multiplayer". Both SV queries are surging this week.
**Expected CTR uplift:** ~2 additional clicks/month, growing.

---

### Fix 3 — `/en/best-online-word-games`
**Queries covered:** best free browser word games 2026 (+171% rising), most popular online word games 2025 2026 (+212% rising) — page has **658 impressions at only 0.46% CTR**

| | Before | After |
|---|---|---|
| **Title** | `Best Free Browser Word Games 2026 — 9 Honest Picks (No Download)` **(65 chars — over 60-char limit)** | `Best Free Browser Word Games 2026 — 9 Honest Picks` (51 chars) |
| **Description** | `Best free browser word games of 2026 — honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, Semantle, LexiClash. Pros, cons & which to pick in 2 minutes.` **(179 chars — over 155-char limit)** | `Honestly ranked: Wordle, NYT Connections, Strands, LexiClash & 5 more. Free, no download, no install. Find the right word game in 2 minutes.` (141 chars) |

**Why:** Both fields were over recommended limits — Google was likely truncating both. Trimmed title exactly matches top rising query.
**Expected CTR uplift:** 0.46% → ~0.8–1.0% → +2–4 clicks/month.

---

## Total Expected Impact
~9–12 additional clicks/month. Full analysis: `docs/seo-daily/2026-05-16.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_019p52jpAqyCTux8hvT2H7AY)_