### PR TITLE
perf(mp,results): kill SP energy bg in MP gameplay + fix Android safe-area + enrich results parallax

### DIFF
--- a/fe-next/app/animations.css
+++ b/fe-next/app/animations.css
@@ -825,6 +825,14 @@
   --combined-safe-area-bottom: calc(max(var(--safe-area-bottom), var(--cap-safe-area-bottom)) + var(--admob-banner-height));
   --combined-safe-area-left: max(var(--safe-area-left), var(--cap-safe-area-left));
   --combined-safe-area-right: max(var(--safe-area-right), var(--cap-safe-area-right));
+
+  /* Safe area without the admob clearance — for elements that already
+     position above the admob banner via `bottom: var(--admob-banner-height)`.
+     Using --combined-safe-area-bottom for their inner padding would
+     double-count the banner. Critical for Android Capacitor where
+     env(safe-area-inset-bottom) reads 0 inside the WebView and the
+     real bottom inset only lives on --cap-safe-area-bottom. */
+  --safe-area-bottom-raw: max(var(--safe-area-bottom), var(--cap-safe-area-bottom));
 }
 
 /* Safe area utility classes */
@@ -834,6 +842,14 @@
 
 .safe-area-bottom {
   padding-bottom: var(--combined-safe-area-bottom);
+}
+
+/* Same as `.safe-area-bottom` but excludes the admob banner clearance — for
+   fixed elements that already use `bottom: var(--admob-banner-height)`. Uses
+   the Capacitor-aware --safe-area-bottom-raw so Android (where env() is 0
+   inside the WebView) still respects the gesture-nav inset. */
+.safe-area-pb {
+  padding-bottom: var(--safe-area-bottom-raw);
 }
 
 .safe-area-left {

--- a/fe-next/components/game/in-game/components/PortraitLayout.tsx
+++ b/fe-next/components/game/in-game/components/PortraitLayout.tsx
@@ -36,7 +36,6 @@ import { BlastMultiplayerOverlay } from '../../BlastMultiplayerOverlay';
 import { WordHuntTargetArea } from '../../WordHuntTargetArea';
 import { WordHuntLifeBar } from '../../WordHuntLifeBar';
 import { WordHuntPlayerLives } from '../../WordHuntPlayerLives';
-import { DynamicEnergyBackground } from '@/components/singleplayer/game/components/DynamicEnergyBackground';
 import { ComboMilestoneAnnouncement } from '../../ComboMilestoneAnnouncement';
 import { ScreenFlashOverlay } from '../../ScreenFlashOverlay';
 import { useHapticsEnabled, useShouldReduceMotion } from '@/contexts/AccessibilityContext';
@@ -320,8 +319,11 @@ export const PortraitLayout = memo<PortraitLayoutProps>(function PortraitLayout(
 
   return (
     <>
-      {/* Dynamic Energy Background - animated vortex, aurora, particles */}
-      <DynamicEnergyBackground />
+      {/* Note: SP's DynamicEnergyBackground intentionally not rendered here.
+          MP gameplay needs every GPU/CPU cycle for grid drag selection; the
+          200%×200% rotating vortex + aurora + scanline + 4 particle layers
+          continuously composited during a drag was the dominant stutter
+          source on mid/low-end Android. */}
 
       {/* Countdown tension: screen border glow at ≤20s.
           WCAG 2.3.3 — pulsing is suppressed under prefers-reduced-motion; color still conveys urgency. */}

--- a/fe-next/components/results/ResultsScrollEffects.tsx
+++ b/fe-next/components/results/ResultsScrollEffects.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import React, { useRef, type ReactNode } from 'react';
-import { m, useScroll, useTransform, useSpring, useReducedMotion, type MotionStyle } from 'framer-motion';
+import {
+  m,
+  useScroll,
+  useTransform,
+  useSpring,
+  useVelocity,
+  useReducedMotion,
+  type MotionStyle,
+} from 'framer-motion';
 
 interface ParallaxBackdropProps {
   /** Scroll container ref. Required — the page uses an inner scrollable, not window. */
@@ -11,12 +19,15 @@ interface ParallaxBackdropProps {
 }
 
 /**
- * Subtle dual-layer parallax backdrop pinned behind the results content.
+ * Multi-layer parallax backdrop pinned behind the results content.
  *
  * Sits absolutely inside the page chrome and tracks the inner scroll container
  * (the MP results layout uses overflow-y inside; window scroll wouldn't catch
- * anything). Two layers drift at different rates so depth reads without
- * overwhelming the foreground. Disabled when reduced-motion is requested.
+ * anything). Three layers drift at different rates so depth reads cleanly:
+ *   - Back: slowest, cyan aura
+ *   - Mid:  hue-shifting magenta+lime nebula, gently scales with depth
+ *   - Front: scroll-velocity-driven highlight, springs into view on fast flicks
+ * Disabled when reduced-motion is requested.
  */
 export const ResultsParallaxBackdrop: React.FC<ParallaxBackdropProps> = ({
   scrollRef,
@@ -25,10 +36,22 @@ export const ResultsParallaxBackdrop: React.FC<ParallaxBackdropProps> = ({
   const reducedMotion = useReducedMotion();
   const { scrollY } = useScroll({ container: scrollRef as React.RefObject<HTMLElement> });
 
-  // Back layer drifts slowly; front layer drifts faster + slight opposite hue.
+  // Back layer drifts slowly; mid layer drifts faster + slight opposite hue.
   const backY = useTransform(scrollY, [0, 600], [0, -intensity * 0.5]);
-  const frontY = useTransform(scrollY, [0, 600], [0, -intensity]);
+  const midY = useTransform(scrollY, [0, 600], [0, -intensity]);
   const auraScale = useTransform(scrollY, [0, 400], [1, 1.08]);
+
+  // Hue rotation on the mid layer — gives the page a subtle dynamic color
+  // shift as the player scrolls without breaking the neo palette.
+  const hueShift = useTransform(scrollY, [0, 800], [0, 18]);
+  const midFilter = useTransform(hueShift, (h) => `hue-rotate(${h}deg)`);
+
+  // Velocity-driven highlight layer — flickers in on fast scroll flicks,
+  // settles out on rest. Spring-smoothed so it never strobes.
+  const velocity = useVelocity(scrollY);
+  const smoothedVelocity = useSpring(velocity, { stiffness: 100, damping: 30, mass: 0.4 });
+  const velocityOpacity = useTransform(smoothedVelocity, [-2000, 0, 2000], [0.18, 0, 0.18]);
+  const velocityY = useTransform(smoothedVelocity, [-2000, 0, 2000], [40, 0, -40]);
 
   if (reducedMotion) return null;
 
@@ -37,17 +60,25 @@ export const ResultsParallaxBackdrop: React.FC<ParallaxBackdropProps> = ({
     background:
       'radial-gradient(circle at 50% 30%, rgba(0,255,255,0.10) 0%, transparent 55%)',
   };
-  const frontStyle: MotionStyle = {
-    y: frontY,
+  const midStyle: MotionStyle = {
+    y: midY,
     scale: auraScale,
+    filter: midFilter,
     background:
       'radial-gradient(circle at 30% 60%, rgba(255,20,147,0.08) 0%, transparent 50%), radial-gradient(circle at 80% 40%, rgba(191,255,0,0.06) 0%, transparent 50%)',
+  };
+  const velocityStyle: MotionStyle = {
+    y: velocityY,
+    opacity: velocityOpacity,
+    background:
+      'radial-gradient(ellipse at 50% 50%, rgba(255,255,255,0.10) 0%, transparent 60%)',
   };
 
   return (
     <div className="absolute inset-0 pointer-events-none overflow-hidden z-0" aria-hidden="true">
       <m.div className="absolute inset-0" style={backStyle} />
-      <m.div className="absolute inset-0" style={frontStyle} />
+      <m.div className="absolute inset-0" style={midStyle} />
+      <m.div className="absolute inset-0" style={velocityStyle} />
     </div>
   );
 };
@@ -98,6 +129,51 @@ export const ResultsSectionReveal: React.FC<SectionRevealProps> = ({
       viewport={{ once: true, amount: 0.2, margin: '0px 0px -10% 0px' }}
       transition={{ type: 'spring', stiffness: 140, damping: 22, mass: 0.6 }}
       style={flat ? undefined : { y }}
+    >
+      {children}
+    </m.div>
+  );
+};
+
+interface HeroTiltProps {
+  children: ReactNode;
+  /** Scroll container ref — same one fed to ResultsParallaxBackdrop. */
+  scrollRef: React.RefObject<HTMLElement | null>;
+  className?: string;
+}
+
+/**
+ * Gentle 3D tilt + lift applied to the cinematic hero block as the user
+ * scrolls down. Translates a tiny amount upward, scales down 4%, and rotates
+ * 6° on X — giving the top section a "leaning back" feel as new content
+ * scrolls in below. No-ops under reduced-motion.
+ */
+export const ResultsHeroTilt: React.FC<HeroTiltProps> = ({
+  children,
+  scrollRef,
+  className,
+}) => {
+  const reducedMotion = useReducedMotion();
+  const { scrollY } = useScroll({ container: scrollRef as React.RefObject<HTMLElement> });
+  const rotateX = useTransform(scrollY, [0, 400], [0, 6]);
+  const scale = useTransform(scrollY, [0, 400], [1, 0.96]);
+  const opacity = useTransform(scrollY, [0, 200, 500], [1, 1, 0.85]);
+
+  if (reducedMotion) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <m.div
+      className={className}
+      style={{
+        rotateX,
+        scale,
+        opacity,
+        transformPerspective: 1000,
+        transformOrigin: 'top center',
+        willChange: 'transform',
+      }}
     >
       {children}
     </m.div>

--- a/fe-next/components/results/StickyReadyBar.tsx
+++ b/fe-next/components/results/StickyReadyBar.tsx
@@ -336,7 +336,7 @@ export default function StickyReadyBar({
     const btnBase = 'w-full h-14 border-3 border-black rounded-xl shadow-hard font-black text-base uppercase tracking-tight flex items-center justify-center gap-3';
 
     return (
-      <div className="flex flex-col gap-2 flex-1 min-w-0 pb-[env(safe-area-inset-bottom)]">
+      <div className="flex flex-col gap-2 flex-1 min-w-0">
         {/* Series Winner Banner */}
         <m.div
           initial={{ scale: 0.9, opacity: 0 }}

--- a/fe-next/components/results/__tests__/ResultsHeroTilt.test.tsx
+++ b/fe-next/components/results/__tests__/ResultsHeroTilt.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * ResultsHeroTilt — the cinematic hero block recedes into 3D as the user
+ * scrolls. Reduced-motion users must get a plain wrapper (no transforms).
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React, { useRef } from 'react';
+import { ResultsHeroTilt } from '../ResultsScrollEffects';
+
+vi.mock('framer-motion', () => ({
+  m: {
+    div: ({ children, style, className, ...props }: React.PropsWithChildren<{ style?: React.CSSProperties; className?: string } & Record<string, unknown>>) => (
+      <div data-testid="hero-tilt" className={className} style={style as React.CSSProperties} {...props}>{children}</div>
+    ),
+  },
+  useScroll: () => ({ scrollY: 0 }),
+  useTransform: () => 0,
+  useSpring: (v: unknown) => v,
+  useVelocity: () => 0,
+  useReducedMotion: vi.fn(() => false),
+}));
+
+import { useReducedMotion } from 'framer-motion';
+
+function Harness({ className }: { className?: string }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  return (
+    <div ref={ref}>
+      <ResultsHeroTilt scrollRef={ref} className={className}>
+        <p>hero content</p>
+      </ResultsHeroTilt>
+    </div>
+  );
+}
+
+describe('ResultsHeroTilt', () => {
+  it('wraps content in a transform-perspective container', () => {
+    const { getByTestId, getByText } = render(<Harness className="podium" />);
+    const tilt = getByTestId('hero-tilt');
+    expect(tilt).toBeTruthy();
+    expect(getByText('hero content')).toBeTruthy();
+    expect(tilt.className).toContain('podium');
+    const style = tilt.getAttribute('style') ?? '';
+    expect(style.toLowerCase()).toContain('transform-origin: top center');
+  });
+
+  it('falls back to a plain div under reduced motion (no transforms)', () => {
+    vi.mocked(useReducedMotion).mockReturnValueOnce(true);
+    const { container, queryByTestId } = render(<Harness className="podium" />);
+    expect(queryByTestId('hero-tilt')).toBeNull();
+    expect(container.querySelector('.podium')).toBeTruthy();
+  });
+});

--- a/fe-next/components/singleplayer/game/components/DynamicEnergyBackground.tsx
+++ b/fe-next/components/singleplayer/game/components/DynamicEnergyBackground.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Circle, Triangle, Square, Sparkles } from 'lucide-react';
+import { useDevicePerformance } from '@/hooks/useDevicePerformance';
 
 const DELAY_1S_STYLE = { animationDelay: '1s' } as const;
 const DELAY_2S_STYLE = { animationDelay: '2s' } as const;
@@ -9,9 +10,17 @@ const DELAY_3S_STYLE = { animationDelay: '3s' } as const;
 
 /**
  * DynamicEnergyBackground - Animated background for Single Player mode
- * Features vortex rotation, aurora waves, floating particles, and scanlines
+ * Features vortex rotation, aurora waves, floating particles, and scanlines.
+ *
+ * Self-gates on device capability: the 200%×200% rotating vortex layer is a
+ * dominant GPU compositor cost. On low-end Android / reduced-motion sessions
+ * the layer combo would keep repainting while the player drags on the grid,
+ * showing up as drag-selection stutter. Returns null in those cases.
  */
-export function DynamicEnergyBackground(): React.ReactElement {
+export function DynamicEnergyBackground(): React.ReactElement | null {
+  const { isLowEnd, prefersReducedMotion, enableComplexAnimations } = useDevicePerformance();
+  if (isLowEnd || prefersReducedMotion || !enableComplexAnimations) return null;
+
   return (
     <>
       {/* Vortex Layer - Slow rotating radial gradient */}

--- a/fe-next/components/singleplayer/game/components/__tests__/DynamicEnergyBackground.test.tsx
+++ b/fe-next/components/singleplayer/game/components/__tests__/DynamicEnergyBackground.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * DynamicEnergyBackground gating tests.
+ *
+ * The vortex / aurora / scanline / particle stack is GPU-expensive (200%×200%
+ * rotating gradient + scrolling stripe). Letting it composite during MP grid
+ * drag selection was the dominant cause of "stutter when selecting words" on
+ * mid/low-end Android. The component now self-gates on device capability so
+ * even single-player surfaces stay smooth on those devices.
+ *
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DynamicEnergyBackground } from '../DynamicEnergyBackground';
+
+const performanceMock = vi.fn();
+
+vi.mock('@/hooks/useDevicePerformance', () => ({
+  useDevicePerformance: () => performanceMock(),
+}));
+
+beforeEach(() => {
+  performanceMock.mockReset();
+});
+
+describe('DynamicEnergyBackground capability gating', () => {
+  it('renders the full vortex/aurora/scanline stack on capable devices', () => {
+    performanceMock.mockReturnValue({
+      isLowEnd: false,
+      prefersReducedMotion: false,
+      enableComplexAnimations: true,
+    });
+
+    const { container } = render(<DynamicEnergyBackground />);
+    expect(container.querySelector('.energy-vortex-layer')).toBeTruthy();
+    expect(container.querySelector('.energy-aurora-layer')).toBeTruthy();
+    expect(container.querySelector('.energy-scanline-layer')).toBeTruthy();
+  });
+
+  it('renders nothing on low-end devices (Android stutter fix)', () => {
+    performanceMock.mockReturnValue({
+      isLowEnd: true,
+      prefersReducedMotion: false,
+      enableComplexAnimations: false,
+    });
+
+    const { container } = render(<DynamicEnergyBackground />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when prefers-reduced-motion is set', () => {
+    performanceMock.mockReturnValue({
+      isLowEnd: false,
+      prefersReducedMotion: true,
+      enableComplexAnimations: false,
+    });
+
+    const { container } = render(<DynamicEnergyBackground />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when complex animations are disabled (mid-range or saver)', () => {
+    performanceMock.mockReturnValue({
+      isLowEnd: false,
+      prefersReducedMotion: false,
+      enableComplexAnimations: false,
+    });
+
+    const { container } = render(<DynamicEnergyBackground />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/fe-next/components/views/ResultsPage.tsx
+++ b/fe-next/components/views/ResultsPage.tsx
@@ -21,7 +21,7 @@ import { useResultsSideEffects } from '@/hooks/useResultsSideEffects';
 import { useHideNavigation } from '@/contexts/NavigationContext';
 import { useIsDesktop } from '@/hooks/useMediaQuery';
 import { useMultiplayerSignupNudge } from '@/hooks/useMultiplayerSignupNudge';
-import { ResultsParallaxBackdrop, ResultsSectionReveal, ResultsScrollProgressRail } from '@/components/results/ResultsScrollEffects';
+import { ResultsParallaxBackdrop, ResultsSectionReveal, ResultsScrollProgressRail, ResultsHeroTilt } from '@/components/results/ResultsScrollEffects';
 import { FloatingReaction } from '@/components/game/QuickReactions';
 import { useQuickReactions } from '@/hooks/useQuickReactions';
 import { useObservedHeight } from '@/hooks/useObservedHeight';
@@ -137,7 +137,7 @@ function DesktopResultsLayout({
           paddingBottom: 'calc(var(--mp-results-cta-h, 8rem) + 1rem)',
         }}
       >
-        <ResultsParallaxBackdrop scrollRef={scrollRef} intensity={110} />
+        <ResultsParallaxBackdrop scrollRef={scrollRef} intensity={140} />
         <ResultsScrollProgressRail scrollRef={scrollRef} />
         {/* Top Bar with Exit Button */}
         <div className="w-full max-w-5xl mx-auto flex items-center justify-end mb-4 relative z-10">
@@ -155,20 +155,24 @@ function DesktopResultsLayout({
           </ResultsSectionReveal>
         )}
 
-        {/* Full-width cinematic area: Hero + Podium + Consolation */}
-        <ResultsSectionReveal index={1} flat className="w-full max-w-5xl mx-auto relative z-10">
-          <ResultsMainContent
-            {...mainContentProps}
-            hideInlineCta={!!gameCode && !isBotsOnlyGame}
-          />
-          {/* Global percentile context — sits below podium so it lands as the player reads
-              their own row. Hides for guests (no userId). */}
-          {userId ? (
-            <div className="mt-2 flex justify-center">
-              <GlobalRankBadge userId={userId} matchScore={matchScore} />
-            </div>
-          ) : null}
-        </ResultsSectionReveal>
+        {/* Full-width cinematic area: Hero + Podium + Consolation.
+            Wrapped in ResultsHeroTilt so the podium gains a gentle 3D recede
+            as the player scrolls further into the page. */}
+        <ResultsHeroTilt scrollRef={scrollRef} className="w-full max-w-5xl mx-auto relative z-10">
+          <ResultsSectionReveal index={1} flat>
+            <ResultsMainContent
+              {...mainContentProps}
+              hideInlineCta={!!gameCode && !isBotsOnlyGame}
+            />
+            {/* Global percentile context — sits below podium so it lands as the player reads
+                their own row. Hides for guests (no userId). */}
+            {userId ? (
+              <div className="mt-2 flex justify-center">
+                <GlobalRankBadge userId={userId} matchScore={matchScore} />
+              </div>
+            ) : null}
+          </ResultsSectionReveal>
+        </ResultsHeroTilt>
 
         {/* Two-column area below the cinematic hero */}
         <div className="w-full max-w-5xl mx-auto mt-6 medium-short:mt-3 desktop-medium-short:mt-4 grid grid-cols-1 lg:grid-cols-2 gap-6 medium-short:gap-3 desktop-medium-short:gap-4 relative z-10">
@@ -991,11 +995,13 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, gameCode, onRetu
             paddingBottom: 'calc(var(--mp-results-cta-h, 9rem) + 1rem)',
           }}
         >
-          <ResultsParallaxBackdrop scrollRef={mobileScrollRef} />
+          <ResultsParallaxBackdrop scrollRef={mobileScrollRef} intensity={120} />
           <div className="max-w-lg mx-auto space-y-6 medium-short:space-y-3 relative z-10">
-            <ResultsSectionReveal index={0} flat>
-              {renderResultsTab()}
-            </ResultsSectionReveal>
+            <ResultsHeroTilt scrollRef={mobileScrollRef}>
+              <ResultsSectionReveal index={0} flat>
+                {renderResultsTab()}
+              </ResultsSectionReveal>
+            </ResultsHeroTilt>
             {/* Global rank badge — mobile, sub-podium */}
             {user?.id ? (
               <ResultsSectionReveal index={1}>
@@ -1033,7 +1039,18 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, gameCode, onRetu
               transition={{ type: 'spring', stiffness: 200, damping: 24, delay: 0.3 }}
               className="bg-neo-navy/95 border-t border-neo-white/8 shadow-[0_-4px_24px_rgba(0,0,0,0.5)]"
             >
-              <div className="px-3 pt-2.5 pb-[max(0.625rem,env(safe-area-inset-bottom))]">
+              {/* Inline style for padding-bottom: Tailwind arbitrary values
+                  don't survive multi-arg max() with var() reliably. Capacitor
+                  fix — Android WebView reports env(safe-area-inset-bottom) as
+                  0, so the real gesture-nav inset only arrives via
+                  --cap-safe-area-bottom (set by useSafeArea hook). */}
+              <div
+                className="px-3 pt-2.5"
+                style={{
+                  paddingBottom:
+                    'max(0.625rem, env(safe-area-inset-bottom, 0px), var(--cap-safe-area-bottom, 0px))',
+                }}
+              >
                 <StickyReadyBar
                   isHost={isHost}
                   isCurrentPlayerReady={isCurrentPlayerReady}


### PR DESCRIPTION
- Drop DynamicEnergyBackground from MultiplayerInGameView's PortraitLayout.
  The 200%×200% rotating vortex + aurora + scanline + 4-particle stack was a
  Single Player ambient layer (per its own docstring) that got threaded into
  the MP game screen. While the user drag-selects on the grid, those layers
  composite every frame, costing GPU bandwidth that the grid path overlay +
  selection escalation needs — surfaces as visible "stutter when selecting
  words" on mid/low-end Android.

- Self-gate DynamicEnergyBackground on useDevicePerformance so even the SP
  callsites stop rendering it on low-end / reduced-motion / saver sessions.
  Locks behavior with DynamicEnergyBackground.test.tsx.

- Results page sticky bar: Android Capacitor's WebView reports
  env(safe-area-inset-bottom) as 0; the real bottom inset only arrives on
  --cap-safe-area-bottom via the capacitor-plugin-safe-area listener.
  Mobile wrapper now uses max(env, var(--cap-safe-area-bottom)) so the bar
  pins to the device gesture-nav edge on Android instead of floating with
  empty space underneath.

- Define .safe-area-pb utility (previously referenced by the desktop sticky
  bar but undefined in CSS — no padding applied at all). It now resolves to
  var(--safe-area-bottom-raw) = max(env, --cap-safe-area-bottom), without
  the admob clearance the wrapper already accounts for via bottom:
  var(--admob-banner-height).

- Drop the inner pb-[env(safe-area-inset-bottom)] from StickyReadyBar's
  own root — it double-counted the safe area on iOS and contributed to the
  bar overlapping its own buttons on Android once --cap-safe-area-bottom
  is honored at the wrapper.

- Results scrolling: bump parallax intensity (desktop 110→140, mobile
  default→120), add a third velocity-driven highlight layer, hue-rotate
  the mid layer over scroll depth, and introduce ResultsHeroTilt — a
  perspective-1000px wrapper that recedes the cinematic hero block 6° on X
  and 4% scale as the player scrolls into the rest of the page. Both new
  effects no-op under reduced-motion.

Tests: 571 passing across results/ + game/ + game/in-game/ +
singleplayer/game/components/. Includes 4 new gating tests for
DynamicEnergyBackground and 2 for ResultsHeroTilt.
Lint: clean on touched files.
Typecheck: clean.

https://claude.ai/code/session_01VvSNYxw8xWSs6u9EsjS6jK