### PR TITLE
perf(mp-classic): kill grid re-render cascade on every word submit

### DIFF
--- a/fe-next/components/game/in-game/hooks/__tests__/useWordSubmission.stableCallback.test.ts
+++ b/fe-next/components/game/in-game/hooks/__tests__/useWordSubmission.stableCallback.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Perf regression test: `handleGridWordSubmit` must keep a stable identity
+ * across `normalizedFoundWords`-only changes.
+ *
+ * In MP classic the parent re-renders the in-game tree on every word event
+ * (player or opponent). Before this guard, the `useCallback` deps array
+ * included `normalizedFoundWords`, so the callback identity flipped on every
+ * word found → broke `<GridComponent>`'s memo via the `onWordSubmit` prop →
+ * forced all 16 `<GridCell>` memos to re-check equality on every accept.
+ * That cascade is what users perceived as "slowness when finding words" in
+ * multiplayer classic mode after the earlier drag-storm fixes landed.
+ *
+ * This test pins the contract: bumping `normalizedFoundWords` (and only that)
+ * must NOT change the returned `handleGridWordSubmit` reference, AND the
+ * duplicate check must still reflect the latest list via the internal Set ref.
+ */
+import { vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const { mockValidateWordLocally, mockCouldBeOnBoard, mockNormalizeWord } = vi.hoisted(() => {
+  const mockValidateWordLocally = vi.fn();
+  const mockCouldBeOnBoard = vi.fn();
+  const mockNormalizeWord = vi.fn((w: string) => w.toLowerCase());
+  return { mockValidateWordLocally, mockCouldBeOnBoard, mockNormalizeWord };
+});
+
+vi.mock('@/utils/clientWordValidator', () => ({
+  validateWordLocally: (...args: any[]) => mockValidateWordLocally(...args),
+  couldBeOnBoard: (...args: any[]) => mockCouldBeOnBoard(...args),
+  normalizeWord: (...args: any[]) => mockNormalizeWord(...args),
+}));
+
+vi.mock('@/utils/haptics', () => ({
+  hapticForWordScore: vi.fn(),
+  hapticError: vi.fn(),
+}));
+
+import type { MutableRefObject } from 'react';
+import { useWordSubmission } from '../useWordSubmission';
+
+function buildOptions(overrides: Partial<Parameters<typeof useWordSubmission>[0]> = {}) {
+  const mockSocket = { emit: vi.fn() } as any;
+  const comboLevelRef: MutableRefObject<number> = { current: 0 };
+
+  return {
+    isPlaying: true,
+    gameActive: true,
+    gameLanguage: 'en' as const,
+    minWordLength: 2,
+    normalizedFoundWords: [],
+    letterGrid: [['T', 'E'], ['S', 'T']] as any,
+    socket: mockSocket,
+    comboLevelRef,
+    t: (k: string) => k,
+    playWordRejectedSound: vi.fn(),
+    announceWordResult: vi.fn(),
+    onWordSubmit: vi.fn(),
+    onResetCombo: vi.fn(),
+    setCurrentFeedback: vi.fn(),
+    setLastWordFoundTime: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('useWordSubmission — handleGridWordSubmit identity stability', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateWordLocally.mockReturnValue({ isValid: true });
+    mockCouldBeOnBoard.mockReturnValue(true);
+    mockNormalizeWord.mockImplementation((w: string) => w.toLowerCase());
+  });
+
+  it('keeps handleGridWordSubmit identity stable when only normalizedFoundWords changes', () => {
+    const opts = buildOptions();
+    const { result, rerender } = renderHook(
+      (p: Parameters<typeof useWordSubmission>[0]) => useWordSubmission(p),
+      { initialProps: opts },
+    );
+
+    const firstCallback = result.current.handleGridWordSubmit;
+
+    // Simulate a word being added — same shape as PlayerView's mappedFoundWords
+    // useMemo producing a new array per word event.
+    rerender({ ...opts, normalizedFoundWords: [{ word: 'cat', isValid: true } as any] });
+    const afterOneWord = result.current.handleGridWordSubmit;
+
+    rerender({ ...opts, normalizedFoundWords: [
+      { word: 'cat', isValid: true } as any,
+      { word: 'dog', isValid: true } as any,
+    ] });
+    const afterTwoWords = result.current.handleGridWordSubmit;
+
+    expect(afterOneWord).toBe(firstCallback);
+    expect(afterTwoWords).toBe(firstCallback);
+  });
+
+  it('still rejects duplicates against the latest foundWords (Set ref stays fresh)', () => {
+    const opts = buildOptions();
+    const { result, rerender } = renderHook(
+      (p: Parameters<typeof useWordSubmission>[0]) => useWordSubmission(p),
+      { initialProps: opts },
+    );
+
+    // Push a found word into the hook — Set ref should update via the effect.
+    rerender({ ...opts, normalizedFoundWords: [{ word: 'cat', isValid: true } as any] });
+
+    act(() => {
+      result.current.handleGridWordSubmit('CAT');
+    });
+
+    // The Set the hook passes to validateWordLocally must contain 'cat'.
+    const lastCall = mockValidateWordLocally.mock.calls[mockValidateWordLocally.mock.calls.length - 1];
+    const passedFourth = lastCall[3];
+    expect(passedFourth instanceof Set).toBe(true);
+    expect((passedFourth as Set<string>).has('cat')).toBe(true);
+  });
+
+  it('rebuilds the Set when gameLanguage changes (covers language-switch on reconnect)', () => {
+    const opts = buildOptions({
+      normalizedFoundWords: [{ word: 'casa', isValid: true } as any],
+    });
+    const { result, rerender } = renderHook(
+      (p: Parameters<typeof useWordSubmission>[0]) => useWordSubmission(p),
+      { initialProps: opts },
+    );
+
+    // Initial language = en
+    act(() => {
+      result.current.handleGridWordSubmit('CASA');
+    });
+    const enSet = mockValidateWordLocally.mock.calls.at(-1)?.[3] as Set<string>;
+    expect(enSet.has('casa')).toBe(true);
+
+    // Mock normalize that tags the language so we can verify rebuild
+    mockNormalizeWord.mockImplementation((w: string, lang: string) => `${lang}:${w.toLowerCase()}`);
+
+    rerender({ ...opts, gameLanguage: 'es' as const });
+
+    act(() => {
+      result.current.handleGridWordSubmit('CASA');
+    });
+    const esSet = mockValidateWordLocally.mock.calls.at(-1)?.[3] as Set<string>;
+    expect(esSet.has('es:casa')).toBe(true);
+  });
+});

--- a/fe-next/components/game/in-game/hooks/useWordSubmission.ts
+++ b/fe-next/components/game/in-game/hooks/useWordSubmission.ts
@@ -5,7 +5,7 @@ import type { Socket } from 'socket.io-client';
 import type { LetterGrid, Language } from '@/shared/types/game';
 import type { FoundWord } from '@/shared/types/view';
 import type { WordFeedback } from '../../WordFormingArea';
-import { validateWordLocally, couldBeOnBoard } from '@/utils/clientWordValidator';
+import { validateWordLocally, couldBeOnBoard, normalizeWord } from '@/utils/clientWordValidator';
 import { hapticForWordScore, hapticError } from '@/utils/haptics';
 import type { TranslationFn } from '../types';
 
@@ -64,21 +64,40 @@ export function useWordSubmission(
   // This ensures the socket emit uses the latest value without waiting for re-render
   const fireRoundActiveRef = useRef(false);
 
+  // Keep the latest foundWords as a normalized Set behind a ref so
+  // `handleGridWordSubmit` doesn't have to depend on `normalizedFoundWords`
+  // identity. Without this, the array reference flipping on every word
+  // submission rebuilt the callback → broke GridComponent memo via the
+  // onWordSubmit prop → forced 16 GridCell equality re-checks per accept.
+  // The Set also gives O(1) duplicate lookup vs the array.some() + per-element
+  // normalizeWord() scan validateWordLocally falls back to.
+  const foundWordsSetRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const lang = (gameLanguage || 'en') as Language;
+    const next = new Set<string>();
+    for (const fw of normalizedFoundWords) {
+      const w = typeof fw === 'string' ? fw : fw.word;
+      if (w) next.add(normalizeWord(w, lang));
+    }
+    foundWordsSetRef.current = next;
+  }, [normalizedFoundWords, gameLanguage]);
+
   const handleGridWordSubmit = useCallback((formedWord: string, meta?: { inputMethod: 'kb' | 'drag' }): void => {
     if (!isPlaying) return;
 
     const currentLang = gameLanguage || 'en';
 
-    // Client-side validation
-    const validation = validateWordLocally(formedWord, currentLang, minWordLength, normalizedFoundWords);
+    // Client-side validation — pass the pre-normalized Set so the lookup is
+    // O(1) and doesn't have to re-normalize every previously-found word per
+    // submit.
+    const validation = validateWordLocally(formedWord, currentLang, minWordLength, foundWordsSetRef.current);
 
     if (!validation.isValid) {
       if (process.env.NODE_ENV === 'development') {
         console.warn('[WORD_SUBMIT] Client rejected word:', {
           word: formedWord,
           errorKey: validation.errorKey,
-          foundWordsCount: normalizedFoundWords.length,
-          foundWordsList: normalizedFoundWords.slice(0, 10).map(w => typeof w === 'string' ? w : w.word),
+          foundWordsCount: foundWordsSetRef.current.size,
         });
       }
       let msg: string;
@@ -150,11 +169,15 @@ export function useWordSubmission(
 
     // Add to local found words
     onWordSubmit?.(formedWord, meta);
+    // Intentionally NOT depending on `normalizedFoundWords`: we read the
+    // already-normalized Set through `foundWordsSetRef` which is refreshed by
+    // the effect above. Putting the array here would force a new callback
+    // identity per word found and re-break the GridComponent memo we just
+    // stabilised — defeating the purpose of this hook's perf shape.
   }, [
     isPlaying,
     gameLanguage,
     minWordLength,
-    normalizedFoundWords,
     letterGrid,
     gameActive,
     socket,


### PR DESCRIPTION
## Summary

Fixes the residual "slowness when finding words" in multiplayer classic mode that persisted after the earlier drag-storm (`74eea11`), countdown/lightning (`c03783b`), and DynamicEnergyBackground (`0b99c54`) perf passes.

## Root cause

`useWordSubmission` (the InGameScreen hook, not the SP one) had `normalizedFoundWords` in `handleGridWordSubmit`'s `useCallback` deps. The chain on every word landing in the store:

1. `setFoundWords` in Zustand
2. `PlayerView.tsx:560` recomputes `mappedFoundWords` (new array)
3. `InGameScreen.tsx:262` recomputes `normalizedFoundWords` (new array)
4. **`handleGridWordSubmit` rebuilds** (deps include `normalizedFoundWords`)
5. `sharedLayoutProps.onWordSubmit` identity flips → `PortraitLayout` memo breaks
6. `GridComponent` memo breaks via the `onWordSubmit` prop
7. All 16 `GridCell` memos re-check equality

This fires per accept (own player ~8–12 words/sec) AND on every other-player word event the parent re-renders through. On mid-tier mobile it reads as the lingering "stutter on submit" that survived the previous fixes.

## Fix

- Stash the latest `normalizedFoundWords` as a normalized `Set<string>` behind a ref, refreshed by a `useEffect` on `normalizedFoundWords` / `gameLanguage`.
- Pass that Set to `validateWordLocally` — it has a `Set` fast-path, so duplicate detection also drops from `O(n)` with a per-element `normalizeWord()` to `O(1)`.
- Drop `normalizedFoundWords` from `handleGridWordSubmit`'s deps. The callback now keeps a stable identity across word events → `<GridComponent>` memo holds → 16-cell equality cascade goes away.

## Test plan

- [x] New `useWordSubmission.stableCallback.test.ts` locks in the contract:
  - callback identity stable across `normalizedFoundWords`-only rerenders
  - Set ref still reflects the latest foundWords for duplicate checks
  - Set rebuilds when `gameLanguage` changes (reconnect parity)
- [x] `vitest run components/game/in-game/hooks` — 43/43 passing (incl. existing comboType + sounds suites)
- [x] `vitest run components/grid` — 112/112 passing
- [x] `vitest run player/` — 665/665 passing
- [x] `tsc --noEmit` — clean
- [x] `eslint` on touched files — clean

## Files

- `fe-next/components/game/in-game/hooks/useWordSubmission.ts` — perf shape change
- `fe-next/components/game/in-game/hooks/__tests__/useWordSubmission.stableCallback.test.ts` — regression lock

https://claude.ai/code/session_01K3mVX7CiicL4ZBxdj4ZnZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3mVX7CiicL4ZBxdj4ZnZX)_