### PR TITLE
perf(mp-classic): memoize desktop shell so word-accept feels instant

### DIFF
--- a/fe-next/components/multiplayer/MultiplayerInGameView.tsx
+++ b/fe-next/components/multiplayer/MultiplayerInGameView.tsx
@@ -268,6 +268,35 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
     byUsername: item.playerName,
   })), [deferredOpponentFeedItems]);
 
+  // Memoize the leaderboard → RosterPlayer and foundWords → LadderWord
+  // mappings. Without these useMemos every parent re-render (timer tick at
+  // ~1Hz, combo updates, etc.) allocated brand-new arrays which then broke
+  // memo on RosterRail / WordsLadder / MyStatsCard / OpponentInsightFeed,
+  // causing the whole desktop shell to re-render on every tick — visible as
+  // sluggish word-accept feedback in multiplayer classic.
+  const rosterPlayers = useMemo(
+    () => leaderboard.map(entry => ({
+      userId: entry.username ?? '',
+      username: entry.username,
+      score: entry.score,
+      wordCount: entry.wordCount,
+      status: entry.disconnected ? ('disconnected' as const) : ('connected' as const),
+      isYou: entry.username === username,
+      customAvatar: entry.avatar?.customAvatar ?? null,
+    })),
+    [leaderboard, username],
+  );
+  const ladderWords = useMemo(
+    () => foundWords.map(fw => ({
+      word: fw.word,
+      score: fw.score ?? 0,
+      ts: fw.timestamp ?? 0,
+      userId: username,
+      inputMethod: fw.inputMethod ?? 'drag',
+    })),
+    [foundWords, username],
+  );
+
   // Effective grid (player may have shufflingGrid fallback)
   const effectiveGrid = letterGrid || shufflingGrid || null;
 
@@ -347,24 +376,9 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
 
   // Desktop shell for classic mode
   if (shellEnabled && gameMode === 'classic') {
-    // Map leaderboard from MultiplayerInGameView shape to RosterPlayer shape
-    const rosterPlayers = leaderboard.map(entry => ({
-      userId: entry.username ?? '',
-      username: entry.username,
-      score: entry.score,
-      status: entry.disconnected ? ('disconnected' as const) : ('connected' as const),
-      isYou: entry.username === username,
-      customAvatar: entry.avatar?.customAvatar ?? null,
-    }));
-
-    // Map foundWords from FoundWord shape to LadderWord shape
-    const ladderWords = foundWords.map((fw) => ({
-      word: fw.word,
-      score: fw.score ?? 0,
-      ts: fw.timestamp ?? 0,
-      userId: username,
-      inputMethod: fw.inputMethod ?? 'drag',
-    }));
+    // rosterPlayers + ladderWords are memoized at the top of the component
+    // (see useMemo above) so timer-driven re-renders don't churn referential
+    // identity and trash downstream memo boundaries.
 
     // Build InGameScreen props object
     const inGameScreenProps = {
@@ -436,25 +450,7 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
   // TypeScript doesn't narrow properly on 'wheel-rush' variant in some builds,
   // but the runtime value is correct (validated in backend/modules/gameModeSelector.ts)
   if ((gameMode as string) === 'wheel-rush' && shellEnabled) {
-    // Map leaderboard from MultiplayerInGameView shape to RosterPlayer shape
-    const rosterPlayers = leaderboard.map(entry => ({
-      userId: entry.username ?? '',
-      username: entry.username,
-      score: entry.score,
-      wordCount: entry.wordCount,
-      status: entry.disconnected ? ('disconnected' as const) : ('connected' as const),
-      isYou: entry.username === username,
-      customAvatar: entry.avatar?.customAvatar ?? null,
-    }));
-
-    // Map foundWords from FoundWord shape to LadderWord shape
-    const ladderWords = foundWords.map((fw) => ({
-      word: fw.word,
-      score: fw.score ?? 0,
-      ts: fw.timestamp ?? 0,
-      userId: username,
-      inputMethod: fw.inputMethod ?? 'drag',
-    }));
+    // rosterPlayers + ladderWords memoized at top of component.
 
     const wheelRushProps = {
       socket,
@@ -483,24 +479,7 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
 
   // Desktop shell for word-hunt mode
   if ((gameMode as string) === 'word-hunt' && shellEnabled) {
-    // Map leaderboard from MultiplayerInGameView shape to RosterPlayer shape
-    const rosterPlayers = leaderboard.map(entry => ({
-      userId: entry.username ?? '',
-      username: entry.username,
-      score: entry.score,
-      status: entry.disconnected ? ('disconnected' as const) : ('connected' as const),
-      isYou: entry.username === username,
-      customAvatar: entry.avatar?.customAvatar ?? null,
-    }));
-
-    // Map foundWords from FoundWord shape to LadderWord shape
-    const ladderWords = foundWords.map((fw) => ({
-      word: fw.word,
-      score: fw.score ?? 0,
-      ts: fw.timestamp ?? 0,
-      userId: username,
-      inputMethod: fw.inputMethod ?? 'drag',
-    }));
+    // rosterPlayers + ladderWords memoized at top of component.
 
     const wordHuntGameProps = {
       grid: effectiveGrid,
@@ -550,22 +529,7 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
       />
     );
     if (shellEnabled) {
-      const rosterPlayers = leaderboard.map(entry => ({
-        userId: entry.username ?? '',
-        username: entry.username,
-        score: entry.score,
-        wordCount: entry.wordCount,
-        status: entry.disconnected ? ('disconnected' as const) : ('connected' as const),
-        isYou: entry.username === username,
-        customAvatar: entry.avatar?.customAvatar ?? null,
-      }));
-      const ladderWords = foundWords.map(fw => ({
-        word: fw.word,
-        score: fw.score ?? 0,
-        ts: fw.timestamp ?? 0,
-        userId: username,
-        inputMethod: fw.inputMethod ?? 'drag',
-      }));
+      // rosterPlayers + ladderWords memoized at top of component.
       return (
         <BlastDesktopAdapter
           roomId={gameCode}

--- a/fe-next/components/multiplayer/desktop/RosterRail.tsx
+++ b/fe-next/components/multiplayer/desktop/RosterRail.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react';
 import Avatar from '@/components/Avatar';
 import type { CustomAvatarConfig } from '@/shared/types/customAvatar';
 
@@ -11,9 +12,16 @@ export interface RosterPlayer {
   customAvatar?: CustomAvatarConfig | null;
 }
 
-export function RosterRail({ players }: { players: RosterPlayer[] }) {
-  const sorted = [...players].sort((a, b) => b.score - a.score);
-  const maxScore = Math.max(...sorted.map(p => p.score), 1);
+function RosterRailImpl({ players }: { players: RosterPlayer[] }) {
+  // Memoize sort + maxScore so the timer-driven parent re-renders (1Hz) don't
+  // re-sort every render. The list itself rarely changes — sort only when
+  // `players` reference does.
+  const { sorted, maxScore } = useMemo(() => {
+    const s = [...players].sort((a, b) => b.score - a.score);
+    let max = 1;
+    for (const p of s) if (p.score > max) max = p.score;
+    return { sorted: s, maxScore: max };
+  }, [players]);
 
   return (
     <ul className="flex flex-col gap-2" data-component="roster-rail" aria-label="Players">
@@ -63,3 +71,5 @@ export function RosterRail({ players }: { players: RosterPlayer[] }) {
     </ul>
   );
 }
+
+export const RosterRail = memo(RosterRailImpl);

--- a/fe-next/components/multiplayer/desktop/StandardDesktopAdapter.tsx
+++ b/fe-next/components/multiplayer/desktop/StandardDesktopAdapter.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { memo, useMemo, type ReactNode } from 'react';
 import { MultiplayerDesktopShell } from './MultiplayerDesktopShell';
 import { RosterRail, type RosterPlayer } from './RosterRail';
 import { WordsLadder, type LadderWord } from './WordsLadder';
@@ -24,74 +24,121 @@ export interface StandardDesktopAdapterProps {
   startTimeMs?: number;
 }
 
-export function StandardDesktopAdapter(props: StandardDesktopAdapterProps) {
+function StandardDesktopAdapterImpl(props: StandardDesktopAdapterProps) {
   const { t } = useLanguage();
-  const slots: ShellSlots = {
-    left: {
-      roster: (
-        <ThemedPanel
-          mode="classic"
-          variant="rail"
-          header={t('mp.insights.rosterHeader')}
-          headerRight={`${props.leaderboard.length}`}
-          testId="standard-roster"
-        >
-          <RosterRail players={props.leaderboard} />
-        </ThemedPanel>
-      ),
-      modeBadge: (
-        <ThemedPanel mode="classic" variant="badge" testId="standard-mode-badge" withTexture>
-          <div className="flex items-center gap-3 animate-mp-shell-fade">
-            <CircularTimer
-              duration={props.totalTime}
-              initialRemainingTime={props.remainingTime}
-              isPlaying
-              size={80}
-              colorFamily="cyan"
-            />
-            <div className="flex flex-col">
-              <span className="text-[10px] font-mono opacity-50">MP</span>
-              <span className="font-neo-display font-bold text-xl uppercase tracking-wide">
-                {t('mp.modeName.classic')}
-              </span>
-            </div>
+  const {
+    roomId,
+    leaderboard,
+    foundWords,
+    remainingTime,
+    totalTime,
+    canvas,
+    meId,
+    opponentWords,
+    startTimeMs,
+  } = props;
+
+  // Memoize each slot subtree so timer-driven re-renders (e.g. remainingTime
+  // ticking each second) don't rebuild the entire ShellSlots graph and
+  // re-render every downstream insight component. Each slot only rebuilds
+  // when its actual inputs change.
+  const rosterSlot = useMemo(
+    () => (
+      <ThemedPanel
+        mode="classic"
+        variant="rail"
+        header={t('mp.insights.rosterHeader')}
+        headerRight={`${leaderboard.length}`}
+        testId="standard-roster"
+      >
+        <RosterRail players={leaderboard} />
+      </ThemedPanel>
+    ),
+    [t, leaderboard],
+  );
+
+  const modeBadgeSlot = useMemo(
+    () => (
+      <ThemedPanel mode="classic" variant="badge" testId="standard-mode-badge" withTexture>
+        <div className="flex items-center gap-3 animate-mp-shell-fade">
+          <CircularTimer
+            duration={totalTime}
+            initialRemainingTime={remainingTime}
+            isPlaying
+            size={80}
+            colorFamily="cyan"
+          />
+          <div className="flex flex-col">
+            <span className="text-[10px] font-mono opacity-50">MP</span>
+            <span className="font-neo-display font-bold text-xl uppercase tracking-wide">
+              {t('mp.modeName.classic')}
+            </span>
           </div>
-        </ThemedPanel>
-      ),
-      secondary: (
-        <MyStatsCard
-          mode="classic"
-          meId={props.meId}
-          foundWords={props.foundWords}
-          startTimeMs={props.startTimeMs}
-        />
-      ),
-    },
-    center: props.canvas,
-    right: {
-      wordsLadder: (
-        <ThemedPanel
-          mode="classic"
-          variant="rail"
-          header={t('mp.insights.foundHeader')}
-          headerRight={`${props.foundWords.length}`}
-          testId="standard-ladder"
-        >
-          <LatestScoreTickBanner mode="classic" meId={props.meId} leaderboard={props.leaderboard} />
-          <WordsLadder words={props.foundWords} meId={props.meId} />
-        </ThemedPanel>
-      ),
-      activityStream: (
-        <div className="flex flex-col gap-2">
-          <PaceDeltaChip mode="classic" leaderboard={props.leaderboard} meId={props.meId} />
-          {props.opponentWords && props.opponentWords.length > 0 && (
-            <OpponentInsightFeed mode="classic" opponentWords={props.opponentWords} />
-          )}
-          <KeyboardHintStrip />
         </div>
-      ),
-    },
-    meta: { mode: 'classic', roomId: props.roomId },
-  };
+      </ThemedPanel>
+    ),
+    [t, totalTime, remainingTime],
+  );
+
+  const secondarySlot = useMemo(
+    () => (
+      <MyStatsCard
+        mode="classic"
+        meId={meId}
+        foundWords={foundWords}
+        startTimeMs={startTimeMs}
+      />
+    ),
+    [meId, foundWords, startTimeMs],
+  );
+
+  const wordsLadderSlot = useMemo(
+    () => (
+      <ThemedPanel
+        mode="classic"
+        variant="rail"
+        header={t('mp.insights.foundHeader')}
+        headerRight={`${foundWords.length}`}
+        testId="standard-ladder"
+      >
+        <LatestScoreTickBanner mode="classic" meId={meId} leaderboard={leaderboard} />
+        <WordsLadder words={foundWords} meId={meId} />
+      </ThemedPanel>
+    ),
+    [t, foundWords, meId, leaderboard],
+  );
+
+  const activityStreamSlot = useMemo(
+    () => (
+      <div className="flex flex-col gap-2">
+        <PaceDeltaChip mode="classic" leaderboard={leaderboard} meId={meId} />
+        {opponentWords && opponentWords.length > 0 && (
+          <OpponentInsightFeed mode="classic" opponentWords={opponentWords} />
+        )}
+        <KeyboardHintStrip />
+      </div>
+    ),
+    [leaderboard, meId, opponentWords],
+  );
+
+  const slots: ShellSlots = useMemo(
+    () => ({
+      left: {
+        roster: rosterSlot,
+        modeBadge: modeBadgeSlot,
+        secondary: secondarySlot,
+      },
+      center: canvas,
+      right: {
+        wordsLadder: wordsLadderSlot,
+        activityStream: activityStreamSlot,
+      },
+      meta: { mode: 'classic', roomId },
+    }),
+    [rosterSlot, modeBadgeSlot, secondarySlot, canvas, wordsLadderSlot, activityStreamSlot, roomId],
+  );
+
   return <MultiplayerDesktopShell slots={slots} />;
 }
+
+export const StandardDesktopAdapter = memo(StandardDesktopAdapterImpl);

--- a/fe-next/components/multiplayer/desktop/WordsLadder.tsx
+++ b/fe-next/components/multiplayer/desktop/WordsLadder.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 export interface LadderWord {
@@ -21,10 +22,14 @@ interface WordsLadderProps {
  * - Stolen words shown with strike-through
  * - Top entry pulses (`animate-ladder-bump`) on insert; reduced-motion no-ops it
  * - aria-live="polite" so screen readers announce new words
+ *
+ * Memoized: parent re-renders on every timer tick (1Hz). Without memo + sort
+ * memoization the entire ladder re-sorted + re-rendered every second even with
+ * no new word, causing visible jank on word accept.
  */
-export function WordsLadder({ words, meId }: WordsLadderProps) {
+function WordsLadderImpl({ words, meId }: WordsLadderProps) {
   const { t } = useLanguage();
-  const sorted = [...words].sort((a, b) => b.ts - a.ts);
+  const sorted = useMemo(() => [...words].sort((a, b) => b.ts - a.ts), [words]);
 
   if (sorted.length === 0) {
     return (
@@ -71,3 +76,5 @@ export function WordsLadder({ words, meId }: WordsLadderProps) {
     </ul>
   );
 }
+
+export const WordsLadder = memo(WordsLadderImpl);


### PR DESCRIPTION
## Summary

Multiplayer classic word-accept felt sluggish because the desktop shell re-rendered the entire right-rail (ladder + insights + roster) on every parent re-render — and the parent re-renders ~1Hz from the timer plus on every combo/word update.

Four memo boundaries were broken; this PR fixes each.

- **`WordsLadder`** — not memoized, re-sorted the full array on every render. → Wrapped in `memo`, sort moved into `useMemo`.
- **`RosterRail`** — not memoized, re-sorted + recomputed `maxScore` every render. → Wrapped in `memo`, sort + max moved into `useMemo` (single-pass loop instead of `Math.max(...arr)` spread).
- **`StandardDesktopAdapter`** — rebuilt the entire `ShellSlots` tree every render, giving every insight component (`PaceDeltaChip`, `LatestScoreTickBanner`, `OpponentInsightFeed`, `MyStatsCard`) a brand-new ReactElement. → Wrapped in `memo`, each slot subtree (`roster`, `modeBadge`, `secondary`, `wordsLadder`, `activityStream`) and the assembled `slots` object are now `useMemo`'d on their actual inputs.
- **`MultiplayerInGameView`** — allocated fresh `rosterPlayers` / `ladderWords` arrays inside each `gameMode` branch on every render, breaking memo identity downstream. → Hoisted both mappings to a single `useMemo` at the top of the component, shared across the four mode branches (classic / wheel-rush / word-hunt / blast).

**Net effect:** a word-accept now only re-renders the ladder (and only when `foundWords` actually changes), instead of re-mounting the whole shell on every 1-second timer tick.

## Test plan

- [x] `vitest run components/multiplayer/desktop/` — all 69 desktop unit tests pass
- [x] `vitest run components/multiplayer/__tests__/MultiplayerInGameView.desktop.test.tsx` — 2/2 pass
- [x] `tsc --noEmit` — zero new errors
- [ ] Smoke: join a multiplayer classic room, find several words in quick succession, confirm the ladder/score updates feel instant (no 200–500ms jank) and the timer keeps ticking smoothly
- [ ] Smoke: confirm wheel-rush / word-hunt / blast desktop shells still render correctly (shared memoized arrays)
- [ ] Smoke: confirm RTL languages still render the ladder correctly (no logical-prop regressions touched)

https://claude.ai/code/session_01FEVtttNh7evReti4dBKZQA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEVtttNh7evReti4dBKZQA)_