### PR TITLE
perf(mp): self-contain opponent-feed subscription to unblock drag rendering

### DIFF
--- a/fe-next/components/multiplayer/MultiplayerInGameView.tsx
+++ b/fe-next/components/multiplayer/MultiplayerInGameView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { memo, useCallback, useDeferredValue, useMemo, useState } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import type { Socket } from 'socket.io-client';
 import { Button } from '../ui/button';
@@ -58,8 +58,7 @@ import type { EarthquakeState } from '@/shared/types/earthquake';
 import type { BoardTheme } from '@/shared/types/socket';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
-import { OpponentWordFeed } from '@/components/multiplayer/OpponentWordFeed';
-import { useOpponentWordFeed } from '@/hooks/useOpponentWordFeed';
+import { OpponentWordFeedConnected } from '@/components/multiplayer/OpponentWordFeedConnected';
 import { useGameMode } from '@/hooks/gameState/store';
 
 // ==================== Types ====================
@@ -254,19 +253,10 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
   // Desktop shell routing (standard mode only)
   const shellEnabled = useDesktopShellEnabled();
 
-  // Opponent word feed. Defer the array + memoize the mapped shape so socket
-  // bursts of opponent words don't allocate a fresh insight array each render
-  // (which broke memo on every consumer downstream — esp. during local drag).
-  const { feedItems: opponentFeedItems } = useOpponentWordFeed({ socket, currentPlayerName: username });
-  const deferredOpponentFeedItems = useDeferredValue(opponentFeedItems);
-  const opponentInsightWords = useMemo(() => deferredOpponentFeedItems.map(item => ({
-    wordLength: item.wordLength,
-    firstLetter: item.firstLetter,
-    lastLetter: item.lastLetter,
-    score: item.score,
-    ts: item.timestamp,
-    byUsername: item.playerName,
-  })), [deferredOpponentFeedItems]);
+  // Opponent feed state lives inside the feed components themselves
+  // (OpponentWordFeedConnected / OpponentInsightFeedConnected) — pushing the
+  // `useOpponentWordFeed` subscription out of this parent stops socket bursts
+  // of opponent words from re-rendering the whole game shell mid-drag.
 
   // Memoize the leaderboard → RosterPlayer and foundWords → LadderWord
   // mappings. Without these useMemos every parent re-render (timer tick at
@@ -440,7 +430,7 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
         remainingTime={remainingTime ?? 0}
         totalTime={totalTime ?? 180}
         meId={username}
-        opponentWords={opponentInsightWords}
+        socket={socket}
         canvas={<InGameScreen {...inGameScreenProps} />}
       />
     );
@@ -471,7 +461,7 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
         totalTime={totalTime ?? 60}
         fogProgress={fogProgress}
         meId={username}
-        opponentWords={opponentInsightWords}
+        socket={socket}
         canvas={<WheelRushView {...wheelRushProps} isDesktopCanvas />}
       />
     );
@@ -505,7 +495,7 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
         totalTime={totalTime ?? 180}
         targetCategory=""
         meId={username}
-        opponentWords={opponentInsightWords}
+        socket={socket}
         canvas={<WordHuntGame {...wordHuntGameProps} />}
       />
     );
@@ -538,7 +528,7 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
           remainingTime={remainingTime ?? 0}
           totalTime={totalTime ?? 60}
           meId={username}
-          opponentWords={opponentInsightWords}
+          socket={socket}
           comboCount={comboLevel}
           comboMultiplier={1 + comboLevel * 0.1}
           canvas={blastCanvas}
@@ -577,7 +567,7 @@ const MultiplayerInGameView = memo<MultiplayerInGameViewProps>(({
       )}
     >
       <div className="relative flex-1 flex flex-col min-h-0">
-        <OpponentWordFeed feedItems={opponentFeedItems} t={t} />
+        <OpponentWordFeedConnected socket={socket} currentPlayerName={username} t={t} />
         <InGameScreen
           // Core identity
           username={username}

--- a/fe-next/components/multiplayer/OpponentWordFeedConnected.tsx
+++ b/fe-next/components/multiplayer/OpponentWordFeedConnected.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { memo } from 'react';
+import type { Socket } from 'socket.io-client';
+import { OpponentWordFeed } from './OpponentWordFeed';
+import { useOpponentWordFeed } from '@/hooks/useOpponentWordFeed';
+
+interface Props {
+  socket: Socket | null;
+  currentPlayerName: string;
+  t: (key: string, params?: Record<string, any>) => string;
+}
+
+/**
+ * Self-contained wrapper around OpponentWordFeed. Owning the
+ * `useOpponentWordFeed` subscription here (rather than in MultiplayerInGameView)
+ * isolates opponent-word socket events from the game shell — they no longer
+ * trigger parent re-renders that overlapped with drag-selection rendering.
+ */
+export const OpponentWordFeedConnected = memo<Props>(function OpponentWordFeedConnected({
+  socket,
+  currentPlayerName,
+  t,
+}) {
+  const { feedItems } = useOpponentWordFeed({ socket, currentPlayerName });
+  return <OpponentWordFeed feedItems={feedItems} t={t} />;
+});

--- a/fe-next/components/multiplayer/__tests__/OpponentWordFeedConnected.test.tsx
+++ b/fe-next/components/multiplayer/__tests__/OpponentWordFeedConnected.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { OpponentWordFeedItem } from '@/hooks/useOpponentWordFeed';
+
+const feedItemsMock = vi.fn<[], OpponentWordFeedItem[]>(() => []);
+vi.mock('@/hooks/useOpponentWordFeed', () => ({
+  useOpponentWordFeed: () => ({ feedItems: feedItemsMock() }),
+}));
+
+vi.mock('@/components/motion/AdaptiveMotion', () => ({
+  AdaptiveAnimatePresence: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AdaptiveMotion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+}));
+
+import { OpponentWordFeedConnected } from '../OpponentWordFeedConnected';
+
+const mockSocket = {} as any;
+
+const mkT = (k: string, params?: Record<string, any>) => {
+  if (k === 'multiplayer.opponentFoundWord') return `${params?.name} found ${params?.length}`;
+  return k;
+};
+
+const mk = (overrides: Partial<OpponentWordFeedItem> = {}): OpponentWordFeedItem => ({
+  id: overrides.id ?? `id-${Math.random()}`,
+  playerId: overrides.playerId ?? 'p',
+  playerName: overrides.playerName ?? 'Alice',
+  wordLength: overrides.wordLength ?? 5,
+  firstLetter: overrides.firstLetter ?? 'A',
+  lastLetter: overrides.lastLetter ?? 'E',
+  score: overrides.score ?? 4,
+  isLongWord: overrides.isLongWord ?? false,
+  timestamp: overrides.timestamp ?? 0,
+});
+
+describe('OpponentWordFeedConnected', () => {
+  beforeEach(() => {
+    feedItemsMock.mockReset();
+    feedItemsMock.mockReturnValue([]);
+  });
+
+  it('renders the feed container even when empty', () => {
+    feedItemsMock.mockReturnValue([]);
+    const { container } = render(
+      <OpponentWordFeedConnected socket={mockSocket} currentPlayerName="me" t={mkT} />
+    );
+    expect(container.querySelector('[data-testid="opponent-word-feed"]')).toBeTruthy();
+  });
+
+  it('passes feedItems from hook to inner component', () => {
+    feedItemsMock.mockReturnValue([
+      mk({ playerName: 'Bob', wordLength: 4, score: 3 }),
+    ]);
+    render(<OpponentWordFeedConnected socket={mockSocket} currentPlayerName="me" t={mkT} />);
+    expect(screen.getByText('Bob found 4')).toBeInTheDocument();
+    expect(screen.getByText('+3')).toBeInTheDocument();
+  });
+});

--- a/fe-next/components/multiplayer/desktop/BlastDesktopAdapter.tsx
+++ b/fe-next/components/multiplayer/desktop/BlastDesktopAdapter.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { Socket } from 'socket.io-client';
 import { MultiplayerDesktopShell } from './MultiplayerDesktopShell';
 import { RosterRail, type RosterPlayer } from './RosterRail';
 import { WordsLadder, type LadderWord } from './WordsLadder';
@@ -6,7 +7,7 @@ import { KeyboardHintStrip } from './KeyboardHintStrip';
 import { ThemedPanel } from './ThemedPanel';
 import CircularTimer from '../../ui/CircularTimer';
 import { MyStatsCard } from './insights/MyStatsCard';
-import { OpponentInsightFeed, type OpponentWord } from './insights/OpponentInsightFeed';
+import { OpponentInsightFeedConnected } from './insights/OpponentInsightFeedConnected';
 import { PaceDeltaChip } from './insights/PaceDeltaChip';
 import { LatestScoreTickBanner } from './insights/LatestScoreTickBanner';
 import { GoalBanner, type BlastGoal } from './insights/GoalBanner';
@@ -24,7 +25,10 @@ export interface BlastDesktopAdapterProps {
   totalTime: number;
   canvas: ReactNode;
   meId?: string;
-  opponentWords?: OpponentWord[];
+  /** Socket reference for self-subscribing opponent-insight feed. The
+   *  feed handles its own `opponentWordFound` listener so socket bursts
+   *  don't cascade into a shell-wide re-render mid-drag. */
+  socket?: Socket | null;
   startTimeMs?: number;
   goal?: BlastGoal;
   comboCount?: number;
@@ -97,8 +101,12 @@ export function BlastDesktopAdapter(props: BlastDesktopAdapterProps) {
         <div className="flex flex-col gap-2">
           <ComboCounter mode="blast" count={props.comboCount ?? 0} multiplier={props.comboMultiplier ?? 1} />
           <PaceDeltaChip mode="blast" leaderboard={props.leaderboard} meId={props.meId} />
-          {props.opponentWords && props.opponentWords.length > 0 && (
-            <OpponentInsightFeed mode="blast" opponentWords={props.opponentWords} />
+          {props.socket && props.meId && (
+            <OpponentInsightFeedConnected
+              mode="blast"
+              socket={props.socket}
+              currentPlayerName={props.meId}
+            />
           )}
           <KeyboardHintStrip />
         </div>

--- a/fe-next/components/multiplayer/desktop/StandardDesktopAdapter.tsx
+++ b/fe-next/components/multiplayer/desktop/StandardDesktopAdapter.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo, type ReactNode } from 'react';
+import type { Socket } from 'socket.io-client';
 import { MultiplayerDesktopShell } from './MultiplayerDesktopShell';
 import { RosterRail, type RosterPlayer } from './RosterRail';
 import { WordsLadder, type LadderWord } from './WordsLadder';
@@ -6,7 +7,7 @@ import { KeyboardHintStrip } from './KeyboardHintStrip';
 import { ThemedPanel } from './ThemedPanel';
 import CircularTimer from '../../ui/CircularTimer';
 import { MyStatsCard } from './insights/MyStatsCard';
-import { OpponentInsightFeed, type OpponentWord } from './insights/OpponentInsightFeed';
+import { OpponentInsightFeedConnected } from './insights/OpponentInsightFeedConnected';
 import { PaceDeltaChip } from './insights/PaceDeltaChip';
 import { LatestScoreTickBanner } from './insights/LatestScoreTickBanner';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -20,7 +21,11 @@ export interface StandardDesktopAdapterProps {
   totalTime: number;
   canvas: ReactNode;
   meId?: string;
-  opponentWords?: OpponentWord[];
+  /** Socket reference for self-subscribing opponent-insight feed. Owning the
+   *  `opponentWordFound` listener inside the feed (rather than the parent
+   *  game view) keeps drag-selection rendering off the path of opponent
+   *  socket bursts. */
+  socket?: Socket | null;
   startTimeMs?: number;
 }
 
@@ -34,7 +39,7 @@ function StandardDesktopAdapterImpl(props: StandardDesktopAdapterProps) {
     totalTime,
     canvas,
     meId,
-    opponentWords,
+    socket,
     startTimeMs,
   } = props;
 
@@ -112,13 +117,17 @@ function StandardDesktopAdapterImpl(props: StandardDesktopAdapterProps) {
     () => (
       <div className="flex flex-col gap-2">
         <PaceDeltaChip mode="classic" leaderboard={leaderboard} meId={meId} />
-        {opponentWords && opponentWords.length > 0 && (
-          <OpponentInsightFeed mode="classic" opponentWords={opponentWords} />
+        {socket && meId && (
+          <OpponentInsightFeedConnected
+            mode="classic"
+            socket={socket}
+            currentPlayerName={meId}
+          />
         )}
         <KeyboardHintStrip />
       </div>
     ),
-    [leaderboard, meId, opponentWords],
+    [leaderboard, meId, socket],
   );
 
   const slots: ShellSlots = useMemo(

--- a/fe-next/components/multiplayer/desktop/WheelRushDesktopAdapter.tsx
+++ b/fe-next/components/multiplayer/desktop/WheelRushDesktopAdapter.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { Socket } from 'socket.io-client';
 import { MultiplayerDesktopShell } from './MultiplayerDesktopShell';
 import { RosterRail, type RosterPlayer } from './RosterRail';
 import { WordsLadder, type LadderWord } from './WordsLadder';
@@ -6,7 +7,7 @@ import { KeyboardHintStrip } from './KeyboardHintStrip';
 import { ThemedPanel } from './ThemedPanel';
 import CircularTimer from '../../ui/CircularTimer';
 import { MyStatsCard } from './insights/MyStatsCard';
-import { OpponentInsightFeed, type OpponentWord } from './insights/OpponentInsightFeed';
+import { OpponentInsightFeedConnected } from './insights/OpponentInsightFeedConnected';
 import { PaceDeltaChip } from './insights/PaceDeltaChip';
 import { LatestScoreTickBanner } from './insights/LatestScoreTickBanner';
 import { SpinCounter } from './insights/SpinCounter';
@@ -24,7 +25,8 @@ export interface WheelRushDesktopAdapterProps {
   fogProgress: number;
   canvas: ReactNode;
   meId?: string;
-  opponentWords?: OpponentWord[];
+  /** Socket reference for self-subscribing opponent-insight feed (see BlastDesktopAdapter). */
+  socket?: Socket | null;
   startTimeMs?: number;
   currentSpin?: number;
   totalSpins?: number;
@@ -111,8 +113,12 @@ export function WheelRushDesktopAdapter(props: WheelRushDesktopAdapterProps) {
       activityStream: (
         <div className="flex flex-col gap-2">
           <PaceDeltaChip mode="wheel-rush" leaderboard={props.leaderboard} meId={props.meId} />
-          {props.opponentWords && props.opponentWords.length > 0 && (
-            <OpponentInsightFeed mode="wheel-rush" opponentWords={props.opponentWords} />
+          {props.socket && props.meId && (
+            <OpponentInsightFeedConnected
+              mode="wheel-rush"
+              socket={props.socket}
+              currentPlayerName={props.meId}
+            />
           )}
           <KeyboardHintStrip />
         </div>

--- a/fe-next/components/multiplayer/desktop/WordHuntDesktopAdapter.tsx
+++ b/fe-next/components/multiplayer/desktop/WordHuntDesktopAdapter.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { Socket } from 'socket.io-client';
 import { MultiplayerDesktopShell } from './MultiplayerDesktopShell';
 import { RosterRail, type RosterPlayer } from './RosterRail';
 import { WordsLadder, type LadderWord } from './WordsLadder';
@@ -6,7 +7,7 @@ import { KeyboardHintStrip } from './KeyboardHintStrip';
 import { ThemedPanel } from './ThemedPanel';
 import CircularTimer from '../../ui/CircularTimer';
 import { MyStatsCard } from './insights/MyStatsCard';
-import { OpponentInsightFeed, type OpponentWord } from './insights/OpponentInsightFeed';
+import { OpponentInsightFeedConnected } from './insights/OpponentInsightFeedConnected';
 import { PaceDeltaChip } from './insights/PaceDeltaChip';
 import { LatestScoreTickBanner } from './insights/LatestScoreTickBanner';
 import { CategoryBanner } from './insights/CategoryBanner';
@@ -23,7 +24,8 @@ export interface WordHuntDesktopAdapterProps {
   targetCategory: string;
   canvas: ReactNode;
   meId?: string;
-  opponentWords?: OpponentWord[];
+  /** Socket reference for self-subscribing opponent-insight feed (see BlastDesktopAdapter). */
+  socket?: Socket | null;
   startTimeMs?: number;
   huntFound?: number;
   huntTarget?: number;
@@ -90,8 +92,12 @@ export function WordHuntDesktopAdapter(props: WordHuntDesktopAdapterProps) {
       activityStream: (
         <div className="flex flex-col gap-2">
           <PaceDeltaChip mode="word-hunt" leaderboard={props.leaderboard} meId={props.meId} />
-          {props.opponentWords && props.opponentWords.length > 0 && (
-            <OpponentInsightFeed mode="word-hunt" opponentWords={props.opponentWords} />
+          {props.socket && props.meId && (
+            <OpponentInsightFeedConnected
+              mode="word-hunt"
+              socket={props.socket}
+              currentPlayerName={props.meId}
+            />
           )}
           <KeyboardHintStrip />
         </div>

--- a/fe-next/components/multiplayer/desktop/insights/OpponentInsightFeedConnected.tsx
+++ b/fe-next/components/multiplayer/desktop/insights/OpponentInsightFeedConnected.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { memo, useMemo } from 'react';
+import type { Socket } from 'socket.io-client';
+import { OpponentInsightFeed, type OpponentWord } from './OpponentInsightFeed';
+import { useOpponentWordFeed } from '@/hooks/useOpponentWordFeed';
+import type { MpDesktopMode } from '../types';
+
+interface Props {
+  socket: Socket | null;
+  currentPlayerName: string;
+  mode: MpDesktopMode;
+  maxItems?: number;
+}
+
+/**
+ * Self-contained wrapper around OpponentInsightFeed. The shell-mode insight
+ * panel subscribes here instead of having the parent (MultiplayerInGameView)
+ * hold opponent-word state. This keeps the drag-selection render path clear
+ * of incidental re-renders triggered by `opponentWordFound` socket events.
+ */
+export const OpponentInsightFeedConnected = memo<Props>(function OpponentInsightFeedConnected({
+  socket,
+  currentPlayerName,
+  mode,
+  maxItems,
+}) {
+  const { feedItems } = useOpponentWordFeed({ socket, currentPlayerName });
+  const opponentWords = useMemo<OpponentWord[]>(
+    () =>
+      feedItems.map((item) => ({
+        wordLength: item.wordLength,
+        firstLetter: item.firstLetter,
+        lastLetter: item.lastLetter,
+        score: item.score,
+        ts: item.timestamp,
+        byUsername: item.playerName,
+      })),
+    [feedItems],
+  );
+  if (opponentWords.length === 0) return null;
+  return <OpponentInsightFeed mode={mode} opponentWords={opponentWords} maxItems={maxItems} />;
+});

--- a/fe-next/components/multiplayer/desktop/insights/__tests__/OpponentInsightFeedConnected.test.tsx
+++ b/fe-next/components/multiplayer/desktop/insights/__tests__/OpponentInsightFeedConnected.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { OpponentWordFeedItem } from '@/hooks/useOpponentWordFeed';
+
+// Mock useOpponentWordFeed so we control feedItems without socket setup
+const feedItemsMock = vi.fn<[], OpponentWordFeedItem[]>(() => []);
+vi.mock('@/hooks/useOpponentWordFeed', () => ({
+  useOpponentWordFeed: () => ({ feedItems: feedItemsMock() }),
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (k: string) => k }),
+}));
+
+import { OpponentInsightFeedConnected } from '../OpponentInsightFeedConnected';
+
+const mockSocket = {} as any;
+
+const mk = (overrides: Partial<OpponentWordFeedItem> = {}): OpponentWordFeedItem => ({
+  id: overrides.id ?? `id-${Math.random()}`,
+  playerId: overrides.playerId ?? 'p',
+  playerName: overrides.playerName ?? 'Alice',
+  wordLength: overrides.wordLength ?? 5,
+  firstLetter: overrides.firstLetter ?? 'A',
+  lastLetter: overrides.lastLetter ?? 'E',
+  score: overrides.score ?? 4,
+  isLongWord: overrides.isLongWord ?? false,
+  timestamp: overrides.timestamp ?? 0,
+});
+
+describe('OpponentInsightFeedConnected', () => {
+  beforeEach(() => {
+    feedItemsMock.mockReset();
+    feedItemsMock.mockReturnValue([]);
+  });
+
+  it('renders nothing when feed is empty', () => {
+    feedItemsMock.mockReturnValue([]);
+    const { container } = render(
+      <OpponentInsightFeedConnected
+        socket={mockSocket}
+        currentPlayerName="me"
+        mode="classic"
+      />
+    );
+    // empty-feed → component returns null
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('maps feedItems → OpponentInsightFeed opponentWords shape', () => {
+    feedItemsMock.mockReturnValue([
+      mk({ id: 'a', playerName: 'Alice', wordLength: 3, firstLetter: 'C', lastLetter: 'T', score: 6, timestamp: 10 }),
+    ]);
+    render(
+      <OpponentInsightFeedConnected
+        socket={mockSocket}
+        currentPlayerName="me"
+        mode="classic"
+      />
+    );
+    // OpponentInsightFeed uses byUsername + score → "+6" + masked word "C·T"
+    expect(screen.getByTestId('opponent-row-C·T')).toBeInTheDocument();
+    expect(screen.getByText('+6')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('honors maxItems prop', () => {
+    feedItemsMock.mockReturnValue(
+      Array.from({ length: 5 }, (_, i) => mk({ id: `i-${i}`, timestamp: i }))
+    );
+    render(
+      <OpponentInsightFeedConnected
+        socket={mockSocket}
+        currentPlayerName="me"
+        mode="classic"
+        maxItems={2}
+      />
+    );
+    const rows = screen.getAllByTestId(/opponent-row-/);
+    expect(rows.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Classic-mode multiplayer felt slow & "stuck" mid-drag on every viewport — mobile portrait + desktop shell alike — because `MultiplayerInGameView` held the `useOpponentWordFeed` subscription at the top of the tree.

Every `opponentWordFound` socket event (and every 3 s auto-remove timer) called `setFeedItems`, which synchronously re-rendered the entire game shell: the parent rebuilt its ~50-field `inGameScreenProps` literal, recreated the `<InGameScreen>` React element passed as `canvas`, and broke the `slots` `useMemo` in the desktop adapters. In a busy room (1–5 word events/sec) this storm overlapped per-letter drag rendering and the user perceived the whole UI (timer, score, insight panels, found-word ladder) as stuck.

## Fix

Push the subscription **down** into the feed components themselves so the parent never sees opponent-word state changes.

- **new** `OpponentWordFeedConnected` — owns the hook for the floating mobile feed
- **new** `OpponentInsightFeedConnected` — owns the hook for the shell insight panel
- The four desktop adapters (`Standard`, `Blast`, `WheelRush`, `WordHunt`) now accept `socket` (was `opponentWords`) and render the Connected version internally
- `MultiplayerInGameView` drops the `useOpponentWordFeed` call, the `useDeferredValue`, and the `opponentInsightWords` `useMemo` entirely

Net effect: opponent socket bursts never touch `MultiplayerInGameView` or any of its memo-stable children outside the feed itself. Drag-selection rendering runs uncontended on every screen size.

## Test plan

- [x] 5 new TDD tests for the Connected wrappers (RED → GREEN cycle): mocks `useOpponentWordFeed`, asserts both wrappers render the inner component with the right item shape, count, and empty-state behaviour
- [x] Full vitest run: **3491/3491 passing**
- [x] `tsc --noEmit` clean on all touched files (remaining repo-wide errors are pre-existing — missing optional packages + backend config)
- [ ] Manual smoke: drag a 6-letter word in mobile-portrait classic MP while opponents are submitting — UI should stay responsive
- [ ] Manual smoke: same in desktop-shell classic MP — insight panel still ticks in, ladder still updates

https://claude.ai/code/session_014XP2Z3dDiturG27Xx4mJEt

---
_Generated by [Claude Code](https://claude.ai/code/session_014XP2Z3dDiturG27Xx4mJEt)_