### PR TITLE
feat(education): GSAP reveals + dark-on-dark contrast fixes

### DIFF
--- a/fe-next/app/[locale]/education/access/PageClient.tsx
+++ b/fe-next/app/[locale]/education/access/PageClient.tsx
@@ -1,30 +1,114 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import Link from 'next/link';
+import { gsap } from 'gsap';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { AccessRequestForm } from '@/components/education/AccessRequestForm';
 import { useTeacherAccess } from '@/lib/education/useTeacherAccess';
+import { useGsapReveal } from '@/lib/animation/useGsapReveal';
+import { isReducedMotionPreferred } from '@/utils/accessibility';
 
 export function PageClient() {
   const { t, language } = useLanguage();
   const { status, latestRequest, hasAccess } = useTeacherAccess();
 
+  // Hero (h1 + lede): GSAP timeline on mount.
+  const heroRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const root = heroRef.current;
+    if (!root) return;
+    const items = root.querySelectorAll<HTMLElement>('[data-access-hero]');
+    if (items.length === 0) return;
+
+    if (isReducedMotionPreferred()) {
+      gsap.set(items, { opacity: 1, y: 0 });
+      return;
+    }
+
+    const tl = gsap.timeline();
+    tl.set(items, { opacity: 0, y: 18 });
+    tl.to(items, {
+      opacity: 1,
+      y: 0,
+      duration: 0.6,
+      ease: 'power3.out',
+      stagger: 0.1,
+    });
+    return () => {
+      tl.kill();
+    };
+  }, []);
+
+  // Status card (approved / pending / declined / form): pop-in when it mounts.
+  const statusRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = statusRef.current;
+    if (!el) return;
+    if (isReducedMotionPreferred()) {
+      gsap.set(el, { opacity: 1, y: 0, scale: 1 });
+      return;
+    }
+    gsap.fromTo(
+      el,
+      { opacity: 0, y: 16, scale: 0.97 },
+      { opacity: 1, y: 0, scale: 1, duration: 0.5, ease: 'back.out(1.7)', delay: 0.35 },
+    );
+  }, [hasAccess, status]);
+
+  // Step cards: staggered scroll reveal.
+  const stepsRef = useGsapReveal<HTMLDivElement>({
+    selector: '[data-access-step]',
+    y: 22,
+    stagger: 0.12,
+    duration: 0.55,
+    ease: 'power3.out',
+  });
+
+  // Try-a-regular-game block: heading + chips slide in together.
+  const tryRef = useGsapReveal<HTMLDivElement>({
+    selector: '[data-access-try]',
+    y: 18,
+    scale: 0.95,
+    stagger: 0.07,
+    duration: 0.5,
+    ease: 'back.out(1.4)',
+  });
+
   return (
     <main className="min-h-screen bg-neo-navy text-neo-white">
       <section className="mx-auto max-w-2xl px-4 py-12">
-        <h1 className="text-4xl font-extrabold leading-tight font-neo-display">{t('education.access.h1')}</h1>
-        <p className="mt-3 text-lg text-neo-white/80">{t('education.access.lede')}</p>
+        <div ref={heroRef}>
+          <h1
+            data-access-hero
+            className="text-4xl font-extrabold leading-tight font-neo-display"
+          >
+            {t('education.access.h1')}
+          </h1>
+          <p data-access-hero className="mt-3 text-lg text-neo-white/80">
+            {t('education.access.lede')}
+          </p>
+        </div>
 
         {hasAccess && (
-          <div className="mt-6 rounded-neo border-neo bg-neo-lime p-6 text-neo-navy shadow-hard">
+          <div
+            ref={statusRef}
+            className="mt-6 rounded-neo border-neo bg-neo-lime p-6 text-neo-navy shadow-hard"
+          >
             <h2 className="text-xl font-bold font-neo-display">{t('education.access.already_approved_title')}</h2>
-            <Link href={`/${language}/teacher`} className="mt-3 inline-block rounded-neo bg-neo-navy px-4 py-2 font-bold text-neo-white border-neo shadow-hard-sm hover:shadow-hard active:shadow-hard-pressed transition-all">
+            <Link
+              href={`/${language}/teacher`}
+              className="mt-3 inline-block rounded-neo bg-neo-navy px-4 py-2 font-bold text-neo-white border-neo shadow-hard-sm hover:shadow-hard active:shadow-hard-pressed transition-all"
+            >
               {t('education.access.go_to_teacher')}
             </Link>
           </div>
         )}
 
         {!hasAccess && status === 'pending' && (
-          <div className="mt-6 rounded-neo border-neo bg-neo-cyan p-6 text-neo-navy shadow-hard">
+          <div
+            ref={statusRef}
+            className="mt-6 rounded-neo border-neo bg-neo-cyan p-6 text-neo-navy shadow-hard"
+          >
             <h2 className="text-xl font-bold font-neo-display">{t('education.access.pending_title')}</h2>
             <p className="mt-2">{t('education.access.pending_body')}</p>
             {latestRequest?.created_at && (
@@ -36,26 +120,36 @@ export function PageClient() {
         )}
 
         {!hasAccess && status === 'declined' && (
-          <div className="mt-6 rounded-neo border-neo bg-neo-pink p-6 text-neo-white shadow-hard">
+          <div
+            ref={statusRef}
+            className="mt-6 rounded-neo border-neo bg-neo-pink p-6 text-neo-white shadow-hard"
+          >
             <h2 className="text-xl font-bold font-neo-display">{t('education.access.declined_title')}</h2>
             {latestRequest?.admin_note && (
-              <div className="mt-3 rounded bg-neo-white/20 p-3">
-                <p className="text-sm">{latestRequest.admin_note}</p>
+              <div className="mt-3 rounded bg-neo-navy/40 p-3 border border-neo-white/20">
+                <p className="text-sm text-neo-white">{latestRequest.admin_note}</p>
               </div>
             )}
-            <p className="mt-3 text-sm text-neo-white/80">{t('education.access.declined_reapply')}</p>
+            <p className="mt-3 text-sm text-neo-white/90">{t('education.access.declined_reapply')}</p>
           </div>
         )}
 
         {!hasAccess && status !== 'pending' && status !== 'declined' && (
-          <div className="mt-6 rounded-neo border-neo-thick bg-neo-navy-light p-6 text-neo-white shadow-hard-lg">
+          <div
+            ref={statusRef}
+            className="mt-6 rounded-neo border-neo-thick bg-neo-navy-light p-6 text-neo-white shadow-hard-lg"
+          >
             <AccessRequestForm />
           </div>
         )}
 
-        <div className="mt-10 grid gap-4 md:grid-cols-3">
+        <div ref={stepsRef} className="mt-10 grid gap-4 md:grid-cols-3">
           {(['step1', 'step2', 'step3'] as const).map((k, i) => (
-            <div key={k} className="rounded-neo border-neo p-4 bg-neo-navy-light">
+            <div
+              key={k}
+              data-access-step
+              className="rounded-neo border-neo p-4 bg-neo-navy-light transition-transform hover:-translate-y-1"
+            >
               <div className="text-3xl font-extrabold text-neo-lime font-neo-display">{i + 1}</div>
               <h3 className="mt-2 font-bold text-neo-white font-neo-display">{t(`education.access.next.${k}_title`)}</h3>
               <p className="mt-1 text-sm text-neo-white/80">{t(`education.access.next.${k}_body`)}</p>
@@ -63,13 +157,41 @@ export function PageClient() {
           ))}
         </div>
 
-        <div className="mt-12 rounded-neo border-neo p-6 bg-neo-navy-light">
-          <h2 className="text-2xl font-bold font-neo-display text-neo-white">{t('education.access.regular_game_title')}</h2>
-          <p className="mt-2 text-neo-white/80">{t('education.access.regular_game_body')}</p>
+        <div
+          ref={tryRef}
+          className="mt-12 rounded-neo border-neo p-6 bg-neo-navy-light"
+        >
+          <h2
+            data-access-try
+            className="text-2xl font-bold font-neo-display text-neo-white"
+          >
+            {t('education.access.regular_game_title')}
+          </h2>
+          <p data-access-try className="mt-2 text-neo-white/80">
+            {t('education.access.regular_game_body')}
+          </p>
           <div className="mt-4 grid gap-3 sm:grid-cols-3">
-            <Link href={`/${language}/multiplayer`} className="rounded-neo bg-neo-pink px-4 py-3 text-center font-bold text-neo-white border-neo shadow-hard hover:shadow-hard-sm active:shadow-hard-pressed transition-all">{t('education.access.try_mp')}</Link>
-            <Link href={`/${language}/blast`} className="rounded-neo bg-neo-cyan px-4 py-3 text-center font-bold text-neo-navy border-neo shadow-hard hover:shadow-hard-sm active:shadow-hard-pressed transition-all">{t('education.access.try_blast')}</Link>
-            <Link href={`/${language}/daily`} className="rounded-neo bg-neo-purple px-4 py-3 text-center font-bold text-neo-white border-neo shadow-hard hover:shadow-hard-sm active:shadow-hard-pressed transition-all">{t('education.access.try_daily')}</Link>
+            <Link
+              data-access-try
+              href={`/${language}/multiplayer`}
+              className="rounded-neo bg-neo-pink px-4 py-3 text-center font-bold text-neo-white border-neo shadow-hard hover:shadow-hard-sm active:shadow-hard-pressed transition-all"
+            >
+              {t('education.access.try_mp')}
+            </Link>
+            <Link
+              data-access-try
+              href={`/${language}/blast`}
+              className="rounded-neo bg-neo-cyan px-4 py-3 text-center font-bold text-neo-navy border-neo shadow-hard hover:shadow-hard-sm active:shadow-hard-pressed transition-all"
+            >
+              {t('education.access.try_blast')}
+            </Link>
+            <Link
+              data-access-try
+              href={`/${language}/daily`}
+              className="rounded-neo bg-neo-purple px-4 py-3 text-center font-bold text-neo-white border-neo shadow-hard hover:shadow-hard-sm active:shadow-hard-pressed transition-all"
+            >
+              {t('education.access.try_daily')}
+            </Link>
           </div>
         </div>
       </section>

--- a/fe-next/components/education/ComparisonStrip.tsx
+++ b/fe-next/components/education/ComparisonStrip.tsx
@@ -1,5 +1,8 @@
 'use client';
+import { useEffect, useRef } from 'react';
+import { gsap } from 'gsap';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { isReducedMotionPreferred } from '@/utils/accessibility';
 
 const COMPETITORS = ['lexiclash', 'kahoot', 'quizlet', 'wordwall'] as const;
 const FEATURES = [
@@ -35,17 +38,100 @@ const MATRIX: Record<
 
 export function ComparisonStrip() {
   const { t } = useLanguage();
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section) return;
+
+    const rm = isReducedMotionPreferred();
+    const heading = section.querySelectorAll<HTMLElement>('[data-compare-head]');
+    const tableEl = section.querySelector<HTMLElement>('[data-compare-table]');
+    const checks = section.querySelectorAll<HTMLElement>('[data-compare-check]');
+    const rows = section.querySelectorAll<HTMLElement>('[data-compare-row]');
+
+    if (rm) {
+      gsap.set([...heading, tableEl, ...rows, ...checks].filter(Boolean) as Element[], {
+        opacity: 1,
+        y: 0,
+        scale: 1,
+      });
+      return;
+    }
+
+    gsap.set(heading, { opacity: 0, y: 18 });
+    if (tableEl) gsap.set(tableEl, { opacity: 0, y: 24 });
+    gsap.set(rows, { opacity: 0, x: -12 });
+    gsap.set(checks, { opacity: 0, scale: 0.4 });
+
+    let played = false;
+    const obs = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting || played) return;
+        played = true;
+
+        const tl = gsap.timeline();
+        tl.to(heading, {
+          opacity: 1,
+          y: 0,
+          duration: 0.55,
+          ease: 'power3.out',
+          stagger: 0.08,
+        });
+        if (tableEl) {
+          tl.to(
+            tableEl,
+            { opacity: 1, y: 0, duration: 0.55, ease: 'power3.out' },
+            '-=0.3',
+          );
+        }
+        tl.to(
+          rows,
+          {
+            opacity: 1,
+            x: 0,
+            duration: 0.4,
+            ease: 'power2.out',
+            stagger: 0.06,
+          },
+          '-=0.25',
+        );
+        tl.to(
+          checks,
+          {
+            opacity: 1,
+            scale: 1,
+            duration: 0.35,
+            ease: 'back.out(2.4)',
+            stagger: 0.05,
+          },
+          '-=0.2',
+        );
+
+        obs.disconnect();
+      },
+      { threshold: 0.15, rootMargin: '0px 0px -10% 0px' },
+    );
+    obs.observe(section);
+    return () => obs.disconnect();
+  }, []);
 
   return (
-    <section className="mx-auto max-w-5xl px-4 py-12 sm:py-16">
-      <h2 className="text-3xl font-neo-display font-black text-neo-navy">
+    <section ref={sectionRef} className="mx-auto max-w-5xl px-4 py-12 sm:py-16">
+      <h2
+        data-compare-head
+        className="text-3xl font-neo-display font-black text-neo-white"
+      >
         {t('education.landing.compare.title')}
       </h2>
-      <p className="mt-2 text-neo-navy/70">
+      <p data-compare-head className="mt-2 text-neo-white/80">
         {t('education.landing.compare.subtitle')}
       </p>
 
-      <div className="mt-6 overflow-x-auto rounded-neo border-neo-thick border-neo-navy">
+      <div
+        data-compare-table
+        className="mt-6 overflow-x-auto rounded-neo border-neo-thick border-neo-navy"
+      >
         <table className="w-full text-sm">
           <thead>
             <tr className="bg-neo-cream border-b-neo-thick border-b-neo-navy">
@@ -66,6 +152,7 @@ export function ComparisonStrip() {
             {FEATURES.map((f, fi) => (
               <tr
                 key={f}
+                data-compare-row
                 className={`${
                   fi % 2 === 0 ? 'bg-neo-cream/40' : 'bg-neo-cream'
                 } border-b border-neo-navy/20`}
@@ -81,7 +168,12 @@ export function ComparisonStrip() {
                     }`}
                   >
                     {MATRIX[f][c] ? (
-                      <span className="text-neo-lime text-lg">✓</span>
+                      <span
+                        data-compare-check
+                        className="inline-block text-neo-lime-dark text-lg"
+                      >
+                        ✓
+                      </span>
                     ) : (
                       <span className="text-neo-navy/40">—</span>
                     )}

--- a/fe-next/components/education/EducationHero.tsx
+++ b/fe-next/components/education/EducationHero.tsx
@@ -1,7 +1,9 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import Link from 'next/link';
+import { gsap } from 'gsap';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { useScrollReveal } from '@/lib/animation/useScrollReveal';
+import { isReducedMotionPreferred } from '@/utils/accessibility';
 
 /**
  * Design tokens (from frontend-design skill):
@@ -9,16 +11,62 @@ import { useScrollReveal } from '@/lib/animation/useScrollReveal';
  * - Primary CTA: bg-neo-lime with shadow-hard (pixel-perfect shadow)
  * - Secondary CTA: border-neo + dark navy text
  * - Decorative dots: neo-lime/neo-pink at low opacity for personality
+ *
+ * Entry: GSAP timeline cascades eyebrow → h1 → sub → CTAs, then floats the
+ * background dots on a slow loop. Decorative only; respects reduced-motion.
  */
 
 export function EducationHero() {
   const { t, language } = useLanguage();
-  const [ref, visible] = useScrollReveal<HTMLDivElement>({ once: true });
+  const rootRef = useRef<HTMLDivElement>(null);
+  const dotsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    const dots = dotsRef.current;
+    if (!root) return;
+
+    const rm = isReducedMotionPreferred();
+    const targets = root.querySelectorAll<HTMLElement>('[data-hero-item]');
+    if (targets.length === 0) return;
+
+    if (rm) {
+      gsap.set(targets, { opacity: 1, y: 0 });
+      return;
+    }
+
+    const tl = gsap.timeline();
+    tl.set(targets, { opacity: 0, y: 24 });
+    tl.to(targets, {
+      opacity: 1,
+      y: 0,
+      duration: 0.7,
+      ease: 'power3.out',
+      stagger: 0.1,
+    });
+
+    let dotsTween: gsap.core.Tween | null = null;
+    if (dots) {
+      dotsTween = gsap.to(dots, {
+        backgroundPosition: '40px 30px, -40px -30px',
+        duration: 14,
+        ease: 'sine.inOut',
+        repeat: -1,
+        yoyo: true,
+      });
+    }
+
+    return () => {
+      tl.kill();
+      dotsTween?.kill();
+    };
+  }, []);
 
   return (
     <section className="relative overflow-hidden bg-gradient-to-b from-neo-cream to-neo-white">
       {/* Decorative background dots */}
       <div
+        ref={dotsRef}
         aria-hidden
         className="pointer-events-none absolute inset-0"
         style={{
@@ -29,22 +77,32 @@ export function EducationHero() {
       />
 
       <div
-        ref={ref}
-        className={`relative mx-auto max-w-4xl px-4 py-16 sm:py-20 text-center transition-all duration-700 ease-out ${
-          visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
-        }`}
+        ref={rootRef}
+        className="relative mx-auto max-w-4xl px-4 py-16 sm:py-20 text-center"
       >
-        <p className="text-sm font-bold uppercase tracking-wider text-neo-pink">
+        <p
+          data-hero-item
+          className="text-sm font-bold uppercase tracking-wider text-neo-pink"
+        >
           {t('education.landing.hero.eyebrow')}
         </p>
-        <h1 className="mt-3 text-4xl sm:text-5xl font-neo-display font-black leading-tight text-neo-navy md:text-6xl">
+        <h1
+          data-hero-item
+          className="mt-3 text-4xl sm:text-5xl font-neo-display font-black leading-tight text-neo-navy md:text-6xl"
+        >
           {t('education.landing.hero.h1')}
         </h1>
-        <p className="education-hero-sub mt-5 text-base sm:text-lg text-neo-navy/70">
+        <p
+          data-hero-item
+          className="education-hero-sub mt-5 text-base sm:text-lg text-neo-navy/70"
+        >
           {t('education.landing.hero.sub')}
         </p>
 
-        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
+        <div
+          data-hero-item
+          className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center"
+        >
           <Link
             href={`/${language}/education/access`}
             className="rounded-neo border-neo-thick border-neo-navy bg-neo-lime px-6 py-3 font-bold text-neo-navy shadow-hard-lg transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-hard"

--- a/fe-next/components/education/MoatTrifectaSection.tsx
+++ b/fe-next/components/education/MoatTrifectaSection.tsx
@@ -1,10 +1,12 @@
 'use client';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { useScrollReveal } from '@/lib/animation/useScrollReveal';
+import { useGsapReveal } from '@/lib/animation/useGsapReveal';
 
 /**
  * Design: 3 cards with mode-specific accent colors (neo-lime, neo-cyan, neo-pink)
- * Stagger: each card delays by 120ms from previous, driven by parent visibility
+ * The h2/subtitle sit on the page's dark navy background — they must use light
+ * text. The cards themselves are cream, so internal text stays navy.
+ * GSAP staggers the heading, subtitle, then cards on scroll-in.
  */
 
 const PILLARS = [
@@ -15,37 +17,35 @@ const PILLARS = [
 
 export function MoatTrifectaSection() {
   const { t } = useLanguage();
-  const [ref, visible] = useScrollReveal<HTMLDivElement>({ once: true });
+  const ref = useGsapReveal<HTMLDivElement>({
+    selector: '[data-moat-item]',
+    y: 28,
+    stagger: 0.12,
+    duration: 0.7,
+  });
 
   return (
     <section className="mx-auto max-w-5xl px-4 py-12 sm:py-16">
       <div ref={ref}>
         <h2
-          className={`text-3xl font-neo-display font-black text-neo-navy text-center transition-all duration-700 ${
-            visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
-          }`}
+          data-moat-item
+          className="text-3xl font-neo-display font-black text-neo-white text-center"
         >
           {t('education.landing.moat.title')}
         </h2>
         <p
-          className={`mt-2 text-center text-neo-navy/60 transition-all duration-700 ${
-            visible ? 'opacity-100' : 'opacity-0'
-          }`}
-          style={{ transitionDelay: visible ? '80ms' : '0ms' }}
+          data-moat-item
+          className="mt-2 text-center text-neo-white/70"
         >
           {t('education.landing.moat.subtitle')}
         </p>
 
         <div className="mt-10 grid gap-6 md:grid-cols-3">
-          {PILLARS.map((p, i) => (
+          {PILLARS.map((p) => (
             <article
               key={p.key}
-              style={{
-                transitionDelay: visible ? `${200 + i * 120}ms` : '0ms',
-              }}
-              className={`rounded-neo border-neo-thick ${p.borderAccent} bg-neo-cream p-6 shadow-hard-lg transition-all duration-700 ${
-                visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'
-              }`}
+              data-moat-item
+              className={`rounded-neo border-neo-thick ${p.borderAccent} bg-neo-cream p-6 shadow-hard-lg transition-transform hover:-translate-y-1`}
             >
               <div className={`mb-4 inline-block rounded-full ${p.accent} px-3 py-1 text-xs font-bold text-neo-navy uppercase`}>
                 {t(`education.landing.moat.${p.key}.tag`)}

--- a/fe-next/components/education/SixModeTour.tsx
+++ b/fe-next/components/education/SixModeTour.tsx
@@ -1,12 +1,14 @@
 'use client';
 import Link from 'next/link';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { useScrollReveal } from '@/lib/animation/useScrollReveal';
+import { useGsapReveal } from '@/lib/animation/useGsapReveal';
 
 /**
- * Design: 6 cards in 2x3 grid on desktop, 1 col on mobile
- * Accent colors mapped statically to avoid Tailwind purging
- * Stagger: each card animates with 80ms delay
+ * Design: 6 cards in 2x3 grid on desktop, 1 col on mobile.
+ * Accent colors mapped statically to avoid Tailwind purging.
+ * Heading sits on the page dark-navy bg, so it must be light text;
+ * cards keep their cream bg with navy text inside.
+ * GSAP cascades heading then each card on scroll-in.
  */
 
 const ACCENT_BG: Record<string, string> = {
@@ -34,28 +36,29 @@ const MODES = [
 
 export function SixModeTour() {
   const { t, language } = useLanguage();
-  const [ref, visible] = useScrollReveal<HTMLDivElement>({ once: true });
+  const ref = useGsapReveal<HTMLElement>({
+    selector: '[data-mode-item]',
+    y: 24,
+    stagger: 0.08,
+    duration: 0.55,
+  });
 
   return (
-    <section className="mx-auto max-w-6xl px-4 py-12 sm:py-16">
-      <h2 className="text-3xl font-neo-display font-black text-neo-navy">
+    <section ref={ref} className="mx-auto max-w-6xl px-4 py-12 sm:py-16">
+      <h2
+        data-mode-item
+        className="text-3xl font-neo-display font-black text-neo-white"
+      >
         {t('education.landing.modes.title')}
       </h2>
 
-      <div
-        ref={ref}
-        className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
-      >
-        {MODES.map((m, i) => (
+      <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {MODES.map((m) => (
           <Link
             key={m.key}
+            data-mode-item
             href={`/${language}${m.href}`}
-            style={{
-              transitionDelay: visible ? `${i * 80}ms` : '0ms',
-            }}
-            className={`group block rounded-neo border-neo-thick border-neo-navy bg-neo-cream p-5 shadow-hard-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-hard ${
-              visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'
-            }`}
+            className="group block rounded-neo border-neo-thick border-neo-navy bg-neo-cream p-5 shadow-hard-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-hard"
           >
             <div
               className={`mb-3 inline-block rounded-full px-2.5 py-1 text-xs font-bold uppercase ${

--- a/fe-next/components/education/TeacherAccessCTA.tsx
+++ b/fe-next/components/education/TeacherAccessCTA.tsx
@@ -1,19 +1,35 @@
 'use client';
 import Link from 'next/link';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { useGsapReveal } from '@/lib/animation/useGsapReveal';
 
 export function TeacherAccessCTA() {
   const { t, language } = useLanguage();
+  const ref = useGsapReveal<HTMLElement>({
+    selector: '[data-cta-item]',
+    y: 18,
+    scale: 0.97,
+    stagger: 0.1,
+    duration: 0.55,
+    ease: 'back.out(1.6)',
+  });
 
   return (
-    <aside className="mx-auto my-12 max-w-3xl rounded-neo border-neo-thick border-neo-navy bg-neo-cream p-6 sm:p-8 shadow-hard-lg">
-      <h2 className="text-2xl font-neo-display font-black text-neo-navy">
+    <aside
+      ref={ref}
+      className="mx-auto my-12 max-w-3xl rounded-neo border-neo-thick border-neo-navy bg-neo-cream p-6 sm:p-8 shadow-hard-lg"
+    >
+      <h2
+        data-cta-item
+        className="text-2xl font-neo-display font-black text-neo-navy"
+      >
         {t('education.landing.cta.title')}
       </h2>
-      <p className="mt-2 text-neo-navy/70">
+      <p data-cta-item className="mt-2 text-neo-navy/70">
         {t('education.landing.cta.body')}
       </p>
       <Link
+        data-cta-item
         href={`/${language}/education/access`}
         className="mt-4 inline-block rounded-neo border-neo-thick border-neo-navy bg-neo-lime px-6 py-3 font-bold text-neo-navy shadow-hard-lg transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-hard"
       >

--- a/fe-next/lib/animation/useGsapReveal.ts
+++ b/fe-next/lib/animation/useGsapReveal.ts
@@ -1,0 +1,83 @@
+'use client';
+import { useEffect, useRef } from 'react';
+import { gsap } from 'gsap';
+import { isReducedMotionPreferred } from '@/utils/accessibility';
+
+interface RevealOptions {
+  /** CSS selector for children to stagger-reveal. If omitted, reveals the container itself. */
+  selector?: string;
+  /** Initial Y offset in px. */
+  y?: number;
+  /** Initial scale. */
+  scale?: number;
+  /** Per-child stagger in seconds. */
+  stagger?: number;
+  /** Animation duration in seconds. */
+  duration?: number;
+  /** Delay before the timeline starts. */
+  delay?: number;
+  /** Easing curve. */
+  ease?: string;
+  /** Observer threshold (0–1). */
+  threshold?: number;
+  /** When true, animation runs once and never reverses. */
+  once?: boolean;
+}
+
+/**
+ * Reveal a container (and optionally its children) when it enters the viewport,
+ * using GSAP for the actual animation. Respects prefers-reduced-motion by
+ * snapping to the final state without animating. Pattern mirrors useScrollReveal
+ * but with GSAP timelines for richer easing + stagger control.
+ */
+export function useGsapReveal<T extends HTMLElement>(opts: RevealOptions = {}) {
+  const ref = useRef<T | null>(null);
+  const {
+    selector,
+    y = 24,
+    scale,
+    stagger = 0.08,
+    duration = 0.6,
+    delay = 0,
+    ease = 'power3.out',
+    threshold = 0.15,
+    once = true,
+  } = opts;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const targets: Element[] = selector
+      ? Array.from(el.querySelectorAll(selector))
+      : [el];
+    if (targets.length === 0) return;
+
+    const rm = isReducedMotionPreferred();
+    const from: gsap.TweenVars = rm
+      ? { opacity: 0 }
+      : { opacity: 0, y, ...(scale !== undefined ? { scale } : {}) };
+    const to: gsap.TweenVars = rm
+      ? { opacity: 1, duration: 0.2, ease: 'none', stagger: 0 }
+      : { opacity: 1, y: 0, scale: 1, duration, ease, stagger, delay };
+
+    gsap.set(targets, from);
+
+    let played = false;
+    const obs = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !played) {
+          played = true;
+          gsap.to(targets, to);
+          if (once) obs.disconnect();
+        }
+      },
+      { threshold, rootMargin: '0px 0px -10% 0px' },
+    );
+
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [selector, y, scale, stagger, duration, delay, ease, threshold, once]);
+
+  return ref;
+}


### PR DESCRIPTION
## Summary

Adds richer GSAP-driven motion to the Education landing page (`/[locale]/education`) and the Teacher Access page (`/[locale]/education/access`), and fixes several dark-text-on-dark-background contrast bugs that were sitting on the page's `bg-neo-navy` shell.

### New animations
A new `lib/animation/useGsapReveal.ts` hook combines `IntersectionObserver` with GSAP `set`/`to`, mirroring the existing `useScrollReveal` API but with richer easing + stagger. All animations respect `prefers-reduced-motion`.

- **EducationHero** — GSAP timeline cascades eyebrow → h1 → sub → CTAs on mount, plus a slow, looped `backgroundPosition` drift on the decorative dots.
- **MoatTrifectaSection** — staggered scroll-in for the title, subtitle, then the 3 pillar cards.
- **SixModeTour** — heading + 6 cards stagger in on scroll.
- **ComparisonStrip** — full timeline: heading → table fade-up → rows slide-in → checkmarks pop with `back.out(2.4)`.
- **TeacherAccessCTA** — back-ease entrance on h2 / body / button.
- **Access page** — hero timeline, status-card pop-in that re-runs on `hasAccess` / `status` changes, 3-step stagger, and a back-ease cascade on the "try a regular game" block.

### Contrast fixes
Several headings were `text-neo-navy` directly on the page's `bg-neo-navy` shell, so they were effectively invisible.

- `MoatTrifectaSection` h2 / subtitle → `text-neo-white` / `text-neo-white/70`
- `SixModeTour` h2 → `text-neo-white`
- `ComparisonStrip` h2 / subtitle → `text-neo-white` / `text-neo-white/80`
- `ComparisonStrip` `✓` checkmark → `text-neo-lime-dark` (bright lime on cream rows was washing out)
- Access page declined-state `admin_note` — white-text on a `bg-neo-white/20` overlay over `bg-neo-pink` was unreadable; swapped to a `bg-neo-navy/40` panel with a subtle `border-neo-white/20`.

## Test plan
- [ ] `/en/education` (unauthenticated) — verify hero cascade, scroll-stagger on each section, headings now visible against navy bg.
- [ ] `/en/education` (teacher logged-in) — shortcut bars + SixModeTour + ComparisonStrip + FAQ render with new motion; no dark-on-dark headings.
- [ ] `/en/education/access` (no request yet) — hero animates, AccessRequestForm pops in, step cards stagger, try-block cascades.
- [ ] `/en/education/access` — pending / declined / approved states each pop in cleanly; declined `admin_note` is legible.
- [ ] `prefers-reduced-motion: reduce` — content appears immediately with no transforms.
- [ ] Existing tests: `EducationLanding.redesign.test.tsx`, `EducationLanding.authShortcut.test.tsx` still pass (text queries unaffected; IntersectionObserver mock leaves elements in DOM).


---
_Generated by [Claude Code](https://claude.ai/code/session_017PQ38YMXxbBvEhz7hhxAbp)_