### PR TITLE
SEO: daily meta tag improvements (2026-05-18)

### DIFF
--- a/docs/seo-daily/2026-05-18.md
+++ b/docs/seo-daily/2026-05-18.md
@@ -1,0 +1,141 @@
+# SEO Daily Report — 2026-05-18
+
+**Data range:** 2026-04-19 → 2026-05-16 (28 days, GSC 2-day lag)
+**Bing:** Blocked — cloud execution IP not in Bing webmaster allowlist; Bing data unavailable this run.
+
+---
+
+## Headline Metrics
+
+### Google (28d)
+
+| Metric | Value |
+|---|---|
+| Total clicks | 49 |
+| Total impressions | 1,757 |
+| Avg CTR | 2.79% |
+| Avg position | 27.7 |
+
+### Google 7d vs prior 7d (last 7d: May 10–16, prior: May 3–9)
+
+| Metric | Last 7d | Prior 7d | Delta |
+|---|---|---|---|
+| Clicks | 13 | 36 | **-63.9%** |
+| Impressions | 352 | 875 | **-59.8%** |
+
+> ⚠️ **Critical alert**: Impressions and clicks dropped ~60% week-over-week. Spanish-language queries (the single largest impression source) fell to 0 impressions in the last 7 days — possible Google algorithm update impact or crawl issue on `/es/` pages. Investigate indexing status for `lexiclash.live/es/*` immediately.
+
+### Branded vs Non-Branded CTR Split (28d)
+
+| Segment | Clicks | Impressions | CTR |
+|---|---|---|---|
+| Branded (`lexiclash`) | 41 | 56 | 73.2% |
+| All non-branded | 8 | 1,701 | **0.47%** |
+
+> ⚠️ Every non-branded ranking query has 0 clicks except a handful. Non-branded CTR is critically low, indicating a title/description mismatch with user intent or snippet quality issues.
+
+---
+
+## Top 10 CTR Opportunities
+
+Queries with ≥30 impressions, actual CTR underperforming expected position-band CTR by ≥30%.
+
+| # | Query | Page | Pos | Imps | Current CTR | Expected CTR | Potential +clicks | Suggested Fix |
+|---|---|---|---|---|---|---|---|---|
+| 1 | scrabble online español | /es/juego-de-palabras-multijugador | 8.7 | 167 | 0.0% | 2.5% | +4 | Add "10.000+ palabras · Jugar ahora" to desc; trim title to ≤60 chars |
+| 2 | scrabble online svenska | /sv/swedish-multiplayer-word-game | 9.2 | 167 | 0.0% | 2.0% | +3 | Shorten title (63→54 chars); add "Spela Nu" CTA |
+| 3 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.4 | 102 | 0.0% | 2.5% | +3 | Same page as #1 — title fix covers this |
+| 4 | scrabble svenska online | /sv/swedish-multiplayer-word-game | 6.1 | 71 | 0.0% | 4.0% | +3 | Same page as #2 — title fix covers this |
+| 5 | jugar scrabble gratis | /es/juego-de-palabras-multijugador | 9.2 | 68 | 0.0% | 2.0% | +1 | Same page as #1 |
+| 6 | scrabble en linea | /es/juego-de-palabras-multijugador | 9.4 | 67 | 0.0% | 2.0% | +1 | Same page as #1 |
+| 7 | scrabble en español online | /es/juego-de-palabras-multijugador | 8.1 | 58 | 0.0% | 2.5% | +1 | Same page as #1 |
+| 8 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 7.3 | 54 | 0.0% | 3.0% | +2 | Same page as #1 |
+| 9 | most popular online word games 2025 2026 | /en/best-online-word-games | 6.2 | 47 | 0.0% | 4.0% | +2 | Title uses "browser" not "online"; add "most popular" signal; trim to ≤60 chars |
+| 10 | best free browser word games 2026 | /en/best-online-word-games | 6.5 | 37 | 0.0% | 4.0% | +1 | Same page as #9 — title fix covers this |
+
+---
+
+## Top 10 Rank-Up Opportunities
+
+Queries at avg position 8–20 with ≥50 impressions.
+
+| # | Query | Page | Pos | Imps | Suggested Action |
+|---|---|---|---|---|---|
+| 1 | scrabble online español | /es/juego-de-palabras-multijugador | 8.7 | 167 | Add 2–3 internal links from homepage ES + blog; strengthen H1 to include "jugar scrabble en español" |
+| 2 | scrabble online svenska | /sv/swedish-multiplayer-word-game | 9.2 | 167 | Internal link from homepage SV; add "wordfeud alternativ" anchor text |
+| 3 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.4 | 102 | Covered by #1 — same page |
+| 4 | jugar scrabble gratis | /es/juego-de-palabras-multijugador | 9.2 | 68 | Same page — improve page authority |
+| 5 | scrabble en linea | /es/juego-de-palabras-multijugador | 9.4 | 67 | Same page — consider adding "en línea" H2 variant |
+| 6 | scrabble en español online | /es/juego-de-palabras-multijugador | 8.1 | 58 | Same page — covered by broad ES push |
+
+---
+
+## Bing Parity Gaps
+
+**Unavailable** — Bing Webmaster API returned HTTP 403 "Host not in allowlist" from this cloud execution IP. Manual check recommended at [bing.com/webmaster](https://www.bing.com/webmasters/). Action: add cloud egress IPs to Bing allowlist, or run this agent from a whitelisted IP.
+
+---
+
+## Rising / Falling Queries (last 7d vs prior 7d, >30% delta)
+
+| Query | Prior 7d imps | Last 7d imps | Delta | Direction |
+|---|---|---|---|---|
+| most popular online word games 2025 2026 | 14 | 33 | +135.7% | 🟢 rising |
+| scrabble online svenska | 40 | 83 | +107.5% | 🟢 rising |
+| scrabble en español online | 46 | 0 | -100.0% | 🔴 fallen |
+| juego palabras netflix | 15 | 0 | -100.0% | 🔴 fallen |
+| scrabble español online | 33 | 0 | -100.0% | 🔴 fallen |
+| jugar scrabble online | 68 | 0 | -100.0% | 🔴 fallen |
+| jugar scrabble gratis | 50 | 0 | -100.0% | 🔴 fallen |
+| scrabble online gratis | 34 | 0 | -100.0% | 🔴 fallen |
+| juego de palabras netflix | 29 | 0 | -100.0% | 🔴 fallen |
+| scrabble juego online | 20 | 0 | -100.0% | 🔴 fallen |
+
+> ⚠️ **Spanish query collapse**: Every ES-language query dropped to exactly 0 impressions in May 10–16. This is not a gradual decline — it's a cliff. Possible causes: (1) May Google core update hit `/es/*` pages, (2) Spanish pages de-indexed or crawl error, (3) structured data issue triggering a manual action. **Check Google Search Console Coverage and Manual Actions tabs immediately.**
+
+---
+
+## GEO / AI Visibility Recommendations
+
+The following queries look like question/intent-based searches where FAQPage schema + clear answer paragraphs would improve AI Overview and SGE snippet eligibility:
+
+| Query | Current Page | Recommendation |
+|---|---|---|
+| most popular online word games 2025 2026 | /en/best-online-word-games | Add FAQPage schema: "What are the most popular online word games in 2026?" with a 2-sentence answer listing top titles |
+| best free browser word games 2026 | /en/best-online-word-games | Add FAQPage schema: "What are the best free browser word games?" — page has a list but no FAQ schema |
+| scrabble online en español | /es/juego-de-palabras-multijugador | Add FAQPage Q: "¿Cómo jugar scrabble online en español gratis?" with step-by-step answer (3 steps: crea sala, comparte enlace, juega) |
+| scrabble online svenska gratis | /sv/swedish-multiplayer-word-game | Add FAQPage Q: "Hur spelar man Scrabble online på svenska gratis?" |
+
+### Draft FAQ Schema for `/en/best-online-word-games`
+
+```json
+{
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What are the most popular online word games in 2026?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The 9 most popular free online word games in 2026 are: LexiClash (real-time multiplayer), Wordle (daily 5-letter), NYT Connections (category grouping), NYT Strands, Spelling Bee, Words With Friends, Scrabble GO, Wordscapes, and Semantle. LexiClash and Wordle are the only two with zero ads and zero download required."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best free browser word game with no download?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "LexiClash and Wordle are the best free word games that run entirely in the browser with no download, no signup, and no ads. LexiClash adds real-time multiplayer for 2–20 players."
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Today's Actions
+
+1. **Meta tags PR** — Opened `seo/daily-2026-05-18`: trimmed Swedish title 63→54 chars, fixed `/en/best-online-word-games` title 65→58 chars (adds "online" keyword to match rising query), strengthened Spanish meta description. Expected: +3–5 clicks/week if CTR lifts to 0.5% on Spanish/Swedish pages.
+2. **Urgent: Spanish query collapse** — All ES queries hit 0 impressions May 10–16. Check GSC Coverage tab + Manual Actions + `site:lexiclash.live/es` in Google Search. If de-indexed, submit sitemap and request reconsideration.
+3. **FAQPage schema** — Add to `/en/best-online-word-games` and `/es/juego-de-palabras-multijugador` for GEO/AI visibility on "most popular word games" queries (rising +135% WoW).

--- a/fe-next/app/[locale]/best-online-word-games/page.tsx
+++ b/fe-next/app/[locale]/best-online-word-games/page.tsx
@@ -15,11 +15,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const canonicalUrl = `${BASE_URL}/en/best-online-word-games`;
 
   return {
-    title: 'Best Free Browser Word Games 2026 — 9 Honest Picks (No Download)',
-    description: 'Best free browser word games of 2026 — honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, Semantle, LexiClash. Pros, cons & which to pick in 2 minutes.',
+    title: 'Best Free Online Word Games 2026 — Top 9 Picks | LexiClash',
+    description: '9 best free online word games of 2026, honestly ranked — Wordle, NYT Connections, LexiClash & more. No download, no signup. Find your pick in 2 min.',
     keywords: 'best free browser word games 2026, best word games 2026, best online word games 2025 2026, most popular online word games 2025 2026, free word games online, nyt connections, nyt strands, spelling bee game, semantle, wordle alternatives, multiplayer word games, word games with friends, word puzzle games online, word games no download, connections game',
     openGraph: {
-      title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',
+      title: 'Best Free Online Word Games 2026 — Top 9 Picks | LexiClash',
       description: 'Best free browser word games of 2026, honestly ranked. Wordle, NYT Connections, LexiClash & more — no download required.',
       locale: 'en_US',
       type: 'website',
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',
+      title: 'Best Free Online Word Games 2026 — Top 9 Picks | LexiClash',
       description: 'Best free browser word games of 2026, honestly ranked. No download required.',
       images: [`${BASE_URL}/og-image-en.webp`],
     },

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -24,11 +24,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
-    description: 'Juega scrabble online en español gratis, sin registro ni descarga. Crea sala, invita amigos por enlace y compite en tiempo real. ¡Empieza en segundos!',
+    title: 'Scrabble Online en Español Gratis — Jugar Ahora | LexiClash',
+    description: 'Juega scrabble online en español gratis — sin registro, sin descarga. 10.000+ palabras, tablero en tiempo real. Crea sala y comparte el enlace.',
     keywords: 'cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
+      title: 'Scrabble Online en Español Gratis — Jugar Ahora | LexiClash',
       description: 'Juega scrabble online en español con amigos en tiempo real. Crea sala, invita por enlace. 100% gratis, sin descargas.',
       locale: 'es_ES',
       type: 'website',
@@ -44,7 +44,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
+      title: 'Scrabble Online en Español Gratis — Jugar Ahora | LexiClash',
       description: 'Juega scrabble online en español con amigos. Sala con enlace, tiempo real, sin registro. ¡100% gratis!',
       images: [`${BASE_URL}/og-image-es.webp`],
     },

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -15,11 +15,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
-    description: 'Spela scrabble online på svenska gratis, utan registrering. Skapa rum, bjud in med länk och tävla i realtid med vänner. 10 000+ ord. Börja nu!',
+    title: 'Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
+    description: 'Spela scrabble online på svenska gratis — utan registrering. 10 000+ ord, spel redo på 10 sek. Skapa rum, bjud in med länk, tävla i realtid.',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid',
     openGraph: {
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
       description: 'Spela scrabble online på svenska med vänner i realtid. Skapa rum, bjud in med länk. Gratis, ingen registrering.',
       locale: 'sv_SE',
       type: 'website',
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
       description: 'Spela scrabble online på svenska: skapa rum, bjud in med länk, tävla i realtid. Gratis, ingen registrering.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },


### PR DESCRIPTION
## Summary

Daily SEO meta tag improvements targeting 3 high-impression / 0-click pages (28d data: 2026-04-19 → 2026-05-16).

## Changes

### 1. `/sv/swedish-multiplayer-word-game` — Swedish page
| | Before | After |
|---|---|---|
| Title | `Scrabble Online Svenska Gratis — Spela Multiplayer \| LexiClash` (63 chars ❌) | `Scrabble Online Svenska Gratis — Spela Nu \| LexiClash` (54 chars ✓) |
| Description | "…Börja nu!" | Leads with "10 000+ ord, spel redo på 10 sek" social proof |

**Why:** "scrabble online svenska" — 167 impressions, 0 clicks, pos 9.2 over 28d. Title was 63 chars (over 60-char display cutoff). "Spela Nu" is a stronger CTA than "Spela Multiplayer".

### 2. `/en/best-online-word-games` — EN best word games page
| | Before | After |
|---|---|---|
| Title | `Best Free Browser Word Games 2026 — 9 Honest Picks (No Download)` (65 chars ❌) | `Best Free Online Word Games 2026 — Top 9 Picks \| LexiClash` (58 chars ✓) |
| Description | 179 chars ❌ (truncated) | 155 chars ✓ |

**Why:** "most popular online word games 2025 2026" rising +135% WoW (14→33 imps), pos 6.2, 0 clicks. Old title said "browser" not "online" — keyword mismatch. Description was 179 chars (truncated in SERPs at ~155).

### 3. `/es/juego-de-palabras-multijugador` — Spanish page
| | Before | After |
|---|---|---|
| Title | `Scrabble Online en Español Gratis — Sin Registro \| LexiClash` (61 chars) | `Scrabble Online en Español Gratis — Jugar Ahora \| LexiClash` (59 chars ✓) |
| Description | Weak end: "¡Empieza en segundos!" | Leads with "10.000+ palabras, tablero en tiempo real" |

**Why:** Spanish page had 1,060 impressions over 28d with near-zero non-branded clicks. "Jugar Ahora" is a clearer action CTA. ⚠️ All ES queries dropped to 0 impressions May 10–16 — check GSC Coverage + Manual Actions urgently.

## Full report
`docs/seo-daily/2026-05-18.md` — 28d metrics, CTR/rank-up tables, trending queries, GEO/AI FAQ schema recommendations, urgent Spanish query collapse alert.

## Expected uplift
~3–5 additional clicks/week once Google re-crawls (typically 3–7 days for ISR pages).

---
_Generated by [Claude Code](https://claude.ai/code/session_012bZcjM8NfMNcfbxSTTU2MN)_