### PR TITLE
perf(mp-classic): freeze leaderboard during word selection

### DIFF
--- a/fe-next/components/game/InGameScreen.tsx
+++ b/fe-next/components/game/InGameScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useEffect, useCallback, useMemo, memo, useState, useDeferredValue } from 'react';
+import { useRef, useEffect, useCallback, useMemo, memo, useState } from 'react';
 import {
   useBlastTileOverlay,
   useWordHuntTargetLength,
@@ -13,7 +13,7 @@ import {
 import { useSoundEffects } from '../../contexts/SoundEffectsContext';
 import { useAnnouncer } from '../GameAnnouncer';
 import { useAutoScrollOnGameStart } from '@/hooks/useAutoScrollOnGameStart';
-import { useSelectionStore, resetSelection } from '@/hooks/useSelectionStore';
+import { useSelectionStore, resetSelection, useFrozenWhileSelecting } from '@/hooks/useSelectionStore';
 import { useTapToDragGuidance } from '@/hooks/useTapToDragGuidance';
 import { useKeyboardWordInput } from '@/hooks/useKeyboardWordInput';
 import { useCrazyGamesLifecycle } from '@/hooks/useCrazyGamesLifecycle';
@@ -203,9 +203,14 @@ const InGameScreen = memo<InGameScreenProps>(function InGameScreen({
   const [currentFeedback, setCurrentFeedback] = useState<WordFeedback | null>(null);
   const [lastWordFoundTime, setLastWordFoundTime] = useState<number>(() => (gameActive ? Date.now() : 0));
 
-  // Deferred values for smoother UI
-  const deferredLeaderboard = useDeferredValue(leaderboard);
-  const deferredFoundWords = useDeferredValue(foundWords);
+  // Freeze leaderboard/found-words while the player is mid-drag. Socket bursts
+  // (opponents scoring 4-6/sec in active MP rooms) used to cascade through
+  // PortraitLayout → CompactLeaderboard / GameLeaderboard during selection,
+  // stealing frame budget from the grid drag rendering ("UI stuck when
+  // selecting words"). The frozen value reveals the latest state the instant
+  // the player releases — leaderboard catches up immediately.
+  const deferredLeaderboard = useFrozenWhileSelecting(leaderboard);
+  const deferredFoundWords = useFrozenWhileSelecting(foundWords);
 
   // Refs
   const gameStatsRef = useRef<HTMLDivElement>(null);

--- a/fe-next/hooks/__tests__/useFrozenWhileSelecting.test.tsx
+++ b/fe-next/hooks/__tests__/useFrozenWhileSelecting.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useSelectionStore,
+  useFrozenWhileSelecting,
+  resetSelection,
+} from '../useSelectionStore';
+
+describe('useFrozenWhileSelecting', () => {
+  beforeEach(() => {
+    resetSelection();
+  });
+
+  it('returns the latest value when no selection is in progress', () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: number }) => useFrozenWhileSelecting(value),
+      { initialProps: { value: 1 } },
+    );
+
+    expect(result.current).toBe(1);
+
+    rerender({ value: 2 });
+    expect(result.current).toBe(2);
+
+    rerender({ value: 3 });
+    expect(result.current).toBe(3);
+  });
+
+  it('holds the previous value while a selection is in progress', () => {
+    const v1 = [{ username: 'a', score: 10 }];
+    const v2 = [{ username: 'a', score: 20 }];
+    const v3 = [{ username: 'a', score: 30 }];
+
+    const { result, rerender } = renderHook(
+      ({ value }: { value: typeof v1 }) => useFrozenWhileSelecting(value),
+      { initialProps: { value: v1 } },
+    );
+
+    expect(result.current).toBe(v1);
+
+    // Player starts a drag
+    act(() => {
+      useSelectionStore.getState().setSelection('C', 1);
+    });
+
+    // Socket update arrives — value changes, but frozen result must NOT.
+    rerender({ value: v2 });
+    expect(result.current).toBe(v1);
+
+    // Another socket update — still frozen.
+    rerender({ value: v3 });
+    expect(result.current).toBe(v1);
+  });
+
+  it('commits the latest value as soon as the selection clears', () => {
+    const v1 = { score: 10 };
+    const v2 = { score: 99 };
+
+    const { result, rerender } = renderHook(
+      ({ value }: { value: typeof v1 }) => useFrozenWhileSelecting(value),
+      { initialProps: { value: v1 } },
+    );
+
+    // Start selection, value changes while frozen
+    act(() => {
+      useSelectionStore.getState().setSelection('CA', 2);
+    });
+    rerender({ value: v2 });
+    expect(result.current).toBe(v1);
+
+    // Selection ends — should immediately reveal the latest value
+    act(() => {
+      resetSelection();
+    });
+    expect(result.current).toBe(v2);
+  });
+
+  it('does not re-subscribe consumers on every letter count change', () => {
+    let renderCount = 0;
+    const { rerender } = renderHook(
+      ({ value }: { value: number }) => {
+        renderCount++;
+        return useFrozenWhileSelecting(value);
+      },
+      { initialProps: { value: 1 } },
+    );
+
+    const initialRenderCount = renderCount;
+
+    // Drag from 1 to 5 letters — boolean isSelecting stays true the whole time
+    act(() => {
+      useSelectionStore.getState().setSelection('A', 1);
+    });
+    const afterStart = renderCount;
+    expect(afterStart).toBeGreaterThan(initialRenderCount);
+
+    act(() => {
+      useSelectionStore.getState().setSelection('AB', 2);
+    });
+    act(() => {
+      useSelectionStore.getState().setSelection('ABC', 3);
+    });
+    act(() => {
+      useSelectionStore.getState().setSelection('ABCD', 4);
+    });
+    act(() => {
+      useSelectionStore.getState().setSelection('ABCDE', 5);
+    });
+
+    // letterCount changed 4 more times, but isSelecting boolean stayed true.
+    // Consumer must NOT re-render on those steps — that's the whole point of
+    // gating on the boolean derived selector instead of the raw count.
+    expect(renderCount).toBe(afterStart);
+
+    // Parent re-renders with same value: no extra count change but a re-render
+    rerender({ value: 1 });
+    expect(renderCount).toBeGreaterThan(afterStart);
+  });
+});

--- a/fe-next/hooks/useSelectionStore.ts
+++ b/fe-next/hooks/useSelectionStore.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 
@@ -24,3 +25,28 @@ export const useSelectionWord = (): string =>
 
 export const useSelectionLetterCount = (): number =>
   useSelectionStore((s) => s.letterCount);
+
+// Boolean-projection selector — only fires consumer re-renders on the 0↔>0
+// boundary, NOT on every letter added during a drag (which letterCount would).
+export const useIsSelecting = (): boolean =>
+  useSelectionStore((s) => s.letterCount > 0);
+
+/**
+ * Hold `value` constant while the player is actively building a word
+ * (letterCount > 0). The latest value is committed the instant the selection
+ * clears.
+ *
+ * Why this exists: socket-driven leaderboard updates fire 4-6/sec in active
+ * multiplayer rooms. Each update used to cascade through the in-game tree
+ * (PortraitLayout → CompactLeaderboard / GameLeaderboard, both heavy
+ * framer-motion subtrees) and stole frame budget from the grid's drag
+ * rendering — "UI feels stuck when selecting words" in MP classic.
+ * useDeferredValue alone wasn't enough because the deferred re-render still
+ * eventually fires and lands mid-drag.
+ */
+export function useFrozenWhileSelecting<T>(value: T): T {
+  const isSelecting = useIsSelecting();
+  const heldRef = useRef(value);
+  if (!isSelecting) heldRef.current = value;
+  return heldRef.current;
+}


### PR DESCRIPTION
## What the player saw
"Multiplayer classic mode is very heavy on the UI and the UI gets stuck when selecting words."

## Root cause
The lag is **multiplayer-specific** because the tile-selection effects exist in single-player too without complaint. The differentiator is socket-driven `updateLeaderboard` events that fire 4-6/sec when opponents score:

1. Socket fires → Zustand `setLeaderboard` → `useLeaderboard()` subscribers re-render.
2. `PlayerView → PlayerInGameView → InGameScreen` propagates the new leaderboard prop.
3. Inside `InGameScreen`, `useDeferredValue(leaderboard)` defers — but it still **eventually** fires a low-priority re-render that lands mid-drag.
4. That deferred render cascades into `PortraitLayout → CompactLeaderboard / GameLeaderboard` (heavy framer-motion subtrees: AnimatePresence score deltas, rank-change arrows, race-track lanes, score-flash sub-state).
5. Frame budget the grid needs for pointer-move rendering gets stolen → stutter, "UI feels stuck."

The existing tile-effect code already suppresses heavy effects during drag (`fullMode = effectiveRenderMode === 'full' && !isDragging` in `GridCellEffects`, plus DOM-class drag toggle in `useGridInteraction`), so the drag path itself is well-optimized. What was missing was guarding it from socket-burst churn from opponents scoring.

## The fix
New `useFrozenWhileSelecting` hook in `hooks/useSelectionStore.ts`:

```ts
export function useFrozenWhileSelecting<T>(value: T): T {
  const isSelecting = useIsSelecting();    // letterCount > 0
  const heldRef = useRef(value);
  if (!isSelecting) heldRef.current = value;
  return heldRef.current;
}
```

- Holds the latest value constant while the player is actively building a word.
- Commits the latest value the instant the selection clears.
- Uses a **boolean** zustand selector (`letterCount > 0`) so consumers only re-render on the 0↔>0 boundary — not on every letter added during a drag. The freeze itself is essentially free.

Applied in `components/game/InGameScreen.tsx` to both `leaderboard` and `foundWords` (replaces the prior `useDeferredValue` wrappers).

## Behavioral notes
- **Multiplayer classic / blast / word-hunt / tournament**: leaderboard freezes during your drag, snaps to latest the moment you release. No frame budget lost to opponent score updates mid-selection.
- **Single-player**: leaderboard doesn't update mid-drag there anyway, so no behavioral change.
- **Post-submit fade**: cells stay "selected" during the fade animation (50-400ms depending on combo), so the leaderboard catches up just after the fade — feels natural and gives the player a brief moment to read their own score before opponents' scores move.

## Tests
- New `hooks/__tests__/useFrozenWhileSelecting.test.tsx` (4 cases):
  - Returns latest value when idle
  - Holds previous value when selection is in progress
  - Commits latest value the instant selection clears
  - Does **not** re-subscribe consumers on every letter count change (the critical perf property)
- Full repo test sweep: **3,223 / 3,223 passing**, type-check clean.

## What this does NOT change
- The grid drag-path itself (already RAF-batched + DOM-class toggle in `useGridInteraction`).
- Tile selection effects (already drag-aware via `fullMode` gating in `GridCellEffects`). If the remaining drag-time effects (primary ripple, glow ring on tier 1+) still feel heavy on low-end devices after this lands, those are a follow-up — they affect SP equally, so they're a different problem from the MP-classic-only "stuck UI" report.

## Test plan
- [ ] MP classic 4-player room: drag a 5-letter word while bots/opponents are scoring — grid stays smooth, leaderboard snaps to current state on release.
- [ ] MP classic mid/low-end Android: confirm pointer-move FPS no longer drops when opponent scores arrive during your drag.
- [ ] Single-player: no behavior change (leaderboard updates only on your own submit).
- [ ] Found words list: same freeze semantics — your fresh word appears immediately on submit since selection has cleared by then.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqvU7oZrhRL7JYibWGbmTh)_