### PR TITLE
fix(mp-results): stop AdMob interstitial stranding players on blank screen

### DIFF
--- a/fe-next/components/__tests__/ResultsPage.adSlot.test.tsx
+++ b/fe-next/components/__tests__/ResultsPage.adSlot.test.tsx
@@ -1,0 +1,379 @@
+/**
+ * ResultsPage Ad Slot Tests
+ *
+ * Bug: Multiplayer results page was missing the `ResultsBannerSlot` component
+ * that every other results page (SP, daily, challenge) uses to display the
+ * native AdMob banner on the post-game screen. `/multiplayer` is also in
+ * GAME_ROUTES so AnchoredNativeBanner is hidden during the whole multiplayer
+ * flow including the results screen — without an inline banner slot, no ads
+ * served on the MP results page and the bottom of the layout collapsed to a
+ * blank white area where an ad was expected.
+ *
+ * The fix is to render `<ResultsBannerSlot placement="multiplayer-round-complete" />`
+ * alongside the existing CrazyGamesBanner in both mobile and desktop layouts —
+ * matching the pattern used by SinglePlayerResults / DailyChallengeResults /
+ * DailyWordHuntResults / ChallengeResults.
+ */
+
+import React from 'react';
+import { act, render, fireEvent, screen } from '@testing-library/react';
+import { LanguageProvider } from '@/contexts/LanguageContext';
+import { NavigationProvider } from '@/contexts/NavigationContext';
+
+const bannerSlotMock = vi.fn();
+
+vi.mock('@/components/ads/ResultsBannerSlot', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    bannerSlotMock(props);
+    return (
+      <div
+        data-testid="results-banner-slot-mock"
+        data-placement={String(props.placement)}
+      />
+    );
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: false, user: null }),
+}));
+
+vi.mock('@/hooks/useWinStreak', () => ({
+  useWinStreak: () => ({ currentStreak: 0, bestStreak: 0, recordWin: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useMobileLandscape', () => ({
+  useMobileLandscape: () => false,
+}));
+
+vi.mock('framer-motion', () => {
+  const motionValueStub = () => ({
+    set: vi.fn(),
+    get: () => 0,
+    on: () => () => {},
+    onChange: () => () => {},
+  });
+  return {
+    m: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...props}>{children}</div>
+      ),
+      button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <button {...props}>{children}</button>
+      ),
+      span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <span {...props}>{children}</span>
+      ),
+    },
+    AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+    useReducedMotion: () => false,
+    useScroll: () => ({
+      scrollX: motionValueStub(),
+      scrollY: motionValueStub(),
+      scrollXProgress: motionValueStub(),
+      scrollYProgress: motionValueStub(),
+    }),
+    useTransform: () => motionValueStub(),
+    useMotionValue: motionValueStub,
+    useVelocity: () => motionValueStub(),
+    useSpring: () => motionValueStub(),
+  };
+});
+
+vi.mock('canvas-confetti', () => ({ __esModule: true, default: vi.fn() }));
+
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const React = require('react');
+    const Component = React.forwardRef((_props: any, _ref: any) => null);
+    Component.displayName = 'DynamicComponent';
+    return Component;
+  },
+}));
+
+const mainContentPropsCapture: { current: any } = { current: null };
+vi.mock('@/components/results/ResultsMainContent', () => ({
+  __esModule: true,
+  ResultsMainContent: (props: any) => {
+    mainContentPropsCapture.current = props;
+    return <div data-testid="results-main-content" />;
+  },
+}));
+
+vi.mock('@/components/results/ResultsPlayerCard', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('@/components/ExitRoomButton', () => ({
+  __esModule: true,
+  default: () => <button data-testid="exit-button">Exit</button>,
+}));
+
+vi.mock('@/components/ui/ConfirmationDialog', () => ({
+  ConfirmationDialog: () => null,
+}));
+
+vi.mock('@/components/auth/AuthModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('@/components/auth/FirstWinSignupModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('@/components/results/ShareWinPrompt', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('@/components/voting/WordFeedbackModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('@/components/results/useResultsSocketEvents', () => ({
+  useResultsSocketEvents: () => ({
+    showWordFeedback: false,
+    wordToVote: null,
+    wordQueue: [],
+    xpGainedData: null,
+    levelUpData: null,
+    showLevelUpCelebration: false,
+    setShowLevelUpCelebration: vi.fn(),
+    setLevelUpData: vi.fn(),
+    nearMisses: [],
+    referralMilestone: null,
+    showReferralMilestone: false,
+    readyUsernames: [],
+    isCurrentPlayerReady: false,
+    handleVote: vi.fn(),
+    handleFeedbackSkip: vi.fn(),
+    handleReferralMilestoneClose: vi.fn(),
+    handleMarkReady: vi.fn(),
+  }),
+}));
+
+vi.mock('@/utils/session', () => ({
+  clearSessionPreservingUsername: vi.fn(),
+}));
+
+vi.mock('@/utils/guestManager', () => ({
+  shouldShowUpgradePrompt: vi.fn(() => false),
+  getGuestStatsSummary: vi.fn(() => ({ gamesPlayed: 5 })),
+  getGuestStats: vi.fn(() => ({ games: 5, words: 0, score: 0 })),
+  updateGuestStatsAfterGame: vi.fn(),
+  isFirstWin: vi.fn(() => false),
+}));
+
+vi.mock('@/hooks/usePostHogFlag', () => ({
+  usePostHogFlag: vi.fn(() => 'after-2nd-game'),
+}));
+
+vi.mock('@/utils/growthTracking', () => ({
+  trackGameCompletion: vi.fn(),
+  trackStreakMilestone: vi.fn(),
+  trackGrowthEvent: vi.fn(),
+}));
+
+vi.mock('@/utils/gameHistoryManager', () => ({
+  addGameToHistory: vi.fn(),
+}));
+
+vi.mock('@/utils/coinManager', () => ({
+  awardGameCoins: vi.fn(() => null),
+}));
+
+vi.mock('@/hooks/useSaveCognitiveScore', () => ({
+  useSaveCognitiveScore: () => ({
+    saveCognitiveScore: vi.fn().mockResolvedValue(null),
+    isSaving: false,
+  }),
+}));
+
+vi.mock('@/hooks/useFirstWinCelebration', () => ({
+  useFirstWinCelebration: vi.fn(),
+}));
+
+vi.mock('@/hooks/useCrazyGamesLifecycle', () => ({
+  useCrazyGamesLifecycle: vi.fn(),
+}));
+
+vi.mock('@/contexts/CoinContext', () => ({
+  useCoinContext: () => ({ refreshCoins: vi.fn() }),
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  syncCoinsToDatabase: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/utils/SocketContext', () => ({
+  useSocket: () => ({
+    socket: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+    isConnected: true,
+  }),
+  useSocketOptional: () => null,
+}));
+
+vi.mock('@/components/RoomChat', () => ({ __esModule: true, default: () => null }));
+
+vi.mock('@/components/CrazyGamesBanner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="crazy-games-banner" />,
+}));
+
+vi.mock('@/components/CrazyGamesSDK', () => ({
+  shouldHideExternalLogin: vi.fn(() => false),
+  useCrazyGames: vi.fn(() => ({
+    isAvailable: false,
+    isOnCrazyGamesPlatform: false,
+    showMidgameAd: vi.fn(),
+    showRewardedAd: vi.fn(),
+    hasAdblock: vi.fn(async () => false),
+    gameplayStart: vi.fn(),
+    gameplayStop: vi.fn(),
+    submitLeaderboardScore: vi.fn(),
+  })),
+}));
+
+vi.mock('@/utils/confettiUtils', () => ({ fireRankConfetti: vi.fn() }));
+
+const showInterstitialMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/hooks/useInterstitialAd', () => ({
+  useInterstitialAd: () => ({ showInterstitial: showInterstitialMock }),
+}));
+
+// Import after all mocks are set up
+import ResultsPage from '@/components/views/ResultsPage';
+
+const renderResultsPage = (props: {
+  finalScores: Array<{ username: string; score: number; allWords?: any[] }>;
+  username: string;
+  isHost?: boolean;
+  socket?: { emit: ReturnType<typeof vi.fn>; on: ReturnType<typeof vi.fn>; off: ReturnType<typeof vi.fn> };
+}) => {
+  const socket = props.socket ?? { emit: vi.fn(), on: vi.fn(), off: vi.fn() };
+  return {
+    socket,
+    ...render(
+      <NavigationProvider>
+        <LanguageProvider>
+          <ResultsPage
+            finalScores={props.finalScores}
+            username={props.username}
+            gameCode="TEST123"
+            onReturnToRoom={vi.fn()}
+            socket={socket as any}
+            duplicateRuleDisabled={false}
+            playerCount={2}
+            isHost={props.isHost ?? false}
+            roomLanguage="en"
+          />
+        </LanguageProvider>
+      </NavigationProvider>,
+    ),
+  };
+};
+
+describe('ResultsPage — AdMob banner slot', () => {
+  beforeEach(() => {
+    bannerSlotMock.mockClear();
+    showInterstitialMock.mockClear();
+    showInterstitialMock.mockResolvedValue(undefined);
+    mainContentPropsCapture.current = null;
+  });
+
+  it('does not fire the AdMob interstitial on results mount', () => {
+    // Bug repro: previously the MP results page fired the interstitial
+    // unconditionally on mount. AdMob's prepare → show pipeline can take
+    // a few seconds, so the user would see results, then a fullscreen
+    // interstitial overlay paint over the page — and when the ad creative
+    // partially rendered, the user was stuck on a blank white screen.
+    // The fix moves the interstitial to a user-initiated transition.
+    renderResultsPage({
+      finalScores: [
+        { username: 'PlayerOne', score: 100, allWords: [{ word: 'test', score: 5, validated: true }] },
+        { username: 'PlayerTwo', score: 50, allWords: [] },
+      ],
+      username: 'PlayerOne',
+    });
+
+    expect(showInterstitialMock).not.toHaveBeenCalled();
+  });
+
+  it('renders ResultsBannerSlot with multiplayer-round-complete placement', () => {
+    // Bug repro: prior to the fix the MP results page was the only results
+    // screen missing ResultsBannerSlot, so AdMob never served on it. Asserting
+    // the slot is mounted with the correct placement string locks in parity
+    // with SP / Daily / Challenge results.
+    renderResultsPage({
+      finalScores: [
+        { username: 'PlayerOne', score: 100, allWords: [{ word: 'test', score: 5, validated: true }] },
+        { username: 'PlayerTwo', score: 50, allWords: [] },
+      ],
+      username: 'PlayerOne',
+    });
+
+    expect(bannerSlotMock).toHaveBeenCalled();
+    const calls = bannerSlotMock.mock.calls;
+    // At least one invocation must carry the MP placement string. Both mobile
+    // and desktop layouts mount the page tree, so multiple calls are expected.
+    const placements = calls.map((args) => args[0]?.placement);
+    expect(placements).toContain('multiplayer-round-complete');
+  });
+
+  it('host start-game awaits the interstitial before emitting startGame (other players wait while host watches ad)', async () => {
+    // Bug repro: previously the host's `socket.emit('resetGame' | 'startGame')`
+    // fired immediately, so the rest of the room dropped into round 2 while
+    // the host's interstitial overlay was still mid-show. Awaiting the
+    // interstitial promise keeps the next-round emit gated on Dismissed so
+    // everyone enters the next round together once the ad-watching host is done.
+    let resolveInterstitial: () => void = () => {};
+    const interstitialPromise = new Promise<void>((resolve) => {
+      resolveInterstitial = resolve;
+    });
+    showInterstitialMock.mockReturnValueOnce(interstitialPromise);
+
+    const { socket } = renderResultsPage({
+      finalScores: [
+        { username: 'Host', score: 100, allWords: [{ word: 'test', score: 5, validated: true }] },
+        { username: 'Other', score: 50, allWords: [] },
+      ],
+      username: 'Host',
+      isHost: true,
+    });
+
+    const onStartGame = mainContentPropsCapture.current?.onStartGame as undefined | (() => Promise<void> | void);
+    expect(typeof onStartGame).toBe('function');
+
+    // Kick off the host's "Play Again" while the interstitial promise is unresolved.
+    const startGamePromise = act(async () => {
+      void onStartGame!();
+    });
+    // Drain microtasks so the awaited interstitial call lands before assertions.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(showInterstitialMock).toHaveBeenCalledWith('multiplayer-round-complete');
+    // Critical assertion: while the interstitial is in flight, no game-start emits.
+    const emitNamesDuringAd = socket.emit.mock.calls.map((c) => c[0]);
+    expect(emitNamesDuringAd).not.toContain('resetGame');
+    expect(emitNamesDuringAd).not.toContain('startGame');
+
+    // Host dismisses the ad — now the next-round emits should land.
+    await act(async () => {
+      resolveInterstitial();
+      await interstitialPromise;
+    });
+    await startGamePromise;
+    await new Promise((r) => setTimeout(r, 0));
+
+    const emitNamesAfterAd = socket.emit.mock.calls.map((c) => c[0]);
+    expect(emitNamesAfterAd).toContain('resetGame');
+  });
+});

--- a/fe-next/components/views/ResultsPage.tsx
+++ b/fe-next/components/views/ResultsPage.tsx
@@ -38,6 +38,7 @@ import { ResultsModals } from '@/components/results/ResultsModals';
 import { ResultsMainContent, type ResultsMainContentProps } from '@/components/results/ResultsMainContent';
 import { ResultsDetailsContent, type ResultsDetailsContentProps } from '@/components/results/ResultsDetailsContent';
 import { PostRoundSummary } from '@/components/results/PostRoundSummary';
+import ResultsBannerSlot from '@/components/ads/ResultsBannerSlot';
 import type { WordHuntResultsSummaryProps } from '@/components/results/WordHuntResultsSummary';
 const StickyReadyBar = dynamic(() => import('@/components/results/StickyReadyBar'), { ssr: false });
 import { ResultsFriendStatusProvider } from '@/components/results/ResultsFriendStatus';
@@ -216,10 +217,13 @@ function DesktopResultsLayout({
           </ResultsSectionReveal>
         </div>
 
-        {/* CrazyGames banner ad — shown after results content */}
+        {/* Post-game banner ad — CrazyGamesBanner covers the web iframe surface;
+            ResultsBannerSlot serves AdMob inside the native app (where
+            /multiplayer is in GAME_ROUTES so AnchoredNativeBanner stays hidden). */}
         <ResultsSectionReveal index={9} flat className="w-full max-w-5xl mx-auto mt-6 relative z-10">
           <CrazyGamesBanner size="728x90" />
         </ResultsSectionReveal>
+        <ResultsBannerSlot placement="multiplayer-round-complete" className="w-full max-w-5xl mx-auto mt-4 relative z-10" />
       </div>
 
       {/* Scroll indicator — subtle bouncing chevron at bottom */}
@@ -291,10 +295,13 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, gameCode, onRetu
     }
   }, []);
 
+  // Hold the interstitial trigger until the host initiates a rematch (see
+  // handleStartGame) instead of firing on mount. AdMob's prepare → show
+  // pipeline takes a few seconds, so the prior mount-fire would paint a
+  // fullscreen overlay over the results page once the user had already
+  // started reading — and a partially-rendered creative left the user
+  // stranded on a blank white screen.
   const { showInterstitial } = useInterstitialAd();
-  useEffect(() => {
-    showInterstitial('multiplayer-round-complete');
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
   const [showExitConfirm, setShowExitConfirm] = useState<boolean>(false);
   // True from the moment exit is confirmed until the hard nav fires. We render
   // a clean black wash so the user never sees a half-torn ResultsPage during
@@ -635,9 +642,17 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, gameCode, onRetu
 
   // Handle host starting a new game directly from results page
   // Must reset game state first (like handleStartNewGame in useHostGameActions)
-  const handleStartGame = useCallback(() => {
+  const handleStartGame = useCallback(async () => {
     if (!socket || !isHost) return;
     logger.log('[RESULTS] Host starting new game from results page');
+
+    // Awaiting the interstitial gates `startGame` so the other players stay
+    // on results while the host watches their ad — without this gate they
+    // would drop into round 2 alone while the host's fullscreen overlay
+    // still covered round 1's results. The promise resolves immediately when
+    // no ad is served (cadence skip, no fill, non-native), so the no-ad
+    // path stays as snappy as before.
+    await showInterstitial('multiplayer-round-complete');
 
     // If idle pre-generation hasn't completed yet, fall back to synchronous
     // generation here (rare — only if host clicks rematch within ~1 frame
@@ -1014,10 +1029,13 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, gameCode, onRetu
             <ResultsSectionReveal index={2}>
               <DailyChallengeInvite isWinner={isCurrentUserWinner} />
             </ResultsSectionReveal>
-            {/* CrazyGames banner ad — mobile size between results and details */}
+            {/* Post-game banner ad — CrazyGamesBanner covers the web iframe surface;
+                ResultsBannerSlot serves AdMob inside the native app (where
+                /multiplayer is in GAME_ROUTES so AnchoredNativeBanner stays hidden). */}
             <ResultsSectionReveal index={3} flat>
               <CrazyGamesBanner size="320x50" />
             </ResultsSectionReveal>
+            <ResultsBannerSlot placement="multiplayer-round-complete" />
             {/* Other players' details (inline, no tab switch needed) */}
             <ResultsSectionReveal index={4}>
               {renderDetailsTab()}

--- a/fe-next/hooks/__tests__/useAdMob.test.tsx
+++ b/fe-next/hooks/__tests__/useAdMob.test.tsx
@@ -60,6 +60,13 @@ vi.mock('@capacitor-community/admob', () => ({
     Dismissed: 'onRewardedVideoAdDismissed',
     Rewarded: 'onRewardedVideoAdReward',
   },
+  InterstitialAdPluginEvents: {
+    Loaded: 'interstitialAdLoaded',
+    FailedToLoad: 'interstitialAdFailedToLoad',
+    Showed: 'interstitialAdShowed',
+    FailedToShow: 'interstitialAdFailedToShow',
+    Dismissed: 'interstitialAdDismissed',
+  },
 }));
 
 import { Capacitor } from '@capacitor/core';
@@ -192,16 +199,33 @@ describe('useAdMob', () => {
     expect(onReward).not.toHaveBeenCalled();
   });
 
+  // Drive showInterstitial through its event-gated promise: the call awaits
+  // Dismissed (or FailedToShow/FailedToLoad). Fire Dismissed after each
+  // attempt so the loop doesn't hang on the 15s safety timeout.
+  const drainInterstitial = async (
+    fn: () => Promise<void>,
+    count: number,
+  ): Promise<void> => {
+    for (let i = 0; i < count; i++) {
+      const p = fn();
+      // Two microtask flushes: one for listener registration, one for prepare/show.
+      await Promise.resolve();
+      await Promise.resolve();
+      fireEvent('interstitialAdDismissed');
+      await p;
+    }
+  };
+
   it('showInterstitial calls recordGameEnd and shows ad when conditions met', async () => {
     const wrapper = makeWrapper(true);
     const { result } = renderHook(() => useAdMob(), { wrapper });
     // Need 6 calls to pass warmup (3) and hit first interstitial (6th total = 3rd post-warmup)
     await act(async () => {
-      for (let i = 0; i < 5; i++) await result.current.showInterstitial();
+      await drainInterstitial(() => result.current.showInterstitial(), 5);
     });
     vi.clearAllMocks();
     await act(async () => {
-      await result.current.showInterstitial();
+      await drainInterstitial(() => result.current.showInterstitial(), 1);
     });
     expect(AdMob.prepareInterstitial).toHaveBeenCalled();
     expect(AdMob.showInterstitial).toHaveBeenCalled();
@@ -212,7 +236,7 @@ describe('useAdMob', () => {
     const { result } = renderHook(() => useAdMob(), { wrapper });
     // Drive 4 successful interstitial cycles: warmup (3) + 4*(3 cycles) = 15 game-ends.
     await act(async () => {
-      for (let i = 0; i < 15; i++) await result.current.showInterstitial();
+      await drainInterstitial(() => result.current.showInterstitial(), 15);
     });
     expect(AdMob.prepareInterstitial).toHaveBeenCalledTimes(4);
     expect(AdMob.showInterstitial).toHaveBeenCalledTimes(4);
@@ -220,10 +244,53 @@ describe('useAdMob', () => {
     // 5th eligible cycle (game-ends 16-18) — must be blocked by cap.
     vi.clearAllMocks();
     await act(async () => {
-      for (let i = 0; i < 3; i++) await result.current.showInterstitial();
+      await drainInterstitial(() => result.current.showInterstitial(), 3);
     });
     expect(AdMob.prepareInterstitial).not.toHaveBeenCalled();
     expect(AdMob.showInterstitial).not.toHaveBeenCalled();
+  });
+
+  it('showInterstitial resolves on Dismissed event (gates next-round emits)', async () => {
+    // The MP host awaits this promise before emitting startGame so other
+    // players stay on results while the fullscreen overlay is showing.
+    // Drive through warmup first, then verify the gated cycle.
+    const wrapper = makeWrapper(true);
+    const { result } = renderHook(() => useAdMob(), { wrapper });
+    await act(async () => {
+      await drainInterstitial(() => result.current.showInterstitial(), 5);
+    });
+
+    let resolved = false;
+    await act(async () => {
+      const p = result.current.showInterstitial().then(() => { resolved = true; });
+      await Promise.resolve();
+      await Promise.resolve();
+      // Before Dismissed: still pending.
+      expect(resolved).toBe(false);
+      fireEvent('interstitialAdDismissed');
+      await p;
+    });
+    expect(resolved).toBe(true);
+  });
+
+  it('showInterstitial resolves on FailedToLoad (no fill must not block the room)', async () => {
+    // If AdMob can't fill the ad, the host shouldn't be stuck waiting and the
+    // rest of the room shouldn't be frozen on the results page.
+    const wrapper = makeWrapper(true);
+    const { result } = renderHook(() => useAdMob(), { wrapper });
+    await act(async () => {
+      await drainInterstitial(() => result.current.showInterstitial(), 5);
+    });
+
+    let resolved = false;
+    await act(async () => {
+      const p = result.current.showInterstitial().then(() => { resolved = true; });
+      await Promise.resolve();
+      await Promise.resolve();
+      fireEvent('interstitialAdFailedToLoad');
+      await p;
+    });
+    expect(resolved).toBe(true);
   });
 
   it('showInterstitial skips ad during warmup', async () => {

--- a/fe-next/hooks/useAdMob.ts
+++ b/fe-next/hooks/useAdMob.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { AdMob, BannerAdSize, BannerAdPosition, RewardAdPluginEvents } from '@capacitor-community/admob';
+import { AdMob, BannerAdSize, BannerAdPosition, RewardAdPluginEvents, InterstitialAdPluginEvents } from '@capacitor-community/admob';
 import { useAdMobContext } from '@/contexts/AdMobContext';
 import type { RewardedSurface, BannerVariant } from '@/lib/admob-config';
 
@@ -95,7 +95,14 @@ export function useAdMob() {
     }
   }, [hasNoAds, getConfig, whenReady]);
 
-  const showInterstitial = useCallback(async () => {
+  // Resolves when the interstitial dismisses, fails, or never serves.
+  // Callers (e.g. MP host's "play again") await this so the next-round emit
+  // doesn't fire while a fullscreen overlay is still in front of the player
+  // — that's what previously stranded the player on a blank white screen
+  // when AdMob's prepare → show pipeline finished after results had painted.
+  // Safety timeout caps the wait in case Dismissed never arrives.
+  const INTERSTITIAL_SAFETY_TIMEOUT_MS = 15000;
+  const showInterstitial = useCallback(async (): Promise<void> => {
     recordGameEnd();
     if (!shouldShowInterstitial()) return;
     const config = getConfig();
@@ -103,11 +110,49 @@ export function useAdMob() {
     // Record before show — gate uses this counter, recording after a thrown
     // showInterstitial would let a broken plugin re-fire indefinitely.
     recordInterstitialShown();
-    try {
-      await whenReady();
-      await AdMob.prepareInterstitial({ adId: config.interstitialAdId });
-      await AdMob.showInterstitial();
-    } catch {}
+
+    const handles: Array<{ remove: () => void | Promise<void> }> = [];
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    await new Promise<void>((resolve) => {
+      const settle = () => {
+        if (settled) return;
+        settled = true;
+        if (timer) { clearTimeout(timer); timer = null; }
+        handles.forEach((h) => { try { h.remove(); } catch {} });
+        handles.length = 0;
+        resolve();
+      };
+
+      // Register listeners BEFORE prepare so a fast plugin can't fire
+      // Dismissed/FailedToShow before we're listening.
+      Promise.all([
+        AdMob.addListener(InterstitialAdPluginEvents.Dismissed, settle),
+        AdMob.addListener(InterstitialAdPluginEvents.FailedToShow, settle),
+        AdMob.addListener(InterstitialAdPluginEvents.FailedToLoad, settle),
+      ])
+        .then((resolved) => {
+          if (settled) {
+            resolved.forEach((h) => { try { h.remove(); } catch {} });
+            return;
+          }
+          handles.push(...resolved);
+        })
+        .catch(() => { /* listener registration is best-effort */ });
+
+      timer = setTimeout(settle, INTERSTITIAL_SAFETY_TIMEOUT_MS);
+
+      (async () => {
+        try {
+          await whenReady();
+          await AdMob.prepareInterstitial({ adId: config.interstitialAdId });
+          await AdMob.showInterstitial();
+        } catch {
+          settle();
+        }
+      })();
+    });
   }, [recordGameEnd, shouldShowInterstitial, recordInterstitialShown, getConfig, whenReady]);
 
   const showBanner = useCallback(async (position = BannerAdPosition.BOTTOM_CENTER, margin?: number, opts?: ShowBannerOptions) => {

--- a/fe-next/hooks/useInterstitialAd.ts
+++ b/fe-next/hooks/useInterstitialAd.ts
@@ -24,8 +24,13 @@ export function useInterstitialAd() {
   const h5Ads = useH5GamesAds();
   const firedRef = useRef<Set<string>>(new Set());
 
+  // Returns a Promise that resolves once the ad cycle has fully completed
+  // (dismissed / failed / never shown). Callers can `await` it to gate
+  // subsequent actions — e.g. the MP host awaits this before emitting
+  // `startGame` so all players stay on results until the ad-watching host
+  // is done. Non-awaiting callers still get the prior fire-and-forget shape.
   const showInterstitial = useCallback(
-    (name: string) => {
+    async (name: string): Promise<void> => {
       if (firedRef.current.has(name)) return;
       firedRef.current.add(name);
 
@@ -41,7 +46,7 @@ export function useInterstitialAd() {
         return;
       }
       if (Capacitor.isNativePlatform()) {
-        adMob.showInterstitial();
+        await adMob.showInterstitial();
         return;
       }
       if (h5EnvEnabled && (isProd || hasH5TestFlag)) {


### PR DESCRIPTION
## Summary

Users reported a blank white screen on the multiplayer results page — page rendered fine, then "after a few seconds" went blank. Root cause was three compounding issues around AdMob on that one screen:

1. **No banner slot.** `/multiplayer` is in `admob-routes` `GAME_ROUTES`, so `AnchoredNativeBanner` is intentionally hidden during the MP flow. SP / Daily / Challenge results all include the inline `ResultsBannerSlot` fallback for this case — the MP results page was the only one missing it, so AdMob never served a banner there.
2. **Interstitial fired on results-page mount.** AdMob's `prepare → show` pipeline takes a few seconds, so the fullscreen overlay painted over results *after* the user had started reading them. When the ad creative partially rendered (only the row of "app install" icons), the user was stranded on a blank white screen.
3. **Interstitial was fire-and-forget.** The host's `socket.emit('resetGame' | 'startGame')` chain ran while the interstitial was still on screen, so other players dropped into round 2 alone.

## Changes

- **`components/views/ResultsPage.tsx`** — render `ResultsBannerSlot placement="multiplayer-round-complete"` alongside the existing `CrazyGamesBanner` in both mobile and desktop layouts (parity with SP / Daily / Challenge). Move the interstitial trigger from results-mount to `handleStartGame` so it acts as a between-rounds transition the user opted into. `handleStartGame` is now `async` and awaits the interstitial before emitting `resetGame`.
- **`hooks/useAdMob.ts`** — `showInterstitial` now returns a `Promise<void>` that resolves on `Dismissed` / `FailedToShow` / `FailedToLoad` (with a 15s safety timeout). Listeners are registered before `prepareInterstitial` and removed on settle.
- **`hooks/useInterstitialAd.ts`** — `showInterstitial` becomes `async` and awaits the AdMob path so callers can gate subsequent actions.
- **`components/__tests__/ResultsPage.adSlot.test.tsx`** — new tests:
  - `ResultsBannerSlot` is rendered with the MP placement
  - interstitial does NOT fire on results mount
  - host's "Play Again" awaits the interstitial before emitting `resetGame` (verifies other players wait for the ad-watching host)
- **`hooks/__tests__/useAdMob.test.tsx`** — extended to drive the new event-gated promise; covers Dismissed resolution and FailedToLoad fallback.

## Test plan

- [x] `npx vitest run components/__tests__/ResultsPage.adSlot.test.tsx` — 3/3 pass
- [x] `npx vitest run hooks/__tests__/useAdMob.test.tsx` — 24/24 pass
- [x] `npx vitest run hooks/__tests__/useInterstitialAd.test.ts` — 7/7 pass
- [x] Full vitest sweep across `hooks/`, `components/results`, `components/views`, `components/ads`, `components/__tests__`, `components/singleplayer/__tests__`, `components/daily/__tests__` — 1493/1493 pass
- [x] `npx tsc --noEmit` clean on touched files
- [ ] Manual smoke on native build: finish an MP round → results render → AdMob banner shows in slot → host taps "Play Again" → interstitial shows fullscreen → other players see results until host dismisses → all players enter round 2 together


---
_Generated by [Claude Code](https://claude.ai/code/session_01B5cvN8PyQWAB64omJFP3Fe)_