### PR TITLE
SEO: daily meta tag improvements (2026-05-19)

### DIFF
--- a/docs/seo-daily/2026-05-19.md
+++ b/docs/seo-daily/2026-05-19.md
@@ -1,124 +1,153 @@
-# SEO Daily — 2026-05-19
+# SEO Daily Report — 2026-05-19
 
-**Window:** 2026-04-20 → 2026-05-17 (28d, GSC has 2-day lag)
-**Recent vs prior 7d:** 2026-05-11–2026-05-17 vs 2026-05-04–2026-05-10
-
-## Headline metrics
-
-| Engine | Clicks | Impressions | CTR |
-|---|---:|---:|---:|
-| Google | 50 | 1899 | 2.63% |
-| Bing | 58 | 1402 | 4.14% |
-| **Total** | **108** | **3301** | **3.27%** |
-
-> Bing drives **54% of total clicks** despite being the smaller search engine — Bing parity gaps below are high-leverage.
-
-## Top 10 CTR opportunities (Google)
-
-Queries underperforming expected CTR by ≥30%, sorted by potential clicks gained.
-
-| # | Query | Page | Pos | Impr | CTR | Expected | Δ Clicks | Suggested fix |
-|--:|---|---|--:|--:|--:|--:|--:|---|
-| 1 | `scrabble online svenska` | `/sv/swedish-multiplayer-word-game` | 9.0 | 191 | 0.00% | 2.00% | +3.8 | Front-load query in title; add stronger benefit hook in meta desc |
-| 2 | `scrabble online español` | `/es/juego-de-palabras-multijugador` | 8.6 | 187 | 0.00% | 2.00% | +3.7 | Front-load query in title; add stronger benefit hook in meta desc |
-| 3 | `scrabble svenska online` | `/sv/swedish-multiplayer-word-game` | 6.2 | 76 | 0.00% | 4.00% | +3.0 | Front-load query in title; add stronger benefit hook in meta desc |
-| 4 | `jugar scrabble online` | `/es/juego-de-palabras-multijugador` | 8.4 | 111 | 0.00% | 2.50% | +2.8 | Front-load query in title; add stronger benefit hook in meta desc |
-| 5 | `jugar scrabble en español gratis` | `/es/juego-de-palabras-multijugador` | 7.4 | 69 | 0.00% | 3.00% | +2.1 | Front-load query in title; add stronger benefit hook in meta desc |
-| 6 | `most popular online word games 2025 2026` | `/en/best-online-word-games` | 6.2 | 53 | 0.00% | 4.00% | +2.1 | Front-load query in title; add stronger benefit hook in meta desc |
-| 7 | `ordhjul` | `/sv/daily` | 5.4 | 31 | 0.00% | 6.00% | +1.9 | Front-load query in title; add stronger benefit hook in meta desc |
-| 8 | `best free browser word games 2026` | `/en/best-online-word-games` | 6.4 | 41 | 0.00% | 4.00% | +1.6 | Add SoftwareApplication+rating schema; current year in title |
-| 9 | `scrabble en español online` | `/es/juego-de-palabras-multijugador` | 8.2 | 62 | 0.00% | 2.50% | +1.6 | Front-load query in title; add stronger benefit hook in meta desc |
-| 10 | `jugar scrabble gratis` | `/es/juego-de-palabras-multijugador` | 9.2 | 68 | 0.00% | 2.00% | +1.4 | Front-load query in title; add stronger benefit hook in meta desc |
-
-## Top 10 rank-up opportunities (Google, pos 8–25)
-
-Queries on page 1 edge or page 2 — small wins push them to page 1.
-
-| # | Query | Page | Pos | Impr | Action |
-|--:|---|---|--:|--:|---|
-| 1 | `scrabble online svenska` | `/sv/swedish-multiplayer-word-game` | 9.0 | 191 | Add internal links from high-authority pages; expand H2 covering query |
-| 2 | `scrabble online español` | `/es/juego-de-palabras-multijugador` | 8.6 | 187 | Add internal links from high-authority pages; expand H2 covering query |
-| 3 | `jugar scrabble online` | `/es/juego-de-palabras-multijugador` | 8.4 | 111 | Add internal links from high-authority pages; expand H2 covering query |
-| 4 | `scrabble en linea` | `/es/juego-de-palabras-multijugador` | 9.3 | 70 | Add internal links from high-authority pages; expand H2 covering query |
-| 5 | `jugar scrabble gratis` | `/es/juego-de-palabras-multijugador` | 9.2 | 68 | Add internal links from high-authority pages; expand H2 covering query |
-| 6 | `scrabble en español online` | `/es/juego-de-palabras-multijugador` | 8.2 | 62 | Add internal links from high-authority pages; expand H2 covering query |
-| 7 | `scrabble online gratis` | `/es/juego-de-palabras-multijugador` | 9.0 | 51 | Add internal links from high-authority pages; expand H2 covering query |
-| 8 | `scrabble español online` | `/es/juego-de-palabras-multijugador` | 9.2 | 50 | Add internal links from high-authority pages; expand H2 covering query |
-| 9 | `jugar scrabble online gratis` | `/es/juego-de-palabras-multijugador` | 8.8 | 41 | Add internal links from high-authority pages; expand H2 covering query |
-| 10 | `scrabble juego online` | `/es/juego-de-palabras-multijugador` | 8.8 | 40 | Add internal links from high-authority pages; expand H2 covering query |
-
-## Bing parity gaps
-
-Queries ranking on Google but invisible on Bing. Submit URLs via IndexNow + check Bing sitemap.
-
-| Query | Google pos | Google impr | Bing | Fix |
-|---|--:|--:|---|---|
-| `scrabble online svenska` | 9.0 | 191 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble online español` | 8.6 | 187 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `jugar scrabble online` | 8.4 | 111 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble svenska online` | 6.2 | 76 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble en linea` | 9.3 | 70 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `jugar scrabble en español gratis` | 7.4 | 69 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `jugar scrabble gratis` | 9.2 | 68 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble en español online` | 8.2 | 62 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `most popular online word games 2025 2026` | 6.2 | 53 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble online gratis` | 9.0 | 51 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-
-## GEO / AI visibility candidates
-
-Question-style queries — add FAQPage schema + clear single-paragraph answers (boosts AI Overview / ChatGPT citation likelihood).
-
-| Query | Page | Pos | Impr | FAQ Q (draft) |
-|---|---|--:|--:|---|
-| `best free browser word games 2026` | `/en/best-online-word-games` | 6.4 | 41 | Best free browser word games 2026? |
-| `best free browser word games 2025 2026` | `/en/best-online-word-games` | 6.9 | 33 | Best free browser word games 2025 2026? |
-| `best competitive word games with global ...` | `/en/leaderboard` | 6.0 | 27 | Best competitive word games with global leaderboards? |
-| `best word games 2026` | `/en/best-online-word-games` | 7.7 | 19 | Best word games 2026? |
-| `best free online word games 2025 2026` | `/en/best-online-word-games` | 5.9 | 18 | Best free online word games 2025 2026? |
-| `best free online word games 2026` | `/en/best-online-word-games` | 5 | 8 | Best free online word games 2026? |
-| `best online word games 2025 2026` | `/en/best-online-word-games` | 4.3 | 6 | Best online word games 2025 2026? |
-| `best online word games` | `/en/best-online-word-games` | 41.8 | 4 | Best online word games? |
-
-## Trends — rising queries (last 7d vs prior 7d)
-
-| Query | Recent 7d | Prior 7d | Change |
-|---|--:|--:|--:|
-| `best word games 2026` | 8 | 1 | +700% |
-| `best free online word games 2026` | 6 | 2 | +200% |
-| `popular online word games 2026` | 5 | 2 | +150% |
-| `scrabble svenska online` | 47 | 21 | +124% |
-| `most popular online word games 2025 2026` | 35 | 18 | +94% |
-
-## Trends — falling queries
-
-| Query | Recent 7d | Prior 7d | Change |
-|---|--:|--:|--:|
-| `juego de palabras netflix` | 0 | 28 | -100% |
-| `juego netflix palabras` | 0 | 12 | -100% |
-| `juego de scrabble en español gratis onli...` | 0 | 6 | -100% |
-| `jugar scrabble gratis` | 0 | 32 | -100% |
-| `scrabble online multijugador` | 0 | 8 | -100% |
-
-## Bing top performers
-
-Where Bing already drives traffic — protect/expand these.
-
-| # | Query | Pos | Impr | Clicks | CTR |
-|--:|---|--:|--:|--:|--:|
-| 1 | `daily express word wheel` | 0.0 | 62 | 0 | 0.00% |
-| 2 | `daily express word wheel` | 0.0 | 50 | 0 | 0.00% |
-| 3 | `boggle wordshake` | 0.0 | 48 | 0 | 0.00% |
-| 4 | `boggle shake` | 0.0 | 35 | 0 | 0.00% |
-| 5 | `boggle shake` | 0.0 | 29 | 0 | 0.00% |
-| 6 | `boggle shake` | 0.0 | 27 | 0 | 0.00% |
-| 7 | `express word wheel today` | 0.0 | 26 | 0 | 0.00% |
-| 8 | `boggle shake` | 0.0 | 23 | 0 | 0.00% |
-
-## Today's actions
-
-- **Fix top-5 CTR opportunities** (~+15 clicks/28d): focus on titles/meta for `boggle-vs-scrabble`, `best-online-word-games`, and other comparison/listicle pages — current titles already include keywords but rank pos 7–9 with 0% CTR suggesting weak SERP appeal vs competitors.
-- **Fix Bing parity** (15 queries) — submit top-ranking Google pages to Bing via IndexNow API: `curl -X POST 'https://www.bing.com/indexnow' -H 'Content-Type: application/json' -d '{"host":"lexiclash.live","key":"<key>","urlList":[...]}'`
-- **Add FAQPage schema** for 10 question-style queries — ChatGPT/Gemini cite FAQ answers directly. Draft answers are in the GEO table above.
+**Data period:** 2026-04-20 → 2026-05-17 (28d, Google only — Bing API blocked from this server IP)
 
 ---
-_Generated by SEO daily routine. Data: GSC `sc-domain:lexiclash.live` + Bing WMT API._
+
+## Headline Metrics
+
+### Google Search Console (28d)
+
+| Metric | 28d Total | Last 7d (May 11–17) | Prior 7d (May 4–10) | Δ |
+|---|---|---|---|---|
+| Clicks | 50 | 9 | 22 | **-59%** |
+| Impressions | 1,899 | 449 | 771 | **-42%** |
+| CTR | 2.63% | 2.00% | 2.85% | -30% |
+| Avg Position | 27.7 | — | — | — |
+
+> **Signal:** Both clicks and impressions declined week-over-week. Most Spanish Scrabble queries lost 76–92% impressions in last 7d — possible algorithm flux or seasonal shift.
+
+### Bing
+
+> **Unavailable** — Bing Webmaster API returned 403 "Host not in allowlist" from this server. Run manually at [bing.com/webmasters](https://www.bing.com/webmasters) → Reports → Query Performance.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+Queries with ≥30 impressions underperforming expected CTR by ≥30%.
+
+| Query | Page | Pos | Impr | CTR | Expected | Gap | Suggested Fix |
+|---|---|---|---|---|---|---|---|
+| scrabble online svenska | `/sv/swedish-multiplayer-word-game` | 9.0 | 191 | 0.00% | 2.0% | 100% | Tighter title starting with exact query; add "Spela Nu" urgency |
+| scrabble online español | `/es/juego-de-palabras-multijugador` | 8.6 | 187 | 0.00% | 2.0% | 100% | Start title with "Jugar Scrabble Online en Español" |
+| jugar scrabble online | `/es/juego-de-palabras-multijugador` | 8.4 | 111 | 0.00% | 2.5% | 100% | Add "en 30 segundos" to desc; test title starting with query verb |
+| scrabble svenska online | `/sv/swedish-multiplayer-word-game` | 6.2 | 76 | 0.00% | 4.0% | 100% | Same page fix as above |
+| scrabble en linea | `/es/juego-de-palabras-multijugador` | 9.3 | 70 | 0.00% | 2.0% | 100% | Same page fix as above |
+| jugar scrabble en español gratis | `/es/juego-de-palabras-multijugador` | 7.4 | 69 | 0.00% | 3.0% | 100% | Same page fix as above |
+| jugar scrabble gratis | `/es/juego-de-palabras-multijugador` | 9.2 | 68 | 0.00% | 2.0% | 100% | Same page fix as above |
+| scrabble en español online | `/es/juego-de-palabras-multijugador` | 8.2 | 62 | 0.00% | 2.5% | 100% | Same page fix as above |
+| most popular online word games 2025 2026 | `/en/best-online-word-games` | 6.2 | 53 | 0.00% | 4.0% | 100% | Title too long (65 chars) — shorten + include "most popular" |
+| best free browser word games 2026 | `/en/best-online-word-games` | 6.4 | 41 | 0.00% | 4.0% | 100% | Same page; desc too long (180 chars) — trim to ≤155 |
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+Queries at position 8–20 with ≥50 impressions; small content/link push could land page 1 top-5.
+
+| Query | Page | Pos | Impr | CTR | Suggested Action |
+|---|---|---|---|---|---|
+| scrabble online svenska | `/sv/swedish-multiplayer-word-game` | 9.0 | 191 | 0.00% | Add H2 "Spela Scrabble Online Svenska"; add SoftwareApplication schema |
+| scrabble online español | `/es/juego-de-palabras-multijugador` | 8.6 | 187 | 0.00% | Add H2 "Scrabble Online en Español"; internal link from /es homepage |
+| jugar scrabble online | `/es/juego-de-palabras-multijugador` | 8.4 | 111 | 0.00% | Ensure "jugar scrabble online" appears in first 100 words of body |
+| scrabble en linea | `/es/juego-de-palabras-multijugador` | 9.3 | 70 | 0.00% | Add FAQ entry: "¿Cómo jugar scrabble en línea?" |
+| jugar scrabble gratis | `/es/juego-de-palabras-multijugador` | 9.2 | 68 | 0.00% | Add FAQ entry: "¿Se puede jugar scrabble gratis?" |
+| scrabble en español online | `/es/juego-de-palabras-multijugador` | 8.2 | 62 | 0.00% | Add HowTo schema for game setup steps |
+| scrabble online gratis | `/es/juego-de-palabras-multijugador` | 9.0 | 51 | 0.00% | Cluster all Scrabble terms into body copy |
+| scrabble español online | `/es/juego-de-palabras-multijugador` | 9.2 | 50 | 2.00% | Improve internal linking from blog posts to this page |
+
+---
+
+## Bing Parity Gaps
+
+> **Skipped** — Bing API returned 403 "Host not in allowlist" from this server. Check manually at [bing.com/webmasters](https://www.bing.com/webmasters) → Reports → Query Performance.
+
+---
+
+## Rising / Falling Queries (Last 7d vs Prior 7d)
+
+### Rising (+30%+ impression growth)
+
+| Query | Prior 7d Impr | Last 7d Impr | Δ | Action |
+|---|---|---|---|---|
+| scrabble svenska online | 21 | 47 | +124% | RISING — capitalize with Swedish page push |
+| most popular online word games 2025 2026 | 18 | 35 | +94% | RISING — fix title/desc on `/en/best-online-word-games` now |
+| ordhjul | 10 | 18 | +80% | RISING — ensure Swedish daily archive pages are indexed |
+| best free browser word games 2026 | 15 | 26 | +73% | RISING — fix best-online-word-games meta tags immediately |
+| scrabble online svenska | 56 | 91 | +62% | RISING — page gaining impressions with 0 clicks; urgent CTR fix |
+| best free browser word games 2025 2026 | 14 | 19 | +36% | RISING — same page fix |
+
+### Falling (-30%+ impression drop)
+
+| Query | Prior 7d Impr | Last 7d Impr | Δ | Action |
+|---|---|---|---|---|
+| scrabble online | 26 | 2 | -92% | Algorithm flux — monitor |
+| scrabble en español online | 40 | 4 | -90% | Monitor; may recover |
+| scrabble en linea | 28 | 3 | -89% | Monitor |
+| jugar scrabble online | 47 | 9 | -81% | Monitor; prior week may have been spike |
+| scrabble online gratis | 28 | 6 | -79% | Monitor |
+| scrabble español online | 29 | 7 | -76% | Monitor |
+| scrabble online español | 82 | 20 | -76% | Monitor — was highest-impression query |
+| lexiclash | 25 | 9 | -64% | Brand query dip — check brand page indexing |
+
+---
+
+## GEO / AI Visibility Recommendations
+
+These queries have question-intent — FAQPage schema and clear answer paragraphs improve visibility in AI Overviews and featured snippets.
+
+### Priority FAQ Schema Candidates
+
+**Page: `/es/juego-de-palabras-multijugador`** — Has `FaqAccordion` component. Verify `FAQPage` JSON-LD is emitted in `<head>`. Add or surface these Q&As:
+
+```json
+{
+  "@type": "Question",
+  "name": "¿Cómo jugar scrabble online en español gratis?",
+  "acceptedAnswer": { "@type": "Answer",
+    "text": "Ve a lexiclash.live, pulsa 'Multijugador', crea una sala y comparte el enlace. Sin registro ni descarga — empieza en 30 segundos." }
+},
+{
+  "@type": "Question",
+  "name": "¿Se puede jugar scrabble en línea gratis sin registro?",
+  "acceptedAnswer": { "@type": "Answer",
+    "text": "Sí. LexiClash es 100% gratuito, sin cuenta. Juega scrabble online en español directamente desde el navegador." }
+},
+{
+  "@type": "Question",
+  "name": "¿Cuál es la mejor alternativa a Scrabble online en español?",
+  "acceptedAnswer": { "@type": "Answer",
+    "text": "LexiClash: multijugador en tiempo real para 2–20 jugadores, gratis, sin descarga, con diccionario español completo." }
+}
+```
+
+**Page: `/sv/swedish-multiplayer-word-game`** — No schema components imported currently. Add `SoftwareApplication` JSON-LD + FAQPage with:
+
+```json
+{
+  "@type": "Question",
+  "name": "Hur spelar man scrabble online på svenska?",
+  "acceptedAnswer": { "@type": "Answer",
+    "text": "Gå till lexiclash.live, klicka på Multiplayer, skapa ett rum och dela länken. Spela scrabble online på svenska gratis i webbläsaren — utan registrering." }
+}
+```
+
+**Page: `/en/best-online-word-games`** — Has 7 FAQs with JSON-LD. Add one for the rising "most popular" query:
+
+```json
+{
+  "@type": "Question",
+  "name": "What are the most popular online word games in 2025 and 2026?",
+  "acceptedAnswer": { "@type": "Answer",
+    "text": "The most popular online word games in 2025–2026: LexiClash (free real-time multiplayer), Wordle (daily 5-letter), NYT Connections, NYT Strands, Spelling Bee, Words With Friends, Scrabble GO, Wordscapes, Semantle. LexiClash is the only free browser option with real-time group play for 2–20+ players." }
+}
+```
+
+---
+
+## Today's Actions
+
+1. **Fix `/en/best-online-word-games` title + desc** — title is 65 chars (over 60 limit), desc is 180 chars (over 155 limit); page has 776 impressions at pos 8.7 with 0.39% CTR and rising query momentum. Implemented in PR `seo/daily-2026-05-19`.
+2. **Fix `/sv/swedish-multiplayer-word-game` title** — 62 chars (over 60 limit); "scrabble online svenska" is rising +124% with 0% CTR at pos 9.0 — highest-leverage quick win. Implemented in PR `seo/daily-2026-05-19`.
+3. **Fix `/es/juego-de-palabras-multijugador` title** — reorder to start with exact query phrase "Jugar Scrabble Online en Español" to improve query-title relevance signal. Implemented in PR `seo/daily-2026-05-19`.

--- a/fe-next/app/[locale]/best-online-word-games/page.tsx
+++ b/fe-next/app/[locale]/best-online-word-games/page.tsx
@@ -15,11 +15,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const canonicalUrl = `${BASE_URL}/en/best-online-word-games`;
 
   return {
-    title: 'Best Free Browser Word Games 2026 — 9 Honest Picks (No Download)',
-    description: 'Best free browser word games of 2026 — honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, Semantle, LexiClash. Pros, cons & which to pick in 2 minutes.',
+    title: 'Best Free Browser Word Games 2026 — Top 9, No Download',
+    description: 'Wordle, NYT Connections, Scrabble GO, LexiClash & more — best free browser word games of 2026, ranked. No download. Pick yours in 2 minutes.',
     keywords: 'best free browser word games 2026, best word games 2026, best online word games 2025 2026, most popular online word games 2025 2026, free word games online, nyt connections, nyt strands, spelling bee game, semantle, wordle alternatives, multiplayer word games, word games with friends, word puzzle games online, word games no download, connections game',
     openGraph: {
-      title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',
+      title: 'Best Free Browser Word Games 2026 — Top 9, No Download',
       description: 'Best free browser word games of 2026, honestly ranked. Wordle, NYT Connections, LexiClash & more — no download required.',
       locale: 'en_US',
       type: 'website',
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',
+      title: 'Best Free Browser Word Games 2026 — Top 9, No Download',
       description: 'Best free browser word games of 2026, honestly ranked. No download required.',
       images: [`${BASE_URL}/og-image-en.webp`],
     },

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -24,11 +24,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
+    title: 'Jugar Scrabble Online en Español — Gratis | LexiClash',
     description: 'Juega scrabble online en español gratis, sin registro ni descarga. Crea sala, invita amigos por enlace y compite en tiempo real. ¡Empieza en segundos!',
     keywords: 'cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
+      title: 'Jugar Scrabble Online en Español — Gratis | LexiClash',
       description: 'Juega scrabble online en español con amigos en tiempo real. Crea sala, invita por enlace. 100% gratis, sin descargas.',
       locale: 'es_ES',
       type: 'website',
@@ -44,7 +44,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
+      title: 'Jugar Scrabble Online en Español — Gratis | LexiClash',
       description: 'Juega scrabble online en español con amigos. Sala con enlace, tiempo real, sin registro. ¡100% gratis!',
       images: [`${BASE_URL}/og-image-es.webp`],
     },

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -15,11 +15,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+    title: 'Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
     description: 'Spela scrabble online på svenska gratis, utan registrering. Skapa rum, bjud in med länk och tävla i realtid med vänner. 10 000+ ord. Börja nu!',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid',
     openGraph: {
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
       description: 'Spela scrabble online på svenska med vänner i realtid. Skapa rum, bjud in med länk. Gratis, ingen registrering.',
       locale: 'sv_SE',
       type: 'website',
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
       description: 'Spela scrabble online på svenska: skapa rum, bjud in med länk, tävla i realtid. Gratis, ingen registrering.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },


### PR DESCRIPTION
## Summary

Three meta-only fixes targeting rising queries with 0% CTR. All titles trimmed to ≤60 chars, description trimmed to ≤155 chars.

---

### Fix 1 — `/en/best-online-word-games` (776 impressions, pos 8.7, 0.39% CTR)

**Old title (64 chars — over limit):**
`Best Free Browser Word Games 2026 — 9 Honest Picks (No Download)`

**New title (54 chars):**
`Best Free Browser Word Games 2026 — Top 9, No Download`

**Old description (178 chars — over limit):**
`Best free browser word games of 2026 — honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, Semantle, LexiClash. Pros, cons & which to pick in 2 minutes.`

**New description (140 chars):**
`Wordle, NYT Connections, Scrabble GO, LexiClash & more — best free browser word games of 2026, ranked. No download. Pick yours in 2 minutes.`

**Expected uplift:** Queries "best free browser word games 2026" (+73% WoW impressions) and "most popular online word games 2025 2026" (+94% WoW) are both rising. Shorter title fits SERP display fully; listing named games in desc improves relevance signal.

---

### Fix 2 — `/sv/swedish-multiplayer-word-game` (191 impressions for "scrabble online svenska", pos 9.0, **0% CTR**)

**Old title (62 chars — over limit):**
`Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash`

**New title (53 chars):**
`Scrabble Online Svenska Gratis — Spela Nu | LexiClash`

**Expected uplift:** "scrabble online svenska" is rising +124% WoW. "Spela Nu" (Play Now) is more action-oriented and trims 9 chars. Query "scrabble svenska online" also at pos 6.2 with 76 impressions and 0% CTR — same page fix.

---

### Fix 3 — `/es/juego-de-palabras-multijugador` (1,185 impressions, pos 9.5, 1.10% CTR)

**Old title (60 chars):**
`Scrabble Online en Español Gratis — Sin Registro | LexiClash`

**New title (53 chars):**
`Jugar Scrabble Online en Español — Gratis | LexiClash`

**Expected uplift:** Starting with the verb "Jugar" matches top query intent ("jugar scrabble online" — 111 impressions, 0% CTR; "jugar scrabble gratis" — 68 impressions, 0% CTR). Google gives extra weight to query-matching tokens at the start of the title.

---

## Test plan

- [ ] `npx next build` passes with no TypeScript errors
- [ ] GSC impressions/CTR for the three pages checked in 7–14 days
- [ ] Confirm titles render in `<head>` via view-source after deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUjgTRHHBhHHNFTX9f2eKb)_