### PR TITLE
fix(daily): daily challenge credits correct quest slot, not "mp game"

### DIFF
--- a/fe-next/backend/modules/__tests__/dailyMissionsManager.test.ts
+++ b/fe-next/backend/modules/__tests__/dailyMissionsManager.test.ts
@@ -3,7 +3,8 @@
  */
 
 import { vi } from 'vitest';
-import { getDailyMissions, completeMission, checkAndClaimGrandSlam, markCelebrated, GRAND_SLAM_COIN_REWARD } from '../dailyMissionsManager';
+import { getDailyMissions, completeMission, completeMissionForMode, checkAndClaimGrandSlam, markCelebrated, GRAND_SLAM_COIN_REWARD } from '../dailyMissionsManager';
+import { getDailyQuestModes } from '../../../shared/dailyQuestPool';
 
 const { mockAwardCoins } = vi.hoisted(() => {
   const mockAwardCoins = vi.fn();
@@ -156,6 +157,49 @@ describe('completeMission', () => {
     const result = await completeMission(PLAYER_ID, 'word_hunt');
 
     expect(result.wordHunt).toBe(true);
+  });
+});
+
+describe('completeMissionForMode', () => {
+  // SLOT_COLUMNS = [word_hunt_completed, adventure_completed, community_completed].
+  // The mode that fills each slot rotates daily, so a mode MUST be credited to
+  // the column for the slot it occupies *that day* — never a hardcoded column.
+  // Regression guard for: completing the Word Hunt daily challenge marked
+  // word_hunt_completed (slot 0) statically; on days where slot 0 is the
+  // `multiplayer` mode the UI then showed "finished mp game".
+  const SLOT_COLUMNS = ['word_hunt_completed', 'adventure_completed', 'community_completed'] as const;
+
+  function setupCompleteMissionChain() {
+    // getDailyMissions (ensure row) + getDailyMissions (return updated) both read maybeSingle
+    mockMaybeSingle.mockResolvedValue({ data: EMPTY_ROW, error: null });
+    // update().eq().eq() resolves with no error
+    mockUpdate.mockReturnValue({
+      eq: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+    });
+  }
+
+  it('credits wordHunt to the slot column it occupies today, not always word_hunt_completed', async () => {
+    // 2026-05-20: modes = [multiplayer, wordHunt, brainDrills] → wordHunt is slot 1
+    const DATE = '2026-05-20';
+    const slot = getDailyQuestModes(DATE).indexOf('wordHunt');
+    expect(slot).toBe(1); // pins the fixture so the assertion below is meaningful
+    setupCompleteMissionChain();
+
+    await completeMissionForMode('player-123', 'wordHunt', DATE);
+
+    expect(mockUpdate).toHaveBeenCalledWith({ adventure_completed: true });
+    expect(mockUpdate).not.toHaveBeenCalledWith({ word_hunt_completed: true });
+  });
+
+  it('credits multiplayer to the slot column it occupies today', async () => {
+    // 2026-05-20: multiplayer is slot 0 → word_hunt_completed
+    const DATE = '2026-05-20';
+    const slot = getDailyQuestModes(DATE).indexOf('multiplayer');
+    setupCompleteMissionChain();
+
+    await completeMissionForMode('player-123', 'multiplayer', DATE);
+
+    expect(mockUpdate).toHaveBeenCalledWith({ [SLOT_COLUMNS[slot]]: true });
   });
 });
 

--- a/fe-next/backend/routes/dailyChallenge/wordHuntRoutes.ts
+++ b/fe-next/backend/routes/dailyChallenge/wordHuntRoutes.ts
@@ -27,7 +27,7 @@ import {
   isValidLanguage,
   computeWordHuntRetryScore,
 } from './utils';
-import { completeMission } from '../../modules/dailyMissionsManager';
+import { completeMissionForMode } from '../../modules/dailyMissionsManager';
 import { updateDailyProfileStats } from './profileStats';
 import { computeCycleProgress, computeWeekScore, getChestTier, type DayScore } from '../../../lib/daily/weeklyChest';
 import { updateQuestProgress } from '../../modules/weeklyQuestManager';
@@ -306,9 +306,12 @@ router.post('/submit', async (req: WordHuntSubmitRequest, res: Response): Promis
     const isRetry = !!existing;
     logger.info('API', `[WordHunt Submit] SUCCESS: id=${(data as { id?: string })?.id}, playerType=${playerId ? 'authenticated' : 'guest'}, displayName=${displayName}, solved=${solved}, isRetry=${isRetry}, isPaidRetry=${isPaidRetry}, penalty=${penaltyApplied}`);
 
-    // Mark daily mission as complete for authenticated users (fire-and-forget)
+    // Mark daily mission as complete for authenticated users (fire-and-forget).
+    // Credit the `wordHunt` *mode* — completeMissionForMode resolves which slot
+    // it occupies today. Writing a fixed column would credit whichever mode
+    // happens to fill that slot (e.g. multiplayer), showing the wrong quest done.
     if (playerId) {
-      completeMission(playerId, 'word_hunt').catch((err) => {
+      completeMissionForMode(playerId, 'wordHunt').catch((err) => {
         logger.error('API', `[WordHunt] Daily mission update failed for ${playerId}: ${(err as Error).message}`);
       });
     }


### PR DESCRIPTION
## Summary

Completing the daily challenge incorrectly showed the **multiplayer** daily quest ("finished mp game") as done.

**Root cause:** The Word Hunt daily-challenge submit handler (`wordHuntRoutes.ts`) marked the static `word_hunt_completed` column (slot 0) directly. Daily-quest slots rotate every day via `getDailyQuestModes()`, and the UI labels each slot with whichever mode fills it that day. On days where slot 0 is the `multiplayer` mode (e.g. today, `[multiplayer, wordHunt, brainDrills]`), crediting slot 0 lit up the multiplayer mission.

The multiplayer (`gameResults.ts`) and brain-drills (`drills/processCompletion.ts`) paths already use the dynamic `completeMissionForMode(...)` helper, which resolves the slot a mode occupies today. The Word Hunt path was the straggler still using the static `completeMission('word_hunt')`.

## Changes

- `backend/routes/dailyChallenge/wordHuntRoutes.ts`: credit `completeMissionForMode(playerId, 'wordHunt')` instead of `completeMission(playerId, 'word_hunt')`.
- `backend/modules/__tests__/dailyMissionsManager.test.ts`: add `completeMissionForMode` contract tests pinning the dynamic-slot mapping (regression guard for this bug class).

## Note / follow-up (out of scope)

The legacy `adventure` and `community` completion handlers (`app/api/adventure/complete/processCompletion.ts`, `engagementHandler.ts`) still call the static `completeMission(...)`. Those modes aren't in the current `DAILY_QUEST_POOL`, so they may be dead paths or a latent variant of the same bug — flagging for a separate look rather than touching them here.

## Test plan

- [x] `dailyMissionsManager.test.ts` — 20 passing (incl. 2 new)
- [x] `wordHuntRetryScore`, `dailyChallengeWordHuntSubmitValidation`, `engagementHandler` — passing
- [x] frontend `useDailyMissions`, `dailyQuestPool`, `DailyMissionsHub` — passing
- [x] typecheck clean on changed files
- [ ] Manual: complete the daily challenge on a day where slot 0 ≠ wordHunt and confirm the **Word Hunt** quest (not multiplayer) is marked complete

https://claude.ai/code/session_01PBSe9tbthfp6z8VnHC6XNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBSe9tbthfp6z8VnHC6XNA)_