### PR TITLE
fix(ads): hide native AdMob banner when a modal or side-nav is open

### DIFF
--- a/fe-next/components/ads/AnchoredNativeBanner.tsx
+++ b/fe-next/components/ads/AnchoredNativeBanner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { Capacitor } from '@capacitor/core';
 import { AdMob, BannerAdPluginEvents, BannerAdPosition } from '@capacitor-community/admob';
@@ -8,10 +8,29 @@ import { useAdMob } from '@/hooks/useAdMob';
 import { useSafeArea } from '@/hooks/useSafeArea';
 import { isAllowedAdBannerRoute } from '@/lib/admob-routes';
 
+// The native AdMob banner is a native view layered ABOVE the WebView, so CSS
+// z-index can't put a modal or side-drawer on top of it — when one opens, the
+// banner paints OVER the overlay's content (e.g. covering a modal's Save/Cancel
+// row). Detect blocking overlays and hide the banner until they close.
+//   • Modals: every in-app modal sets `aria-modal="true"`/`role="dialog"` and
+//     unmounts when closed, so its presence in the DOM ⇒ a modal is open.
+//   • Side-nav drawer: doesn't use a dialog role but locks body scroll, so
+//     `body.style.overflow === 'hidden'` ⇒ the drawer (or a scroll-locking
+//     modal) is open.
+function hasBlockingOverlay(): boolean {
+  if (typeof document === 'undefined') return false;
+  if (document.body.style.overflow === 'hidden') return true;
+  return document.querySelector('[aria-modal="true"], [role="dialog"]') !== null;
+}
+
 export default function AnchoredNativeBanner() {
   const pathname = usePathname();
   const { showBanner, hideBanner } = useAdMob();
   const safeArea = useSafeArea();
+  // Lazy init reads the DOM synchronously so the banner effect's first run
+  // already knows an overlay is open — avoids a show-then-hide flash when the
+  // banner mounts onto a route that already has a modal/drawer open.
+  const [overlayOpen, setOverlayOpen] = useState<boolean>(() => hasBlockingOverlay());
 
   useEffect(() => {
     if (!Capacitor.isNativePlatform()) return;
@@ -54,6 +73,26 @@ export default function AnchoredNativeBanner() {
     };
   }, [safeArea.bottom]);
 
+  // Track open modals / side-nav drawer. Modals portal directly into <body> and
+  // the drawer toggles body's inline `overflow`, so a non-subtree childList +
+  // style observer on <body> catches every open/close without scanning the
+  // whole DOM on each mutation.
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+
+    const update = () => setOverlayOpen(hasBlockingOverlay());
+    update();
+
+    const observer = new MutationObserver(update);
+    observer.observe(document.body, {
+      childList: true,
+      attributes: true,
+      attributeFilter: ['style'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
   useEffect(() => {
     if (!Capacitor.isNativePlatform()) return;
 
@@ -62,7 +101,9 @@ export default function AnchoredNativeBanner() {
     const isAndroid = Capacitor.getPlatform() === 'android';
     const safeBottom = safeArea.bottom || 0;
 
-    if (!isAllowedAdBannerRoute(pathname)) {
+    // Hide while an overlay is open (banner would paint over it) or on gameplay
+    // routes. Re-runs when `overlayOpen` flips false → banner shows again.
+    if (overlayOpen || !isAllowedAdBannerRoute(pathname)) {
       hideBanner();
       document.documentElement.style.setProperty('--admob-banner-height', '0px');
       return () => { cancelled = true; };
@@ -126,7 +167,7 @@ export default function AnchoredNativeBanner() {
       cancelAnimationFrame(rafId);
       htmlObserver.disconnect();
     };
-  }, [pathname, showBanner, hideBanner, safeArea.bottom]);
+  }, [pathname, showBanner, hideBanner, safeArea.bottom, overlayOpen]);
 
   return null;
 }

--- a/fe-next/components/ads/__tests__/AnchoredNativeBanner.test.tsx
+++ b/fe-next/components/ads/__tests__/AnchoredNativeBanner.test.tsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, waitFor } from '@testing-library/react';
 
 const { showBanner, hideBanner, mockPathname, addListener, mockPlatform, mockSafeArea } = vi.hoisted(() => ({
   showBanner: vi.fn(),
@@ -56,6 +56,8 @@ describe('AnchoredNativeBanner', () => {
     mockPathname.current = '/';
     mockPlatform.current = 'ios';
     mockSafeArea.current = { top: 0, bottom: 0, left: 0, right: 0 };
+    document.body.style.overflow = '';
+    document.querySelectorAll('[data-test-overlay]').forEach((el) => el.remove());
   });
   afterEach(cleanup);
 
@@ -262,6 +264,56 @@ describe('AnchoredNativeBanner', () => {
       document.documentElement.style.removeProperty('--bottom-nav-height');
       document.head.removeChild(style);
     }
+  });
+
+  it('hides banner while an aria-modal dialog is open (native banner would paint over the modal)', async () => {
+    mockPathname.current = '/';
+    const modal = document.createElement('div');
+    modal.setAttribute('data-test-overlay', '');
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    document.body.appendChild(modal);
+    render(<AnchoredNativeBanner />);
+    await Promise.resolve();
+    expect(showBanner).not.toHaveBeenCalled();
+    expect(hideBanner).toHaveBeenCalled();
+  });
+
+  it('hides banner while body scroll is locked (side-nav drawer open)', async () => {
+    mockPathname.current = '/';
+    document.body.style.overflow = 'hidden';
+    render(<AnchoredNativeBanner />);
+    await Promise.resolve();
+    expect(showBanner).not.toHaveBeenCalled();
+    expect(hideBanner).toHaveBeenCalled();
+  });
+
+  it('re-shows banner after the overlay closes', async () => {
+    mockPathname.current = '/';
+    const modal = document.createElement('div');
+    modal.setAttribute('data-test-overlay', '');
+    modal.setAttribute('aria-modal', 'true');
+    document.body.appendChild(modal);
+    render(<AnchoredNativeBanner />);
+    await Promise.resolve();
+    expect(showBanner).not.toHaveBeenCalled();
+
+    modal.remove();
+    await waitFor(() => expect(showBanner).toHaveBeenCalledWith('BOTTOM_CENTER', 0, { variant: 'content' }));
+  });
+
+  it('hides banner when an overlay opens after the banner was shown', async () => {
+    mockPathname.current = '/';
+    render(<AnchoredNativeBanner />);
+    await Promise.resolve();
+    expect(showBanner).toHaveBeenCalledTimes(1);
+
+    hideBanner.mockClear();
+    const modal = document.createElement('div');
+    modal.setAttribute('data-test-overlay', '');
+    modal.setAttribute('aria-modal', 'true');
+    document.body.appendChild(modal);
+    await waitFor(() => expect(hideBanner).toHaveBeenCalled());
   });
 
   it('registers FailedToLoad and Closed listeners that reset --admob-banner-height', async () => {


### PR DESCRIPTION
## Summary

The native AdMob anchored banner is a **native view layered above the Capacitor WebView**, so CSS `z-index` can never put in-WebView UI on top of it. When a modal (e.g. the avatar builder "בונה דמויות") or the side-navigation drawer opened, the banner painted **over** their content — in the reported screenshot it sat on top of the modal's Save/Cancel action row.

Fix: detect any open blocking overlay in `AnchoredNativeBanner` and hide the native banner until it closes, then re-show it.

- **Modals** — every in-app modal sets `aria-modal="true"`/`role="dialog"` and unmounts on close, so the presence of such an element in the DOM means a modal is open.
- **Side-nav drawer** — doesn't use a dialog role but locks body scroll, so `document.body.style.overflow === 'hidden'` covers it (and any scroll-locking modal).

A non-subtree `MutationObserver` on `<body>` (childList + the `style` attribute) catches every open/close cheaply: modals portal directly into `<body>` and the drawer toggles `<body>`'s inline `overflow`. A lazy `useState` initializer reads the DOM synchronously so the banner doesn't briefly flash before hiding when it mounts onto a route that already has an overlay open.

This is a central fix — no need to wire show/hide into each of the ~40 modal components.

## Test plan

- [x] New tests in `AnchoredNativeBanner.test.tsx` (TDD red→green): hides on open `aria-modal` dialog; hides when body scroll is locked (drawer); re-shows after overlay closes; hides when an overlay opens after the banner was already shown.
- [x] Full `components/ads` + `useAdMob` + `essential-providers-admob` suites pass (92 tests).
- [x] `tsc --noEmit` clean for the changed file; `eslint` clean.
- [ ] Manual verification on a native build (open avatar builder / side-nav, confirm banner disappears and returns on close).

https://claude.ai/code/session_01XAqakVg9GH91FCnpmXG4Wz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAqakVg9GH91FCnpmXG4Wz)_