### PR TITLE
SEO: daily meta tag improvements (2026-05-24)

### DIFF
--- a/docs/seo-daily/2026-05-24.md
+++ b/docs/seo-daily/2026-05-24.md
@@ -1,0 +1,157 @@
+# SEO Daily Report — 2026-05-24
+
+**Data range:** 2026-04-25 → 2026-05-22 (28d Google Search Console)  
+**Bing:** API returned 403 — key requires IP allowlisting from production origin; section skipped.
+
+---
+
+## Headline Metrics
+
+### Google Search Console (28d)
+
+| Metric | Value |
+|---|---|
+| Total Clicks | 56 |
+| Total Impressions | 3,316 |
+| Overall CTR | 1.69% |
+| Avg Position | 26.4 |
+
+### 7d-vs-7d Trend
+
+| Period | Clicks | Impressions |
+|---|---|---|
+| Last 7d (2026-05-16–22) | 12 | 1,623 |
+| Prior 7d (2026-05-09–15) | 12 | 406 |
+| Delta | ±0 (0%) | **+1,217 (+300%)** |
+
+> **Key signal:** Impressions tripled week-over-week but clicks stayed flat. CTR is the #1 priority — the site is appearing for many more queries but not winning the click.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+Queries with ≥30 impressions where actual CTR underperforms position-expected CTR by ≥30%.
+
+| Query | Page | Pos | Impr | Actual CTR | Expected CTR | Gap | Fix |
+|---|---|---|---|---|---|---|---|
+| scrabble online español | /es/juego-de-palabras-multijugador | 8.7 | 351 | 0.00% | 2.00% | −100% | Trim meta desc (163→≤155 chars) |
+| scrabble online svenska | /sv/swedish-multiplayer-word-game | 8.5 | 289 | 0.00% | 2.00% | −100% | Trim meta desc (175→≤155 chars) |
+| jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 7.7 | 244 | 0.00% | 2.50% | −100% | Same page — desc fix |
+| scrabble en linea | /es/juego-de-palabras-multijugador | 8.6 | 239 | 0.00% | 2.00% | −100% | Same page — desc fix |
+| jugar scrabble online | /es/juego-de-palabras-multijugador | 8.4 | 200 | 0.00% | 2.50% | −100% | Same page — desc fix |
+| jugar scrabble gratis | /es/juego-de-palabras-multijugador | 8.1 | 146 | 0.00% | 2.50% | −100% | Same page — desc fix |
+| scrabble online gratis | /es/juego-de-palabras-multijugador | 9.4 | 140 | 0.00% | 2.00% | −100% | Same page — desc fix |
+| scrabble en español online | /es/juego-de-palabras-multijugador | 8.6 | 115 | 0.00% | 2.00% | −100% | Same page — desc fix |
+| scrabble juego online | /es/juego-de-palabras-multijugador | 9.0 | 105 | 0.00% | 2.00% | −100% | Same page — desc fix |
+| most popular online word games 2025 2026 | /en/best-online-word-games | 6.2 | 58 | 0.00% | 4.00% | −100% | Trim title (77→≤60) + desc (172→≤155) |
+
+> **Note on 0% CTR pattern:** Multiple queries show 0 clicks despite 100s of impressions at pos 8–9. Hypothesis: meta descriptions are being truncated mid-sentence (ES desc is 163 chars, SV is 175 chars; Google truncates at ~155). A truncated, incomplete sentence signals low quality to searchers and suppresses clicks. Fixing this is the single highest-ROI action.
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+Queries at avg position 8–20 with ≥50 impressions. Small content or link improvements could push to page 1.
+
+| Query | Page | Pos | Impr | Clicks | Suggested Action |
+|---|---|---|---|---|---|
+| scrabble online español | /es/juego-de-palabras-multijugador | 8.7 | 351 | 0 | Internal links from homepage + H2 with exact phrase |
+| scrabble online svenska | /sv/swedish-multiplayer-word-game | 8.5 | 289 | 0 | Internal links from SV homepage + H2 with exact phrase |
+| scrabble en linea | /es/juego-de-palabras-multijugador | 8.6 | 239 | 0 | Add H2 "¿Cómo jugar Scrabble en línea?" |
+| jugar scrabble online | /es/juego-de-palabras-multijugador | 8.4 | 200 | 0 | Use exact phrase in first 100 words of body |
+| jugar scrabble gratis | /es/juego-de-palabras-multijugador | 8.1 | 146 | 0 | Add "gratis" to H1 / hero subtitle |
+| scrabble online gratis | /es/juego-de-palabras-multijugador | 9.4 | 140 | 0 | Same as above |
+| scrabble en español online | /es/juego-de-palabras-multijugador | 8.6 | 115 | 0 | Keyword in OG title |
+| scrabble juego online | /es/juego-de-palabras-multijugador | 9.0 | 105 | 0 | H2 with phrase |
+| scrabble español online | /es/juego-de-palabras-multijugador | 8.9 | 97 | 1 | Add to breadcrumb schema |
+| scrabble online | /es/juego-de-palabras-multijugador | 10.5 | 83 | 0 | Canonical page needs exact-match anchor in nav |
+
+---
+
+## Bing Parity Gaps
+
+**Skipped — Bing Webmaster API returned HTTP 403.** The API key `c13df4f2164643cabd986b652269b1c5` appears to require requests from a whitelisted IP (production server). Re-run from a production/staging machine or add this session's egress IP to the Bing Webmaster allowed list.
+
+---
+
+## Rising / Falling Queries (7d vs prior 7d)
+
+### Rising (>+30% impressions)
+
+| Query | Prior 7d Impr | Last 7d Impr | Delta |
+|---|---|---|---|
+| popular online word puzzle games 2025 2026 | 2 | 5 | +150% |
+| dagens ord | 1 | 2 | +100% |
+| free games like spelling bee | 1 | 2 | +100% |
+| games like boggle | 1 | 2 | +100% |
+| best competitive word games with global leaderboards | 7 | 10 | +43% |
+
+### Falling (>−30% impressions)
+
+| Query | Prior 7d Impr | Last 7d Impr | Delta |
+|---|---|---|---|
+| best word games 2026 | 8 | 2 | −75% |
+| most popular online word games 2025 2026 | 35 | 11 | −69% |
+| best free browser word games 2026 | 24 | 8 | −67% |
+| best word games online | 3 | 1 | −67% |
+| scrabble svenska online | 62 | 23 | −63% |
+| best free browser word games 2025 2026 | 20 | 10 | −50% |
+| best online word games | 4 | 2 | −50% |
+| boggle game online free play | 2 | 1 | −50% |
+| boggle like game | 2 | 1 | −50% |
+| ordhjul | 19 | 10 | −47% |
+
+> **Watch:** "scrabble svenska online" fell 63% and "ordhjul" fell 47% — both SV-market queries. Consider whether SV content was recently changed or if a competitor gained ground.
+
+---
+
+## GEO / AI Visibility Recommendations
+
+Queries that look like questions or "best X" searches are candidates for FAQPage schema + direct answer paragraphs (for AI Overviews, Perplexity, ChatGPT citations).
+
+### FAQ Schema Candidates
+
+| Query | Page | Pos | Impr |
+|---|---|---|---|
+| best free browser word games 2026 | /en/best-online-word-games | 7.5 | 45 |
+| best competitive word games with global leaderboards | /en/competitive-word-games | 5.2 | 31 |
+| what are the best free word games online | (not mapped) | 45.2 | 4 |
+| play word game online with friends browser | (not mapped) | 25.0 | 3 |
+
+### Draft FAQ Q&A for `/en/best-online-word-games`
+
+The page already has FAQPage schema in place (`/en/best-online-word-games` has a `faqs` array rendered via JSON-LD). Recommend adding two more entries targeting the falling queries:
+
+```json
+{
+  "q": "What are the best free browser word games in 2026?",
+  "a": "The best free browser word games in 2026 are LexiClash (real-time multiplayer, 8 modes, no install), Wordle (daily 5-letter), NYT Connections (group-16), NYT Strands, and Spelling Bee. LexiClash is the only one supporting 2–20 players in the same session without any download."
+},
+{
+  "q": "What word games are popular in 2025 and 2026?",
+  "a": "The most popular online word games across 2025–2026 are Wordle, LexiClash, NYT Connections, NYT Strands, Spelling Bee, Scrabble GO, and Words With Friends. LexiClash gained the most in 2025–2026 with Adventure, Blast, and party modes added."
+}
+```
+
+### Missing Schema Gaps
+
+- `/es/juego-de-palabras-multijugador`: Has `VideoGameJsonLd` + `BreadcrumbJsonLd` ✓. Missing **FAQPage** schema — the page has a `<FaqAccordion>` component but it's unclear if JSON-LD is wired up. Add FAQPage schema referencing existing FAQ data.
+- `/sv/swedish-multiplayer-word-game`: Has FAQs in page component but **no JSON-LD schema** at all. Add `VideoGameJsonLd` + `FAQPage` schema.
+
+---
+
+## Meta Tag Inspection
+
+| Page | Title (chars) | Description (chars) | Issue |
+|---|---|---|---|
+| /es/juego-de-palabras-multijugador | `Scrabble Online en Español Gratis — Sin Registro \| LexiClash` (60) | 163 chars | **Desc truncated** (+8 over limit) |
+| /sv/swedish-multiplayer-word-game | `Scrabble Online Svenska Gratis — Spela Multiplayer \| LexiClash` (62) | 175 chars | **Desc truncated** (+20 over limit) |
+| /en/best-online-word-games | `Most Popular Online Word Games 2025–2026 — 9 Honest Picks (Free, No Download)` (77) | 172 chars | **Title too long** (+17) + **Desc truncated** (+17) |
+
+---
+
+## Today's Actions (3-bullet summary)
+
+1. **Fix meta descriptions** on `/es/juego-de-palabras-multijugador` and `/sv/swedish-multiplayer-word-game` — both exceed 155 chars and are truncated mid-sentence in SERPs. This is the most likely cause of 0% CTR across 1,500+ Spanish and Swedish impressions.
+2. **Shorten title + desc** on `/en/best-online-word-games` — title is 77 chars (limit 60), preventing full display; shorter title with exact query phrase improves CTR on "best online word games 2026" cluster.
+3. **Add FAQPage JSON-LD** to `/sv/swedish-multiplayer-word-game` — currently has FAQs in JSX but no structured data. Quick win for AI Overviews visibility on Swedish market queries.

--- a/fe-next/app/[locale]/best-online-word-games/page.tsx
+++ b/fe-next/app/[locale]/best-online-word-games/page.tsx
@@ -15,8 +15,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const canonicalUrl = `${BASE_URL}/en/best-online-word-games`;
 
   return {
-    title: 'Most Popular Online Word Games 2025–2026 — 9 Honest Picks (Free, No Download)',
-    description: 'Most popular free online word games 2025–2026, honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, Semantle, LexiClash. Pros, cons & which to pick.',
+    title: 'Best Online Word Games 2026 — 9 Free Picks, No Download',
+    description: 'Best free online word games 2026, honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, LexiClash — pros & cons, no download needed.',
     keywords: 'best free browser word games 2026, best word games 2026, best online word games 2025 2026, most popular online word games 2025 2026, free word games online, nyt connections, nyt strands, spelling bee game, semantle, wordle alternatives, multiplayer word games, word games with friends, word puzzle games online, word games no download, connections game',
     openGraph: {
       title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   return {
     title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
-    description: 'Juega scrabble online en español gratis — sin registro, sin descarga. Partidas en tiempo real para 2-20 jugadores. Crea sala, invita con enlace. 10.000+ palabras.',
+    description: 'Juega scrabble online en español gratis, sin registro ni descarga. 2-20 jugadores en tiempo real. Crea sala e invita con un enlace — ¡empieza ya!',
     keywords: 'cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
       title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   return {
     title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
-    description: 'Spela scrabble online på svenska gratis mot 2-20 spelare i realtid — utan registrering, utan nedladdning. Skapa rum, bjud in med länk. Prova även dagligt ordhjul och Ordjakt.',
+    description: 'Spela scrabble online på svenska gratis, utan registrering. 2-20 spelare i realtid. Skapa rum och bjud in med en länk — börja spela nu!',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
       title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',

--- a/fe-next/lib/wordTower/__tests__/towerColumn.test.ts
+++ b/fe-next/lib/wordTower/__tests__/towerColumn.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildTowerColumn, cellAltitudes, wordColor, blendColors, hexToHsl } from '../towerColumn';
+const buildCol2 = buildTowerColumn;
 
 describe('buildTowerColumn', () => {
   it('empty tower → no cells', () => {
@@ -132,7 +133,6 @@ describe('cellAltitudes', () => {
   });
 });
 
-import { buildTowerColumn as buildCol2 } from '../towerColumn';
 describe('buildTowerColumn — 2-char vowel connector', () => {
   it('merges a 2-char shared prefix into the previous two tiles', () => {
     // CAT->TEA (share T, 1) ; TEA->EAR (share EA, 2)

--- a/fe-next/lib/wordTower/__tests__/wordTowerManager.test.ts
+++ b/fe-next/lib/wordTower/__tests__/wordTowerManager.test.ts
@@ -22,6 +22,9 @@ import {
   serializeWordTowerState,
   restoreWordTowerState,
   WORD_TOWER_SAVE_VERSION,
+  rerollStart,
+  nextChainAnchor,
+  damageTower,
 } from '../wordTowerManager';
 import {
   WORD_TOWER_TRAY_SIZE,
@@ -261,8 +264,6 @@ describe('wordTowerManager — serialize/restore', () => {
   });
 });
 
-import { rerollStart } from '../wordTowerManager';
-
 describe('rerollStart (dead-end escape)', () => {
   const base = () => initWordTowerState({ gameCode: 'g1', playerId: 'p1', language: 'en' });
 
@@ -296,7 +297,6 @@ describe('rerollStart (dead-end escape)', () => {
   });
 });
 
-import { nextChainAnchor } from '../wordTowerManager';
 describe('nextChainAnchor (vowel-ending chain skip)', () => {
   it('chains on the last letter for consonant endings', () => {
     expect(nextChainAnchor('CAT', 'en')).toBe('T');
@@ -307,7 +307,6 @@ describe('nextChainAnchor (vowel-ending chain skip)', () => {
   });
 });
 
-import { damageTower } from '../wordTowerManager';
 describe('damageTower (hazard ruin)', () => {
   const built = () => ({
     ...initWordTowerState({ gameCode: 'G', playerId: 'p1', language: 'en' as const }),


### PR DESCRIPTION
## Summary

Fixes meta descriptions truncated in SERPs and an over-length title. Root cause of suspected 0% CTR across ~1,500 Spanish and Swedish impressions/week at positions 8–9.

## Changes

| File | What changed | Why |
|---|---|---|
| `/es/juego-de-palabras-multijugador/page.tsx` | Desc: 163 → 143 chars | Truncated mid-sentence; complete CTA now fits |
| `/sv/swedish-multiplayer-word-game/page.tsx` | Desc: 175 → 144 chars | Truncated mid-sentence; complete CTA now fits |
| `/en/best-online-word-games/page.tsx` | Title: 77 → 55 chars; Desc: 172 → 151 chars | Title was hidden in SERPs; exact query "Best Online Word Games 2026" now leads |
| `docs/seo-daily/2026-05-24.md` | New daily SEO report | 28d GSC data, opportunity buckets, GEO recommendations |

## Query → old text → new text → expected CTR uplift

**1. "scrabble online español" (351 impr, pos 8.7, 0% CTR)**
- Page: `/es/juego-de-palabras-multijugador`
- Old desc (163 chars, truncated): `Juega scrabble online en español gratis — sin registro, sin descarga. Partidas en tiempo real para 2-20 jugadores. Crea sala, invita con enlace. 10.000+ pa…`
- New desc (143 chars): `Juega scrabble online en español gratis, sin registro ni descarga. 2-20 jugadores en tiempo real. Crea sala e invita con un enlace — ¡empieza ya!`
- Expected uplift: 0% → ~2% CTR = **+7 clicks/28d** on this query alone; covers ~8 co-ranking Spanish queries on same page

**2. "scrabble online svenska" (289 impr, pos 8.5, 0% CTR)**
- Page: `/sv/swedish-multiplayer-word-game`
- Old desc (175 chars, truncated): `Spela scrabble online på svenska gratis mot 2-20 spelare i realtid — utan registrering, utan nedladdning. Skapa rum, bjud in med länk. Prova även dagligt…`
- New desc (144 chars): `Spela scrabble online på svenska gratis, utan registrering. 2-20 spelare i realtid. Skapa rum och bjud in med en länk — börja spela nu!`
- Expected uplift: 0% → ~2% CTR = **+6 clicks/28d**

**3. "most popular online word games 2025 2026" (58 impr, pos 6.2, 0% CTR)**
- Page: `/en/best-online-word-games`
- Old title (77 chars, cut off in SERPs): `Most Popular Online Word Games 2025–2026 — 9 Honest Picks (Free, No Download)`
- New title (55 chars): `Best Online Word Games 2026 — 9 Free Picks, No Download`
- Old desc (172 chars): `Most popular free online word games 2025–2026, honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, Semantle, LexiClash. Pros, co…`
- New desc (151 chars): `Best free online word games 2026, honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, LexiClash — pros & cons, no download needed.`
- Expected uplift: 0% → ~4% CTR = **+2 clicks/28d**

## Test plan

- [ ] Verify SERP snippets via Google Search Console "URL Inspection" after deploy — confirm no `…` truncation
- [ ] Check mobile and desktop preview in GSC rich results test
- [ ] Run existing page tests: `fe-next/app/[locale]/juego-de-palabras-multijugador/components/__tests__/`
- [ ] Monitor CTR delta in GSC 14 days post-deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_018E5thmn2iDSRp9vYZqNMe6)_