### PR TITLE
fix(admob): rescue rewarded ad stuck on show-phase stall

### DIFF
--- a/fe-next/hooks/useAdMob.rewarded.test.ts
+++ b/fe-next/hooks/useAdMob.rewarded.test.ts
@@ -35,7 +35,7 @@ vi.mock('@/contexts/AdMobContext', () => ({
   }),
 }));
 
-import { useAdMob, REWARD_PREPARE_TIMEOUT_MS } from './useAdMob';
+import { useAdMob, REWARD_PREPARE_TIMEOUT_MS, REWARD_SAFETY_TIMEOUT_MS } from './useAdMob';
 
 const flush = () => Promise.resolve();
 
@@ -75,6 +75,39 @@ describe('useAdMob.showRewarded — prepare-phase stall guard', () => {
     expect(onReward).not.toHaveBeenCalled();
     // crucially: we never showed an un-listened ad after bailing
     expect(showRewardVideoAd).not.toHaveBeenCalled();
+  });
+
+  it('recovers when show stalls — settles via the safety timeout after showRewardVideoAd hangs with no event', async () => {
+    // The real "stuck in reward ads" bug: prepare resolves (an ad loaded) and
+    // we call show, but showRewardVideoAd() never resolves AND no Rewarded/
+    // Dismissed/Failed event ever fires (backgrounded WebView, buggy mediation
+    // adapter). The UI must not hang in status='showing' forever — the safety
+    // watchdog has to cover the show phase, not just the post-show event wait.
+    prepareRewardVideoAd.mockResolvedValue(undefined);
+    showRewardVideoAd.mockReturnValue(new Promise<void>(() => {}));
+
+    const { result } = renderHook(() => useAdMob());
+    const onReward = vi.fn();
+    const onError = vi.fn();
+
+    result.current.showRewarded(onReward, onError);
+
+    // drain listener registration + whenReady() + prepare microtasks
+    await flush();
+    await flush();
+    await flush();
+    await flush();
+
+    expect(showRewardVideoAd).toHaveBeenCalledTimes(1);
+    // before the safety timeout: still showing, neither resolved nor errored
+    expect(onError).not.toHaveBeenCalled();
+    expect(onReward).not.toHaveBeenCalled();
+
+    // advance past the safety watchdog — UI is freed with a retry error
+    await vi.advanceTimersByTimeAsync(REWARD_SAFETY_TIMEOUT_MS + 10);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onReward).not.toHaveBeenCalled();
   });
 
   it('shows the ad normally when prepare resolves before the timeout', async () => {

--- a/fe-next/hooks/useAdMob.ts
+++ b/fe-next/hooks/useAdMob.ts
@@ -19,6 +19,14 @@ export interface ShowRewardedOptions {
 // instant (preloaded).
 export const REWARD_PREPARE_TIMEOUT_MS = 12000;
 
+// Overall watchdog for the show-and-reward lifecycle. AdMob's rewarded video
+// can stall at *show* time — a backgrounded WebView or buggy mediation adapter
+// fires NO Rewarded/Dismissed/Failed event AND never resolves
+// `showRewardVideoAd()`. AdMob's own rewarded video tops out at 30s, so 90s is
+// well past any legitimate ad lifecycle: real events settle and clear this
+// well before it fires.
+export const REWARD_SAFETY_TIMEOUT_MS = 90000;
+
 export interface ShowBannerOptions {
   variant?: BannerVariant;
 }
@@ -46,12 +54,6 @@ export function useAdMob() {
     let safetyTimer: ReturnType<typeof setTimeout> | null = null;
     let prepareTimer: ReturnType<typeof setTimeout> | null = null;
     const REWARD_GRACE_MS = 750;
-    // Backstop for the v8 plugin's silent-stall case: poor network, backgrounded
-    // WebView, or a buggy mediation adapter can fire NO Rewarded/Dismissed/Failed
-    // event at all — leaving the UI's `status='showing'` flag forever-on and
-    // blocking the user from any further opt-in. AdMob's own rewarded video tops
-    // out at 30s, so 90s is well past any legitimate ad lifecycle.
-    const REWARD_SAFETY_TIMEOUT_MS = 90000;
     const handles: Array<{ remove: () => void | Promise<void> }> = [];
 
     const cleanup = () => {
@@ -112,16 +114,20 @@ export function useAdMob() {
             // would grant no reward. Leave the prepared ad cached for retry.
             if (settled) return;
             if (prepareTimer) { clearTimeout(prepareTimer); prepareTimer = null; }
+            // Arm the safety watchdog BEFORE showing — not after show resolves.
+            // The plugin can stall *during* show: `showRewardVideoAd()` never
+            // resolves and no Rewarded/Dismissed/Failed event fires, which left
+            // the old code awaiting show forever (the watchdog was never armed)
+            // and the UI frozen in status='showing' — the "stuck in reward ads"
+            // bug. Arming it here covers the whole show-and-reward window; a
+            // real ad fires its events well within REWARD_SAFETY_TIMEOUT_MS,
+            // and finishRef is idempotent so the watchdog is harmless if it
+            // outlives a normal ad.
+            safetyTimer = setTimeout(
+              () => finishRef(false, 'Ad timed out — please try again'),
+              REWARD_SAFETY_TIMEOUT_MS,
+            );
             await AdMob.showRewardVideoAd();
-            // Arm the safety timer only AFTER show resolves. If the plugin then
-            // stalls and never fires Rewarded/Dismissed/Failed, this rescues
-            // the UI.
-            if (!settled) {
-              safetyTimer = setTimeout(
-                () => finishRef(false, 'Ad timed out — please try again'),
-                REWARD_SAFETY_TIMEOUT_MS,
-              );
-            }
           } catch (err) {
             const msg = err instanceof Error ? err.message : 'Ad failed';
             finishRef(false, msg);

--- a/fe-next/lib/wordTower/__tests__/towerColumn.test.ts
+++ b/fe-next/lib/wordTower/__tests__/towerColumn.test.ts
@@ -132,11 +132,10 @@ describe('cellAltitudes', () => {
   });
 });
 
-import { buildTowerColumn as buildCol2 } from '../towerColumn';
 describe('buildTowerColumn — 2-char vowel connector', () => {
   it('merges a 2-char shared prefix into the previous two tiles', () => {
     // CAT->TEA (share T, 1) ; TEA->EAR (share EA, 2)
-    const cells = buildCol2([{ word: 'CAT' }, { word: 'TEA' }, { word: 'EAR' }]);
+    const cells = buildTowerColumn([{ word: 'CAT' }, { word: 'TEA' }, { word: 'EAR' }]);
     const letters = cells.filter((c) => c.kind === 'letter');
     expect(letters.map((c) => (c as { char: string }).char).join('')).toBe('CATEAR');
     // the E and A (TEA's last two) are shared connectors with EAR

--- a/fe-next/lib/wordTower/__tests__/wordTowerManager.test.ts
+++ b/fe-next/lib/wordTower/__tests__/wordTowerManager.test.ts
@@ -22,6 +22,9 @@ import {
   serializeWordTowerState,
   restoreWordTowerState,
   WORD_TOWER_SAVE_VERSION,
+  rerollStart,
+  nextChainAnchor,
+  damageTower,
 } from '../wordTowerManager';
 import {
   WORD_TOWER_TRAY_SIZE,
@@ -261,8 +264,6 @@ describe('wordTowerManager — serialize/restore', () => {
   });
 });
 
-import { rerollStart } from '../wordTowerManager';
-
 describe('rerollStart (dead-end escape)', () => {
   const base = () => initWordTowerState({ gameCode: 'g1', playerId: 'p1', language: 'en' });
 
@@ -296,7 +297,6 @@ describe('rerollStart (dead-end escape)', () => {
   });
 });
 
-import { nextChainAnchor } from '../wordTowerManager';
 describe('nextChainAnchor (vowel-ending chain skip)', () => {
   it('chains on the last letter for consonant endings', () => {
     expect(nextChainAnchor('CAT', 'en')).toBe('T');
@@ -307,7 +307,6 @@ describe('nextChainAnchor (vowel-ending chain skip)', () => {
   });
 });
 
-import { damageTower } from '../wordTowerManager';
 describe('damageTower (hazard ruin)', () => {
   const built = () => ({
     ...initWordTowerState({ gameCode: 'G', playerId: 'p1', language: 'en' as const }),


### PR DESCRIPTION
## Problem

Native AdMob rewarded ads could get **stuck** — the watch-ad button (e.g. `RewardedAdGoldButton`) sits disabled with a spinner forever and the user can never complete or dismiss the flow.

### Root cause

In `useAdMob.ts` `showRewarded()`, the 90s safety watchdog was armed **only after** `await AdMob.showRewardVideoAd()` resolved:

```ts
await AdMob.showRewardVideoAd();
if (!settled) { safetyTimer = setTimeout(...); }  // ← never reached on a show-phase stall
```

But the `@capacitor-community/admob` v8 plugin can stall **during** show — a backgrounded WebView or a buggy mediation adapter fires **no** `Rewarded`/`Dismissed`/`Failed` event **and** never resolves `showRewardVideoAd()`. In that case the `await` hangs forever, the watchdog is never armed, and the hook stays in `status='showing'` indefinitely. The UI stays stuck with no recovery.

(The existing `prepareTimer` only guards the *load* phase, and the per-event grace timer only fires once an event arrives — neither covers a silent show-phase stall.)

## Fix

Arm the safety watchdog **before** `showRewardVideoAd()`, so it covers the whole show-and-reward window instead of just the post-resolve event wait. `finishRef` is idempotent (guarded by `settled`, with `cleanup()` clearing all timers), so a real ad's `Rewarded`/`Dismissed` events settle and clear the watchdog well within the 90s ceiling — the timer is harmless if it ever outlives a normal ad. On a genuine stall the watchdog now frees the UI with a retry message.

`REWARD_SAFETY_TIMEOUT_MS` was hoisted to module scope and exported (mirroring `REWARD_PREPARE_TIMEOUT_MS`) so it can be asserted in tests.

## Tests (TDD)

Added a regression test in `useAdMob.rewarded.test.ts` that simulates a show-phase stall (`showRewardVideoAd` never resolves, no event fires) and asserts the UI recovers via the safety timeout. Verified it **fails** against the old arm-after-show ordering and **passes** with the fix.

## Test plan

- [x] `vitest run hooks/useAdMob.rewarded.test.ts` — 3 passed
- [x] `AdMobContext.test.tsx` + `essential-providers-admob.test.tsx` — no regressions (21 passed)
- [x] `tsc --noEmit` — no type errors in AdMob files
- [x] `eslint` on changed files — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01MarE863jFe4XikYwgaDVJg)_