### PR TITLE
feat(daily): in-game mute + reduce-effects toggles for daily challenge

### DIFF
--- a/fe-next/components/daily/DailyWordHuntSurvival.tsx
+++ b/fe-next/components/daily/DailyWordHuntSurvival.tsx
@@ -13,6 +13,7 @@ const WordHuntEffectsCanvas = dynamic(
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useDesktopLayout } from '@/hooks/useDesktopLayout';
 import { useDevicePerformance } from '@/hooks/useDevicePerformance';
+import { useReducedEffects } from '@/hooks/useReducedEffects';
 import { useNavigationGuard } from '@/hooks/useNavigationGuard';
 import { useHasRealAdProvider } from '@/hooks/useHasRealAdProvider';
 import { useCoinsFromContext } from '@/contexts/CoinContext';
@@ -86,11 +87,14 @@ const DailyWordHuntSurvival: React.FC<DailyWordHuntSurvivalProps> = ({
   const { isDesktop, isTv } = useDesktopLayout();
   const setIsInGame = useHideNavigation();
 
-  // Performance optimization for low-end devices
+  // Performance optimization for low-end devices + player opt-out.
+  // The in-game effects toggle (and OS reduced-motion) collapse onto the same
+  // skipAnimations lever that already gates particles, flashes, and confetti.
   const { isLowEnd, enableComplexAnimations } = useDevicePerformance();
+  const [effectsReduced] = useReducedEffects();
   const skipAnimations = useMemo(
-    () => isLowEnd || !enableComplexAnimations,
-    [isLowEnd, enableComplexAnimations]
+    () => isLowEnd || !enableComplexAnimations || effectsReduced,
+    [isLowEnd, enableComplexAnimations, effectsReduced]
   );
 
   // Extra-life offer state (rewarded ad OR coin-spend on life=0, single-use per run)
@@ -226,8 +230,8 @@ const DailyWordHuntSurvival: React.FC<DailyWordHuntSurvivalProps> = ({
       const cx = canvasSize.width / 2;
       const cy = canvasSize.height / 2;
       if (state.feedbackType === 'valid-word') {
-        triggerReward('wordFound');
         if (!skipAnimations) {
+          triggerReward('wordFound');
           setFlashColor('bg-green-400/15');
           setFlashTrigger((n) => n + 1);
           pushEffect({
@@ -238,9 +242,9 @@ const DailyWordHuntSurvival: React.FC<DailyWordHuntSurvivalProps> = ({
           });
         }
       } else if (state.feedbackType === 'target-found') {
-        triggerReward('levelUp');
-        setShowTargetConfetti(true);
         if (!skipAnimations) {
+          triggerReward('levelUp');
+          setShowTargetConfetti(true);
           setFlashColor('bg-neo-lime/20');
           setFlashTrigger((n) => n + 1);
           pushEffect({ type: 'targetFound', x: cx, y: cy });

--- a/fe-next/components/daily/survival/SurvivalAudioEffectsControls.test.tsx
+++ b/fe-next/components/daily/survival/SurvivalAudioEffectsControls.test.tsx
@@ -58,7 +58,7 @@ function resetState() {
 }
 
 const audioButton = () => screen.getByRole('button', { name: /mute|unmute/i });
-const effectsButton = () => screen.getByRole('button', { name: /reduceEffects|enableEffects/i });
+const effectsButton = () => screen.getByRole('button', { name: /disableAnimations|effects\.enable/i });
 
 describe('SurvivalAudioEffectsControls', () => {
   beforeEach(resetState);

--- a/fe-next/components/daily/survival/SurvivalAudioEffectsControls.test.tsx
+++ b/fe-next/components/daily/survival/SurvivalAudioEffectsControls.test.tsx
@@ -1,0 +1,131 @@
+import { vi } from 'vitest';
+import React from 'react';
+import { render, fireEvent, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * Behavior tests for the in-game audio + effects controls.
+ *
+ * Reviewer feedback (daily challenge): "couldn't find a mute button for the
+ * music" and "way too many lights and bells and whistles". These controls live
+ * in the in-game header (the only chrome visible during play) and give the
+ * player a one-tap mute (music + SFX) and a one-tap effects toggle.
+ *
+ * Audio button mirrors the master mute behaviour from MusicControls:
+ *   - any channel audible → mute both
+ *   - both already muted   → unmute both
+ *   - never flip a channel against the chosen direction (drift is corrected)
+ *   - audio not unlocked    → unlock first, toggle nothing
+ */
+
+const musicState = {
+  isMuted: false,
+  audioUnlocked: true,
+  toggleMute: vi.fn(),
+  unlockAudio: vi.fn(),
+};
+
+const sfxState = {
+  sfxMuted: false,
+  toggleSfxMute: vi.fn(),
+};
+
+let effectsReduced = false;
+const toggleEffects = vi.fn(() => {
+  effectsReduced = !effectsReduced;
+});
+
+vi.mock('@/contexts/MusicContext', () => ({ useMusic: () => musicState }));
+vi.mock('@/contexts/SoundEffectsContext', () => ({ useSoundEffects: () => sfxState }));
+vi.mock('@/hooks/useReducedEffects', () => ({
+  useReducedEffects: () => [effectsReduced, toggleEffects] as [boolean, () => void],
+}));
+
+// Import AFTER mocks so the component closes over them.
+import { SurvivalAudioEffectsControls } from './SurvivalAudioEffectsControls';
+
+const t = (key: string) => key;
+
+function resetState() {
+  musicState.isMuted = false;
+  musicState.audioUnlocked = true;
+  musicState.toggleMute.mockClear();
+  musicState.unlockAudio.mockClear();
+  sfxState.sfxMuted = false;
+  sfxState.toggleSfxMute.mockClear();
+  effectsReduced = false;
+  toggleEffects.mockClear();
+}
+
+const audioButton = () => screen.getByRole('button', { name: /mute|unmute/i });
+const effectsButton = () => screen.getByRole('button', { name: /reduceEffects|enableEffects/i });
+
+describe('SurvivalAudioEffectsControls', () => {
+  beforeEach(resetState);
+  afterEach(cleanup);
+
+  describe('audio mute button (music + SFX together)', () => {
+    it('mutes both music and SFX when both are audible', () => {
+      render(<SurvivalAudioEffectsControls t={t} />);
+      fireEvent.click(audioButton());
+
+      expect(musicState.toggleMute).toHaveBeenCalledTimes(1);
+      expect(sfxState.toggleSfxMute).toHaveBeenCalledTimes(1);
+    });
+
+    it('unmutes both when both are muted', () => {
+      musicState.isMuted = true;
+      sfxState.sfxMuted = true;
+
+      render(<SurvivalAudioEffectsControls t={t} />);
+      fireEvent.click(audioButton());
+
+      expect(musicState.toggleMute).toHaveBeenCalledTimes(1);
+      expect(sfxState.toggleSfxMute).toHaveBeenCalledTimes(1);
+    });
+
+    it('corrects drift: only music muted → mutes SFX, leaves music muted', () => {
+      musicState.isMuted = true;
+      sfxState.sfxMuted = false;
+
+      render(<SurvivalAudioEffectsControls t={t} />);
+      fireEvent.click(audioButton());
+
+      expect(musicState.toggleMute).not.toHaveBeenCalled();
+      expect(sfxState.toggleSfxMute).toHaveBeenCalledTimes(1);
+    });
+
+    it('unlocks audio first (and toggles nothing) when audio is not unlocked', () => {
+      musicState.audioUnlocked = false;
+
+      render(<SurvivalAudioEffectsControls t={t} />);
+      fireEvent.click(audioButton());
+
+      expect(musicState.unlockAudio).toHaveBeenCalledTimes(1);
+      expect(musicState.toggleMute).not.toHaveBeenCalled();
+      expect(sfxState.toggleSfxMute).not.toHaveBeenCalled();
+    });
+
+    it('shows a distinct muted label/icon when both channels are muted', () => {
+      musicState.isMuted = true;
+      sfxState.sfxMuted = true;
+
+      render(<SurvivalAudioEffectsControls t={t} />);
+      expect(screen.getByRole('button', { name: /unmute/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('effects toggle', () => {
+    it('toggles reduced-effects when clicked', () => {
+      render(<SurvivalAudioEffectsControls t={t} />);
+      fireEvent.click(effectsButton());
+
+      expect(toggleEffects).toHaveBeenCalledTimes(1);
+    });
+
+    it('exposes effects state via aria-pressed (off by default → not pressed)', () => {
+      render(<SurvivalAudioEffectsControls t={t} />);
+      expect(effectsButton()).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+});

--- a/fe-next/components/daily/survival/SurvivalAudioEffectsControls.tsx
+++ b/fe-next/components/daily/survival/SurvivalAudioEffectsControls.tsx
@@ -47,9 +47,11 @@ export const SurvivalAudioEffectsControls = memo<SurvivalAudioEffectsControlsPro
   }, [audioUnlocked, unlockAudio, isMuted, sfxMuted, toggleMute, toggleSfxMute]);
 
   const audioLabel = allMuted ? t('music.unmute', 'Unmute') : t('music.mute', 'Mute');
+  // Reuse the established effects.* keys (already localized in every locale) so
+  // the toggle needs no new translation strings.
   const effectsLabel = effectsReduced
-    ? t('music.enableEffects', 'Turn effects on')
-    : t('music.reduceEffects', 'Reduce effects');
+    ? t('effects.enable', 'Enable effects')
+    : t('effects.disableAnimations', 'Disable effects');
 
   return (
     <div className="flex items-center gap-1.5" role="group" aria-label={t('music.controls', 'Sound controls')}>

--- a/fe-next/components/daily/survival/SurvivalAudioEffectsControls.tsx
+++ b/fe-next/components/daily/survival/SurvivalAudioEffectsControls.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React, { memo, useCallback } from 'react';
+import { Volume2, VolumeX, Sparkles } from 'lucide-react';
+import { useMusic } from '@/contexts/MusicContext';
+import { useSoundEffects } from '@/contexts/SoundEffectsContext';
+import { useReducedEffects } from '@/hooks/useReducedEffects';
+
+export interface SurvivalAudioEffectsControlsProps {
+  t: (key: string, fallback?: string) => string;
+}
+
+const BTN_BASE =
+  'flex items-center justify-center w-9 h-9 min-w-[36px] min-h-[36px] bg-neo-black/50 border-2 border-neo-cream/10 rounded-full hover:bg-neo-black/70 active:scale-95 transition-all duration-150';
+
+/**
+ * SurvivalAudioEffectsControls — in-game audio + effects toggles.
+ *
+ * The app's main MusicControls live in the global header, which AutoHideHeader
+ * removes during active gameplay — so the daily challenge had no on-screen mute
+ * or effects control. This compact pair sits in the in-game header bar:
+ *  - Audio button mutes/unmutes music AND sfx together (master-mute parity).
+ *  - Effects button suppresses particles/flashes/confetti (remembered).
+ */
+export const SurvivalAudioEffectsControls = memo<SurvivalAudioEffectsControlsProps>(({ t }) => {
+  const { isMuted, toggleMute, audioUnlocked, unlockAudio } = useMusic();
+  const { sfxMuted, toggleSfxMute } = useSoundEffects();
+  const [effectsReduced, toggleEffects] = useReducedEffects();
+
+  const allMuted = isMuted && sfxMuted;
+
+  // Coherent target (mirrors MusicControls): any channel audible → mute both;
+  // both muted → unmute both. Never flip a channel against the chosen direction.
+  const handleAudioClick = useCallback(() => {
+    if (!audioUnlocked) {
+      unlockAudio();
+      return;
+    }
+    const anyAudible = !isMuted || !sfxMuted;
+    if (anyAudible) {
+      if (!isMuted) toggleMute();
+      if (!sfxMuted) toggleSfxMute();
+    } else {
+      if (isMuted) toggleMute();
+      if (sfxMuted) toggleSfxMute();
+    }
+  }, [audioUnlocked, unlockAudio, isMuted, sfxMuted, toggleMute, toggleSfxMute]);
+
+  const audioLabel = allMuted ? t('music.unmute', 'Unmute') : t('music.mute', 'Mute');
+  const effectsLabel = effectsReduced
+    ? t('music.enableEffects', 'Turn effects on')
+    : t('music.reduceEffects', 'Reduce effects');
+
+  return (
+    <div className="flex items-center gap-1.5" role="group" aria-label={t('music.controls', 'Sound controls')}>
+      <button
+        type="button"
+        onClick={handleAudioClick}
+        className={`${BTN_BASE} ${allMuted ? 'text-neo-cream/40' : 'text-neo-cream/70'}`}
+        aria-label={audioLabel}
+        aria-pressed={!allMuted}
+        title={allMuted ? t('music.soundOff', 'Sound off') : t('music.soundOn', 'Sound on')}
+      >
+        {allMuted
+          ? <VolumeX className="w-4 h-4" strokeWidth={2.5} aria-hidden="true" />
+          : <Volume2 className="w-4 h-4" strokeWidth={2.5} aria-hidden="true" />}
+      </button>
+
+      <button
+        type="button"
+        onClick={toggleEffects}
+        className={`${BTN_BASE} ${effectsReduced ? 'text-neo-cream/40' : 'text-neo-lime/80'}`}
+        aria-label={effectsLabel}
+        aria-pressed={effectsReduced}
+        title={effectsLabel}
+      >
+        <Sparkles className="w-4 h-4" strokeWidth={2.5} aria-hidden="true" />
+      </button>
+    </div>
+  );
+});
+
+SurvivalAudioEffectsControls.displayName = 'SurvivalAudioEffectsControls';
+
+export default SurvivalAudioEffectsControls;

--- a/fe-next/components/daily/survival/SurvivalHeader.tsx
+++ b/fe-next/components/daily/survival/SurvivalHeader.tsx
@@ -3,6 +3,7 @@
 import React, { memo } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { AccumulatedScoreDisplay } from './AccumulatedScoreDisplay';
+import { SurvivalAudioEffectsControls } from './SurvivalAudioEffectsControls';
 
 export interface SurvivalHeaderProps {
   liveScore: number;
@@ -31,13 +32,17 @@ export const SurvivalHeader = memo<SurvivalHeaderProps>(({
 }) => {
   return (
     <div className="sticky top-0 z-20 flex items-center justify-between mb-1 px-2 py-1 max-w-3xl mx-auto w-full bg-neo-navy/90 backdrop-blur-sm rounded-b-neo overflow-visible">
-      <button
-        onClick={onQuitClick}
-        className="flex items-center gap-1.5 bg-neo-black/50 text-neo-cream/60 px-2.5 py-1.5 text-xs font-bold uppercase tracking-wide border-2 border-neo-cream/10 rounded-full hover:bg-neo-black/70 hover:text-neo-cream/80 active:scale-95 transition-all duration-150"
-      >
-        <ArrowLeft className="w-4 h-4 rtl:rotate-180" />
-        {t('common.quit')}
-      </button>
+      <div className="flex items-center gap-1.5">
+        <button
+          onClick={onQuitClick}
+          className="flex items-center gap-1.5 bg-neo-black/50 text-neo-cream/60 px-2.5 py-1.5 text-xs font-bold uppercase tracking-wide border-2 border-neo-cream/10 rounded-full hover:bg-neo-black/70 hover:text-neo-cream/80 active:scale-95 transition-all duration-150"
+        >
+          <ArrowLeft className="w-4 h-4 rtl:rotate-180" />
+          {t('common.quit')}
+        </button>
+
+        <SurvivalAudioEffectsControls t={t} />
+      </div>
 
       <AccumulatedScoreDisplay
         currentScore={liveScore}

--- a/fe-next/hooks/useReducedEffects.test.tsx
+++ b/fe-next/hooks/useReducedEffects.test.tsx
@@ -1,0 +1,69 @@
+import { renderHook, act } from '@testing-library/react';
+import { useReducedEffects, setReducedEffects } from './useReducedEffects';
+
+const STORAGE_KEY = 'boggle_reduce_effects';
+
+describe('useReducedEffects', () => {
+  beforeEach(() => {
+    // Reset the shared module store + persisted value before each test.
+    setReducedEffects(false);
+    window.localStorage.clear();
+  });
+
+  it('defaults to false (effects ON) when nothing is persisted', () => {
+    const { result } = renderHook(() => useReducedEffects());
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('toggle() turns effects-reduction on and persists it', () => {
+    const { result } = renderHook(() => useReducedEffects());
+
+    act(() => {
+      result.current[1]();
+    });
+
+    expect(result.current[0]).toBe(true);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  it('toggle() twice returns to false', () => {
+    const { result } = renderHook(() => useReducedEffects());
+
+    act(() => result.current[1]());
+    act(() => result.current[1]());
+
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('setReducedEffects updates an already-mounted hook (reactive store)', () => {
+    const { result } = renderHook(() => useReducedEffects());
+
+    act(() => {
+      setReducedEffects(true);
+    });
+
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('keeps two independent hook instances in sync', () => {
+    const a = renderHook(() => useReducedEffects());
+    const b = renderHook(() => useReducedEffects());
+
+    act(() => {
+      a.result.current[1]();
+    });
+
+    expect(a.result.current[0]).toBe(true);
+    expect(b.result.current[0]).toBe(true);
+  });
+
+  it('reads a previously persisted value on a fresh module load', async () => {
+    window.localStorage.setItem(STORAGE_KEY, 'true');
+    vi.resetModules();
+
+    const fresh = await import('./useReducedEffects');
+    const { result } = renderHook(() => fresh.useReducedEffects());
+
+    expect(result.current[0]).toBe(true);
+  });
+});

--- a/fe-next/hooks/useReducedEffects.ts
+++ b/fe-next/hooks/useReducedEffects.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useCallback, useSyncExternalStore } from 'react';
+
+/**
+ * useReducedEffects — opt-out switch for the daily challenge's heavy visual
+ * effects (particle bursts, screen flashes, confetti).
+ *
+ * Effects stay ON by default; players who find them overwhelming can switch
+ * them off in-game and the choice is remembered. Backed by a tiny module-level
+ * store so the in-game toggle and the gameplay surface that reads the flag stay
+ * in sync without prop-drilling or a context provider, and synced across tabs.
+ */
+
+const STORAGE_KEY = 'boggle_reduce_effects';
+
+const listeners = new Set<() => void>();
+let cached: boolean | null = null;
+let storageBound = false;
+
+function readFromStorage(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function getSnapshot(): boolean {
+  if (cached === null) cached = readFromStorage();
+  return cached;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+/** Imperatively set the reduced-effects preference (used by the toggle). */
+export function setReducedEffects(value: boolean): void {
+  cached = value;
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, value ? 'true' : 'false');
+    } catch {
+      // Storage disabled/full — keep the in-memory value so the UI stays live.
+    }
+  }
+  emit();
+}
+
+function handleStorage(event: StorageEvent): void {
+  if (event.key !== STORAGE_KEY) return;
+  cached = event.newValue === 'true';
+  emit();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  if (!storageBound && typeof window !== 'undefined') {
+    window.addEventListener('storage', handleStorage);
+    storageBound = true;
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && storageBound && typeof window !== 'undefined') {
+      window.removeEventListener('storage', handleStorage);
+      storageBound = false;
+    }
+  };
+}
+
+/**
+ * @returns `[reduced, toggle]` — `reduced` is true when heavy effects should be
+ * suppressed; `toggle` flips the preference and persists it.
+ */
+export function useReducedEffects(): [boolean, () => void] {
+  const reduced = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const toggle = useCallback(() => {
+    setReducedEffects(!getSnapshot());
+  }, []);
+  return [reduced, toggle];
+}


### PR DESCRIPTION
## Why

Playtest feedback on the daily challenge:

> Way too many lights and bells and whistles, and I couldn't find a mute button for the music, which I found obnoxious. I know a lot of people like that sort of thing though...

Two real gaps:

1. **No on-screen mute during play.** The global header holds `MusicControls`, but `AutoHideHeader` removes the entire header during active gameplay — so once the daily challenge starts there is *no* way to mute the music or SFX. The complaint is a genuine discoverability bug.
2. **Relentless visual effects with no opt-out.** Particle bursts, screen flashes, and confetti fire constantly and could only be calmed via the OS `prefers-reduced-motion` setting.

The reviewer hedged ("a lot of people like that sort of thing"), so the goal is **control, not removal** — effects stay on by default and become switch-offable.

## What

Adds a compact control pair to the in-game `SurvivalHeader` (renders in **both** the mobile and desktop survival layouts), next to the Quit button:

- **Audio toggle** — mutes/unmutes background music **and** SFX together, mirroring the coherent master-mute logic in `MusicControls` (any channel audible → mute both; both muted → unmute both; unlock audio first if needed).
- **Effects toggle** — suppresses particles, screen flashes, and confetti. Effects stay **ON by default**; the off-choice is remembered across sessions and tabs.

The reduce-effects preference is a tiny `useSyncExternalStore`-backed store (`useReducedEffects`) that folds onto the existing `skipAnimations` lever already used for low-end devices and reduced-motion — so it reuses the well-tested suppression path and now also gates the previously-always-on reward / target-confetti bursts.

The control labels reuse existing, already-localized translation keys (`music.*` for audio, `effects.disableAnimations` / `effects.enable` for the effects toggle), so **no new translation strings are introduced** — the feature is fully localized in every locale.

## Files

- `hooks/useReducedEffects.ts` — reactive, persisted reduce-effects store (+ tests)
- `components/daily/survival/SurvivalAudioEffectsControls.tsx` — the in-game control pair (+ tests)
- `components/daily/survival/SurvivalHeader.tsx` — renders the controls beside Quit
- `components/daily/DailyWordHuntSurvival.tsx` — wires the flag into `skipAnimations` + gates reward/confetti

## Test plan

- [x] `useReducedEffects` unit tests (default off, toggle+persist, reactive store, cross-instance sync, fresh-load read) — pass
- [x] `SurvivalAudioEffectsControls` behavior tests (mute both / unmute both / drift correction / unlock-first / effects toggle / aria state) — pass
- [x] Daily + cross-tree tests that render `DailyWordHuntSurvival` / `SurvivalHeader` (760+ tests) — green, no regressions
- [x] `tsc --noEmit` clean, eslint clean on changed files, `check:translations` no longer flags this PR's keys
- [ ] Manual in-browser check of the live daily challenge — not run (the web env has no app secrets to boot the custom server); logic is covered by the rendering tests above

## CI note

The `lint` / `test` / `lighthouse` checks are red, but these failures are **pre-existing on `master`** and unrelated to this change:
- `lint` → `check:translations` fails on 21 missing `shiritori.*` / `wordAlchemy.*` keys that are already absent from `master`'s `en.js` (this PR adds no missing keys).
- `test` shard + `lighthouse` → fail on `master` as well (lighthouse builds/runs the whole app).

This PR's own code is correct and fully tested; addressing the master-level debt is out of scope here.