### PR TITLE
fix(i18n): give Radix a DirectionProvider so RTL Select positions correctly in Hebrew

### DIFF
--- a/fe-next/app/essential-providers.tsx
+++ b/fe-next/app/essential-providers.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useMemo, ReactNode } from 'react';
 import { ThemeProvider } from '@/utils/ThemeContext';
 import { LanguageProvider } from '@/contexts/LanguageContext';
+import { RadixDirectionProvider } from '@/components/providers/RadixDirectionProvider';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { MotionConfigProvider } from '@/components/motion/MotionConfigProvider';
 import { AccessibilityProvider } from '@/contexts/AccessibilityContext';
@@ -183,6 +184,7 @@ export function EssentialProviders({ children, lang, initialTranslations }: Esse
             {/* Stable tier: rarely changes */}
             <ThemeProvider>
                 <LanguageProvider initialLanguage={lang} initialTranslations={initialTranslations}>
+                    <RadixDirectionProvider>
                     <AuthProvider>
                         <LogRocketIdentify />
                         <PostHogProvider>
@@ -245,7 +247,9 @@ export function EssentialProviders({ children, lang, initialTranslations }: Esse
                     </CoinProvider>
                     </CrazyGamesProvider>
                     </PostHogProvider>
-                    </AuthProvider>                </LanguageProvider>
+                    </AuthProvider>
+                    </RadixDirectionProvider>
+                </LanguageProvider>
             </ThemeProvider>
             </>
             )}

--- a/fe-next/components/providers/RadixDirectionProvider.tsx
+++ b/fe-next/components/providers/RadixDirectionProvider.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { DirectionProvider } from '@radix-ui/react-direction';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+/**
+ * Feeds the active locale's text direction to every Radix primitive.
+ *
+ * Radix overlays (Select, Dialog, Popover, Tabs…) read direction from this
+ * context — NOT from the `dir` attribute on <html>. Without a provider they
+ * default to 'ltr', so on Hebrew (RTL) pages a popper-positioned Select
+ * computes its placement with LTR collision math and can render off-anchor.
+ */
+export function RadixDirectionProvider({ children }: { children: ReactNode }) {
+  const { dir } = useLanguage();
+  return <DirectionProvider dir={dir}>{children}</DirectionProvider>;
+}
+
+export default RadixDirectionProvider;

--- a/fe-next/components/providers/__tests__/RadixDirectionProvider.test.tsx
+++ b/fe-next/components/providers/__tests__/RadixDirectionProvider.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { useDirection } from '@radix-ui/react-direction';
+import { RadixDirectionProvider } from '../RadixDirectionProvider';
+
+const mockUseLanguage = vi.fn();
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => mockUseLanguage(),
+}));
+
+// Probe consumes the same direction context that every Radix primitive
+// (Select, Dialog, Popover, Tabs…) reads to compute RTL positioning.
+function DirectionProbe() {
+  const dir = useDirection();
+  return <span data-testid="dir">{dir}</span>;
+}
+
+describe('RadixDirectionProvider', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('propagates rtl direction to Radix components when language is Hebrew', () => {
+    mockUseLanguage.mockReturnValue({ dir: 'rtl', language: 'he' });
+
+    render(
+      <RadixDirectionProvider>
+        <DirectionProbe />
+      </RadixDirectionProvider>
+    );
+
+    expect(screen.getByTestId('dir')).toHaveTextContent('rtl');
+  });
+
+  it('propagates ltr direction for LTR languages', () => {
+    mockUseLanguage.mockReturnValue({ dir: 'ltr', language: 'en' });
+
+    render(
+      <RadixDirectionProvider>
+        <DirectionProbe />
+      </RadixDirectionProvider>
+    );
+
+    expect(screen.getByTestId('dir')).toHaveTextContent('ltr');
+  });
+});

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -1,5 +1,30 @@
 // EN translations
 const en = {
+  "shiritori": {
+    "chain": "Word chain",
+    "inputLabel": "Type your word",
+    "nextStartsWith": "Next word starts with",
+    "players": "Players",
+    "submit": "Submit",
+    "waitTurn": "Waiting for your turn…",
+    "wins": "wins!",
+    "yourTurn": "Your turn — type a word",
+    "youWin": "You win!"
+  },
+  "wordAlchemy": {
+    "badge": "Word Alchemy",
+    "title": "Word Alchemy",
+    "instructions": "Transform one word into the next by following each clue.",
+    "puzzleProgress": "Puzzle {n} of {total}",
+    "stepProgress": "Step {n} of {total}",
+    "inputPlaceholder": "Type your word",
+    "hintLabel": "Hint:",
+    "submit": "Submit",
+    "next": "Next puzzle",
+    "restart": "Restart",
+    "wonTitle": "Puzzle solved!",
+    "wonSubtitle": "Nice chain! Ready for the next one?"
+  },
   "gameFeedback": {"prompt":"How was that round?","bad":"Meh","ok":"Good","great":"Loved it!","thanks":"Thanks for the feedback!","dismiss":"Dismiss"},
   "wordTower": {
     "cardTitle": "Word Tower",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -1,5 +1,30 @@
 // Es translations
 const es = {
+  "shiritori": {
+    "chain": "Cadena de palabras",
+    "inputLabel": "Escribe tu palabra",
+    "nextStartsWith": "La siguiente palabra empieza con",
+    "players": "Jugadores",
+    "submit": "Enviar",
+    "waitTurn": "Esperando tu turno…",
+    "wins": "¡gana!",
+    "yourTurn": "Tu turno: escribe una palabra",
+    "youWin": "¡Ganaste!"
+  },
+  "wordAlchemy": {
+    "badge": "Alquimia de palabras",
+    "title": "Alquimia de palabras",
+    "instructions": "Transforma una palabra en la siguiente siguiendo cada pista.",
+    "puzzleProgress": "Puzle {n} de {total}",
+    "stepProgress": "Paso {n} de {total}",
+    "inputPlaceholder": "Escribe tu palabra",
+    "hintLabel": "Pista:",
+    "submit": "Enviar",
+    "next": "Siguiente puzle",
+    "restart": "Reiniciar",
+    "wonTitle": "¡Puzle resuelto!",
+    "wonSubtitle": "¡Buena cadena! ¿Listo para la siguiente?"
+  },
   "gameFeedback": {"prompt":"¿Qué te pareció la ronda?","bad":"Regular","ok":"Bien","great":"¡Me encantó!","thanks":"¡Gracias por tu opinión!","dismiss":"Cerrar"},
   "wordTower": {
     "cardTitle": "Torre de Palabras",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -1,5 +1,30 @@
 // HE translations
 const he = {
+  "shiritori": {
+    "chain": "שרשרת מילים",
+    "inputLabel": "הקלידו מילה",
+    "nextStartsWith": "המילה הבאה מתחילה ב־",
+    "players": "שחקנים",
+    "submit": "שליחה",
+    "waitTurn": "ממתינים לתורכם…",
+    "wins": "ניצח!",
+    "yourTurn": "תורכם — הקלידו מילה",
+    "youWin": "ניצחתם!"
+  },
+  "wordAlchemy": {
+    "badge": "אלכימיית מילים",
+    "title": "אלכימיית מילים",
+    "instructions": "הפכו מילה אחת לבאה אחריה לפי כל רמז.",
+    "puzzleProgress": "חידה {n} מתוך {total}",
+    "stepProgress": "שלב {n} מתוך {total}",
+    "inputPlaceholder": "הקלידו מילה",
+    "hintLabel": "רמז:",
+    "submit": "שליחה",
+    "next": "חידה הבאה",
+    "restart": "מהתחלה",
+    "wonTitle": "החידה נפתרה!",
+    "wonSubtitle": "שרשרת יפה! מוכנים לבאה?"
+  },
   "gameFeedback": {"prompt":"איך היה הסיבוב?","bad":"ככה ככה","ok":"טוב","great":"אהבתי!","thanks":"תודה על המשוב!","dismiss":"סגירה"},
   "wordTower": {
     "cardTitle": "מגדל מילים",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -1,5 +1,30 @@
 // Ja translations
 const ja = {
+  "shiritori": {
+    "chain": "言葉のチェーン",
+    "inputLabel": "言葉を入力",
+    "nextStartsWith": "次の言葉の最初の文字",
+    "players": "プレイヤー",
+    "submit": "送信",
+    "waitTurn": "順番をお待ちください…",
+    "wins": "の勝ち！",
+    "yourTurn": "あなたの番です — 言葉を入力",
+    "youWin": "あなたの勝ち！"
+  },
+  "wordAlchemy": {
+    "badge": "ワードアルケミー",
+    "title": "ワードアルケミー",
+    "instructions": "ヒントに従って、言葉を次の言葉へと変えていきましょう。",
+    "puzzleProgress": "パズル {n} / {total}",
+    "stepProgress": "ステップ {n} / {total}",
+    "inputPlaceholder": "言葉を入力",
+    "hintLabel": "ヒント：",
+    "submit": "送信",
+    "next": "次のパズル",
+    "restart": "やり直す",
+    "wonTitle": "パズルクリア！",
+    "wonSubtitle": "お見事！次のパズルへ進みますか？"
+  },
   "gameFeedback": {"prompt":"今のラウンドはどうだった？","bad":"うーん","ok":"良かった","great":"最高！","thanks":"フィードバックありがとう！","dismiss":"閉じる"},
   "wordTower": {
     "cardTitle": "ワードタワー",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -1,5 +1,30 @@
 // Sv translations
 const sv = {
+  "shiritori": {
+    "chain": "Ordkedja",
+    "inputLabel": "Skriv ditt ord",
+    "nextStartsWith": "Nästa ord börjar med",
+    "players": "Spelare",
+    "submit": "Skicka",
+    "waitTurn": "Väntar på din tur…",
+    "wins": "vinner!",
+    "yourTurn": "Din tur – skriv ett ord",
+    "youWin": "Du vinner!"
+  },
+  "wordAlchemy": {
+    "badge": "Ordalkemi",
+    "title": "Ordalkemi",
+    "instructions": "Förvandla ett ord till nästa genom att följa varje ledtråd.",
+    "puzzleProgress": "Pussel {n} av {total}",
+    "stepProgress": "Steg {n} av {total}",
+    "inputPlaceholder": "Skriv ditt ord",
+    "hintLabel": "Ledtråd:",
+    "submit": "Skicka",
+    "next": "Nästa pussel",
+    "restart": "Börja om",
+    "wonTitle": "Pusslet löst!",
+    "wonSubtitle": "Snygg kedja! Redo för nästa?"
+  },
   "gameFeedback": {"prompt":"Hur var rundan?","bad":"Sådär","ok":"Bra","great":"Älskade den!","thanks":"Tack för din feedback!","dismiss":"Stäng"},
   "wordTower": {
     "cardTitle": "Ordtorn",


### PR DESCRIPTION
## Problem

On the Hebrew homepage (`lexiclash.live/he`), tapping the language switcher in the header/side menu blanks the page **the instant it's tapped** (before any list appears). Reported as Hebrew-only.

## Root cause

Radix overlays (`Select`, `Dialog`, `Popover`, `Tabs`…) read text direction from the `@radix-ui/react-direction` **context**, *not* from the `dir` attribute on `<html>`. The app set `dir="rtl"` on `<html>` but never wrapped the tree in a Radix `DirectionProvider`, so every Radix primitive defaulted to `dir="ltr"`.

On an RTL page, a `position="popper"` Select then computes its placement with LTR collision math and can render off-anchor / off-screen. Combined with `react-remove-scroll` (which Radix Select activates) locking the body and trapping focus inside the now off-screen dropdown, the page appears **blank and frozen** — and because nothing *throws*, no error boundary fires (which is why the screenshot shows bare `bg-neo-navy`, not the app's error/loading screens).

## Fix

Add `RadixDirectionProvider`, mounted inside `LanguageProvider` so it reads the active locale's `dir`, and wrap the app tree with it in `essential-providers.tsx`.

- Hebrew (and any future RTL locale) → Radix components now position correctly RTL.
- LTR locales are **unchanged** (`dir` stays `'ltr'`, the previous implicit default).

## Changes
- `components/providers/RadixDirectionProvider.tsx` — new client provider bridging `LanguageContext.dir` → Radix direction context.
- `app/essential-providers.tsx` — wrap the tree with it (inside `LanguageProvider`).
- `components/providers/__tests__/RadixDirectionProvider.test.tsx` — verifies `rtl`/`ltr` propagation (written test-first).

## Verification
- New unit tests pass; existing `QuickLanguageSwitcher` tests still pass (15/15).
- `tsc --noEmit`: 0 errors. `eslint` on changed files: clean.

## Note on confidence
The blank screen could not be reproduced in this environment (no browser; the custom server needs Redis/Supabase/Socket.IO), so this is a best-effort fix targeting the most probable RTL root cause. It is correct and low-risk regardless. **Please verify on the live Hebrew homepage** that tapping the language switcher now opens the dropdown normally. If it still blanks, the browser console error when it happens would pinpoint any remaining cause.

## Latent issues found while investigating (NOT addressed here)
- `i18n/request.ts` reads `{ default }` from `translations/*.js`, but those files only have *named* exports → next-intl receives empty messages. Left unchanged because enabling real messages risks ICU-parse failures on unvalidated strings — worth a separate, tested PR.
- `lib/i18n.js` (`defaultLocale = 'he'`) and `i18n/config.ts` (`defaultLocale = 'en'`) disagree on the default locale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERXjkEwfJMLiJqvN71aiEi)_