### PR TITLE
SEO: daily meta tag improvements (2026-05-26)

### DIFF
--- a/docs/seo-daily/2026-05-26.md
+++ b/docs/seo-daily/2026-05-26.md
@@ -1,0 +1,145 @@
+# SEO Daily Report — 2026-05-26
+
+**Data range:** 2026-04-27 → 2026-05-24 (28 days, GSC 2-day lag applied)
+
+---
+
+## Headline Metrics
+
+### Google Search Console
+
+| Metric | 28d Total |
+|---|---|
+| Clicks | 63 |
+| Impressions | 4,295 |
+| Avg CTR | 1.47% |
+| Avg Position | 10.1 |
+
+**7d vs prior-7d delta:** Aggregate-only data available; per-period split requires date-dimensioned query. Flag for next pull enhancement.
+
+**Top pages by impressions (28d):**
+
+| Page | Impressions | Clicks | CTR | Avg Pos |
+|---|---|---|---|---|
+| /es/juego-de-palabras-multijugador | 3,565 | 15 | 0.42% | 9.0 |
+| /en/best-online-word-games | 833 | 4 | 0.48% | 9.5 |
+| /sv/swedish-multiplayer-word-game | 491 | 0 | 0.00% | 8.4 |
+| /en/leaderboard | 297 | 1 | 0.34% | 4.7 |
+| /es/blog/netflix-word-game-2026-rise | 278 | 4 | 1.44% | 7.2 |
+
+**Brand query health:** `lexiclash` → 52 clicks / 66 impressions = **78.79% CTR** at pos 1.2. Healthy.
+
+### Bing Webmaster Tools
+
+**Status: Unavailable** — API returned `Host not in allowlist`. Site `https://lexiclash.live/` may not be verified in Bing Webmaster Tools, or sandbox network blocks ssl.bing.com. Bing parity section skipped.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+Criteria: impressions ≥ 30, actual CTR < 70% of expected CTR for position band.
+
+| # | Query | Page | Pos | Imp | CTR% | Exp CTR% | Gap | Suggested Fix |
+|---|---|---|---|---|---|---|---|---|
+| 1 | scrabble online español | /es/juego-de-palabras-multijugador | 8.8 | 428 | 0.00% | 2.50% | 2.5pp | Fix ES desc truncation (was 162 chars → 148); add urgency CTA |
+| 2 | scrabble en linea | /es/juego-de-palabras-multijugador | 8.5 | 356 | 0.00% | 2.50% | 2.5pp | Same page as #1 — desc fix covers this |
+| 3 | scrabble online svenska | /sv/swedish-multiplayer-word-game | 8.3 | 338 | 0.00% | 2.50% | 2.5pp | Fix SV title (was 62 chars) + desc (was 174 chars → 144) |
+| 4 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 7.6 | 322 | 0.00% | 3.00% | 3.0pp | Covered by ES desc fix |
+| 5 | scrabble online gratis | /es/juego-de-palabras-multijugador | 9.5 | 256 | 0.00% | 2.00% | 2.0pp | Covered by ES desc fix |
+| 6 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.4 | 224 | 0.00% | 2.50% | 2.5pp | Covered by ES desc fix |
+| 7 | scrabble online | /es/juego-de-palabras-multijugador | 8.9 | 223 | 0.45% | 2.50% | 2.05pp | Covered by ES desc fix |
+| 8 | jugar scrabble gratis | /es/juego-de-palabras-multijugador | 7.9 | 198 | 0.00% | 3.00% | 3.0pp | Covered by ES desc fix |
+| 9 | scrabble juego online | /es/juego-de-palabras-multijugador | 9.1 | 154 | 0.00% | 2.00% | 2.0pp | Covered by ES desc fix |
+| 10 | scrabble en español online | /es/juego-de-palabras-multijugador | 8.6 | 138 | 0.72% | 2.50% | 1.78pp | Covered by ES desc fix |
+
+**Root cause insight:** The Spanish page accounts for 9 of the top 10 CTR failures. The meta description was **162 chars** (7 over limit), causing Google to rewrite/truncate snippets and likely display an unhelpful auto-generated snippet that does not match search intent. The Swedish page title was **62 chars** (2 over) and description **174 chars** (19 over) — same truncation problem. **Fixed in today's PR.**
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+Criteria: avg position 8–20, impressions ≥ 50.
+
+| # | Query | Page | Pos | Imp | Suggested Action |
+|---|---|---|---|---|---|
+| 1 | scrabble online español | /es/juego-de-palabras-multijugador | 8.8 | 428 | Add H2 "Jugar Scrabble Online en Español"; internal links from blog posts |
+| 2 | scrabble en linea | /es/juego-de-palabras-multijugador | 8.5 | 356 | Add "en línea" synonym in intro paragraph; consolidate to one canonical ES page |
+| 3 | scrabble online svenska | /sv/swedish-multiplayer-word-game | 8.3 | 338 | Add VideoGame JSON-LD (missing on SV page; exists on ES); add H2 in Swedish |
+| 4 | scrabble online gratis | /es/juego-de-palabras-multijugador | 9.5 | 256 | Strengthen "gratis" signal: add pricing section or "100% gratuito" H2 |
+| 5 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.4 | 224 | Add CTA button text "Jugar Ahora" visible above fold |
+| 6 | scrabble online | /es/juego-de-palabras-multijugador | 8.9 | 223 | Build backlinks from Spanish gaming directories |
+| 7 | scrabble juego online | /es/juego-de-palabras-multijugador | 9.1 | 154 | Add FAQ question "¿Qué es un juego de scrabble online?" |
+| 8 | scrabble en español online | /es/juego-de-palabras-multijugador | 8.6 | 138 | Add hreflang self-referencing `es-ES` canonical check |
+| 9 | scrabble español online | /es/juego-de-palabras-multijugador | 8.9 | 103 | FAQ: "¿Cómo jugar scrabble en español online?" |
+| 10 | scrabble online gratis en español | /es/juego-de-palabras-multijugador | 9.4 | 84 | Internal links from homepage /es locale to ES page |
+
+---
+
+## Bing Parity Gaps
+
+**Skipped** — Bing Webmaster API returned `Host not in allowlist`. To fix: verify `https://lexiclash.live/` in Bing Webmaster Tools at https://www.bing.com/webmasters, then rerun pull script.
+
+---
+
+## GEO / AI Visibility Recommendations
+
+These queries look like questions or comparison searches where FAQPage schema + clear answer paragraphs improve AI Overview / SGE inclusion:
+
+| Query | Imp | Page | Status | Recommendation |
+|---|---|---|---|---|
+| most popular online word games 2025 2026 | 59 | /en/best-online-word-games | No FAQ schema | Add FAQPage JSON-LD: "What are the most popular free word games in 2026?" |
+| best free browser word games 2026 | 45 | /en/best-online-word-games | No FAQ schema | Add FAQ: "What are the best free word games you can play in a browser?" |
+| ordhjul | 44 | /sv/daily | No FAQ schema | Add FAQ: "Vad är ordhjul?" + SoftwareApplication schema on /sv/daily |
+| best free browser word games 2025 2026 | 37 | /en/best-online-word-games | No FAQ schema | Covered by FAQ above |
+
+**Draft FAQPage entries for `/en/best-online-word-games`:**
+
+```json
+{
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What are the most popular free online word games in 2026?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The most popular free online word games in 2026 include Wordle, NYT Connections, NYT Strands, Spelling Bee, Semantle, Scrabble GO, and LexiClash. LexiClash is the only option with real-time multiplayer for 2–50 players, no signup required."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the best free browser word games with no download?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The best free browser word games with no download are LexiClash (real-time multiplayer), Wordle (daily), NYT Connections (daily grouping), and Semantle (semantic guessing). All run in any modern browser."
+      }
+    }
+  ]
+}
+```
+
+**Swedish VideoGame schema gap:** `/sv/swedish-multiplayer-word-game` is missing the `VideoGame` + `SoftwareApplication` JSON-LD block that the Spanish page has. Adding it could improve rich result eligibility for "scrabble online svenska" (338 imp, pos 8.3).
+
+---
+
+## Meta Tag Fixes Applied Today (PR)
+
+Three pages had titles and/or descriptions exceeding Google's display limits, causing snippet truncation or rewriting:
+
+| Page | Field | Old | New | Change |
+|---|---|---|---|---|
+| /es/juego-de-palabras-multijugador | description | 162 chars (**over**) | 148 chars ✓ | Removed padding phrase "Partidas en tiempo real para 2-50 jugadores. Crea sala, invita con enlace. 10.000+ palabras" → condensed |
+| /sv/swedish-multiplayer-word-game | title | 62 chars (**over**) | 56 chars ✓ | "Spela Multiplayer" → "Multiplayer" |
+| /sv/swedish-multiplayer-word-game | description | 174 chars (**over**) | 144 chars ✓ | Removed "Prova även dagligt ordhjul och Ordjakt" tail; tightened structure |
+| /en/best-online-word-games | title | 77 chars (**over**) | 56 chars ✓ | Removed parenthetical, reordered |
+| /en/best-online-word-games | description | 173 chars (**over**) | 138 chars ✓ | Removed redundant game list tail |
+
+**Expected CTR uplift:** Fixing truncation on the Spanish page alone covers 9 queries totalling ~2,300 impressions/28d. Even a 1pp CTR improvement = ~23 additional clicks per 28-day period.
+
+---
+
+## Today's Actions
+
+1. **PR opened** — `seo/daily-2026-05-26`: Fix 5 over-limit meta fields across ES/SV/EN pages; fixes snippet truncation on 3,500+ monthly impressions.
+2. **Next sprint** — Add `VideoGame` + `SoftwareApplication` JSON-LD to `/sv/swedish-multiplayer-word-game` (copy pattern from ES page); add `FAQPage` JSON-LD to `/en/best-online-word-games`.
+3. **Bing** — Verify lexiclash.live in Bing Webmaster Tools to unlock API access and enable Bing parity gap analysis.

--- a/fe-next/app/[locale]/best-online-word-games/page.tsx
+++ b/fe-next/app/[locale]/best-online-word-games/page.tsx
@@ -15,8 +15,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const canonicalUrl = `${BASE_URL}/en/best-online-word-games`;
 
   return {
-    title: 'Most Popular Online Word Games 2025–2026 — 9 Honest Picks (Free, No Download)',
-    description: 'Most popular free online word games 2025–2026, honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, Semantle, LexiClash. Pros, cons & which to pick.',
+    title: 'Best Online Word Games 2026 — 9 Honest Picks | LexiClash',
+    description: 'Best free online word games 2026, honestly ranked. Wordle, NYT Connections, Scrabble GO, LexiClash & more — no download, no signup needed.',
     keywords: 'best free browser word games 2026, best word games 2026, best online word games 2025 2026, most popular online word games 2025 2026, free word games online, nyt connections, nyt strands, spelling bee game, semantle, wordle alternatives, multiplayer word games, word games with friends, word puzzle games online, word games no download, connections game',
     openGraph: {
       title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   return {
     title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
-    description: 'Juega scrabble online en español gratis — sin registro, sin descarga. Partidas en tiempo real para 2-50 jugadores. Crea sala, invita con enlace. 10.000+ palabras.',
+    description: 'Juega scrabble online en español gratis — sin registro ni descarga. 2–50 jugadores en tiempo real, +10.000 palabras. Crea sala e invita con enlace →',
     keywords: 'cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
       title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -15,11 +15,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
-    description: 'Spela scrabble online på svenska gratis mot 2-20 spelare i realtid — utan registrering, utan nedladdning. Skapa rum, bjud in med länk. Prova även dagligt ordhjul och Ordjakt.',
+    title: 'Scrabble Online Svenska Gratis — Multiplayer | LexiClash',
+    description: 'Spela scrabble online på svenska gratis mot 2–20 spelare i realtid. Utan registrering, utan nedladdning. Skapa rum, bjud in med länk. Börja nu →',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis — Multiplayer | LexiClash',
       description: 'Spela scrabble online på svenska med vänner i realtid. Skapa rum, bjud in med länk. Gratis, ingen registrering.',
       locale: 'sv_SE',
       type: 'website',
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis — Multiplayer | LexiClash',
       description: 'Spela scrabble online på svenska: skapa rum, bjud in med länk, tävla i realtid. Gratis, ingen registrering.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },


### PR DESCRIPTION
## Summary

Five meta fields across three pages were over Google's display limits, causing snippet truncation/rewriting on ~4,295 monthly impressions. This PR brings all fields within spec.

## Changes

| Page | Field | Old (chars) | New (chars) | Issue fixed |
|---|---|---|---|---|
| `/es/juego-de-palabras-multijugador` | description | 162 ❌ | 148 ✓ | Truncation on 9 Spanish "scrabble online" queries (2,300+ imp/28d) |
| `/sv/swedish-multiplayer-word-game` | title | 62 ❌ | 56 ✓ | Title clipped for "scrabble online svenska" (338 imp, pos 8.3) |
| `/sv/swedish-multiplayer-word-game` | description | 174 ❌ | 144 ✓ | Same page — desc 19 chars over limit |
| `/en/best-online-word-games` | title | 77 ❌ | 56 ✓ | Title clipped for "best online word games 2026" queries |
| `/en/best-online-word-games` | description | 173 ❌ | 138 ✓ | Desc 18 chars over limit |

## Expected CTR Uplift

- Spanish page alone covers 9 queries with ~2,300 impressions/28d at 0% CTR. Fixing truncation so Google serves the intended snippet rather than an auto-generated one. Even +1pp CTR ≈ +23 clicks/month.
- Swedish page: 338 imp at 0 clicks/28d. Title + desc both fixed.
- English best-games page: 833 imp at 0.48% CTR; title shortening improves display score.

## No content changes

Only `title` and `description` strings in `generateMetadata()` were modified. No component, logic, or copy changes.

## Daily SEO report

Full analysis at `docs/seo-daily/2026-05-26.md` — includes CTR opportunity table, rank-up opportunities, GEO/AI visibility recommendations, and Bing verification action item.

---
_Generated by [Claude Code](https://claude.ai/code/session_016CfcKbCYrJVmwLQ7o5Ud1Z)_