### PR TITLE
fix(mascot): celebration overlay stuck on daily results (regression)

### DIFF
--- a/fe-next/components/mascot/MascotCelebrationVideo.tsx
+++ b/fe-next/components/mascot/MascotCelebrationVideo.tsx
@@ -104,9 +104,10 @@ export const MascotCelebrationVideo = memo(function MascotCelebrationVideo({
         paddingBottom: 'max(env(safe-area-inset-bottom, 0px), var(--cap-safe-area-bottom, 0px))',
         paddingLeft: 'env(safe-area-inset-left, 0px)',
         paddingRight: 'env(safe-area-inset-right, 0px)',
-        background: 'rgba(10, 24, 40, 0.55)',
-        backdropFilter: 'blur(4px)',
-        WebkitBackdropFilter: 'blur(4px)',
+        // No dim/blur backdrop and click-through: the celebration plays over the
+        // live results so the text stays readable and the page stays scrollable
+        // and tappable the whole time it's on screen.
+        pointerEvents: 'none',
         zIndex: 9998,
         animation: 'lcMcvEnter 280ms ease-out both, lcMcvExit 320ms ease-in forwards',
         animationDelay: `0ms, ${Math.max(autoDismissMs - 280, 0)}ms`,

--- a/fe-next/components/mascot/MascotCelebrationVideo.tsx
+++ b/fe-next/components/mascot/MascotCelebrationVideo.tsx
@@ -66,7 +66,17 @@ export const MascotCelebrationVideo = memo(function MascotCelebrationVideo({
   const variant = VARIANTS[kind];
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [reducedMotion, setReducedMotion] = useState(false);
-  const handleDone = useCallback(() => onDone?.(), [onDone]);
+  // Keep the latest onDone in a ref so the auto-dismiss timer below depends only
+  // on autoDismissMs. Parents commonly pass a fresh inline `onDone` arrow on
+  // every render (e.g. DailyWordHuntResults re-renders each second from its
+  // countdown); keying the timer on the callback identity would clear+reset it
+  // before it ever fires, leaving this fixed full-screen overlay stuck on top of
+  // the page and blocking scroll/taps.
+  const onDoneRef = useRef(onDone);
+  useEffect(() => {
+    onDoneRef.current = onDone;
+  });
+  const handleDone = useCallback(() => onDoneRef.current?.(), []);
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');

--- a/fe-next/components/mascot/__tests__/MascotCelebrationVideo.test.tsx
+++ b/fe-next/components/mascot/__tests__/MascotCelebrationVideo.test.tsx
@@ -84,6 +84,18 @@ describe('MascotCelebrationVideo', () => {
     expect(onDone).toHaveBeenCalledTimes(1);
   });
 
+  it('overlay is non-blocking: click-through and no dimming backdrop', () => {
+    // The celebration must not hide ("kiss") the results text or block
+    // scroll/taps. Overlay should be pointer-events:none with no dark/blur
+    // backdrop, so the live results stay readable and scrollable while the
+    // mascot video + halo glow play on top, then fade.
+    render(<MascotCelebrationVideo kind="champion" />);
+    const overlay = screen.getByTestId('mascot-celebration-video');
+    expect(overlay.style.pointerEvents).toBe('none');
+    expect(overlay.style.background).toBe('');
+    expect(overlay.style.backdropFilter).toBe('');
+  });
+
   it('never calls onDone when autoDismissMs is 0', () => {
     const onDone = vi.fn();
     render(<MascotCelebrationVideo kind="knight" autoDismissMs={0} onDone={onDone} />);

--- a/fe-next/components/mascot/__tests__/MascotCelebrationVideo.test.tsx
+++ b/fe-next/components/mascot/__tests__/MascotCelebrationVideo.test.tsx
@@ -64,6 +64,26 @@ describe('MascotCelebrationVideo', () => {
     expect(onDone).toHaveBeenCalledTimes(1);
   });
 
+  it('still auto-dismisses when the parent re-renders with a fresh onDone every tick', () => {
+    // Regression: a parent with a 1s countdown (e.g. DailyWordHuntResults) passes
+    // a NEW inline `onDone` arrow on every render. If the auto-dismiss timer is
+    // keyed on that callback identity it gets cleared+reset every second and the
+    // fixed full-screen overlay never dismisses — leaving the results page
+    // unresponsive and unscrollable. The timer must survive parent re-renders.
+    const onDone = vi.fn();
+    const { rerender } = render(
+      <MascotCelebrationVideo kind="streak" autoDismissMs={2600} onDone={() => onDone()} />,
+    );
+    // Three 1s ticks → 3s of wall-clock, re-rendering with a new onDone each time.
+    for (let i = 0; i < 3; i++) {
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      rerender(<MascotCelebrationVideo kind="streak" autoDismissMs={2600} onDone={() => onDone()} />);
+    }
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
   it('never calls onDone when autoDismissMs is 0', () => {
     const onDone = vi.fn();
     render(<MascotCelebrationVideo kind="knight" autoDismissMs={0} onDone={onDone} />);


### PR DESCRIPTION
## Summary

Fixes the daily-challenge results regression where the page became **unresponsive and unscrollable** after finishing, and the celebration video/confetti kept **covering the results text** on the result screens.

### Root cause
`MascotCelebrationVideo`'s auto-dismiss `setTimeout` was keyed on the `onDone` callback identity:

```ts
const handleDone = useCallback(() => onDone?.(), [onDone]);
useEffect(() => {
  const t = window.setTimeout(handleDone, autoDismissMs);
  return () => window.clearTimeout(t);
}, [autoDismissMs, handleDone]);
```

All three result screens (`ResultsPage`, `DailyWordHuntResults`, `WordWheelResults`) pass a **fresh inline `onDone` arrow on every render**. On the daily challenge, the parent runs `useInterval(() => setCountdown(...), 1000)`, re-rendering once per second. Each re-render changed `onDone` → changed `handleDone` → the effect cleared and reset the 2600 ms timer. Since the timer reset every 1000 ms it **never reached 2600 ms and never fired**, so the `position: fixed; inset: 0; z-index: 9998` overlay (with dim backdrop) stayed up permanently — covering the text ("kissing the text") and blocking scroll/taps. The same mechanism caused late/stuck dismissal on the other result screens ("more places").

### Fix
Hold the latest `onDone` in a ref so the auto-dismiss timer effect depends only on `autoDismissMs` and is set once on mount. The video's `onEnded` handler stays stable too. No call-site changes needed — one component-level fix covers all three result screens.

## Test plan
- [x] New RED→GREEN unit test: overlay still auto-dismisses (`onDone` fires exactly once) when the parent re-renders with a fresh `onDone` every 1 s tick.
- [x] Existing `MascotCelebrationVideo` tests still pass (reduced-motion, `autoDismissMs={0}`, on-time dismissal, variant src, overlay role).
- [x] `components/mascot` + `DailyWordHuntResults.mascot` suites green (29 tests).
- [x] ESLint + `tsc --noEmit` clean for the changed files.
- [ ] Manual: finish a daily Word Hunt → overlay dismisses in ~2.6 s, results page scrolls and is tappable.

https://claude.ai/code/session_01XdNoZqVS4jgKUJhWTGKQRW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdNoZqVS4jgKUJhWTGKQRW)_