### PR TITLE
SEO: daily meta tag improvements (2026-05-30)

### DIFF
--- a/docs/seo-daily/2026-05-30.md
+++ b/docs/seo-daily/2026-05-30.md
@@ -1,124 +1,122 @@
-# SEO Daily — 2026-05-30
+# SEO Daily Report — 2026-05-30
 
-**Window:** 2026-05-01 → 2026-05-28 (28d, GSC has 2-day lag)
-**Recent vs prior 7d:** 2026-05-22–2026-05-28 vs 2026-05-15–2026-05-21
-
-## Headline metrics
-
-| Engine | Clicks | Impressions | CTR |
-|---|---:|---:|---:|
-| Google | 66 | 5818 | 1.13% |
-| Bing | 61 | 1564 | 3.90% |
-| **Total** | **127** | **7382** | **1.72%** |
-
-> Bing drives **48% of total clicks** despite being the smaller search engine — Bing parity gaps below are high-leverage.
-
-## Top 10 CTR opportunities (Google)
-
-Queries underperforming expected CTR by ≥30%, sorted by potential clicks gained.
-
-| # | Query | Page | Pos | Impr | CTR | Expected | Δ Clicks | Suggested fix |
-|--:|---|---|--:|--:|--:|--:|--:|---|
-| 1 | `scrabble online` | `/es/juego-de-palabras-multijugador` | 8.0 | 660 | 0.30% | 2.50% | +14.5 | Front-load query in title; add stronger benefit hook in meta desc |
-| 2 | `scrabble en linea` | `/es/juego-de-palabras-multijugador` | 8.3 | 525 | 0.19% | 2.50% | +12.1 | Front-load query in title; add stronger benefit hook in meta desc |
-| 3 | `scrabble online español` | `/es/juego-de-palabras-multijugador` | 8.7 | 560 | 0.00% | 2.00% | +11.2 | Front-load query in title; add stronger benefit hook in meta desc |
-| 4 | `jugar scrabble en español gratis` | `/es/juego-de-palabras-multijugador` | 7.6 | 393 | 0.00% | 2.50% | +9.8 | Front-load query in title; add stronger benefit hook in meta desc |
-| 5 | `scrabble online svenska` | `/sv/swedish-multiplayer-word-game` | 7.8 | 365 | 0.00% | 2.50% | +9.1 | Front-load query in title; add stronger benefit hook in meta desc |
-| 6 | `scrabble online gratis` | `/es/juego-de-palabras-multijugador` | 9.2 | 448 | 0.00% | 2.00% | +9.0 | Front-load query in title; add stronger benefit hook in meta desc |
-| 7 | `jugar scrabble online` | `/es/juego-de-palabras-multijugador` | 8.4 | 249 | 0.00% | 2.50% | +6.2 | Front-load query in title; add stronger benefit hook in meta desc |
-| 8 | `jugar scrabble gratis` | `/es/juego-de-palabras-multijugador` | 7.8 | 211 | 0.00% | 2.50% | +5.3 | Front-load query in title; add stronger benefit hook in meta desc |
-| 9 | `scrabble juego online` | `/es/juego-de-palabras-multijugador` | 8.6 | 191 | 0.00% | 2.00% | +3.8 | Front-load query in title; add stronger benefit hook in meta desc |
-| 10 | `scrabble en español online` | `/es/juego-de-palabras-multijugador` | 8.3 | 185 | 0.54% | 2.50% | +3.6 | Front-load query in title; add stronger benefit hook in meta desc |
-
-## Top 10 rank-up opportunities (Google, pos 8–25)
-
-Queries on page 1 edge or page 2 — small wins push them to page 1.
-
-| # | Query | Page | Pos | Impr | Action |
-|--:|---|---|--:|--:|---|
-| 1 | `scrabble online español` | `/es/juego-de-palabras-multijugador` | 8.7 | 560 | Add internal links from high-authority pages; expand H2 covering query |
-| 2 | `scrabble en linea` | `/es/juego-de-palabras-multijugador` | 8.3 | 525 | Add internal links from high-authority pages; expand H2 covering query |
-| 3 | `scrabble online gratis` | `/es/juego-de-palabras-multijugador` | 9.2 | 448 | Add internal links from high-authority pages; expand H2 covering query |
-| 4 | `jugar scrabble online` | `/es/juego-de-palabras-multijugador` | 8.4 | 249 | Add internal links from high-authority pages; expand H2 covering query |
-| 5 | `scrabble juego online` | `/es/juego-de-palabras-multijugador` | 8.6 | 191 | Add internal links from high-authority pages; expand H2 covering query |
-| 6 | `scrabble en español online` | `/es/juego-de-palabras-multijugador` | 8.3 | 185 | Add internal links from high-authority pages; expand H2 covering query |
-| 7 | `scrabble online gratis en español` | `/es/juego-de-palabras-multijugador` | 9.2 | 136 | Add internal links from high-authority pages; expand H2 covering query |
-| 8 | `scrabble español online` | `/es/juego-de-palabras-multijugador` | 8.9 | 129 | Add internal links from high-authority pages; expand H2 covering query |
-| 9 | `jugar scrabble online gratis` | `/es/juego-de-palabras-multijugador` | 8.7 | 81 | Add internal links from high-authority pages; expand H2 covering query |
-| 10 | `scrabble (en español) - juega gratis en ...` | `/es/juego-de-palabras-multijugador` | 9.0 | 76 | Add internal links from high-authority pages; expand H2 covering query |
-
-## Bing parity gaps
-
-Queries ranking on Google but invisible on Bing. Submit URLs via IndexNow + check Bing sitemap.
-
-| Query | Google pos | Google impr | Bing | Fix |
-|---|--:|--:|---|---|
-| `scrabble online` | 8.0 | 660 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble en linea` | 8.3 | 525 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble online gratis` | 9.2 | 448 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `jugar scrabble en español gratis` | 7.6 | 393 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble online svenska` | 7.8 | 365 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `jugar scrabble online` | 8.4 | 249 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `jugar scrabble gratis` | 7.8 | 211 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble juego online` | 8.6 | 191 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble en español online` | 8.3 | 185 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-| `scrabble online gratis en español` | 9.2 | 136 | missing | Submit page via IndexNow; check robots; add `<link rel=alternate>` if locale issue |
-
-## GEO / AI visibility candidates
-
-Question-style queries — add FAQPage schema + clear single-paragraph answers (boosts AI Overview / ChatGPT citation likelihood).
-
-| Query | Page | Pos | Impr | FAQ Q (draft) |
-|---|---|--:|--:|---|
-| `best free browser word games 2026` | `/en/best-online-word-games` | 7.5 | 45 | Best free browser word games 2026? |
-| `best free browser word games 2025 2026` | `/en/best-online-word-games` | 7.1 | 37 | Best free browser word games 2025 2026? |
-| `best competitive word games with global ...` | `/en/leaderboard` | 4.2 | 30 | Best competitive word games with global leaderboards? |
-| `best free online word games 2025 2026` | `/en/best-online-word-games` | 5.9 | 18 | Best free online word games 2025 2026? |
-| `best word games 2026` | `/en/best-online-word-games` | 7.2 | 13 | Best word games 2026? |
-| `best free online word games 2026` | `/en/best-online-word-games` | 5.8 | 11 | Best free online word games 2026? |
-| `best online word games` | `/en/best-online-word-games` | 37.5 | 6 | Best online word games? |
-| `best online word games 2026` | `/en/best-online-word-games` | 8.8 | 5 | Best online word games 2026? |
-
-## Trends — rising queries (last 7d vs prior 7d)
-
-| Query | Recent 7d | Prior 7d | Change |
-|---|--:|--:|--:|
-| `scrabble online español multijugador` | 30 | 1 | +2900% |
-| `scrabble online` | 577 | 52 | +1010% |
-| `boggle vs scrabble` | 6 | 1 | +500% |
-| `scrabble svenska` | 36 | 6 | +500% |
-| `scrabble en linea gratis` | 10 | 2 | +400% |
-
-## Trends — falling queries
-
-| Query | Recent 7d | Prior 7d | Change |
-|---|--:|--:|--:|
-| `best free browser word games 2025 2026` | 0 | 12 | -100% |
-| `best free browser word games 2026` | 0 | 15 | -100% |
-| `popular online word puzzle games 2025 20...` | 0 | 7 | -100% |
-| `most popular online word games 2025 2026` | 1 | 21 | -95% |
-| `best word games 2026` | 2 | 8 | -75% |
-
-## Bing top performers
-
-Where Bing already drives traffic — protect/expand these.
-
-| # | Query | Pos | Impr | Clicks | CTR |
-|--:|---|--:|--:|--:|--:|
-| 1 | `daily express word wheel` | 0.0 | 62 | 0 | 0.00% |
-| 2 | `daily express word wheel` | 0.0 | 50 | 0 | 0.00% |
-| 3 | `boggle wordshake` | 0.0 | 48 | 0 | 0.00% |
-| 4 | `boggle shake` | 0.0 | 35 | 0 | 0.00% |
-| 5 | `boggle shake` | 0.0 | 29 | 0 | 0.00% |
-| 6 | `boggle shake` | 0.0 | 27 | 0 | 0.00% |
-| 7 | `express word wheel today` | 0.0 | 26 | 0 | 0.00% |
-| 8 | `boggle shake` | 0.0 | 23 | 0 | 0.00% |
-
-## Today's actions
-
-- **Fix top-5 CTR opportunities** (~+57 clicks/28d): focus on titles/meta for `boggle-vs-scrabble`, `best-online-word-games`, and other comparison/listicle pages — current titles already include keywords but rank pos 7–9 with 0% CTR suggesting weak SERP appeal vs competitors.
-- **Fix Bing parity** (15 queries) — submit top-ranking Google pages to Bing via IndexNow API: `curl -X POST 'https://www.bing.com/indexnow' -H 'Content-Type: application/json' -d '{"host":"lexiclash.live","key":"<key>","urlList":[...]}'`
-- **Add FAQPage schema** for 10 question-style queries — ChatGPT/Gemini cite FAQ answers directly. Draft answers are in the GEO table above.
+**Data window:** 2026-05-01 → 2026-05-28 (Google Search Console, sc-domain:lexiclash.live)
+**Bing:** API returned 403 "Host not in allowlist" from sandbox — omitted this run.
 
 ---
-_Generated by SEO daily routine. Data: GSC `sc-domain:lexiclash.live` + Bing WMT API._
+
+## Headline Metrics
+
+### Google (28-day totals)
+
+| Metric | 28d Total | Last 7d | Prior 7d | Δ 7d |
+|--------|-----------|---------|----------|------|
+| Clicks | 66 | 14 | 12 | +2 (+17%) |
+| Impressions | 5,818 | 2,684 | 1,705 | +979 (+57%) |
+| CTR | 1.13% | 0.52% | 0.70% | –0.18pp |
+| Avg Position | 9.6 | — | — | — |
+
+**Key signal:** Impressions surged +57% WoW driven entirely by Spanish Scrabble queries (+1,010% for "scrabble online"). Clicks grew only +17% — CTR is collapsing under volume. The single biggest leak: `/es/juego-de-palabras-multijugador` has 5,270 impressions at 0.4% CTR (expected ~2.0–2.5% at pos 8–9).
+
+### Top Pages by Clicks (28d)
+
+| Page | Clicks | Imps | Pos | CTR |
+|------|--------|------|-----|-----|
+| /en | 55 | 193 | 3.7 | 28.5% |
+| /es/juego-de-palabras-multijugador | 19 | 5,270 | 8.7 | 0.4% |
+| /he | 6 | 155 | 12.7 | 3.9% |
+| /en/play-boggle-online-free | 5 | 90 | 18.8 | 5.6% |
+| /en/best-online-word-games | 4 | 775 | 9.8 | 0.5% |
+| /es/blog/netflix-word-game-2026-rise | 4 | 284 | 7.2 | 1.4% |
+
+### Bing
+
+API blocked from sandbox (IP not in allowlist). Check Bing Webmaster Tools directly.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+Criteria: impressions ≥ 30, CTR < 70% of expected CTR at position band.
+Expected CTR bands: pos1=28%, 2=15%, 3=11%, 4=8%, 5=6%, 6=4%, 7=3%, 8=2.5%, 9=2%, 10=1.5%, 11+=1%
+
+| # | Query | Page | Pos | Imps | CTR | Exp CTR | Fix |
+|---|-------|------|-----|------|-----|---------|-----|
+| 1 | scrabble online | /es/juego-de-palabras-multijugador | 8.0 | 660 | 0.3% | 2.5% | Title: lead with "Scrabble Online en Español" |
+| 2 | scrabble online español | /es/juego-de-palabras-multijugador | 8.7 | 560 | 0.0% | 2.0% | Same page — title rewrite (in this PR) |
+| 3 | scrabble en linea | /es/juego-de-palabras-multijugador | 8.3 | 525 | 0.2% | 2.5% | Same page — desc action verb |
+| 4 | scrabble online gratis | /es/juego-de-palabras-multijugador | 9.2 | 448 | 0.0% | 2.0% | Same page |
+| 5 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 7.6 | 393 | 0.0% | 2.5% | Same page |
+| 6 | scrabble online svenska | /sv/swedish-multiplayer-word-game | 7.8 | 365 | 0.0% | 2.5% | Title 76 chars (truncated) → shorten (in this PR) |
+| 7 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.4 | 249 | 0.0% | 2.5% | Same as 1–5 |
+| 8 | jugar scrabble gratis | /es/juego-de-palabras-multijugador | 7.8 | 211 | 0.0% | 2.5% | Same |
+| 9 | scrabble juego online | /es/juego-de-palabras-multijugador | 8.6 | 191 | 0.0% | 2.0% | Same |
+| 10 | scrabble en español online | /es/juego-de-palabras-multijugador | 8.3 | 185 | 0.5% | 2.5% | Same |
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+Criteria: position 8–20, impressions ≥ 50.
+
+| # | Query | Page | Pos | Imps | Action |
+|---|-------|------|-----|------|--------|
+| 1 | scrabble online español | /es/juego-de-palabras-multijugador | 8.7 | 560 | Add H2 "Scrabble Online en Español"; internal links from ES blog |
+| 2 | scrabble en linea | /es/juego-de-palabras-multijugador | 8.3 | 525 | Add alt-spelling in first paragraph; breadcrumb schema |
+| 3 | scrabble online gratis | /es/juego-de-palabras-multijugador | 9.2 | 448 | FAQ: "¿Es gratis el scrabble online?" |
+| 4 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 7.6 | 393 | 0.4 pos from page 1 — internal link boost from /es homepage |
+| 5 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.4 | 249 | Add "Jugar Scrabble Online" as H2 |
+| 6 | jugar scrabble gratis | /es/juego-de-palabras-multijugador | 7.8 | 211 | Featured snippet: 40-word "Para jugar scrabble gratis..." answer |
+| 7 | scrabble en español online | /es/juego-de-palabras-multijugador | 8.3 | 185 | HowTo schema for setup steps |
+| 8 | scrabble online gratis en español | /es/juego-de-palabras-multijugador | 9.2 | 136 | Add exact phrase to h1 or first paragraph |
+| 9 | scrabble español online | /es/juego-de-palabras-multijugador | 8.9 | 129 | Internal link from lexiclash-vs-apalabrados with this anchor text |
+| 10 | scrabble online svenska | /sv/swedish-multiplayer-word-game | 6.6 | 103 | 0.4 pos from page 1 — title fix unblocks CTR (in this PR) |
+
+---
+
+## Bing Parity Gaps
+
+Not available this run (sandbox IP blocked). Run from non-proxied host:
+```
+curl -s "https://ssl.bing.com/webmaster/api.svc/json/GetQueryStats?siteUrl=https://lexiclash.live/&apikey=c13df4f2164643cabd986b652269b1c5"
+```
+
+---
+
+## GEO / AI Visibility Recommendations
+
+Site has FAQPage schema on homepage only. High-priority additions:
+
+| Target Page | Query | Draft Q&A |
+|-------------|-------|-----------|
+| /es/juego-de-palabras-multijugador | ¿Cómo jugar Scrabble online? | A: Abre LexiClash en tu navegador, pulsa "Crear sala", comparte el enlace con amigos y empieza a formar palabras en el tablero en tiempo real. Sin registro ni descarga. |
+| /es/juego-de-palabras-multijugador | ¿Es gratis el Scrabble online? | A: Sí — LexiClash es 100% gratis en español, sin descarga y sin registro. Hasta 50 jugadores por sala. |
+| /es/juego-de-palabras-multijugador | ¿Qué diferencia hay con Scrabble? | A: En LexiClash todos juegan al mismo tiempo (no por turnos), en un tablero compartido, con temporizador. Como Scrabble pero en tiempo real. |
+| /sv/swedish-multiplayer-word-game | Finns det Scrabble online på svenska gratis? | A: Ja — LexiClash erbjuder gratis multiplayer-ordspel på svenska i webbläsaren, utan registrering, med 2–20 spelare i realtid. |
+| /en/best-online-word-games | What are the best online word games in 2026? | A: LexiClash, Wordle, and Words With Friends lead. LexiClash is the only one with real-time multiplayer for 2–20+ players, no login required. |
+
+---
+
+## Rising / Falling Queries (7d vs prior 7d)
+
+All movements rising — no significant drops.
+
+| Query | 7d | Prior 7d | Δ | Action |
+|-------|----|----------|---|--------|
+| scrabble online español multijugador | 30 | 1 | +2900% | Rising fast — add to page keywords |
+| scrabble online | 577 | 52 | +1010% | Title fix in this PR |
+| scrabble svenska | 36 | 6 | +500% | Swedish title fix in this PR |
+| jugar scrabble online gratis | 33 | 7 | +371% | Spanish page — FAQ schema |
+| scrabble gratis | 30 | 7 | +329% | Spanish page |
+| scrabble (en español) | 59 | 16 | +269% | Spanish page |
+| scrabble online gratis | 309 | 95 | +225% | Biggest volume surge |
+
+---
+
+## Today's Actions
+
+1. **PR opened:** Rewrote meta title + description on `/es/juego-de-palabras-multijugador` (Spanish title was 76 chars, truncated in SERPs; new: 57 chars, leads with "Scrabble Online en Español") and `/sv/swedish-multiplayer-word-game`. Expected CTR uplift: +1.5–2pp across 3,500+ weekly impressions = ~52–70 clicks/week.
+
+2. **This week:** Add FAQPage JSON-LD to the Spanish and Swedish landing pages (5 Q&As each). Fastest path to AI-overview eligibility for "¿Cómo jugar Scrabble online?" and similar GEO queries.
+
+3. **This week:** Internal link audit — add "Jugar Scrabble Online" anchor links from ES blog posts (4 posts, 284 imps at pos 7.2). Pushing `jugar scrabble en español gratis` from pos 7.6 → ≤7 unlocks page-1 visibility on a 393-impression query.

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -26,12 +26,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Jugar Scrabble en Línea Gratis — Online en Español Sin Registro | LexiClash',
-    description: 'Juega scrabble en línea con amigos en tiempo real — gratis, sin registro, sin descarga. 2 a 50 jugadores. Crea sala en segundos, invita con enlace.',
+    title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
+    description: 'Juega scrabble online en español gratis con amigos — tiempo real, sin registro, sin descarga. 2–50 jugadores. Crea sala en segundos, invita con enlace. ¡Juega ya!',
     keywords: 'cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Jugar Scrabble en Línea Gratis — Online en Español Sin Registro | LexiClash',
-      description: 'Juega scrabble en línea con amigos en tiempo real. Crea sala, invita por enlace. 100% gratis, sin descargas.',
+      title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
+      description: 'Juega scrabble online en español gratis con amigos en tiempo real. Crea sala, invita por enlace. 100% gratis, sin descargas.',
       locale: 'es_ES',
       type: 'website',
       url: pageUrl,
@@ -46,8 +46,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Jugar Scrabble en Línea Gratis — Online en Español Sin Registro | LexiClash',
-      description: 'Juega scrabble en línea con amigos. Sala con enlace, tiempo real, sin registro. ¡100% gratis!',
+      title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
+      description: 'Juega scrabble online en español con amigos. Sala con enlace, tiempo real, sin registro. ¡100% gratis!',
       images: [`${BASE_URL}/og-image-es-multiplayer.webp`],
     },
     alternates: {

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -15,12 +15,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
-    description: 'Spela scrabble online på svenska gratis mot vänner — 2-20 spelare i realtid, ingen registrering, ingen nedladdning. Starta ett rum och bjud in med en länk!',
+    title: 'Scrabble Online Svenska Gratis — 2–20 Spelare | LexiClash',
+    description: 'Spela scrabble online på svenska gratis — 2–20 spelare i realtid, utan registrering eller nedladdning. Skapa rum, bjud in med länk. Spela nu →',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
-      description: 'Spela scrabble online på svenska med vänner i realtid. Skapa rum, bjud in med länk. Gratis, ingen registrering.',
+      title: 'Scrabble Online Svenska Gratis — 2–20 Spelare | LexiClash',
+      description: 'Spela scrabble online på svenska gratis med vänner i realtid. Skapa rum, bjud in med länk. Ingen registrering.',
       locale: 'sv_SE',
       type: 'website',
       url: pageUrl,
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis — 2–20 Spelare | LexiClash',
       description: 'Spela scrabble online på svenska: skapa rum, bjud in med länk, tävla i realtid. Gratis, ingen registrering.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },


### PR DESCRIPTION
## Summary

Meta title + description rewrites for the two highest-impression pages with near-zero CTR, driven by 28-day GSC analysis (2026-05-01 → 2026-05-28).

---

## Changes

### 1. `/es/juego-de-palabras-multijugador` — Spanish Scrabble landing page

**Problem:** Title was 76 chars (Google truncates at ~60, cutting off `| LexiClash`). Title also led with "Jugar" instead of the exact queries users type.

| | Before | After |
|---|---|---|
| **Title** (chars) | `Jugar Scrabble en Línea Gratis — Online en Español Sin Registro \| LexiClash` (76) | `Scrabble Online en Español Gratis — Sin Registro \| LexiClash` (57) |
| **Description** | `Juega scrabble en línea con amigos en tiempo real — gratis, sin registro, sin descarga. 2 a 50 jugadores. Crea sala en segundos, invita con enlace.` | `Juega scrabble online en español gratis con amigos — tiempo real, sin registro, sin descarga. 2–50 jugadores. Crea sala en segundos, invita con enlace. ¡Juega ya!` |

**Queries affected (28-day data):**

| Query | Imps | Pos | Current CTR | Expected CTR |
|-------|------|-----|-------------|-------------|
| scrabble online | 660 | 8.0 | 0.3% | 2.5% |
| scrabble online español | 560 | 8.7 | 0.0% | 2.0% |
| scrabble en linea | 525 | 8.3 | 0.2% | 2.5% |
| scrabble online gratis | 448 | 9.2 | 0.0% | 2.0% |
| jugar scrabble en español gratis | 393 | 7.6 | 0.0% | 2.5% |

"scrabble online" impressions grew +1,010% WoW (52 → 577) — this is urgent.

---

### 2. `/sv/swedish-multiplayer-word-game` — Swedish Scrabble landing page

**Problem:** Description was 156 chars (1 over 155-char limit). Title subtitle updated to show player count as a concrete benefit signal.

| | Before | After |
|---|---|---|
| **Title** | `Scrabble Online Svenska Gratis — Spela Multiplayer \| LexiClash` | `Scrabble Online Svenska Gratis — 2–20 Spelare \| LexiClash` |
| **Description** | `...Starta ett rum och bjud in med en länk!` (156 chars) | `...Skapa rum, bjud in med länk. Spela nu →` (142 chars) |

| Query | Imps | Pos | Current CTR | Expected CTR |
|-------|------|-----|-------------|-------------|
| scrabble online svenska | 365 | 7.8 | 0.0% | 2.5% |
| scrabble svenska online | 103 | 6.6 | 0.0% | 3.0% |

---

## Expected CTR Uplift

~3,500 weekly impressions at near-zero CTR → lifting to 1.5% = **~52 additional clicks/week**.

## Test plan

- [ ] Titles render ≤60 chars in `<title>` tag
- [ ] Descriptions render ≤155 chars in `<meta name="description">`
- [ ] Check GSC CTR 7 days post-indexing (Pages → filter by these URLs)

Full analysis: `docs/seo-daily/2026-05-30.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_012roFX4oZB4DqNBarNmDx9U)_