### PR TITLE
fix(header): decouple side-menu scroll from swipe-to-close drag

### DIFF
--- a/fe-next/components/__tests__/Header.menuScroll.test.tsx
+++ b/fe-next/components/__tests__/Header.menuScroll.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Test: Side-menu (HeaderMobileMenu) vertical scroll on mobile
+ *
+ * Regression guard. The drawer must be scrollable on touch devices. The
+ * bug: the outermost drawer element was BOTH the framer-motion `drag="x"`
+ * swipe-to-close target AND the `overflow-y-auto` scroll container. A
+ * framer drag gesture sitting directly on the scroll container arbitrates
+ * the touch gesture and swallows vertical scrolling — so the menu can't be
+ * scrolled. (The app's other drawer, MobileGameDrawer, deliberately keeps
+ * `drag` on a separate element from the scroller for exactly this reason.)
+ *
+ * Fix: the swipe-to-close drag layer and the scrollable body are SEPARATE
+ * elements — the drag wrapper does not scroll, and the inner scroll body
+ * owns `overflow-y-auto` + `touch-action: pan-y`.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import Header from '../Header';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), pathname: '/' }),
+  usePathname: () => '/',
+}));
+
+vi.mock('next/link', () => {
+  const MockLink = ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>;
+  MockLink.displayName = 'MockLink';
+  return { default: MockLink };
+});
+
+vi.mock('../../contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (key: string) => key, language: 'en', currentFlag: '🇺🇸' }),
+}));
+
+const mockAuthContext = {
+  isAuthenticated: true,
+  isAdmin: false,
+  profile: { username: 'ohad', total_coins: 1000, total_xp: 500 },
+  refreshProfile: vi.fn(),
+};
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mockAuthContext,
+}));
+
+vi.mock('../../hooks/useUnclaimedGifts', () => ({
+  useUnclaimedGifts: () => ({ unclaimedCount: 0, gifts: [], refresh: vi.fn(), claimGift: vi.fn() }),
+}));
+
+vi.mock('../../hooks/useSafeArea', () => ({
+  useSafeArea: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+vi.mock('../../utils/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'dark', toggleTheme: vi.fn() }),
+}));
+
+// Mock framer-motion: render motion elements as plain DOM, spreading props
+// (so `drag` etc. land as attributes we can introspect).
+vi.mock('framer-motion', () => ({
+  m: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+    button: ({ children, ...props }: React.HTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+    span: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) => <span {...props}>{children}</span>,
+    nav: ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => <nav {...props}>{children}</nav>,
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  domAnimation: {},
+}));
+
+vi.mock('../MusicControls', () => ({ __esModule: true, default: () => <div data-testid="music-controls">Music</div> }));
+vi.mock('../CoinBalance', () => ({ CoinBalance: ({ coins }: { coins: number }) => <div data-testid="coin-balance">{coins}</div> }));
+vi.mock('../QuickLanguageSwitcher', () => ({ QuickLanguageSwitcher: () => <div data-testid="language-switcher">Lang</div> }));
+vi.mock('../auth/AuthButton', () => ({ __esModule: true, default: () => <div data-testid="auth-button">Auth</div> }));
+
+describe('Side-menu vertical scroll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthContext.isAdmin = false;
+  });
+
+  it('keeps the scrollable menu body separate from the swipe-to-close drag layer', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+
+    const hamburger = screen.getByRole('button', { name: /common.openMenu/i });
+    await user.click(hamburger);
+
+    // The scrollable body owns vertical scroll + pan-y touch-action.
+    const scroller = await screen.findByTestId('mobile-menu-scroll');
+    expect(scroller.className).toContain('overflow-y-auto');
+    expect(scroller).toHaveStyle({ touchAction: 'pan-y' });
+
+    // The swipe-to-close drag layer must NOT be the scroll container —
+    // a framer drag gesture on the scroller swallows vertical touch scroll.
+    const drawer = screen.getByTestId('mobile-menu-drawer');
+    expect(drawer.className).not.toContain('overflow-y-auto');
+    expect(drawer).not.toBe(scroller);
+  });
+});

--- a/fe-next/components/header/HeaderMobileMenu.tsx
+++ b/fe-next/components/header/HeaderMobileMenu.tsx
@@ -387,17 +387,33 @@ const HeaderMobileMenu = memo<HeaderMobileMenuProps>(({ unclaimedCount, onOpenGi
                                 dragConstraints={{ left: isRtl ? -200 : 0, right: isRtl ? 0 : 200 }}
                                 dragElastic={0.15}
                                 onDragEnd={handleDragEnd}
+                                data-testid="mobile-menu-drawer"
                                 className={cn(
                                     "fixed top-0 bottom-0 w-[320px] sm:w-[360px] max-w-[88vw] z-80",
                                     "bg-neo-navy border-neo-black",
-                                    "shadow-hard-xl overflow-y-auto overflow-x-hidden",
-                                    "pb-[max(env(safe-area-inset-bottom),1rem)]",
+                                    // The drag layer must NOT scroll: a framer-motion drag gesture
+                                    // sitting on the scroll container arbitrates touch and swallows
+                                    // vertical scrolling, making the menu feel unscrollable. We keep
+                                    // swipe-to-close here and delegate scrolling to the inner body
+                                    // below (same separation MobileGameDrawer uses).
+                                    "shadow-hard-xl overflow-hidden flex flex-col",
                                     isRtl
                                         ? "left-0 border-r-4 rounded-r-neo-lg"
                                         : "right-0 border-l-4 rounded-l-neo-lg"
                                 )}
                                 style={{ touchAction: 'pan-y' }}
                             >
+                              {/* ── Scrollable body — owns vertical scroll, decoupled from the
+                                  swipe-to-close drag layer so native touch scroll works. ── */}
+                              <div
+                                data-testid="mobile-menu-scroll"
+                                className={cn(
+                                    "relative flex-1 min-h-0",
+                                    "overflow-y-auto overflow-x-hidden overscroll-contain",
+                                    "pb-[max(env(safe-area-inset-bottom),1rem)]"
+                                )}
+                                style={{ touchAction: 'pan-y', WebkitOverflowScrolling: 'touch' }}
+                              >
                                 {/* ── Close button (top corner) ── */}
                                 <div
                                     className={cn(
@@ -963,6 +979,7 @@ const HeaderMobileMenu = memo<HeaderMobileMenuProps>(({ unclaimedCount, onOpenGi
                                         </span>
                                     </m.div>
                                 </m.div>
+                              </div>
                             </m.div>
                         </>
                     )}


### PR DESCRIPTION
The side drawer couldn't be scrolled on mobile because its outermost
element was BOTH the framer-motion drag="x" swipe-to-close target AND the
overflow-y-auto scroll container. A drag gesture sitting directly on the
scroll port arbitrates the touch gesture and swallows vertical scrolling,
so the menu felt frozen. The prior fix (2429de5) only addressed the inner
notification list trap, not this deeper conflict.

Fix: keep drag="x" on the outer positioned wrapper (now a non-scrolling
flex column) and move overflow-y-auto + touch-action: pan-y into a
dedicated inner scroll body — the same drag/scroll separation the app's
MobileGameDrawer already uses. Safe-area bottom padding and overscroll
containment move to the scroll body so content clears the inset while it
scrolls.

https://claude.ai/code/session_01CfRbxmqub8GbHvoyrgrdCj