### PR TITLE
fix(header): stop side menu shaking/blocking on scroll (remove framer drag)

### DIFF
--- a/fe-next/components/__tests__/Header.menuScroll.test.tsx
+++ b/fe-next/components/__tests__/Header.menuScroll.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import Header from '../Header';
@@ -95,10 +95,51 @@ describe('Side-menu vertical scroll', () => {
     expect(scroller.className).toContain('overflow-y-auto');
     expect(scroller).toHaveStyle({ touchAction: 'pan-y' });
 
-    // The swipe-to-close drag layer must NOT be the scroll container —
-    // a framer drag gesture on the scroller swallows vertical touch scroll.
+    // The scroll body must NOT be the swipe-to-close target.
     const drawer = screen.getByTestId('mobile-menu-drawer');
     expect(drawer.className).not.toContain('overflow-y-auto');
     expect(drawer).not.toBe(scroller);
+  });
+
+  it('does not attach a framer-motion drag gesture to the drawer', async () => {
+    // A framer `drag` gesture engages on the horizontal component of any
+    // diagonal scroll and elastically translates the drawer — the menu
+    // "shakes" / springs back instead of scrolling. Swipe-to-close must be
+    // implemented WITHOUT framer drag so native vertical scroll is untouched.
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: /common.openMenu/i }));
+
+    const drawer = await screen.findByTestId('mobile-menu-drawer');
+    expect(drawer).not.toHaveAttribute('drag');
+    expect(drawer).not.toHaveAttribute('dragelastic');
+  });
+
+  it('closes on a deliberate horizontal swipe toward the edge', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: /common.openMenu/i }));
+
+    const drawer = await screen.findByTestId('mobile-menu-drawer');
+    // LTR: swipe right (dx dominant, > threshold) closes the drawer.
+    fireEvent.touchStart(drawer, { touches: [{ clientX: 300, clientY: 200 }] });
+    fireEvent.touchEnd(drawer, { changedTouches: [{ clientX: 395, clientY: 206 }] });
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('mobile-menu-scroll')).not.toBeInTheDocument()
+    );
+  });
+
+  it('does NOT close on a vertical scroll gesture (the regression)', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: /common.openMenu/i }));
+
+    const drawer = await screen.findByTestId('mobile-menu-drawer');
+    // A downward scroll: small dx, large dy → must be treated as scroll, not close.
+    fireEvent.touchStart(drawer, { touches: [{ clientX: 300, clientY: 400 }] });
+    fireEvent.touchEnd(drawer, { changedTouches: [{ clientX: 306, clientY: 120 }] });
+
+    expect(screen.getByTestId('mobile-menu-scroll')).toBeInTheDocument();
   });
 });

--- a/fe-next/components/header/HeaderMobileMenu.tsx
+++ b/fe-next/components/header/HeaderMobileMenu.tsx
@@ -1,6 +1,6 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState, type TouchEvent as ReactTouchEvent } from 'react';
 import { createPortal } from 'react-dom';
-import { LazyMotion, domAnimation, m, AnimatePresence, type PanInfo } from 'framer-motion';
+import { LazyMotion, domAnimation, m, AnimatePresence } from 'framer-motion';
 import { Menu, X, Settings, Trophy, ScrollText, Coffee, Accessibility, Info, HelpCircle, Mail, Cookie, Gift, Users, UserPlus, ChevronRight, Sparkles, User, Flame, Bell, Check, Pencil, Bug } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -254,12 +254,28 @@ const HeaderMobileMenu = memo<HeaderMobileMenuProps>(({ unclaimedCount, onOpenGi
     const handleSignUp = useCallback(() => { closeMenu(); onSignUp(); }, [closeMenu, onSignUp]);
     const handleOpenGift = useCallback(() => { closeMenu(); onOpenGiftModal(); }, [closeMenu, onOpenGiftModal]);
 
-    // Swipe-to-close handler (RTL-aware)
-    const handleDragEnd = useCallback((_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
-        const shouldClose = isRtl
-            ? info.offset.x < -SWIPE_CLOSE_THRESHOLD
-            : info.offset.x > SWIPE_CLOSE_THRESHOLD;
-        if (shouldClose) setShowMobileMenu(false);
+    // Swipe-to-close (RTL-aware) — passive touch tracking, NOT framer `drag`.
+    // A framer drag gesture on the drawer fights vertical scrolling: any
+    // diagonal movement engages the elastic horizontal drag, so the menu
+    // shakes / springs back instead of scrolling. We instead detect a
+    // deliberate horizontal swipe on touchend and never translate the element,
+    // leaving native vertical scrolling completely untouched.
+    const swipeStartRef = useRef<{ x: number; y: number } | null>(null);
+    const handleTouchStart = useCallback((e: ReactTouchEvent) => {
+        const touch = e.touches[0];
+        swipeStartRef.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
+    }, []);
+    const handleTouchEnd = useCallback((e: ReactTouchEvent) => {
+        const start = swipeStartRef.current;
+        swipeStartRef.current = null;
+        const touch = e.changedTouches[0];
+        if (!start || !touch) return;
+        const dx = touch.clientX - start.x;
+        const dy = touch.clientY - start.y;
+        // Vertical-dominant or short gestures are scrolls — ignore them.
+        if (Math.abs(dx) < SWIPE_CLOSE_THRESHOLD || Math.abs(dx) <= Math.abs(dy)) return;
+        const closing = isRtl ? dx < 0 : dx > 0;
+        if (closing) setShowMobileMenu(false);
     }, [isRtl]);
 
     const storedAvatar = getStoredCustomAvatar();
@@ -383,25 +399,20 @@ const HeaderMobileMenu = memo<HeaderMobileMenuProps>(({ unclaimedCount, onOpenGi
                                 animate={{ x: 0 }}
                                 exit={{ x: isRtl ? '-100%' : '100%' }}
                                 transition={{ type: 'spring', damping: 28, stiffness: 320 }}
-                                drag="x"
-                                dragConstraints={{ left: isRtl ? -200 : 0, right: isRtl ? 0 : 200 }}
-                                dragElastic={0.15}
-                                onDragEnd={handleDragEnd}
+                                onTouchStart={handleTouchStart}
+                                onTouchEnd={handleTouchEnd}
                                 data-testid="mobile-menu-drawer"
                                 className={cn(
                                     "fixed top-0 bottom-0 w-[320px] sm:w-[360px] max-w-[88vw] z-80",
                                     "bg-neo-navy border-neo-black",
-                                    // The drag layer must NOT scroll: a framer-motion drag gesture
-                                    // sitting on the scroll container arbitrates touch and swallows
-                                    // vertical scrolling, making the menu feel unscrollable. We keep
-                                    // swipe-to-close here and delegate scrolling to the inner body
-                                    // below (same separation MobileGameDrawer uses).
+                                    // Non-scrolling shell. Vertical scrolling lives on the inner
+                                    // body below; swipe-to-close is handled by the passive touch
+                                    // handlers above (no framer `drag`, so nothing fights scroll).
                                     "shadow-hard-xl overflow-hidden flex flex-col",
                                     isRtl
                                         ? "left-0 border-r-4 rounded-r-neo-lg"
                                         : "right-0 border-l-4 rounded-l-neo-lg"
                                 )}
-                                style={{ touchAction: 'pan-y' }}
                             >
                               {/* ── Scrollable body — owns vertical scroll, decoupled from the
                                   swipe-to-close drag layer so native touch scroll works. ── */}


### PR DESCRIPTION
## Problem

The mobile side menu couldn't be scrolled — it "shook" and "pushed back" when trying to scroll down.

## Root cause

The drawer carried a Framer Motion `drag="x"` (swipe-to-close) gesture **on the same element chain as the scroll container**. Any diagonal/downward scroll engaged the elastic horizontal drag, so the panel slid sideways and sprang back instead of scrolling. A Framer `drag` gesture and reliable native vertical scroll fight over the same touch — they're fundamentally incompatible here.

(An earlier attempt to merely *decouple* the scroll container from the drag element wasn't enough, because the `drag` gesture itself still lived on the drawer.)

## Fix

- **Removed the Framer `drag` gesture entirely** from the drawer.
- Re-implemented swipe-to-close as a **passive `touchstart`/`touchend` detector** that:
  - closes only on a deliberate **horizontal-dominant** swipe toward the edge (`|dx| > threshold` and `|dx| > |dy|`), RTL-aware;
  - **never translates the element** — so there's nothing to shake or spring back, and vertical scrolling is now pure native browser behavior.
- Kept the decoupled inner scroll body (`overflow-y-auto` + `touch-action: pan-y` + safe-area padding).

Swipe-to-close still works; it just no longer drags the panel under your finger.

## Tests

TDD — failing tests written first, then implementation:
- drawer has no Framer `drag` gesture;
- a horizontal swipe closes the menu;
- **a vertical scroll gesture does NOT close it** (regression guard);
- scroll body is a separate element from the swipe layer.

All 4 menu-scroll tests pass; broader header suite (17 tests) stays green; no type errors in changed files.

## Note

Validated via unit tests and static analysis; not exercised on a physical touchscreen in CI. This removes the mechanism that was provably causing the shake.

https://claude.ai/code/session_01CfRbxmqub8GbHvoyrgrdCj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfRbxmqub8GbHvoyrgrdCj)_