### PR TITLE
fix(header): cap side-menu drawer to viewport height so it always scrolls

### DIFF
--- a/fe-next/components/__tests__/Header.menuScroll.test.tsx
+++ b/fe-next/components/__tests__/Header.menuScroll.test.tsx
@@ -130,6 +130,24 @@ describe('Side-menu vertical scroll', () => {
     );
   });
 
+  it('caps the drawer to the viewport height so a transformed <html> ancestor cannot make it unscrollable', async () => {
+    // Root cause of "can't scroll the side menu": the drawer is `position: fixed
+    // top-0 bottom-0`, so it sizes to its containing block. A native WebView
+    // repaint hack briefly sets `transform: translateZ(0)` on <html>; if that
+    // transform lingers (rAF dropped under native ad compositing), <html> becomes
+    // the containing block and the drawer sizes to the DOCUMENT height instead of
+    // the viewport. Its overflow-y-auto body then fits all content without
+    // overflowing — so it can't scroll, while the menu still looks full.
+    // An explicit viewport-relative max-height keeps the drawer bounded to the
+    // visible viewport regardless of which element is its containing block.
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: /common.openMenu/i }));
+
+    const drawer = await screen.findByTestId('mobile-menu-drawer');
+    expect(drawer.className).toContain('max-h-[100dvh]');
+  });
+
   it('does NOT close on a vertical scroll gesture (the regression)', async () => {
     const user = userEvent.setup();
     render(<Header />);

--- a/fe-next/components/header/HeaderMobileMenu.tsx
+++ b/fe-next/components/header/HeaderMobileMenu.tsx
@@ -404,6 +404,17 @@ const HeaderMobileMenu = memo<HeaderMobileMenuProps>(({ unclaimedCount, onOpenGi
                                 data-testid="mobile-menu-drawer"
                                 className={cn(
                                     "fixed top-0 bottom-0 w-[320px] sm:w-[360px] max-w-[88vw] z-80",
+                                    // Viewport-relative height cap. The drawer is `fixed top-0
+                                    // bottom-0`, so it sizes to its containing block — normally the
+                                    // viewport. But the native WebView repaint hack briefly sets
+                                    // `transform: translateZ(0)` on <html>; if that transform lingers
+                                    // (rAF starved under native-ad compositing), <html> becomes the
+                                    // containing block and the drawer grows to the DOCUMENT height.
+                                    // Its overflow-y-auto body then fits all content without
+                                    // overflowing, so the menu can't scroll while still looking full.
+                                    // `max-h-[100dvh]` keeps it bounded to the visible viewport
+                                    // regardless of which ancestor is the containing block.
+                                    "max-h-[100dvh]",
                                     "bg-neo-navy border-neo-black",
                                     // Non-scrolling shell. Vertical scrolling lives on the inner
                                     // body below; swipe-to-close is handled by the passive touch


### PR DESCRIPTION
The side menu drawer is `position: fixed top-0 bottom-0`, so it sizes to
its containing block. The native WebView repaint hack briefly promotes
<html> with `transform: translateZ(0)`; if that transform lingers (rAF
starved under native-ad compositing), <html> becomes the containing block
and the drawer grows to the DOCUMENT height instead of the viewport. Its
overflow-y-auto body then fits all content without overflowing, so the
menu can't scroll while still appearing full — exactly the reported bug.

Prior fixes (removing framer drag, decoupling the scroll/swipe layers)
addressed a different cause and are already shipped, so the menu was still
unscrollable. Add `max-h-[100dvh]` to bound the drawer to the visible
viewport regardless of which ancestor is its containing block, making the
inner body overflow and scroll in all cases.

Regression test asserts the drawer carries the viewport height cap.