### PR TITLE
SEO: daily meta tag improvements (2026-06-01)

### DIFF
--- a/docs/seo-daily/2026-06-01.md
+++ b/docs/seo-daily/2026-06-01.md
@@ -1,0 +1,102 @@
+# SEO Daily Report — 2026-06-01
+
+**Data range:** 2026-05-03 → 2026-05-30 (28 days, GSC 2-day lag)
+
+---
+
+## Headline Metrics
+
+### Google Search Console (28d)
+
+| Metric | Value |
+|---|---|
+| Total clicks | 71 |
+| Total impressions | 7,823 |
+| Overall CTR | 0.91% |
+| Avg position | 24.2 |
+| Unique queries | 216 |
+| Unique pages | 313 |
+
+**7d vs prior-7d delta:** Time-series breakdown not available in this pull (single 28d window). Re-run with windowed queries for delta tracking.
+
+### Bing Webmaster Tools
+
+Bing API blocked: `Host not in allowlist` from cloud execution environment. Run from a whitelisted IP or configure Bing API host exceptions.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+> Queries with ≥30 impressions where actual CTR < 70% of expected CTR for their avg position.
+
+| # | Query | Page | Avg Pos | Impressions | Actual CTR | Expected CTR | Gap | +Clicks est. | Fix |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | scrabble online | /es/juego-de-palabras-multijugador | 7.2 | 1,246 | 0.4% | 2.5% | −84% | +26 | **Title truncated (75 chars) — shorten to ≤60** |
+| 2 | scrabble en linea | /es/juego-de-palabras-multijugador | 8.1 | 723 | 0.3% | 2.0% | −85% | +12 | Same page — title fix cascades |
+| 3 | scrabble online gratis | /es/juego-de-palabras-multijugador | 8.9 | 711 | 0.0% | 2.0% | −100% | +14 | Same page — title fix cascades |
+| 4 | scrabble online español | /es/juego-de-palabras-multijugador | 8.5 | 706 | 0.0% | 2.0% | −100% | +14 | Same page — title fix cascades |
+| 5 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 7.6 | 459 | 0.0% | 2.5% | −100% | +11 | Same page — title fix cascades |
+| 6 | scrabble online svenska | /sv/swedish-multiplayer-word-game | 7.5 | 382 | 0.0% | 2.5% | −100% | +10 | **Title truncated (62 chars) — shorten to ≤60** |
+| 7 | scrabble en español online | /es/juego-de-palabras-multijugador | 7.9 | 283 | 0.4% | 2.5% | −84% | +6 | Same as #1 |
+| 8 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.2 | 248 | 0.0% | 2.0% | −100% | +5 | Same as #1 |
+| 9 | scrabble juego online | /es/juego-de-palabras-multijugador | 8.0 | 241 | 0.0% | 2.5% | −100% | +6 | Same as #1 |
+| 10 | jugar scrabble gratis | /es/juego-de-palabras-multijugador | 7.4 | 222 | 0.0% | 2.5% | −100% | +6 | Same as #1 |
+
+**Root cause:** The `/es/juego-de-palabras-multijugador` title tag is **75 characters** — Google truncates at ~60px-equivalent chars, hiding the brand and making the SERP snippet unreadable. This single fix affects rows 1–5 and 7–10 (nine of the top ten opportunities).
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+> Queries at avg position 8–20 with ≥50 impressions. Small content/link improvements push to page 1.
+
+| # | Query | Page | Avg Pos | Impressions | Suggested Action |
+|---|---|---|---|---|---|
+| 1 | scrabble en linea | /es/juego-de-palabras-multijugador | 8.1 | 723 | Add H2: "Scrabble en línea gratis — sin registro"; internal links from blog posts |
+| 2 | scrabble online gratis | /es/juego-de-palabras-multijugador | 8.9 | 711 | Add H2: "Scrabble online gratis sin descarga"; boost with 1–2 internal links |
+| 3 | scrabble online español | /es/juego-de-palabras-multijugador | 8.5 | 706 | Existing H1/title covers this — fix title truncation first |
+| 4 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.2 | 248 | Add FAQ: "¿Cómo jugar scrabble online gratis?" |
+| 5 | scrabble online gratis en español | /es/juego-de-palabras-multijugador | 8.9 | 173 | Long-tail; covered by fix #1 + FAQ schema |
+| 6 | scrabble (en español) - juega gratis en línea | /es/juego-de-palabras-multijugador | 8.7 | 150 | Google is matching this as an entity — add exact phrase in body copy |
+| 7 | scrabble español online | /es/juego-de-palabras-multijugador | 8.7 | 142 | Covered by title fix |
+| 8 | jugar scrabble online gratis | /es/juego-de-palabras-multijugador | 8.6 | 105 | Add FAQ entry targeting this exact phrase |
+| 9 | scrabble gratis en español | /es/juego-de-palabras-multijugador | 9.5 | 98 | Position 9.5 → needs more topical depth; add "¿Es gratis LexiClash?" FAQ |
+| 10 | scrabble svenska | /sv/swedish-multiplayer-word-game | 8.7 | 91 | Fix Swedish title + add FAQ: "Vad är ett bra Scrabble-alternativ?" |
+
+---
+
+## Bing Parity Gaps
+
+Bing data unavailable (API host restriction in cloud environment). Manual check recommended via Bing Webmaster Tools dashboard for the top 5 Google queries above.
+
+---
+
+## GEO / AI Visibility Recommendations
+
+The following queries have question-intent or comparison-intent — prime FAQPage schema candidates for AI Overviews and ChatGPT/Perplexity citations.
+
+### `/es/juego-de-palabras-multijugador` — Draft FAQ additions
+
+The page already has `FaqAccordion` component and `VideoGameJsonLd`. Verify FAQPage schema is rendered in JSON-LD. Add or expand:
+
+| Question | Draft Answer |
+|---|---|
+| ¿Cómo jugar scrabble online gratis? | LexiClash es una alternativa gratuita a Scrabble que puedes jugar en el navegador sin registro. Crea una sala, comparte el enlace y empieza a jugar en segundos. |
+| ¿Cuál es la mejor alternativa a Scrabble online en español? | LexiClash es la alternativa más rápida: multijugador en tiempo real (no por turnos), hasta 50 jugadores, gratis y sin descargas. |
+| ¿Necesito descargar algo para jugar scrabble online? | No. LexiClash funciona directamente en el navegador — en móvil o escritorio — sin descargas ni registro. |
+| ¿Puedo jugar scrabble en español sin registrarme? | Sí. Puedes crear o unirte a una sala de LexiClash sin crear cuenta. Solo comparte el enlace con tus amigos. |
+
+### `/sv/swedish-multiplayer-word-game` — Draft FAQ additions
+
+| Question | Draft Answer |
+|---|---|
+| Hur spelar man scrabble online gratis på svenska? | Med LexiClash kan du spela direkt i webbläsaren utan nedladdning eller registrering. Skapa ett rum och bjud in vänner via länk. |
+| Vad är ett bra Scrabble-alternativ på svenska? | LexiClash är ett realtids-ordspel på svenska där alla spelar samtidigt — ingen väntan på tur, gratis och utan app. |
+
+---
+
+## Today's 3-Bullet Action Plan
+
+1. **SHIP TODAY (PR ready):** Shorten title tags on 3 pages — `/es/juego-de-palabras-multijugador` (75→51 chars), `/sv/swedish-multiplayer-word-game` (62→42 chars), `/en/best-online-word-games` (70→50 chars). Estimated +26–40 clicks/28d from Spanish page alone once CTR normalises.
+2. **THIS WEEK:** Add 3–4 FAQ entries to the Spanish multiplayer page (see GEO section above) and verify FAQPage JSON-LD is rendering. This targets the AI Overview slot for "cómo jugar scrabble online" queries.
+3. **THIS WEEK:** Add 2 H2 headings to the Spanish page with exact query phrases: "Scrabble en línea gratis sin registro" and "Juega scrabble online gratis sin descargar". Both queries rank 8.1–8.9 with 700+ impressions — a small relevance signal improvement could push them to page 1.

--- a/fe-next/app/[locale]/best-online-word-games/page.tsx
+++ b/fe-next/app/[locale]/best-online-word-games/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const canonicalUrl = `${BASE_URL}/en/best-online-word-games`;
 
   return {
-    title: 'Best Free Browser Word Games 2026 — 9 Honest Picks (Free, No Download)',
+    title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',
     description: 'Best free browser word games of 2026, honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, LexiClash and more. No download, no signup — pick your game.',
     keywords: 'best free browser word games 2026, best word games 2026, best online word games 2025 2026, most popular online word games 2025 2026, free word games online, nyt connections, nyt strands, spelling bee game, semantle, wordle alternatives, multiplayer word games, word games with friends, word puzzle games online, word games no download, connections game',
     openGraph: {

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,11 +27,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Scrabble Online Gratis en Español — Multijugador en Tiempo Real | LexiClash',
-    description: 'Juega scrabble online con amigos en tiempo real — no por turnos. Sin registro, sin descarga. Hasta 50 jugadores. Crea sala en segundos, invita por enlace.',
+    title: 'Juega Scrabble Online Gratis en Español | LexiClash',
+    description: 'Scrabble online en español gratis y sin registro. Multijugador en tiempo real — sin esperar turnos. Hasta 50 jugadores. ¡Empieza ya!',
     keywords: 'cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Scrabble Online Gratis en Español — Multijugador en Tiempo Real | LexiClash',
+      title: 'Juega Scrabble Online Gratis en Español | LexiClash',
       description: 'Juega scrabble online en tiempo real — no por turnos. Crea sala, invita por enlace. 100% gratis, sin descargas.',
       locale: 'es_ES',
       type: 'website',
@@ -47,7 +47,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Gratis en Español — Multijugador en Tiempo Real | LexiClash',
+      title: 'Juega Scrabble Online Gratis en Español | LexiClash',
       description: 'Juega scrabble online en tiempo real — no por turnos. Sala con enlace, sin registro. ¡Hasta 50 jugadores!',
       images: [`${BASE_URL}/og-image-es-multiplayer.webp`],
     },

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -16,11 +16,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+    title: 'Scrabble Online Svenska Gratis | LexiClash',
     description: 'Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk, tävla direkt. Gratis, ingen app, ingen registrering.',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis | LexiClash',
       description: 'Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk. Gratis, ingen registrering.',
       locale: 'sv_SE',
       type: 'website',
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Scrabble Online Svenska Gratis | LexiClash',
       description: 'Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk, tävla direkt. Gratis.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },


### PR DESCRIPTION
## Summary

Three title tags were over 60 characters, causing Google to truncate them in SERPs. This is the root cause of near-0% CTR on the site's highest-impression queries (7,450+ impressions/28d at 0.3% CTR vs expected 2%+).

## Changes

| File | Old title (chars) | New title (chars) | Affected queries |
|---|---|---|---|
| `/es/juego-de-palabras-multijugador/page.tsx` | `Scrabble Online Gratis en Español — Multijugador en Tiempo Real \| LexiClash` **(75 chars)** | `Juega Scrabble Online Gratis en Español \| LexiClash` **(51 chars)** | scrabble online (1,246 impr), scrabble en linea (723), scrabble online gratis (711), scrabble online español (706), + 6 more |
| `/sv/swedish-multiplayer-word-game/page.tsx` | `Scrabble Online Svenska Gratis — Spela Multiplayer \| LexiClash` **(62 chars)** | `Scrabble Online Svenska Gratis \| LexiClash` **(42 chars)** | scrabble online svenska (382 impr), scrabble svenska online (106) |
| `/en/best-online-word-games/page.tsx` | `Best Free Browser Word Games 2026 — 9 Honest Picks (Free, No Download)` **(70 chars)** | `Best Free Browser Word Games 2026 — 9 Honest Picks` **(50 chars)** | most popular online word games 2025 2026 (59 impr), best free browser word games 2026 (45 impr) |

Also adds `docs/seo-daily/2026-06-01.md` with full 28-day opportunity analysis.

## Expected CTR Uplift

- Spanish MP page: +26–80 clicks/28d (0.3% → 2%+ at avg pos 8.3, 7,450 impressions)
- Swedish page: +9–16 clicks/28d
- Best word games page: +3–5 clicks/28d

## Test plan

- [ ] Verify title renders at ≤60 chars in browser `<title>` on each page
- [ ] Check OG/Twitter title in social debugger (all `openGraph.title` and `twitter.title` variants updated)
- [ ] No body content changes — purely meta/head tag modifications

https://claude.ai/code/session_01RXjwkEfFDn6HV2qrKfaU2M

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXjwkEfFDn6HV2qrKfaU2M)_