### PR TITLE
SEO: daily meta tag improvements (2026-06-03)

### DIFF
--- a/docs/seo-daily/2026-06-03.md
+++ b/docs/seo-daily/2026-06-03.md
@@ -1,10 +1,25 @@
-# SEO Daily Report — 2026-06-03
+# SEO Daily Report — 2026-06-03 (Updated — GSC data now available)
 
 ## Data Sources
-- **GSC**: Unavailable — ADC missing `webmasters.readonly` scope. Fix: `gcloud auth application-default login --scopes=...,https://www.googleapis.com/auth/webmasters.readonly`
-- **Bing WMT**: ✅ Available — 455 unique queries, 1,837 impressions, 73 clicks over analysis window
+- **GSC**: ✅ Available — 240 queries, 8,564 impressions, 70 clicks, period 2026-05-05 → 2026-06-01
+- **Bing WMT**: 403 host-not-in-allowlist from this environment (previous run captured 455 queries — see prior entries below). To re-enable: whitelist execution IP in Bing Webmaster Tools.
 
-## Headline Metrics (Bing)
+## Headline Metrics (Google — 28 days)
+
+| Metric | Value |
+|---|---|
+| Clicks | 70 |
+| Impressions | 8,564 |
+| Overall CTR | 0.82% |
+| Avg Position | 8.8 |
+| Unique Queries | 240 |
+| Unique Pages Indexed | 314 |
+| CTR opportunities found | 32 |
+| Rank-up opportunities found | 15 |
+
+**Headline insight:** 8,564 impressions → only 70 clicks (0.82% CTR). Dominant cause: the ES landing page title is 79 chars — truncated in SERP, causing 0–0.4% CTR across all Spanish scrabble queries despite positions 6–9.
+
+## Headline Metrics (Bing — prior run)
 
 | Metric | Value |
 |---|---|
@@ -12,12 +27,29 @@
 | Total impressions | 1,837 |
 | Total clicks | 73 |
 | Avg CTR | 3.97% |
-| CTR opportunities found | 21 |
-| Rank-up opportunities found | 11 |
 
-_GSC unavailable — clicks/position data is Bing-only this run._
+## Top 10 CTR Opportunities (Google — new data)
 
-## Top 10 CTR Opportunities (Bing)
+Criteria: ≥30 impressions, CTR < 70% of expected for position band.
+
+| # | Query | Page | Pos | Impr | CTR% | Exp CTR% | Fix |
+|---|---|---|---|---|---|---|---|
+| 1 | scrabble online | /es/juego-de-palabras-multijugador | 6.7 | 1,607 | 0.37% | 3.0% | **Shorten title 79→59 chars** (truncation is killing CTR) |
+| 2 | scrabble online gratis | /es/juego-de-palabras-multijugador | 8.7 | 810 | 0.00% | 2.0% | Title fix + desc 173→152 chars |
+| 3 | scrabble en linea | /es/juego-de-palabras-multijugador | 7.8 | 746 | 0.40% | 2.5% | Title fix (same page) |
+| 4 | scrabble online español | /es/juego-de-palabras-multijugador | 8.4 | 744 | 0.13% | 2.5% | Title fix |
+| 5 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 7.5 | 467 | 0.21% | 3.0% | Title fix |
+| 6 | scrabble online svenska | /sv/swedish-multiplayer-word-game | 7.3 | 395 | 0.00% | 3.0% | **Shorten SV title 62→54 chars** + stronger CTA |
+| 7 | scrabble en español online | /es/juego-de-palabras-multijugador | 7.6 | 324 | 0.31% | 2.5% | Title fix |
+| 8 | scrabble juego online | /es/juego-de-palabras-multijugador | 7.5 | 279 | 0.36% | 2.5% | Title fix |
+| 9 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.2 | 233 | 0.00% | 2.5% | Title fix |
+| 10 | jugar scrabble gratis | /es/juego-de-palabras-multijugador | 6.9 | 213 | 0.00% | 3.0% | Title fix |
+
+**Root cause:** All top 10 opportunities trace to 2 pages. ES page title (79 chars) is truncated in SERP. SV page (62 chars) is marginally over and has 0% CTR across all Swedish scrabble queries.
+
+**Estimated uplift:** ES title fix alone → moving ~4,600 impressions from 0.1–0.4% to 1.5–2.5% CTR = ~+50–90 clicks/28d.
+
+## Top 10 CTR Opportunities (Bing — prior run)
 
 | # | Query | Pos | Impr | CTR | Expected | Δ Clicks | Fix |
 |---|---|---|---|---|---|---|---|
@@ -73,15 +105,50 @@ _Unavailable — requires GSC with `webmasters.readonly` scope._
 
 `play boggle word shake free no download` at pos 4.0, 12.8% CTR — this is the best-converting query. Protect: don't dilute this page with unrelated content.
 
+## Top 10 Rank-Up Opportunities (Google)
+
+Criteria: position 8–20, ≥50 impressions.
+
+| # | Query | Page | Pos | Impr | Action |
+|---|---|---|---|---|---|
+| 1 | scrabble online gratis | /es/juego-de-palabras-multijugador | 8.7 | 810 | Add exact H2 "Scrabble Online Gratis en Español"; internal links from blog posts |
+| 2 | scrabble online español | /es/juego-de-palabras-multijugador | 8.4 | 744 | Use phrase in first 100 body words; add as H2 |
+| 3 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.2 | 233 | Use phrase in body opening paragraph |
+| 4 | scrabble online gratis en español | /es/juego-de-palabras-multijugador | 8.7 | 188 | Long-tail H2 or FAQ |
+| 5 | scrabble español online | /es/juego-de-palabras-multijugador | 8.6 | 133 | Title fix + add as H2 |
+| 6 | scrabble svenska | /sv/swedish-multiplayer-word-game | 8.7 | 111 | H1 currently says "Multiplayer Ordspel" — add "Scrabble Svenska" as exact H2 |
+| 7 | scrabble gratis en español | /es/juego-de-palabras-multijugador | 8.5 | 104 | Add FAQ: "¿Cómo jugar scrabble gratis en español?" |
+| 8 | jugar scrabble online gratis | /es/juego-de-palabras-multijugador | 8.2 | 102 | Body copy + FAQ |
+| 9 | scrabble online español multijugador | /es/juego-de-palabras-multijugador | 9.2 | 84 | Add as H2 subheading |
+| 10 | scrabble en linea español | /es/juego-de-palabras-multijugador | 8.2 | 80 | H2 candidate |
+
+## Bing Parity Gaps
+
+Bing API returned 403 from this environment — Bing parity analysis not available this run.
+
+## GEO / AI Visibility Recommendations
+
+| Query | Type | Recommendation |
+|---|---|---|
+| "cómo jugar scrabble online español gratis" | How-to / AI | Add to ES FAQPage in `data.ts` — page already has FAQPage schema |
+| "cuál es la mejor alternativa a scrabble en español" | Comparison | Add Q&A to ES FAQPage |
+| "where to play scrabble online in spanish" | AI answer | English FAQ entry on ES page |
+| "scrabble gratis en español sin registrarse" | Feature query | FAQ: "Sin registro, sin descarga — funciona en el navegador" |
+| "best free online word games 2026" | Best-of / AI | Title mismatch on `/en/best-online-word-games` (says "browser" not "online") |
+
+ES and SV pages already have `FAQPage + HowTo` schema in place.
+
+**Draft FAQ additions for `data.ts` on ES page:**
+- Q: "¿Cómo jugar scrabble online español gratis sin registrarse?" A: "Entra a lexiclash.live desde cualquier navegador — sin registro, sin descarga. Pulsa 'Crear sala', comparte el enlace por WhatsApp y empieza en segundos. Hasta 50 jugadores."
+- Q: "¿Cuál es la mejor alternativa a Scrabble en español gratis?" A: "LexiClash combina Scrabble, Boggle y Apalabrados en tiempo real. Gratis, hasta 50 jugadores, más de 10.000 palabras en español — sin por-turnos."
+
 ## Today's Actions
 
-1. ✅ **daily-word-wheel**: Removed "Alternative" from en title + desc. Was: `"Daily Express Word Wheel Alternative — Free..."` → Now: `"Daily Express Word Wheel — Free Word Puzzle Game | LexiClash"`. Expected: 2–3 incremental Bing clicks/day on 150 impr.
-
-2. ✅ **boggle-word-shake-free**: Title rewritten for energy + no-download hook. Was: `"Boggle WordShake Free Online — Play Boggle Shake"` → Now: `"Boggle Word Shake Free — Play Boggle Online No Download"`. Desc adds urgency + social proof. Expected: 1–2 incremental clicks/day.
-
-3. **Next run**: Add FAQPage JSON-LD schema to boggle-word-shake-free (uses `components/seo/` wrappers per project rules). Queries like "what is boggle word shake" have no schema.
-
-4. **GSC fix** (manual): `gcloud auth application-default login --no-launch-browser --scopes=openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/webmasters.readonly` — unlocks trends, CTR delta verification, country dimension.
+1. ✅ **ES page title** — shortened 79→59 chars: `"Scrabble Online en Español Gratis — Juega Ahora | LexiClash"`. Addresses 12 CTR-opportunity queries, ~4,600 impressions/28d. Est. +50–90 clicks/28d.
+2. ✅ **SV page title** — shortened 62→54 chars: `"Scrabble Online Svenska Gratis — Spela Nu | LexiClash"`. Addresses 619 impressions at 0% CTR.
+3. ✅ **best-online-word-games title** — shortened 71→50 chars, changed "browser" to "online" to match query intent. Desc shortened 177→145 chars.
+4. **Previous actions (Bing):** daily-word-wheel and boggle-word-shake-free titles fixed in prior runs — monitor Bing CTR in next available run.
+5. **Next:** Add 2 FAQ entries to ES `data.ts` for GEO/AI visibility; add "Scrabble Svenska" H2 to SV page.
 
 ## Founder Directive Note
 

--- a/fe-next/app/[locale]/best-online-word-games/page.tsx
+++ b/fe-next/app/[locale]/best-online-word-games/page.tsx
@@ -16,12 +16,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const canonicalUrl = `${BASE_URL}/en/best-online-word-games`;
 
   return {
-    title: 'Best Free Browser Word Games 2026 — 9 Honest Picks (Free, No Download)',
-    description: 'Best free browser word games of 2026, honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, LexiClash and more. No download, no signup — pick your game.',
+    title: 'Best Free Online Word Games 2026 — 9 Honest Picks',
+    description: '9 best free online word games of 2026, honestly ranked — Wordle, Connections, Strands, Spelling Bee, Scrabble GO, LexiClash & more. No download, no signup.',
     keywords: 'best free browser word games 2026, best word games 2026, best online word games 2025 2026, most popular online word games 2025 2026, free word games online, nyt connections, nyt strands, spelling bee game, semantle, wordle alternatives, multiplayer word games, word games with friends, word puzzle games online, word games no download, connections game',
     openGraph: {
-      title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',
-      description: 'Best free browser word games of 2026, honestly ranked. Wordle, NYT Connections, LexiClash & more — no download required.',
+      title: 'Best Free Online Word Games 2026 — 9 Honest Picks',
+      description: '9 best free online word games of 2026, honestly ranked — Wordle, Connections, LexiClash & more. No download required.',
       locale: 'en_US',
       type: 'website',
       url: pageUrl,
@@ -29,8 +29,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',
-      description: 'Best free browser word games of 2026, honestly ranked. No download required.',
+      title: 'Best Free Online Word Games 2026 — 9 Honest Picks',
+      description: '9 best free online word games of 2026, honestly ranked. No download, no signup.',
       images: [`${BASE_URL}/og-image-en.webp`],
     },
     alternates: {

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,8 +27,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Jugar Scrabble en Español Online Gratis — Multijugador Tiempo Real | LexiClash',
-    description: 'Jugar scrabble en español online gratis con amigos en tiempo real — no por turnos. Sin registro, sin descarga. Hasta 50 jugadores. Crea sala en segundos, invita por enlace.',
+    title: 'Scrabble Online en Español Gratis — Juega Ahora | LexiClash',
+    description: 'Juega scrabble en español gratis con amigos — tiempo real, no por turnos. Sin registro, sin descarga. Hasta 50 jugadores. Crea sala e invita por enlace.',
     keywords: 'jugar scrabble en español online gratis, scrabble en español online gratis, scrabble online español, cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
       title: 'Jugar Scrabble en Español Online Gratis — Tiempo Real | LexiClash',

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+    title: 'Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
     description: 'Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk, tävla direkt. Gratis, ingen app, ingen registrering.',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {


### PR DESCRIPTION
## Summary

3 meta-only fixes identified from 28-day GSC data (8,564 impressions, 70 clicks, 0.82% overall CTR). All title/description lengths verified ≤60/≤155 chars.

---

### Fix 1 — ES Spanish scrabble page (`/es/juego-de-palabras-multijugador`)

**Root cause:** Title was 79 chars — Google truncates at ~60, so SERP showed `"Jugar Scrabble en Español Online Gratis — Multijug..."`. This page has 12 CTR-opportunity queries (~4,600 combined impressions) at 0–0.4% CTR vs 2–3% expected.

| | Before | After |
|---|---|---|
| Title (chars) | `Jugar Scrabble en Español Online Gratis — Multijugador Tiempo Real \| LexiClash` (79) | `Scrabble Online en Español Gratis — Juega Ahora \| LexiClash` (59 ✓) |
| Description (chars) | 173 chars (over limit) | 152 chars ✓ |

**Expected CTR uplift:** ~+50–90 clicks/28d (moving ~4,600 imp from 0.2% → 1.5–2.5%)

---

### Fix 2 — SV Swedish page (`/sv/swedish-multiplayer-word-game`)

Title was 62 chars (just over limit). Queries "scrabble online svenska" (395 imp, pos 7.3) and "scrabble svenska online" (108 imp, pos 6.5) both had **0% CTR**.

| | Before | After |
|---|---|---|
| Title | `Scrabble Online Svenska Gratis — Spela Multiplayer \| LexiClash` (62) | `Scrabble Online Svenska Gratis — Spela Nu \| LexiClash` (53 ✓) |

**Expected CTR uplift:** ~+5–10 clicks/28d on 619 combined impressions

---

### Fix 3 — Best online word games page (`/en/best-online-word-games`)

Title was 71 chars and used "browser" while search queries use "online" — intent mismatch. Description was 177 chars. All queries at 0% CTR at positions 6.5–7.7.

| | Before | After |
|---|---|---|
| Title | `Best Free Browser Word Games 2026 — 9 Honest Picks (Free, No Download)` (71) | `Best Free Online Word Games 2026 — 9 Honest Picks` (49 ✓) |
| Description | 177 chars (over limit) | 155 chars ✓ |

**Expected CTR uplift:** ~+3–8 clicks/28d on 139 impressions at 0% CTR

---

## Data source

GSC 28-day pull: 2026-05-05 → 2026-06-01 | 240 queries | 8,564 impressions | 70 clicks | avg pos 8.8

Full analysis: `docs/seo-daily/2026-06-03.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvVmZBoo49NFosjRiZiNZz)_