### PR TITLE
fix(daily): word wheel landscape overflow + ad covering the Play button

### DIFF
--- a/fe-next/.gitignore
+++ b/fe-next/.gitignore
@@ -96,3 +96,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/README.md
 public/dicts/
+
+# Lighthouse CI report output (npm run lighthouse:ci)
+.lighthouseci/

--- a/fe-next/__tests__/lighthouseConfig.test.ts
+++ b/fe-next/__tests__/lighthouseConfig.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+
+/**
+ * Regression guard for the Lighthouse CI configs.
+ *
+ * `package.json` runs `lhci autorun --config=./lighthouserc.mobile.cjs` (and
+ * `.desktop.cjs`). Those files were referenced but never committed, so the CI
+ * `lighthouse` job failed every run with `ENOENT`. This test fails loudly if
+ * either config goes missing or loses the fields lhci needs to boot the server
+ * and collect.
+ */
+const ROOT = path.resolve(__dirname, '..');
+
+describe('Lighthouse CI configs', () => {
+  for (const file of ['lighthouserc.mobile.cjs', 'lighthouserc.desktop.cjs']) {
+    describe(file, () => {
+      const abs = path.join(ROOT, file);
+
+      it('exists on disk (matches the package.json lighthouse:ci scripts)', () => {
+        expect(fs.existsSync(abs)).toBe(true);
+      });
+
+      it('exports a valid lhci config that boots the server and collects a URL', () => {
+        const cfg = require(abs);
+        expect(cfg?.ci?.collect?.startServerCommand).toBeTruthy();
+        // Must point lhci at the custom server's port (3001), not the default 3000.
+        expect(cfg.ci.collect.startServerReadyPattern).toBeTruthy();
+        expect(Array.isArray(cfg.ci.collect.url)).toBe(true);
+        expect(cfg.ci.collect.url.length).toBeGreaterThan(0);
+        expect(cfg.ci.collect.url.every((u: string) => u.includes(':3001'))).toBe(true);
+        // Assertions present (warn-level is fine) + an upload target so autorun exits 0.
+        expect(cfg.ci.assert).toBeTruthy();
+        expect(cfg.ci.upload?.target).toBeTruthy();
+      });
+    });
+  }
+});

--- a/fe-next/components/ads/AnchoredNativeBanner.tsx
+++ b/fe-next/components/ads/AnchoredNativeBanner.tsx
@@ -63,8 +63,22 @@ export default function AnchoredNativeBanner() {
     const safeBottom = safeArea.bottom || 0;
 
     if (!isAllowedAdBannerRoute(pathname)) {
-      hideBanner();
-      document.documentElement.style.setProperty('--admob-banner-height', '0px');
+      // Hide first, collapse the reservation only AFTER the native overlay is
+      // actually gone. A native banner composites ABOVE the WebView, so zeroing
+      // --admob-banner-height synchronously drops bottom-anchored CTAs (e.g. the
+      // daily ready-screen Play button) into the band the still-painted banner
+      // occupies for the duration of the hide latency — that's the "ad covers
+      // the button sometimes" race on navigation into a blocked route.
+      void (async () => {
+        try {
+          await hideBanner();
+        } finally {
+          if (!cancelled) {
+            document.documentElement.style.setProperty('--admob-banner-height', '0px');
+            try { localStorage.setItem('lc_admob_h', '0'); } catch {}
+          }
+        }
+      })();
       return () => { cancelled = true; };
     }
 

--- a/fe-next/components/ads/__tests__/AnchoredNativeBanner.test.tsx
+++ b/fe-next/components/ads/__tests__/AnchoredNativeBanner.test.tsx
@@ -194,6 +194,31 @@ describe('AnchoredNativeBanner', () => {
     expect(hideBanner).toHaveBeenCalled();
   });
 
+  it('keeps --admob-banner-height reserved until the banner actually hides on a blocked route', async () => {
+    // Repro for the daily ready-screen Play CTA being covered "sometimes":
+    // navigating from a banner-allowed route (banner showing, var=90px) into a
+    // blocked /daily route. The native banner composites ABOVE the WebView, so
+    // zeroing the reservation synchronously drops bottom-anchored CTAs into the
+    // band the still-painted banner occupies until hideBanner() resolves.
+    document.documentElement.style.setProperty('--admob-banner-height', '90px');
+    let resolveHide!: () => void;
+    hideBanner.mockReturnValueOnce(new Promise<void>((r) => { resolveHide = () => r(); }));
+    mockPathname.current = '/daily/word-hunt';
+
+    render(<AnchoredNativeBanner />);
+    await Promise.resolve();
+
+    // WHILE the hide is in flight the reservation must persist (CTA stays lifted).
+    expect(hideBanner).toHaveBeenCalled();
+    expect(document.documentElement.style.getPropertyValue('--admob-banner-height')).toBe('90px');
+
+    // WHEN the native overlay is actually gone, the reservation collapses.
+    resolveHide();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(document.documentElement.style.getPropertyValue('--admob-banner-height')).toBe('0px');
+  });
+
   it('registers SizeChanged listener on mount', async () => {
     render(<AnchoredNativeBanner />);
     await Promise.resolve();

--- a/fe-next/components/daily/WordWheelGame.tsx
+++ b/fe-next/components/daily/WordWheelGame.tsx
@@ -628,18 +628,36 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
   // Keep submit ref fresh so double-tap handler (created earlier) can reach the latest closure.
   useEffect(() => { handleSubmitRef.current = handleSubmit; }, [handleSubmit]);
 
-  // Responsive wheel radius based on the wheel div width (not the game container).
-  // The container is height-capped on short viewports (max-w/max-h below), so the
-  // measured width shrinks there and the orbit pulls inward to stay inside the rim.
+  // Responsive wheel radius measured from the wheel div's *smaller* dimension.
+  // The container is height-capped on short/landscape viewports (max-w/max-h
+  // below), so the measured box shrinks there and the orbit pulls inward to stay
+  // inside the rim. Using min(w,h) keeps letters inside even if the box ends up
+  // non-square (e.g. a viewport cap binds height but not width).
+  // On short viewports the `short:` variant shrinks the letters too, so we feed a
+  // smaller maxRadius / minRadius / letterAllowance to match — otherwise the orbit
+  // would floor onto the (still-large) center letter.
   const [wheelRadius, setWheelRadius] = useState(96);
   useEffect(() => {
     const el = wheelContainerRef.current;
     if (!el) return;
-    const update = () => setWheelRadius(computeWheelRadius(el.getBoundingClientRect().width, 136));
+    const shortVp = typeof window !== 'undefined' ? window.matchMedia('(max-height: 600px)') : null;
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      const size = Math.min(rect.width, rect.height);
+      setWheelRadius(
+        shortVp?.matches
+          ? computeWheelRadius(size, 88, 40, 44)
+          : computeWheelRadius(size, 136),
+      );
+    };
     update();
     const ro = new ResizeObserver(update);
     ro.observe(el);
-    return () => ro.disconnect();
+    shortVp?.addEventListener?.('change', update);
+    return () => {
+      ro.disconnect();
+      shortVp?.removeEventListener?.('change', update);
+    };
   }, []);
 
   // ── Keyboard input ──
@@ -748,7 +766,7 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
           (flex-1 + justify-center sibling below) to re-center. */}
       <m.div
         data-testid="word-builder"
-        className="relative w-full h-[52px] sm:h-[72px] flex items-center justify-center"
+        className="relative w-full h-[52px] sm:h-[72px] short:h-[44px] flex items-center justify-center"
         animate={
           wordBuilderShake
             ? { x: [-4, 4, -3, 3, -1, 0] }
@@ -919,7 +937,7 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
           left a 100–250px gap between the wheel and Submit. The inline-submit
           chip near the word-builder still serves as the primary CTA when the
           found-words list grows past viewport. */}
-      <div className="@container/wheel [container-type:size] flex-1 flex flex-col items-center justify-center w-full min-h-0 gap-2 py-1" data-testid="wheel-cluster">
+      <div className="@container/wheel [container-type:size] flex-1 flex flex-col items-center justify-center w-full min-h-0 gap-2 py-1 short:gap-0.5 short:py-0" data-testid="wheel-cluster">
       {/* Tap-to-remove + double-tap-to-submit hint — fixed-height reserved
           slot (h-*, not min-h-*) so even font/locale ascender variance can't
           grow the slot when builtLetters mounts/unmounts the hint text. */}
@@ -937,11 +955,19 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
       {/* ── The Wheel ── */}
       <div
         ref={wheelContainerRef}
+        data-testid="wheel-orbit"
         // Height-cap (max-*) only binds when smaller than the fixed size, so tall
         // screens are unchanged while short/landscape ones shrink the wheel to fit
         // the cluster instead of overlapping the pills above / buttons below.
         // Reserve ~116px (tap-hint + rule-hint + action bar + gaps); floor 176px.
-        className="relative w-64 h-64 sm:w-80 sm:h-80 md:w-96 md:h-96 max-w-[max(176px,calc(100cqb-116px))] max-h-[max(176px,calc(100cqb-116px))] shrink-0 flex items-center justify-center touch-none"
+        //
+        // short: (≤600px tall, incl. desktop 1136×473) adds a *viewport* cap
+        // (svh) so the wheel can never exceed the viewport even when the flex /
+        // cqb height-chain fails to propagate a bounded height — the prior
+        // cqb-only cap left it stuck at the fixed h-96 (384px) and the orbit
+        // collided with the instruction text above and the action bar below.
+        // Lower reserve (72px, chrome is tightened on short) and floor (132px).
+        className="relative w-64 h-64 sm:w-80 sm:h-80 md:w-96 md:h-96 max-w-[max(176px,calc(100cqb-116px))] max-h-[max(176px,calc(100cqb-116px))] short:max-w-[max(132px,min(calc(100cqb-72px),46svh))] short:max-h-[max(132px,min(calc(100cqb-72px),46svh))] shrink-0 flex items-center justify-center touch-none"
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
@@ -998,15 +1024,17 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
         ))}
       </div>
 
-      {/* ── Center letter rule hint ── */}
-      <p className="text-neo-white text-xs text-center">
+      {/* ── Center letter rule hint ── (hidden on short viewports to reclaim
+          vertical room for the wheel; the same rule is shown on the intro/ready
+          screen, so no information is lost mid-game). */}
+      <p className="text-neo-white text-xs text-center short:hidden">
         {t('wordWheel.centerLetterRule')} &middot; {t('wordWheel.minLetters', { min: '3' })}
       </p>
 
       {/* ── Action Buttons (inline below wheel, glued via flex cluster) ── */}
       <div
         data-testid="word-wheel-action-bar"
-        className="w-full flex items-center justify-center gap-3 mt-1"
+        className="w-full flex items-center justify-center gap-3 mt-1 short:mt-0"
       >
         {/* Clear */}
         <m.button

--- a/fe-next/components/daily/__tests__/WordWheelGame.shortViewport.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelGame.shortViewport.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Short / landscape viewport regression (e.g. desktop 1136×473).
+ *
+ * Bug: the wheel's height cap relied solely on container-query units
+ * (`max-h-[max(176px,calc(100cqb-116px))]`) with a hard 176px floor. When the
+ * flex height-chain doesn't propagate a bounded height — or on a genuinely short
+ * viewport — `cqb` resolves large, the cap never binds, and the wheel renders at
+ * its fixed `h-96` (384px). That overflows the ~473px viewport, so the
+ * `justify-center` cluster pushes the orbit letters into the instruction text
+ * above and the FORMAR / action bar below.
+ *
+ * Fix: on short viewports the wheel is additionally capped by a *viewport*
+ * fraction (`svh`) and given a lower floor + tightened chrome, so it always
+ * shrinks to fit and can never overlap its siblings.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/utils/growthTracking', () => ({
+  trackGameStart: vi.fn(),
+  trackGameEnd: vi.fn(),
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ language: 'en', t: (k: string) => k }),
+}));
+
+vi.mock('@/contexts/SoundEffectsContext', () => ({
+  useSoundEffects: () => ({
+    playTileSelectSound: vi.fn(),
+    playWordAcceptedSound: vi.fn(),
+    playWordRejectedSound: vi.fn(),
+    playComboSound: vi.fn(),
+    playLegendaryWordSound: vi.fn(),
+    playEpicVictorySound: vi.fn(),
+    playCountdownBeep: vi.fn(),
+    playBoardShuffleSound: vi.fn(),
+    playButtonClickSound: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useWordWheelKeyboard', () => ({
+  useWordWheelKeyboard: () => ({ keyboardFocused: false }),
+}));
+
+vi.mock('../WordWheelPixiRing', () => ({
+  __esModule: true,
+  default: () => <div data-testid="pixi-ring-stub" />,
+}));
+
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => () => <div data-testid="dynamic-stub" />,
+}));
+
+vi.mock('@/utils/dailyChallenge/wordWheelGeneration', () => ({
+  isValidWordWheelWord: () => true,
+}));
+
+vi.mock('@/utils/dailyChallenge/wordWheelScoring', () => ({
+  scoreWord: () => 5,
+}));
+
+import WordWheelGame from '../WordWheelGame';
+import type { WordWheelPuzzle } from '@/utils/dailyChallenge/wordWheelGeneration';
+
+const puzzle: WordWheelPuzzle = {
+  centerLetter: 'A',
+  outerLetters: ['B', 'C', 'D', 'E', 'F', 'G'],
+  validWords: ['CAB'],
+  language: 'en',
+} as unknown as WordWheelPuzzle;
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch;
+});
+
+describe('WordWheelGame short-viewport wheel sizing', () => {
+  function renderGame() {
+    render(
+      <WordWheelGame
+        puzzle={puzzle}
+        duration={60}
+        onComplete={vi.fn()}
+        onValidateWord={vi.fn().mockResolvedValue(true)}
+        onEffect={vi.fn()}
+        language="en"
+      />
+    );
+    return screen.getByTestId('wheel-orbit');
+  }
+
+  it('caps the wheel by a viewport fraction (svh) on short viewports so it cannot overflow', () => {
+    const orbit = renderGame();
+    // A short:-prefixed max-height that references svh — guarantees the wheel is
+    // bounded by the viewport even if the flex/cqb height-chain breaks down.
+    expect(orbit.className).toMatch(/short:max-h-\[[^\]]*svh/);
+    expect(orbit.className).toMatch(/short:max-w-\[[^\]]*svh/);
+  });
+
+  it('still keeps the unconstrained (tall-viewport) fixed sizing untouched', () => {
+    const orbit = renderGame();
+    // Base fixed sizes remain so tall phones/tablets are unchanged.
+    expect(orbit.className).toMatch(/\bh-64\b/);
+    expect(orbit.className).toMatch(/sm:h-80/);
+    expect(orbit.className).toMatch(/md:h-96/);
+  });
+});

--- a/fe-next/lib/wordWheel/__tests__/wheelGeometry.test.ts
+++ b/fe-next/lib/wordWheel/__tests__/wheelGeometry.test.ts
@@ -34,4 +34,24 @@ describe('computeWheelRadius', () => {
   it('returns an integer (px transforms should not be sub-pixel)', () => {
     expect(Number.isInteger(computeWheelRadius(257, 136))).toBe(true);
   });
+
+  it('accepts a smaller letter allowance so a height-capped short wheel keeps letters inside', () => {
+    // GIVEN a short/landscape wheel where the box is shrunk to ~140px and the
+    // letters are also shrunk (short: variant → 48px outer letters)
+    // WHEN computing the radius with a reduced allowance matching the small letters
+    // THEN the orbit is larger than it would be with the default 60px allowance,
+    //      because less rim space is reserved for the (now smaller) letters.
+    const tightAllowance = computeWheelRadius(140, 88, 40, 44);
+    const defaultAllowance = computeWheelRadius(140, 88, 40);
+    expect(tightAllowance).toBe(Math.round((140 - 44) / 2)); // 48
+    expect(defaultAllowance).toBe(Math.round((140 - WHEEL_LETTER_ALLOWANCE_PX) / 2)); // 40
+    expect(tightAllowance).toBeGreaterThan(defaultAllowance);
+  });
+
+  it('still clamps to the short min/max bounds with a custom allowance', () => {
+    // Tiny box → floored to the (lower) short minRadius, not the default 52.
+    expect(computeWheelRadius(60, 88, 40, 44)).toBe(40);
+    // Large box → capped to the (lower) short maxRadius.
+    expect(computeWheelRadius(400, 88, 40, 44)).toBe(88);
+  });
 });

--- a/fe-next/lib/wordWheel/wheelGeometry.ts
+++ b/fe-next/lib/wordWheel/wheelGeometry.ts
@@ -22,15 +22,22 @@ export const WHEEL_LETTER_ALLOWANCE_PX = 60;
  * @param containerWidthPx rendered wheel width (getBoundingClientRect)
  * @param maxRadius        upper bound (96 mobile, 136/140 desktop)
  * @param minRadius        lower bound; keeps a tiny wheel usable
+ * @param letterAllowance  rim space reserved for one outer letter. Defaults to
+ *                         {@link WHEEL_LETTER_ALLOWANCE_PX}; pass a smaller value
+ *                         on short/landscape viewports where the `short:` variant
+ *                         shrinks the letters, so the orbit isn't over-reserved
+ *                         (which would otherwise floor a small wheel onto its
+ *                         center letter).
  */
 export function computeWheelRadius(
   containerWidthPx: number,
   maxRadius: number,
   minRadius = 52,
+  letterAllowance = WHEEL_LETTER_ALLOWANCE_PX,
 ): number {
   if (!Number.isFinite(containerWidthPx) || containerWidthPx <= 0) {
     return minRadius;
   }
-  const fitInsideRim = (containerWidthPx - WHEEL_LETTER_ALLOWANCE_PX) / 2;
+  const fitInsideRim = (containerWidthPx - letterAllowance) / 2;
   return Math.round(Math.max(minRadius, Math.min(maxRadius, fitInsideRim)));
 }

--- a/fe-next/lighthouserc.desktop.cjs
+++ b/fe-next/lighthouserc.desktop.cjs
@@ -1,0 +1,37 @@
+/**
+ * Lighthouse CI — desktop profile. Run via `npm run lighthouse:ci:desktop`
+ * (`lhci autorun --config=./lighthouserc.desktop.cjs`), after the mobile pass.
+ *
+ * Same booting/upload strategy as lighthouserc.mobile.cjs (see that file's
+ * header) — boots the custom server on PORT 3001, audits one representative
+ * route, warn-level assertions, reports written to ./.lighthouseci.
+ */
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: 'npm run start',
+      startServerReadyPattern: 'Server ready',
+      startServerReadyTimeout: 120000,
+      url: ['http://localhost:3001/en'],
+      numberOfRuns: 1,
+      settings: {
+        preset: 'desktop',
+      },
+    },
+    assert: {
+      assertions: {
+        // Desktop typically scores higher than mobile; keep warn-level so a dip
+        // is visible in the report without failing the (non-gating) check.
+        'categories:performance': ['warn', { minScore: 0.7 }],
+        'categories:accessibility': ['warn', { minScore: 0.9 }],
+        'categories:best-practices': ['warn', { minScore: 0.9 }],
+        'categories:seo': ['warn', { minScore: 0.9 }],
+      },
+    },
+    upload: {
+      target: 'filesystem',
+      outputDir: './.lighthouseci',
+      reportFilenamePattern: 'desktop-%%PATHNAME%%-%%DATETIME%%.report.%%EXTENSION%%',
+    },
+  },
+};

--- a/fe-next/lighthouserc.mobile.cjs
+++ b/fe-next/lighthouserc.mobile.cjs
@@ -1,0 +1,51 @@
+/**
+ * Lighthouse CI — mobile profile. Run via `npm run lighthouse:ci:mobile`
+ * (`lhci autorun --config=./lighthouserc.mobile.cjs`).
+ *
+ * The CI `lighthouse` job builds the app first, then this config boots the
+ * project's custom server (`npm run start`, which listens on PORT 3001 and
+ * logs "Server ready") and audits a representative route.
+ *
+ * Assertions are intentionally `warn`-level: the job is non-gating
+ * (`continue-on-error: true`, and not part of the `ci-success` gate), so it
+ * should surface regressions without hard-failing. Tighten the minScores or
+ * add performance budgets here once the team agrees on thresholds.
+ *
+ * Reports are written to ./.lighthouseci (gitignored) rather than uploaded to
+ * temporary public storage, so the run needs no extra network/credentials.
+ */
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: 'npm run start',
+      startServerReadyPattern: 'Server ready',
+      startServerReadyTimeout: 120000,
+      url: ['http://localhost:3001/en'],
+      numberOfRuns: 1,
+      settings: {
+        // Lighthouse's default form factor is already mobile; make it explicit.
+        formFactor: 'mobile',
+        screenEmulation: {
+          mobile: true,
+          width: 412,
+          height: 823,
+          deviceScaleFactor: 1.75,
+          disabled: false,
+        },
+      },
+    },
+    assert: {
+      assertions: {
+        'categories:performance': ['warn', { minScore: 0.5 }],
+        'categories:accessibility': ['warn', { minScore: 0.9 }],
+        'categories:best-practices': ['warn', { minScore: 0.9 }],
+        'categories:seo': ['warn', { minScore: 0.9 }],
+      },
+    },
+    upload: {
+      target: 'filesystem',
+      outputDir: './.lighthouseci',
+      reportFilenamePattern: 'mobile-%%PATHNAME%%-%%DATETIME%%.report.%%EXTENSION%%',
+    },
+  },
+};


### PR DESCRIPTION
Three changes: two daily-challenge bug fixes from the reported screenshots, plus a CI config the failures surfaced.

---

## 1. Word Wheel overflows on short / landscape viewports (e.g. desktop 1136×473)

**Symptom:** the orbit letters overlap the instruction text above and the **FORMAR** / action bar below.

**Root cause:** the wheel's height cap relied **solely** on container-query units —
`max-h-[max(176px,calc(100cqb-116px))]` with a hard **176px floor**. When the flex / `cqb`
height-chain doesn't propagate a bounded height (or on a genuinely short viewport), `cqb`
resolves large, the cap never binds, and the wheel renders at its fixed `h-96` (**384px**) —
taller than the viewport. The `justify-center` cluster then overflows symmetrically and the
letters collide with their siblings.

**Fix**
- Added a `short:` (`@media (max-height:600px)`) **viewport cap (`svh`)** that bounds the wheel by a viewport fraction *and* `cqb`, with a lower floor: `short:max-h-[max(132px,min(calc(100cqb-72px),46svh))]` (+ matching `max-w`).
- Tightened cluster chrome on short viewports (hide redundant rule hint, smaller gaps/padding, shorter word-builder).
- Radius geometry measures from `min(width,height)` and feeds short-tuned `maxRadius`/`minRadius`/`letterAllowance` so the orbit doesn't floor onto the center letter. `computeWheelRadius` gained an optional, backward-compatible 4th `letterAllowance` param.

Tall phones/tablets are **untouched**.

## 2. AdMob banner covers the daily ready-screen Play CTA "sometimes" (native app)

**Root cause:** `/daily` is a banner-**blocked** route, but on navigation into it the anchored
banner's `--admob-banner-height` was zeroed **synchronously** while the native overlay was still
painted (`hideBanner()` has latency; a native banner composites *above* the WebView). The green
Play CTA keys off `--bottom-stack-height`, so it dropped into the band the lingering banner still
occupied — covered intermittently, depending on hide timing.

**Fix:** `await hideBanner()` before collapsing `--admob-banner-height`. Guarded by the existing
`cancelled` flag so a fast re-navigation can't stomp a fresh banner height.

## 3. Restore missing Lighthouse CI configs

The failing CI surfaced that `package.json`'s `lighthouse:ci` scripts reference
`lighthouserc.mobile.cjs` / `lighthouserc.desktop.cjs`, which **were never committed** — so the
`lighthouse` job failed every run with `ENOENT` (repo-wide, predates this PR).

**Fix:** added both configs — boot the custom server (`npm run start`, PORT 3001, `"Server ready"`
log), audit `/en` once per profile, **warn-level** category assertions (non-blocking; budgets TBD
by the team), reports to `.lighthouseci` via filesystem upload (no network/creds). Added a
regression test that fails if either config goes missing, and gitignored the output dir.

---

## Tests (strict TDD — RED → GREEN)
- `lib/wordWheel/__tests__/wheelGeometry.test.ts` — `letterAllowance` param + short bounds.
- `components/daily/__tests__/WordWheelGame.shortViewport.test.tsx` — `svh` short-cap present; tall sizing preserved.
- `components/ads/__tests__/AnchoredNativeBanner.test.tsx` — reservation held until `hideBanner()` resolves on a blocked route.
- `__tests__/lighthouseConfig.test.ts` — both lhci configs exist & expose the fields lhci needs.

## Known CI noise (unrelated to this PR)
The `ci-success` gate (`needs: [lint, type-check, test, build, bundle-analysis]`) has been going red
due to **pre-existing, unrelated flaky tests** on a resource-starved runner — `Header.musicControls`
(vitest worker-teardown rpc race) and `CrazyGamesSDK.embedSticky` (`waitFor` timeout). Both pass
locally and touch none of this PR's code; left as-is per discussion. `lighthouse` is `continue-on-error`
and not part of the gate.

https://claude.ai/code/session_01P1CvB9SRKgZHxoqryQvkTq