### PR TITLE
fix(mp): reconcile client/server round state to stop "game not in progress"

### DIFF
--- a/fe-next/backend/handlers/__tests__/wordHandler.test.ts
+++ b/fe-next/backend/handlers/__tests__/wordHandler.test.ts
@@ -104,7 +104,12 @@ vi.mock('../../../backend/modules/botManager', () => ({ isBot: vi.fn(() => false
 
 vi.mock('../../../backend/utils/errorHandler', () => ({
   emitError: vi.fn(),
-  ErrorCodes: { WORD_PROCESSING_ERROR: 'WORD_PROCESSING_ERROR', INVALID_STATE: 'INVALID_STATE' },
+  ErrorCodes: {
+    WORD_PROCESSING_ERROR: 'WORD_PROCESSING_ERROR',
+    INVALID_STATE: 'INVALID_STATE',
+    GAME_NOT_IN_PROGRESS: 'GAME_NOT_IN_PROGRESS',
+    PLAYER_NOT_IN_GAME: 'PLAYER_NOT_IN_GAME',
+  },
 }));
 
 vi.mock('../../../backend/middleware/rateLimiterRedis', () => ({
@@ -302,6 +307,56 @@ describe('wordHandler submitWord error handling', () => {
 
       // WHEN: User submits a word — should handle gracefully without throwing
       await expect(handlers['submitWord']({ word: 'test' })).resolves.not.toThrow();
+    });
+  });
+
+  describe('post-game grace window', () => {
+    // A player's last-second word often arrives just after the server has moved
+    // the round to 'finished'. The grace window must be forgiving enough to
+    // absorb real mobile/laggy latency instead of bouncing the word back as
+    // GAME_NOT_IN_PROGRESS. These tests pin the boundary behaviour.
+    const baseFinishedGame = {
+      gameCode: 'TEST123',
+      gameState: 'finished' as const,
+      language: 'en',
+      minWordLength: 2,
+      letterGrid: [['T', 'E'], ['S', 'T']],
+      letterPositions: new Map(),
+      playerWords: {},
+      playerWordDetails: {},
+      playerScores: {},
+      playerCombos: {},
+      users: { testUser: { isHost: false } },
+    };
+
+    it('accepts a word submitted 2s after the round finished (within the widened grace)', async () => {
+      // GIVEN: round finished 2s ago — beyond the old 1.5s window, within the new one
+      (getGame as Mock).mockReturnValue({
+        ...baseFinishedGame,
+        gameEndedAt: Date.now() - 2000,
+      });
+      (isWordOnBoardAsync as Mock).mockResolvedValue(true);
+
+      // WHEN: the late word arrives
+      await handlers['submitWord']({ word: 'test' });
+
+      // THEN: it is NOT rejected as not-in-progress
+      expect(emitError).not.toHaveBeenCalledWith(expect.anything(), 'GAME_NOT_IN_PROGRESS');
+      expect(emitError).not.toHaveBeenCalledWith(expect.anything(), 'GAME_NOT_IN_PROGRESS', expect.anything());
+    });
+
+    it('rejects a word submitted long after the grace window has closed', async () => {
+      // GIVEN: round finished 5s ago — outside any reasonable grace window
+      (getGame as Mock).mockReturnValue({
+        ...baseFinishedGame,
+        gameEndedAt: Date.now() - 5000,
+      });
+
+      // WHEN: the very-late word arrives
+      await handlers['submitWord']({ word: 'test' });
+
+      // THEN: it is rejected as not-in-progress
+      expect(emitError).toHaveBeenCalledWith(expect.anything(), 'GAME_NOT_IN_PROGRESS');
     });
   });
 });

--- a/fe-next/backend/handlers/wordHandler.ts
+++ b/fe-next/backend/handlers/wordHandler.ts
@@ -39,6 +39,7 @@ import { handleValidatedWord, handleWordBecameValid, handlePeerRejection, type P
 import { ensurePlayerState } from './playerDataInit';
 import { spamDetector, PenaltyTier, InvalidReason, type InvalidReasonValue } from '../modules/spamDetector.js';
 import { acquireGracePeriodLock, releaseGracePeriodLock } from '../services/gracePeriodLock';
+import { WORD_SUBMIT_GRACE_PERIOD_MS } from '../utils/graceWindow.js';
 import { calculateWordScore } from '../modules/scoringEngine.js';
 import { isWordShapeWeird } from '@/shared/utils/wordShapeFilter';
 import type { Language } from '@/shared/types';
@@ -201,9 +202,12 @@ function registerWordHandlers(io: Server, socket: Socket): void {
 
       const game = getGame(gameCode);
 
-      // Grace period: Allow word submissions for 1.5 seconds after game ends
-      // This handles network latency where client submits before receiving endGame event
-      const GRACE_PERIOD_MS = 1500;
+      // Grace period: Allow word submissions for a short window after the game
+      // ends. This handles network latency where a client submits a last-second
+      // word before it receives the endGame / timeUpdate(0) events (common on
+      // mobile and backgrounded tabs). Centralized in graceWindow.ts so the
+      // distributed grace lock TTL stays in lock-step. Env-overridable.
+      const GRACE_PERIOD_MS = WORD_SUBMIT_GRACE_PERIOD_MS;
       const isWithinGracePeriod = game?.gameEndedAt &&
         (Date.now() - game.gameEndedAt) < GRACE_PERIOD_MS &&
         game.gameState === 'finished';

--- a/fe-next/backend/services/gracePeriodLock.ts
+++ b/fe-next/backend/services/gracePeriodLock.ts
@@ -9,10 +9,13 @@
 import { randomUUID } from 'crypto';
 import { LOCK_PREFIX } from '../redis/config';
 import { acquireGameLock, releaseGameLock } from '../redis/locking';
+import { GRACE_PERIOD_LOCK_TTL_MS } from '../utils/graceWindow';
 import logger from '../utils/logger';
 
-// Grace period lock specific configuration
-const GRACE_PERIOD_LOCK_TTL = 2000; // 2 seconds max (grace period is 1.5s)
+// Grace period lock specific configuration. TTL is derived from the shared
+// grace-window constant so it always outlives the submit grace period (see
+// graceWindow.ts) — they previously drifted (lock 2s, grace 1.5s, hardcoded).
+const GRACE_PERIOD_LOCK_TTL = GRACE_PERIOD_LOCK_TTL_MS;
 const GRACE_PERIOD_LOCK_PREFIX = `${LOCK_PREFIX}:graceperiod`;
 
 /**

--- a/fe-next/backend/utils/__tests__/graceWindow.test.ts
+++ b/fe-next/backend/utils/__tests__/graceWindow.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Grace Window constants
+ *
+ * The post-game word-submit grace window is the single cushion that lets a
+ * player's last-second word land after the server has already transitioned the
+ * round to 'finished'. The previous 1.5s value was too tight for mobile / laggy
+ * links (a backgrounded tab routinely takes >1.5s to receive endGame), so
+ * last-second submissions were rejected as GAME_NOT_IN_PROGRESS. These tests pin
+ * the contract: a forgiving default, an env override, and a distributed-lock TTL
+ * that always outlives the grace window.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  WORD_SUBMIT_GRACE_PERIOD_MS,
+  GRACE_PERIOD_LOCK_TTL_MS,
+} from '../graceWindow';
+
+describe('graceWindow constants', () => {
+  it('defaults the word-submit grace window to a mobile-forgiving value (>= 3000ms)', () => {
+    expect(WORD_SUBMIT_GRACE_PERIOD_MS).toBeGreaterThanOrEqual(3000);
+  });
+
+  it('keeps the grace lock TTL strictly longer than the grace window', () => {
+    // The distributed lock must not expire before the grace window closes, or a
+    // late submission could be processed twice across instances.
+    expect(GRACE_PERIOD_LOCK_TTL_MS).toBeGreaterThan(WORD_SUBMIT_GRACE_PERIOD_MS);
+  });
+});

--- a/fe-next/backend/utils/graceWindow.ts
+++ b/fe-next/backend/utils/graceWindow.ts
@@ -1,0 +1,33 @@
+/**
+ * Post-game word-submit grace window
+ *
+ * When the server timer hits 0 the round transitions to 'finished' and the
+ * authoritative game state stops accepting words. But a player's last-second
+ * word is often already in flight — and on mobile / backgrounded tabs / laggy
+ * links the client can take well over a second to even receive the `endGame`
+ * and `timeUpdate(0)` events that tell it to stop. Without a forgiving cushion
+ * those in-flight words bounce back as GAME_NOT_IN_PROGRESS, which players
+ * experience as "it says game not in progress a lot".
+ *
+ * This is the single source of truth for that cushion so the word handler and
+ * the distributed grace-period lock can never drift apart.
+ */
+
+/**
+ * How long after a round finishes the server still accepts a word submission.
+ * Env-overridable so we can tune per-environment without a redeploy.
+ * Default widened from the original 1.5s to 3s after field reports of frequent
+ * end-of-round rejections on mobile.
+ */
+export const WORD_SUBMIT_GRACE_PERIOD_MS = parseInt(
+  process.env.WORD_SUBMIT_GRACE_PERIOD_MS || '3000',
+  10,
+);
+
+/**
+ * TTL for the per-player distributed lock that de-dupes grace-window
+ * submissions across instances. Must always outlive the grace window itself,
+ * otherwise the lock could expire mid-window and let a late word be processed
+ * twice.
+ */
+export const GRACE_PERIOD_LOCK_TTL_MS = WORD_SUBMIT_GRACE_PERIOD_MS + 1000;

--- a/fe-next/hooks/__tests__/useMultiplayerSocket.gameStateRecovery.test.ts
+++ b/fe-next/hooks/__tests__/useMultiplayerSocket.gameStateRecovery.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * useMultiplayerSocket — GAME_NOT_IN_PROGRESS recovery contract
+ *
+ * Root cause of "game not in progress a lot": the client's local `gameActive`
+ * flag and the server's `gameState` can drift (server restart bumps the room's
+ * gameSessionId backwards so `timeUpdate`s get filtered; a missed `endGame`;
+ * a stale board after reset). When that happens the player keeps submitting
+ * words and the server keeps replying GAME_NOT_IN_PROGRESS.
+ *
+ * Previously the only response was `socket.emit('debugGameState')` whose
+ * `debugGameStateResponse` handler merely logged — so the error repeated with
+ * no recovery. This test pins the fix: on GAME_NOT_IN_PROGRESS the client must
+ * trigger the real recovery path (`requestGameState`), and the
+ * `debugGameStateResponse` handler must reconcile (recover/reset) instead of
+ * being a pure log no-op.
+ */
+const source = readFileSync(
+  resolve(__dirname, '../useMultiplayerSocket.ts'),
+  'utf8',
+);
+
+describe('useMultiplayerSocket — game state recovery', () => {
+  it('requests authoritative game state when the server rejects with GAME_NOT_IN_PROGRESS', () => {
+    // The error handler branch that detects the not-in-progress mismatch must
+    // kick off the recovery path that the server actually services
+    // (requestGameState resends startGame / results), not just a debug query.
+    const errorHandler = source.slice(
+      source.indexOf("data?.code === 'GAME_NOT_IN_PROGRESS'"),
+    );
+    const branch = errorHandler.slice(0, errorHandler.indexOf('}'));
+    expect(branch).toMatch(/emit\(['"]requestGameState['"]\)/);
+  });
+
+  it('reconciles client state inside debugGameStateResponse instead of only logging', () => {
+    const handlerStart = source.indexOf("socketInstance.on('debugGameStateResponse'");
+    expect(handlerStart).toBeGreaterThan(-1);
+    // Grab the handler body up to the closing of the arrow callback.
+    const handlerBody = source.slice(handlerStart, handlerStart + 1400);
+    // It must act on the reported server state, not just log it.
+    expect(handlerBody).toMatch(/gameState/);
+    // 'waiting' on the server while the client thinks it's mid-game means the
+    // round was reset out from under the client — fall back to the reset path.
+    expect(handlerBody).toMatch(/onGameReset|requestGameState/);
+  });
+});

--- a/fe-next/hooks/useMultiplayerSocket.ts
+++ b/fe-next/hooks/useMultiplayerSocket.ts
@@ -316,6 +316,23 @@ export function useMultiplayerSocket(
 
     socketInstance.on('debugGameStateResponse', (data) => {
       logger.debug('[useMultiplayerSocket] Server game state:', data);
+      // Reconcile a client/server desync surfaced by a GAME_NOT_IN_PROGRESS
+      // rejection. If the server reports anything other than an active round,
+      // the client must stop treating the board as live.
+      const serverState = data?.gameState as string | undefined;
+      if (!serverState || serverState === 'in-progress') return;
+      if (serverState === 'finished' || serverState === 'validating') {
+        // Results exist (or are being computed) — pull them so the client
+        // leaves the dead board and shows the results screen.
+        logger.log('[SOCKET.IO] Server round finished while client active - requesting results');
+        socketInstance.emit('requestGameState');
+      } else if (serverState === 'waiting') {
+        // Round was reset out from under the client (host restarted / new
+        // round). Fall back to the reset path so the board is cleared and the
+        // player lands back in the lobby instead of submitting into the void.
+        logger.log('[SOCKET.IO] Server round reset while client active - clearing stale board');
+        optionsRef.current.onGameReset();
+      }
     });
 
     socketInstance.on('error', (data) => {
@@ -350,7 +367,15 @@ export function useMultiplayerSocket(
       }
 
       if (data?.code === 'GAME_NOT_IN_PROGRESS' || data?.message?.includes('not in progress')) {
-        logger.log('[SOCKET.IO] Game state mismatch - querying server for actual state');
+        // The client's local `gameActive` flag and the server's authoritative
+        // `gameState` have drifted (missed endGame, stale board after reset, or
+        // a gameSessionId desync after a server restart). `requestGameState` is
+        // the real recovery path: the server re-emits startGame (resyncs an
+        // in-progress round) or validatedScores (a finished round). We ALSO emit
+        // debugGameState so the response handler can reconcile the 'waiting'
+        // case (round was reset out from under us) that requestGameState ignores.
+        logger.log('[SOCKET.IO] Game state mismatch - requesting authoritative state to recover');
+        socketInstance.emit('requestGameState');
         socketInstance.emit('debugGameState');
       }
 

--- a/fe-next/player/hooks/socket/__tests__/usePlayerGameEvents.recoveryResync.test.ts
+++ b/fe-next/player/hooks/socket/__tests__/usePlayerGameEvents.recoveryResync.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * usePlayerGameEvents — recovery emits bypass the stale-session filter
+ *
+ * The stale-session guard drops any startGame whose gameSessionId is LOWER than
+ * the client's `gameSessionIdRef`. That is correct for genuinely-stale duplicate
+ * events, but it also silently drops the server's RECOVERY startGame after a
+ * server restart / instance switch — exactly when the client's ref has run ahead
+ * of the (reset) server counter. The result: the watchdog fires
+ * `requestGameState`, the server resends startGame with its real (lower) session
+ * id, and the client drops it again → the player stays stuck on a dead board and
+ * every submit returns GAME_NOT_IN_PROGRESS.
+ *
+ * Recovery/reconnect/late-join emits always carry the server's authoritative
+ * current state (they set `reconnect: true`), so they must bypass the
+ * stale-session filter and re-sync the ref downward.
+ */
+const source = readFileSync(
+  resolve(__dirname, '../usePlayerGameEvents.ts'),
+  'utf8',
+);
+
+describe('usePlayerGameEvents — recovery resync', () => {
+  it('does not drop a reconnect/recovery startGame on a lower gameSessionId', () => {
+    // Isolate the region from the top of handleStartGame up to the stale-session
+    // log line — this is where the guard (and its recovery exemption) must live.
+    const handleStart = source.slice(source.indexOf('const handleStartGame'));
+    const guardIdx = handleStart.indexOf('Ignoring stale startGame from old session');
+    expect(guardIdx).toBeGreaterThan(-1);
+    const guardRegion = handleStart.slice(0, guardIdx);
+    // The guard must derive a recovery flag from the reconnect marker...
+    expect(guardRegion).toMatch(/data\.reconnect/);
+    // ...and the stale-session condition itself must exempt that recovery flag,
+    // so a lower-session recovery emit is NOT dropped.
+    const lastIf = guardRegion.lastIndexOf('if (');
+    const condition = guardRegion.slice(lastIf);
+    expect(condition).toMatch(/!isRecoveryEmit|isRecoveryEmit\s*===\s*false|!.*reconnect/);
+  });
+});

--- a/fe-next/player/hooks/socket/usePlayerGameEvents.ts
+++ b/fe-next/player/hooks/socket/usePlayerGameEvents.ts
@@ -281,8 +281,18 @@ export function usePlayerGameEvents({
 
     const handleStartGame = (data: StartGameBroadcast) => {
       const ext = data as StartGameBroadcastExt;
-      // Validate session - ignore stale events
-      if (gameSessionIdRef.current !== null && ext.gameSessionId !== undefined &&
+      // Validate session - ignore stale events.
+      //
+      // EXCEPTION: reconnect/recovery/late-join emits (reconnect === true) always
+      // carry the server's authoritative CURRENT state. After a server restart or
+      // instance switch the room's gameSessionId resets backwards, so the client's
+      // ref runs ahead of the live server value — and the stale filter would then
+      // silently drop the very recovery startGame that requestGameState fetched to
+      // unstick the player. Letting recovery emits through re-syncs the ref
+      // downward (set below) so subsequent timeUpdates stop being filtered too.
+      const isRecoveryEmit = data.reconnect === true;
+      if (!isRecoveryEmit &&
+          gameSessionIdRef.current !== null && ext.gameSessionId !== undefined &&
           ext.gameSessionId < gameSessionIdRef.current) {
         logger.log('[PLAYER] Ignoring stale startGame from old session');
         return;


### PR DESCRIPTION
## Problem

In multiplayer, players frequently see **"game not in progress"** when submitting words. The game *start* is actually robust (the server flips to `in-progress` at the very top of the start handler, before any client can submit). The failures are all on the **end / reset / recovery** side.

## Root cause

The client's **local `gameActive` flag** and the server's **authoritative `gameState`** are derived from completely different signals, and nothing reconciled them when they drift. Once drifted, the client keeps the board live, the player keeps submitting, and the server keeps replying `GAME_NOT_IN_PROGRESS` — that repetition is the "a lot".

Three independent mechanisms drove the drift:

1. **No recovery on the error.** `GAME_NOT_IN_PROGRESS` only emitted `debugGameState`, whose response handler *just logged* (`useMultiplayerSocket.ts`). No reconciliation → the error repeated until a slower 5s watchdog happened to fire.
2. **Recovery emits were filtered out.** After a server restart/instance switch the room's `gameSessionId` resets backwards, so the client's `gameSessionIdRef` runs ahead. The stale-session filter in `usePlayerGameEvents` then **dropped the very recovery `startGame`** that `requestGameState` fetched to unstick the player → permanently stuck on a dead board.
3. **Grace window too tight.** The 1.5s post-end grace (and a separately-hardcoded 2s lock TTL) was too short for mobile/backgrounded tabs to receive `endGame`/`timeUpdate(0)`, so last-second words were rejected.

## Fixes (three reinforcing changes)

1. **Error recovery** (`useMultiplayerSocket.ts`): on `GAME_NOT_IN_PROGRESS`, emit `requestGameState` (the real recovery path) and make `debugGameStateResponse` reconcile — pull results when the server round is `finished`/`validating`, or clear the board via `onGameReset()` when the server has reset to `waiting`.
2. **Recovery resync** (`usePlayerGameEvents.ts`): reconnect/recovery `startGame` emits (`reconnect === true`) now bypass the stale-`gameSessionId` filter and re-sync the ref downward, so subsequent `timeUpdate`s stop being filtered too.
3. **Grace window** (`backend/utils/graceWindow.ts`): centralized the post-game submit grace, widened **1.5s → 3s** (env-overridable via `WORD_SUBMIT_GRACE_PERIOD_MS`), and derived the distributed grace-lock TTL from it so the two can never drift apart again.

## Tests

TDD (RED → GREEN). New/extended tests, all passing:
- `backend/utils/__tests__/graceWindow.test.ts` — grace defaults + lock-TTL invariant
- `backend/handlers/__tests__/wordHandler.test.ts` — accepts a word 2s after finish (within widened grace), rejects at 5s
- `hooks/__tests__/useMultiplayerSocket.gameStateRecovery.test.ts` — error triggers `requestGameState`; response handler reconciles
- `player/hooks/socket/__tests__/usePlayerGameEvents.recoveryResync.test.ts` — recovery emits bypass the stale-session filter

Regression suites green: backend `wordHandler`/`gameLifecycle` (128), `player/hooks/socket` (29), timer-stall watchdog (10). `tsc` + `eslint` clean on changed files.

## Notes
- Net behavior change for players: end-of-round latency tolerance ~doubled; desynced clients now self-heal from the error instead of spamming it.
- `WORD_SUBMIT_GRACE_PERIOD_MS` can be tuned per-environment without a redeploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149cyfodvbiNF5F8aCfnBUH)_