### PR TITLE
fix: stop useChurnSignals timer churn and restore Sentry error visibility

### DIFF
--- a/fe-next/hooks/__tests__/useChurnSignals.test.tsx
+++ b/fe-next/hooks/__tests__/useChurnSignals.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * useChurnSignals Hook Tests
+ *
+ * Regression guard for the "failed to report signals {}" + app-unresponsive
+ * report. The hook must:
+ *  - report via an authenticated POST (so it stops 401-ing),
+ *  - keep a STABLE reportSignals identity across the 1Hz session-length
+ *    re-renders (so the report interval is not torn down/recreated every
+ *    second — the source of the unresponsiveness),
+ *  - guard against overlapping in-flight reports,
+ *  - log a real Error (never an empty {}) when a report fails,
+ *  - no-op cleanly when there is no authenticated user.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const { mockUseAuth } = vi.hoisted(() => ({ mockUseAuth: vi.fn() }));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: (...args: unknown[]) => mockUseAuth(...args),
+}));
+
+const { mockPostWithAuth } = vi.hoisted(() => ({ mockPostWithAuth: vi.fn() }));
+vi.mock('@/utils/authFetch', () => ({
+  postWithAuth: (...args: unknown[]) => mockPostWithAuth(...args),
+}));
+
+const { mockLoggerError } = vi.hoisted(() => ({ mockLoggerError: vi.fn() }));
+vi.mock('@/utils/logger', () => ({
+  default: { error: (...a: unknown[]) => mockLoggerError(...a), warn: vi.fn(), log: vi.fn(), debug: vi.fn() },
+}));
+
+import { useChurnSignals } from '../useChurnSignals';
+
+const okResponse = () => ({ ok: true, status: 200, json: async () => ({}) }) as unknown as Response;
+
+beforeEach(() => {
+  mockUseAuth.mockReturnValue({ user: { id: 'user-123' } });
+  mockPostWithAuth.mockReset();
+  mockPostWithAuth.mockResolvedValue(okResponse());
+  mockLoggerError.mockReset();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useChurnSignals', () => {
+  it('reports via authenticated POST to the churn-signals endpoint', async () => {
+    const { result } = renderHook(() => useChurnSignals());
+
+    await act(async () => {
+      await result.current.reportSignals();
+    });
+
+    expect(mockPostWithAuth).toHaveBeenCalledTimes(1);
+    expect(mockPostWithAuth.mock.calls[0][0]).toBe('/api/growth/churn-signals');
+  });
+
+  it('does not start overlapping reports while one is in flight', async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    mockPostWithAuth.mockReturnValue(new Promise<Response>((res) => { resolveFetch = res; }));
+
+    const { result } = renderHook(() => useChurnSignals());
+
+    await act(async () => {
+      // fire two reports back-to-back before the first resolves
+      result.current.reportSignals();
+      result.current.reportSignals();
+    });
+
+    expect(mockPostWithAuth).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFetch(okResponse());
+    });
+  });
+
+  it('logs a real Error (not an empty object) when the report fails', async () => {
+    mockPostWithAuth.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useChurnSignals());
+
+    await act(async () => {
+      await result.current.reportSignals();
+    });
+
+    await waitFor(() => expect(mockLoggerError).toHaveBeenCalled());
+    const errArg = mockLoggerError.mock.calls[0].find((a: unknown) => a instanceof Error);
+    expect(errArg).toBeInstanceOf(Error);
+  });
+
+  it('treats a non-ok HTTP response as a failure and logs it', async () => {
+    mockPostWithAuth.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) } as unknown as Response);
+
+    const { result } = renderHook(() => useChurnSignals());
+
+    await act(async () => {
+      await result.current.reportSignals();
+    });
+
+    await waitFor(() => expect(mockLoggerError).toHaveBeenCalled());
+    const errArg = mockLoggerError.mock.calls[0].find((a: unknown) => a instanceof Error);
+    expect(errArg).toBeInstanceOf(Error);
+  });
+
+  it('keeps a stable reportSignals identity across re-renders', () => {
+    const { result, rerender } = renderHook(() => useChurnSignals());
+    const first = result.current.reportSignals;
+    rerender();
+    rerender();
+    expect(result.current.reportSignals).toBe(first);
+  });
+
+  it('does nothing when there is no authenticated user', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    const { result } = renderHook(() => useChurnSignals());
+
+    await act(async () => {
+      await result.current.reportSignals();
+    });
+
+    expect(mockPostWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('fires the periodic report exactly once per interval despite 1Hz re-renders', async () => {
+    vi.useFakeTimers();
+    try {
+      renderHook(() => useChurnSignals());
+
+      // Advance 5 minutes worth of 1-second session-length ticks + the report interval.
+      await act(async () => {
+        vi.advanceTimersByTime(5 * 60 * 1000);
+      });
+
+      // Exactly one periodic report — not zero (interval never reset away) and
+      // not many (no duplicate intervals stacking up).
+      expect(mockPostWithAuth).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/fe-next/hooks/useChurnSignals.ts
+++ b/fe-next/hooks/useChurnSignals.ts
@@ -8,12 +8,13 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useMutation } from '@tanstack/react-query';
 import { useAuth } from '@/contexts/AuthContext';
+import { postWithAuth } from '@/utils/authFetch';
 import logger from '@/utils/logger';
 
 const STORAGE_KEY = 'lexiclash_churn_signals';
 const REPORT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const ENDPOINT = '/api/growth/churn-signals';
 
 interface StoredSignals {
   sessionStartedAt: number;
@@ -65,6 +66,16 @@ function saveSignals(signals: StoredSignals): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(signals));
 }
 
+function buildPayload(userId: string, signals: StoredSignals) {
+  return {
+    userId,
+    avgSessionLengthSeconds: Math.floor((Date.now() - signals.sessionStartedAt) / 1000),
+    gamesPerSession: signals.gamesPlayed,
+    socialInteractions: signals.socialInteractions,
+    notificationDismissals: signals.notificationDismissals,
+  };
+}
+
 export function useChurnSignals(): UseChurnSignalsReturn {
   const { user } = useAuth();
   const userId = user?.id ?? null;
@@ -72,47 +83,36 @@ export function useChurnSignals(): UseChurnSignalsReturn {
   const signalsRef = useRef<StoredSignals>(getStoredSignals());
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const reportIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Guards against overlapping in-flight reports. A failed/slow request must
+  // never queue up a backlog of concurrent POSTs.
+  const inFlightRef = useRef(false);
 
-  const reportMutation = useMutation({
-    mutationFn: async (payload: {
-      userId: string;
-      avgSessionLengthSeconds: number;
-      gamesPerSession: number;
-      socialInteractions: number;
-      notificationDismissals: number;
-    }) => {
-      await fetch('/api/growth/churn-signals', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-    },
-    onSuccess: () => {
-      signalsRef.current = {
-        ...signalsRef.current,
-        lastReportedAt: Date.now(),
-      };
-      saveSignals(signalsRef.current);
-    },
-    onError: (err) => {
-      logger.error('useChurnSignals: failed to report signals', err);
-    },
-  });
-
+  // Stable across renders (depends only on userId). Previously this depended on
+  // the react-query mutation object, whose identity changed on every render —
+  // and because the 1Hz session-length tick re-renders the component, the
+  // report interval below was torn down and recreated every second (so it
+  // never actually fired, and the constant timer churn degraded the app).
   const reportSignals = useCallback(async () => {
     if (!userId) return;
+    if (inFlightRef.current) return;
 
+    inFlightRef.current = true;
     const signals = signalsRef.current;
-    const sessionLengthSeconds = Math.floor((Date.now() - signals.sessionStartedAt) / 1000);
-
-    reportMutation.mutate({
-      userId,
-      avgSessionLengthSeconds: sessionLengthSeconds,
-      gamesPerSession: signals.gamesPlayed,
-      socialInteractions: signals.socialInteractions,
-      notificationDismissals: signals.notificationDismissals,
-    });
-  }, [userId, reportMutation]);
+    try {
+      const response = await postWithAuth(ENDPOINT, buildPayload(userId, signals));
+      if (!response.ok) {
+        throw new Error(`churn-signals report failed with status ${response.status}`);
+      }
+      signalsRef.current = { ...signalsRef.current, lastReportedAt: Date.now() };
+      saveSignals(signalsRef.current);
+    } catch (err) {
+      // Pass the Error as an argument so Sentry captures the stack (the logger
+      // scans all args for an Error) instead of serialising it to "{}".
+      logger.error('useChurnSignals: failed to report signals', err);
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, [userId]);
 
   const trackGamePlayed = useCallback(() => {
     signalsRef.current.gamesPlayed += 1;
@@ -147,7 +147,8 @@ export function useChurnSignals(): UseChurnSignalsReturn {
     };
   }, []);
 
-  // Report every 5 minutes
+  // Report every 5 minutes. reportSignals is stable, so this interval is set up
+  // once per session (not rebuilt on every render).
   useEffect(() => {
     if (!userId) return;
 
@@ -160,25 +161,16 @@ export function useChurnSignals(): UseChurnSignalsReturn {
     };
   }, [userId, reportSignals]);
 
-  // Report on session end (beforeunload)
+  // Report on session end (beforeunload). sendBeacon is best-effort and cannot
+  // carry an Authorization header, so it is purely supplementary to the
+  // authenticated periodic report above.
   useEffect(() => {
     if (!userId || typeof window === 'undefined') return;
 
     const handleUnload = () => {
-      const signals = signalsRef.current;
-      const sessionLengthSeconds = Math.floor((Date.now() - signals.sessionStartedAt) / 1000);
-
-      // Use sendBeacon for reliable delivery on unload
-      const payload = JSON.stringify({
-        userId,
-        avgSessionLengthSeconds: sessionLengthSeconds,
-        gamesPerSession: signals.gamesPlayed,
-        socialInteractions: signals.socialInteractions,
-        notificationDismissals: signals.notificationDismissals,
-      });
-
+      const payload = JSON.stringify(buildPayload(userId, signalsRef.current));
       if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
-        navigator.sendBeacon('/api/growth/churn-signals', new Blob([payload], { type: 'application/json' }));
+        navigator.sendBeacon(ENDPOINT, new Blob([payload], { type: 'application/json' }));
       }
     };
 

--- a/fe-next/utils/__tests__/logger.errorSerialization.test.ts
+++ b/fe-next/utils/__tests__/logger.errorSerialization.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Logger error-serialization tests
+ *
+ * Regression guard for the "{}" symptom: callers overwhelmingly use the
+ * pattern `logger.error('some message:', err)` where the Error is NOT the
+ * first argument. The production Sentry path must still capture the Error
+ * (with its stack) via captureException instead of JSON.stringify-ing it
+ * into "{}" and dropping it through captureMessage.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const { captureException, captureMessage } = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => captureException(...args),
+  captureMessage: (...args: unknown[]) => captureMessage(...args),
+}));
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+async function loadLoggerInProduction() {
+  vi.resetModules();
+  captureException.mockClear();
+  captureMessage.mockClear();
+  // logger reads NODE_ENV at module-eval time, so set it before importing.
+  (process.env as Record<string, string>).NODE_ENV = 'production';
+  const mod = await import('../logger');
+  return mod.default;
+}
+
+describe('logger error serialization (production)', () => {
+  afterEach(() => {
+    (process.env as Record<string, string>).NODE_ENV = ORIGINAL_NODE_ENV ?? 'test';
+  });
+
+  it('captures the Error via captureException when it is NOT the first argument', async () => {
+    const logger = await loadLoggerInProduction();
+    const realError = new Error('boom: real cause with stack');
+
+    logger.error('useChurnSignals: failed to report signals', realError);
+
+    // The actual Error object must reach Sentry so the stack/grouping survive.
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException.mock.calls[0][0]).toBe(realError);
+
+    // It must NOT be funnelled through captureMessage as "... {}".
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('includes the leading string message as context when capturing an Error', async () => {
+    const logger = await loadLoggerInProduction();
+    const realError = new Error('network down');
+
+    logger.error('Auth callback exception:', realError);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [errArg, options] = captureException.mock.calls[0] as [unknown, Record<string, any>];
+    expect(errArg).toBe(realError);
+    const contextValues = JSON.stringify(options?.contexts ?? {});
+    expect(contextValues).toContain('Auth callback exception:');
+  });
+
+  it('still uses captureMessage when no Error object is present', async () => {
+    const logger = await loadLoggerInProduction();
+
+    logger.error('plain message', { code: 42 });
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures the Error even when it is the first argument (existing behavior preserved)', async () => {
+    const logger = await loadLoggerInProduction();
+    const realError = new Error('first-arg error');
+
+    logger.error(realError, 'extra context');
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException.mock.calls[0][0]).toBe(realError);
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('logger warn serialization (production)', () => {
+  afterEach(() => {
+    (process.env as Record<string, string>).NODE_ENV = ORIGINAL_NODE_ENV ?? 'test';
+  });
+
+  it('captures an Error passed to warn via captureException at warning level (not "{}")', async () => {
+    const logger = await loadLoggerInProduction();
+    const realError = new Error('leaderboard sync failed');
+
+    logger.warn('[useLeaderboardSync] Failed to sync leaderboard:', realError);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException.mock.calls[0][0]).toBe(realError);
+    // level should be downgraded to warning
+    const options = captureException.mock.calls[0][1] as Record<string, any>;
+    expect(options?.level).toBe('warning');
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('still uses captureMessage for warn when no Error object is present', async () => {
+    const logger = await loadLoggerInProduction();
+
+    logger.warn('plain warning', { detail: true });
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/fe-next/utils/logger.ts
+++ b/fe-next/utils/logger.ts
@@ -35,7 +35,25 @@ class FrontendLogger {
    */
   warn(...args: unknown[]): void {
     if (isProduction) {
-      // Send to Sentry but don't show in console
+      // Send to Sentry but don't show in console.
+      // Like error(), a common pattern is `logger.warn('msg:', err)`. Capture
+      // the Error so its stack survives instead of becoming "{}".
+      const errorArg = args.find((arg): arg is Error => arg instanceof Error);
+
+      if (errorArg) {
+        Sentry.captureException(errorArg, {
+          level: 'warning',
+          contexts: {
+            warning_details: {
+              additional_args: args
+                .filter(arg => arg !== errorArg)
+                .map(arg => String(arg))
+            }
+          }
+        });
+        return;
+      }
+
       const message = args.map(arg =>
         typeof arg === 'string' ? arg : JSON.stringify(arg)
       ).join(' ');
@@ -60,15 +78,22 @@ class FrontendLogger {
    */
   error(...args: unknown[]): void {
     if (isProduction) {
-      // Send to Sentry but don't show in console
-      const firstArg = args[0];
+      // Send to Sentry but don't show in console.
+      // Scan ALL args for an Error — the dominant call pattern is
+      // `logger.error('some message:', err)`, where the Error is NOT the
+      // first argument. JSON.stringify-ing an Error yields "{}" (its fields
+      // are non-enumerable), so funnelling these through captureMessage
+      // silently drops the stack and real message. captureException keeps
+      // both and groups correctly.
+      const errorArg = args.find((arg): arg is Error => arg instanceof Error);
 
-      if (firstArg instanceof Error) {
-        // If it's an Error object, capture it properly
-        Sentry.captureException(firstArg, {
+      if (errorArg) {
+        Sentry.captureException(errorArg, {
           contexts: {
             error_details: {
-              additional_args: args.slice(1).map(arg => String(arg))
+              additional_args: args
+                .filter(arg => arg !== errorArg)
+                .map(arg => String(arg))
             }
           }
         });


### PR DESCRIPTION
## Problem

Two reported symptoms, both surfacing as a useless `{}` in logs:

- `useChurnSignals: failed to report signals {}` — and the whole app felt **unresponsive**.
- `Auth callback exception: {}`.

## Root causes

### 1. `useChurnSignals` timer churn + broken/unauthenticated reporting (the unresponsiveness)
`reportSignals` was a `useCallback` that depended on the **react-query mutation object**, whose identity changes on every render. Because the hook's 1Hz session-length tick re-renders the component every second, the "report every 5 minutes" `useEffect` (which depended on `reportSignals`) was **torn down and recreated every single second**:

- the 5-minute interval never survived long enough to fire, so periodic reporting silently never happened, and
- the constant `clearInterval`/`setInterval` churn (in a component mounted in the **root layout**) degraded responsiveness.

On top of that, the report used a raw `fetch` with **no `Authorization` header** (the endpoint requires a Bearer token, so every report `401`'d) and **never checked `response.ok`**.

**Fix:** rewrote the hook without react-query. `reportSignals` is now stable (`deps: [userId]`), posts through `authFetch.postWithAuth` (authenticated + token refresh), checks `response.ok`, and guards against overlapping in-flight reports.

### 2. The `{}` itself — a systemic logger bug (explains *both* reports)
`logger.error('some message:', err)` passed the `Error` as the **second** argument. The production Sentry path only called `captureException` when the **first** arg was an `Error`; otherwise it `JSON.stringify`'d everything — and `JSON.stringify(error)` is `"{}"` because `Error` fields are non-enumerable. The real message and stack were dropped through `captureMessage`.

This is the dominant call pattern across the codebase (~1200 `logger.error(...)` + ~50 `logger.warn(...)` sites), so error visibility was broadly degraded — including the separately reported `Auth callback exception: {}`.

**Fix:** `logger.error` / `logger.warn` now scan **all** arguments for an `Error` and route it through `captureException` (warn at `level: 'warning'`), preserving stack and Sentry grouping. The remaining args become context.

## "More issues like this"
- The `{}` was not specific to churn signals — it was the logger, affecting every `logger.error('msg', err)` / `logger.warn('msg', err)` site. Fixing the logger fixes all of them at once (incl. the auth-callback report).
- Swept hooks for the same react-query-object-in-dependency-array churn pattern; it was isolated to `useChurnSignals`.

## Tests (TDD, RED → GREEN)
- `utils/__tests__/logger.errorSerialization.test.ts` — Error captured via `captureException` regardless of arg position (and not `{}` via `captureMessage`), for both `error` and `warn`.
- `hooks/__tests__/useChurnSignals.test.tsx` — authenticated POST, stable `reportSignals` identity across re-renders, in-flight guard, non-ok/rejection logs a real `Error`, no-op without a user, and the periodic report fires **exactly once** per interval despite 1Hz re-renders.

All 13 tests pass; `tsc --noEmit` clean on the changed files.

https://claude.ai/code/session_018538E6DvxrAPU8QXvfVSua

---
_Generated by [Claude Code](https://claude.ai/code/session_018538E6DvxrAPU8QXvfVSua)_