### PR TITLE
Polish Wheel Rush MP: calm found-words, single rival, translate-safe tiles, reconnect sync

### DIFF
--- a/fe-next/backend/handlers/__tests__/wheelRushHandler.test.ts
+++ b/fe-next/backend/handlers/__tests__/wheelRushHandler.test.ts
@@ -46,10 +46,16 @@ vi.mock('../../modules/wheelRushManager', () => ({
   reapExpiredLocks: vi.fn(() => []),
 }));
 
+vi.mock('../../modules/scoreManager', () => ({
+  getLeaderboard: vi.fn(() => []),
+  getLeaderboardThrottled: vi.fn(),
+}));
+
 import { handleSubmitWheelWord, handleRequestWheelRushState } from '../wheelRushHandler';
 import { broadcastToRoom } from '../../utils/socketHelpers';
 import { getGame, updatePlayerScore, addPlayerWord } from '../../modules/gameStateManager';
 import { validateWheelSubmission, applyWheelWord } from '../../modules/wheelRushManager';
+import { getLeaderboard } from '../../modules/scoreManager';
 import timerManager from '../../utils/timerManager';
 
 const mkSocket = () => ({ id: 's1', emit: vi.fn() } as unknown as Socket);
@@ -161,6 +167,24 @@ describe('wheelRushHandler', () => {
       const sock = mkSocket();
       handleRequestWheelRushState(sock);
       expect(sock.emit).not.toHaveBeenCalled();
+    });
+
+    it('also pushes the current leaderboard so a reconnecting player sees fresh opponent scores immediately', () => {
+      // Reconnect/late-join: opponent scores only otherwise refresh on the next
+      // score event, leaving the rival chip stale (or empty) until then.
+      (getGame as unknown as Mock).mockReturnValue(gameBase);
+      (getLeaderboard as unknown as Mock).mockReturnValue([
+        { username: 'p1', score: 30 },
+        { username: 'p2', score: 50 },
+      ]);
+      const sock = mkSocket();
+      handleRequestWheelRushState(sock);
+      expect(sock.emit).toHaveBeenCalledWith('updateLeaderboard', {
+        leaderboard: [
+          { username: 'p1', score: 30 },
+          { username: 'p2', score: 50 },
+        ],
+      });
     });
   });
 

--- a/fe-next/backend/handlers/wheelRushHandler.ts
+++ b/fe-next/backend/handlers/wheelRushHandler.ts
@@ -12,6 +12,7 @@ import {
   addPlayerWord,
 } from '../modules/gameStateManager.js';
 import {
+  getLeaderboard,
   getLeaderboardThrottled,
   type LeaderboardPlayer,
   type ScoreGameBase,
@@ -152,6 +153,12 @@ export function handleRequestWheelRushState(socket: Socket): void {
     closed: state.closed ?? [],
     myWords: username ? (state.foundWords?.[username] ?? []) : [],
   });
+  // Also push a fresh leaderboard directly to this socket. Opponent scores
+  // otherwise only refresh on the next score broadcast, so a reconnecting or
+  // late-joining player would stare at a stale (or empty) rival chip until
+  // someone next scores. This is a single-socket emit, not a room broadcast.
+  const leaderboard = getLeaderboard(game as unknown as ScoreGameBase, gameCode);
+  socket.emit('updateLeaderboard', { leaderboard });
 }
 
 export function registerWheelRushHandlers(io: Server, socket: Socket): void {

--- a/fe-next/components/daily/WordWheelParts.tsx
+++ b/fe-next/components/daily/WordWheelParts.tsx
@@ -78,8 +78,12 @@ export const WheelLetter: React.FC<WheelLetterProps> = ({
     <m.button
       ref={btnRef}
       type="button"
+      // `translate="no"` (+ notranslate) stops browser auto-translation from
+      // rewriting a single letter into a word in the target language — e.g.
+      // Google Translate turning the tile "I" into Indonesian "saya".
+      translate="no"
       className={cn(
-        'absolute inset-0 m-auto flex items-center justify-center font-neo-display font-black uppercase select-none touch-manipulation',
+        'notranslate absolute inset-0 m-auto flex items-center justify-center font-neo-display font-black uppercase select-none touch-manipulation',
         // Invisible hit-area expander (≥48px WCAG AAA). Fixes rageclicks on Hebrew RTL wheel.
         'before:absolute before:-inset-2 before:content-[""]',
         'border-3 border-neo-black rounded-full transition-colors duration-150',
@@ -152,8 +156,9 @@ export const WordTile: React.FC<WordTileProps> = ({ letter, index, onRemove, isC
   return (
   <m.button
     type="button"
+    translate="no"
     className={cn(
-      'group relative w-8 h-10 sm:w-10 sm:h-12 md:w-12 md:h-14 rounded-neo border-3 border-neo-black flex items-center justify-center touch-manipulation',
+      'notranslate group relative w-8 h-10 sm:w-10 sm:h-12 md:w-12 md:h-14 rounded-neo border-3 border-neo-black flex items-center justify-center touch-manipulation',
       'before:absolute before:-inset-2 before:content-[""]',
       'font-neo-display font-black text-base sm:text-lg md:text-xl cursor-pointer',
       'active:shadow-hard-pressed active:translate-x-px active:translate-y-px',

--- a/fe-next/components/daily/__tests__/WheelLetter.tapFeedback.test.tsx
+++ b/fe-next/components/daily/__tests__/WheelLetter.tapFeedback.test.tsx
@@ -84,6 +84,23 @@ describe('WheelLetter mobile tap feedback', () => {
     expect(btn.className).toMatch(/before:-inset-2/);
   });
 
+  it('guards each letter from browser auto-translation (e.g. "I" must not become "saya")', () => {
+    render(
+      <WheelLetter
+        letter="I"
+        isCenter={false}
+        angle={0}
+        radius={100}
+        onPress={vi.fn()}
+        isUsed={false}
+        index={1}
+      />
+    );
+    const btn = screen.getByRole('button', { name: 'I' });
+    expect(btn.getAttribute('translate')).toBe('no');
+    expect(btn.className).toContain('notranslate');
+  });
+
   it('used letters expose aria-pressed=true + tapToRemove label', () => {
     render(
       <WheelLetter

--- a/fe-next/components/multiplayer/WheelRushHeader.tsx
+++ b/fe-next/components/multiplayer/WheelRushHeader.tsx
@@ -6,6 +6,7 @@ import Avatar from '@/components/Avatar';
 import { Button } from '@/components/ui/button';
 import CircularTimer from '@/components/ui/CircularTimer';
 import { cn } from '@/lib/utils';
+import { selectClosestRival } from '@/lib/wheelRush/closestRival';
 import type { Avatar as AvatarType, PresenceStatus } from '@/shared/types/game';
 
 export interface WheelRushPlayer {
@@ -39,10 +40,12 @@ const ProgressBar: React.FC<{ ratio: number; tone: 'self' | 'opp' }> = ({ ratio,
 
 export const WheelRushHeader: React.FC<Props> = ({ leaderboard, username, fogActive, remainingTime, totalTime, onQuit, t }) => {
   const self = useMemo(() => leaderboard.find(p => p.username === username), [leaderboard, username]);
-  const opponents = useMemo(
-    () => leaderboard.filter(p => p.username !== username).sort((a, b) => b.score - a.score).slice(0, 3),
-    [leaderboard, username],
-  );
+  // Surface a SINGLE rival — the opponent nearest in score — so the player
+  // focuses on one head-to-head instead of scanning a crowded rail.
+  const opponents = useMemo(() => {
+    const rival = selectClosestRival(leaderboard, username);
+    return rival ? [rival] : [];
+  }, [leaderboard, username]);
   const maxScore = useMemo(() => leaderboard.reduce((m, p) => Math.max(m, p.score), 0), [leaderboard]);
   const leaderScore = Math.max(maxScore, 1);
   const selfScore = self?.score ?? 0;
@@ -78,13 +81,13 @@ export const WheelRushHeader: React.FC<Props> = ({ leaderboard, username, fogAct
                       )}
                     />
                   </span>
-                  <span dir="auto" className="font-neo-display font-bold text-[11px] text-neo-white truncate">{p.username}</span>
+                  <span dir="auto" translate="no" className="notranslate font-neo-display font-bold text-[11px] text-neo-white truncate">{p.username}</span>
                 </div>
                 <div className="flex items-baseline justify-between mt-0.5">
                   {fogActive ? (
                     <span className="font-neo-display font-black text-sm text-neo-cyan tracking-wider">???</span>
                   ) : (
-                    <span className="font-neo-display font-black text-sm text-neo-white tabular-nums">{p.score}</span>
+                    <span translate="no" className="notranslate font-neo-display font-black text-sm text-neo-white tabular-nums">{p.score}</span>
                   )}
                   {!fogActive && (p.wordCount ?? 0) > 0 && (
                     <span className="text-[10px] text-neo-white tabular-nums">{p.wordCount}w</span>
@@ -139,13 +142,14 @@ export const WheelRushHeader: React.FC<Props> = ({ leaderboard, username, fogAct
         <div className="flex flex-col min-w-0 flex-1">
           <span className="flex items-center gap-1 text-[11px] font-neo-display font-bold uppercase tracking-wide opacity-70">
             {isLeader && <Crown className="w-3 h-3" />}
-            <span dir="auto" className="truncate">{self?.username ?? username}</span>
+            <span dir="auto" translate="no" className="notranslate truncate">{self?.username ?? username}</span>
           </span>
           {!fogActive && <ProgressBar ratio={selfScore / leaderScore} tone="self" />}
         </div>
         <span
           data-testid="wheel-self-score"
-          className="font-neo-display font-black text-3xl leading-none tabular-nums shrink-0"
+          translate="no"
+          className="notranslate font-neo-display font-black text-3xl leading-none tabular-nums shrink-0"
         >
           {selfScore}
         </span>

--- a/fe-next/components/multiplayer/WheelRushPieces.test.tsx
+++ b/fe-next/components/multiplayer/WheelRushPieces.test.tsx
@@ -22,3 +22,47 @@ describe('MyWordsChips word direction', () => {
     expect(screen.getByTestId('my-words-slot')).toHaveAttribute('dir', 'ltr');
   });
 });
+
+describe('MyWordsChips styling', () => {
+  const entry = (kind: WordEntry['kind']): WordEntry => ({ word: 'VEND', kind, score: 24, ts: 0 });
+
+  it('guards the words list from browser auto-translation (letters must not be rewritten)', () => {
+    render(<MyWordsChips words={[entry('locked')]} />);
+    const slot = screen.getByTestId('my-words-slot');
+    expect(slot).toHaveAttribute('translate', 'no');
+    expect(slot.className).toContain('notranslate');
+  });
+
+  it('renders calm, dark chips instead of full-saturation fills', () => {
+    const { container } = render(<MyWordsChips words={[entry('closed')]} />);
+    const chip = container.querySelector('[data-kind="closed"]') as HTMLElement;
+    // Closed words use the neutral dark surface — NOT the old solid bg-neo-cyan.
+    expect(chip.className).toContain('bg-neo-navy-light');
+    expect(chip.className).not.toContain('bg-neo-cyan ');
+  });
+
+  it('gives every chip the same fixed height so the row never looks ragged', () => {
+    const { container } = render(
+      <MyWordsChips words={[entry('locked'), entry('stolen'), entry('closed'), entry('stolen-from-me')]} />,
+    );
+    const chips = container.querySelectorAll('[data-kind]');
+    expect(chips.length).toBe(4);
+    chips.forEach(chip => expect((chip as HTMLElement).className).toContain('h-7'));
+  });
+
+  it('still distinguishes word status by a subtle tinted border per kind', () => {
+    const { container } = render(
+      <MyWordsChips words={[entry('locked'), entry('stolen'), entry('stolen-from-me')]} />,
+    );
+    expect((container.querySelector('[data-kind="locked"]') as HTMLElement).className).toContain('border-neo-lime');
+    expect((container.querySelector('[data-kind="stolen"]') as HTMLElement).className).toContain('border-neo-pink');
+    const lost = container.querySelector('[data-kind="stolen-from-me"]') as HTMLElement;
+    expect(lost.className).toContain('border-neo-red');
+    expect(lost.className).toContain('line-through');
+  });
+
+  it('shows the score on a chip', () => {
+    render(<MyWordsChips words={[entry('locked')]} />);
+    expect(screen.getByText('+24')).toBeTruthy();
+  });
+});

--- a/fe-next/components/multiplayer/WheelRushPieces.tsx
+++ b/fe-next/components/multiplayer/WheelRushPieces.tsx
@@ -19,6 +19,20 @@ interface MyWordsChipsProps {
   dir?: 'rtl' | 'ltr';
 }
 
+// Calm, dark chips that mirror the daily-challenge found-words language
+// (bg-neo-navy-light surface, white text) instead of full-saturation fills.
+// Status is encoded by a subtle tinted border + a small accent on the score
+// so the list reads as a quiet log, not a distracting rave. Each chip is a
+// fixed height so the row never looks ragged. `translate="no"` keeps browser
+// auto-translation (e.g. Indonesian turning the letters "I" into "saya") from
+// rewriting the player's own words.
+const CHIP_TONE: Record<WordEntry['kind'], { chip: string; score: string }> = {
+  locked: { chip: 'bg-neo-lime/15 border-neo-lime', score: 'text-neo-lime' },
+  closed: { chip: 'bg-neo-navy-light border-neo-black', score: 'text-neo-cyan' },
+  stolen: { chip: 'bg-neo-pink/15 border-neo-pink', score: 'text-neo-pink' },
+  'stolen-from-me': { chip: 'bg-neo-red/10 border-neo-red text-neo-white/50 line-through', score: 'text-neo-red/70' },
+};
+
 export const MyWordsChips: React.FC<MyWordsChipsProps> = ({ words, dir = 'ltr' }) => {
   // Always render a fixed-height slot so the wheel cluster's `flex-1
   // justify-center` doesn't re-center when the first chip lands. Empty
@@ -26,25 +40,27 @@ export const MyWordsChips: React.FC<MyWordsChipsProps> = ({ words, dir = 'ltr' }
   return (
     <div
       dir={dir}
+      translate="no"
       data-testid="my-words-slot"
-      className="h-16 overflow-y-auto flex flex-wrap gap-1.5 justify-center"
+      className="notranslate h-16 overflow-y-auto flex flex-wrap content-start gap-1.5 justify-center"
     >
-      {words.slice(0, 20).map((w, i) => (
-        <span
-          key={`${w.word}-${i}`}
-          data-kind={w.kind}
-          dir={dir}
-          className={cn(
-            'px-2 py-0.5 rounded border-2 border-neo-black text-xs font-neo-body font-bold',
-            w.kind === 'stolen-from-me' ? 'bg-neo-red text-neo-white line-through' :
-            w.kind === 'stolen' ? 'bg-neo-pink text-neo-white' :
-            w.kind === 'closed' ? 'bg-neo-cyan text-neo-black' :
-            'bg-neo-lime text-neo-black',
-          )}
-        >
-          {w.word}{w.score ? ` +${w.score}` : ''}
-        </span>
-      ))}
+      {words.slice(0, 20).map((w, i) => {
+        const tone = CHIP_TONE[w.kind];
+        return (
+          <span
+            key={`${w.word}-${i}`}
+            data-kind={w.kind}
+            dir={dir}
+            className={cn(
+              'inline-flex items-center h-7 px-2.5 rounded-neo border-2 text-neo-white text-xs font-semibold whitespace-nowrap shadow-hard-xs',
+              tone.chip,
+            )}
+          >
+            {w.word}
+            {w.score ? <span className={cn('ms-1 font-black', tone.score)}>+{w.score}</span> : null}
+          </span>
+        );
+      })}
     </div>
   );
 };

--- a/fe-next/components/multiplayer/WheelRushView.tsx
+++ b/fe-next/components/multiplayer/WheelRushView.tsx
@@ -19,6 +19,7 @@ import { MyWordsChips, type WordEntry } from './WheelRushPieces';
 import { WheelRushHeader } from './WheelRushHeader';
 import { WheelRushCelebration, type WheelCelebration } from './WheelRushCelebration';
 import { classifyLetterCoverage } from '@/lib/wheelRush/letterCoverage';
+import { selectClosestRival } from '@/lib/wheelRush/closestRival';
 import { computeWheelRadius } from '@/lib/wordWheel/wheelGeometry';
 import { fireConfetti } from '@/utils/confettiUtils';
 import { FloatingReaction } from '@/components/game/QuickReactions';
@@ -132,18 +133,16 @@ export const WheelRushView: React.FC<Props> = ({ socket, username, leaderboard, 
   // Hidden while fog-of-war is active so we don't leak masked opponent
   // scores. The slot itself stays mounted (reserved height) to prevent
   // mid-match layout shift when the pill toggles.
-  const nextRival = useMemo(() => {
-    if (fogActive) return null;
-    const me = leaderboard.find(p => p.username === username);
-    const myScore = me?.score ?? 0;
-    return leaderboard
-      .filter(p => p.username !== username && p.score > myScore)
-      .sort((a, b) => a.score - b.score)[0] ?? null;
-  }, [leaderboard, username, fogActive]);
-
-  const pointsToPass = nextRival
-    ? nextRival.score - (leaderboard.find(p => p.username === username)?.score ?? 0)
-    : 0;
+  // Single closest rival — same selection the header uses, so the pill and the
+  // header chip never point at two different people. The pill is a *chase*
+  // prompt, so it only shows when that one rival is ahead of me.
+  const closestRival = useMemo(
+    () => (fogActive ? null : selectClosestRival(leaderboard, username)),
+    [leaderboard, username, fogActive],
+  );
+  const myScore = leaderboard.find(p => p.username === username)?.score ?? 0;
+  const nextRival = closestRival && closestRival.score > myScore ? closestRival : null;
+  const pointsToPass = nextRival ? nextRival.score - myScore : 0;
 
   const fbTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const autoResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -626,7 +625,7 @@ export const WheelRushView: React.FC<Props> = ({ socket, username, leaderboard, 
                 userId={nextRival.username}
                 className="shrink-0 rounded-full"
               />
-              <span dir="auto">
+              <span dir="auto" translate="no" className="notranslate">
                 {t('wordWheel.pointsToPass', { count: pointsToPass, name: nextRival.username })}
               </span>
             </m.div>

--- a/fe-next/components/multiplayer/__tests__/WheelRushHeader.test.tsx
+++ b/fe-next/components/multiplayer/__tests__/WheelRushHeader.test.tsx
@@ -30,7 +30,8 @@ describe('WheelRushHeader', () => {
     expect(within(badge).getByTestId('wheel-self-avatar')).toBeTruthy();
   });
 
-  it('renders each opponent with name, score and avatar in the opponent rail', () => {
+  it('renders the rival with name, score and avatar in the opponent rail', () => {
+    // alice=30; bob gap 20 (ahead), carol gap 20 (behind) → tie breaks to bob.
     setup();
     const rail = screen.getByTestId('wheel-opponent-rail');
     const bob = within(rail).getByTestId('wheel-opp-bob');
@@ -45,7 +46,10 @@ describe('WheelRushHeader', () => {
     expect(within(rail).queryByTestId('wheel-opp-alice')).toBeNull();
   });
 
-  it('limits the opponent rail to the top 3 opponents by score', () => {
+  it('shows only the single closest rival — never a crowd of opponents', () => {
+    // alice=5; the nearest opponent by score is erin (60). Everyone else,
+    // including the board leader bob (90), is hidden to keep the player focused
+    // on one head-to-head.
     setup({
       leaderboard: [
         { username: 'alice', score: 5 },
@@ -56,10 +60,10 @@ describe('WheelRushHeader', () => {
       ],
     });
     const rail = screen.getByTestId('wheel-opponent-rail');
-    expect(within(rail).getByTestId('wheel-opp-bob')).toBeTruthy();
-    expect(within(rail).getByTestId('wheel-opp-carol')).toBeTruthy();
-    expect(within(rail).getByTestId('wheel-opp-dave')).toBeTruthy();
-    expect(within(rail).queryByTestId('wheel-opp-erin')).toBeNull();
+    expect(within(rail).getByTestId('wheel-opp-erin')).toBeTruthy();
+    expect(within(rail).queryByTestId('wheel-opp-bob')).toBeNull();
+    expect(within(rail).queryByTestId('wheel-opp-carol')).toBeNull();
+    expect(within(rail).queryByTestId('wheel-opp-dave')).toBeNull();
   });
 
   it('masks opponent scores with ??? while fog is active but keeps the self score visible', () => {

--- a/fe-next/lib/wheelRush/__tests__/closestRival.test.ts
+++ b/fe-next/lib/wheelRush/__tests__/closestRival.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { selectClosestRival } from '../closestRival';
+
+const p = (username: string, score: number) => ({ username, score });
+
+describe('selectClosestRival', () => {
+  it('returns null when there are no opponents', () => {
+    expect(selectClosestRival([p('alice', 10)], 'alice')).toBeNull();
+    expect(selectClosestRival([], 'alice')).toBeNull();
+  });
+
+  it('returns the only opponent when there is exactly one', () => {
+    const rival = selectClosestRival([p('alice', 10), p('bob', 40)], 'alice');
+    expect(rival?.username).toBe('bob');
+  });
+
+  it('never returns the current player even if scores tie', () => {
+    const rival = selectClosestRival([p('alice', 30), p('bob', 30)], 'alice');
+    expect(rival?.username).toBe('bob');
+  });
+
+  it('picks the opponent whose score is nearest to mine (not the leader)', () => {
+    // me=30; bob gap=60, carol gap=5 → carol is the closest rival even though
+    // bob leads the board. Focus follows the neck-and-neck threat.
+    const rival = selectClosestRival(
+      [p('alice', 30), p('bob', 90), p('carol', 25)],
+      'alice',
+    );
+    expect(rival?.username).toBe('carol');
+  });
+
+  it('breaks an equal-gap tie in favour of the opponent ahead (the chase target)', () => {
+    // me=30; bob=50 (gap 20, ahead), carol=10 (gap 20, behind) → prefer bob.
+    const rival = selectClosestRival(
+      [p('alice', 30), p('bob', 50), p('carol', 10)],
+      'alice',
+    );
+    expect(rival?.username).toBe('bob');
+  });
+
+  it('still finds the closest rival when everyone is behind me', () => {
+    // me=100; bob=40 (gap 60), carol=80 (gap 20) → carol is closest.
+    const rival = selectClosestRival(
+      [p('alice', 100), p('bob', 40), p('carol', 80)],
+      'alice',
+    );
+    expect(rival?.username).toBe('carol');
+  });
+
+  it('is deterministic for fully tied opponents (stable by username)', () => {
+    const board = [p('me', 0), p('zoe', 50), p('amy', 50)];
+    expect(selectClosestRival(board, 'me')?.username).toBe('amy');
+  });
+});

--- a/fe-next/lib/wheelRush/closestRival.ts
+++ b/fe-next/lib/wheelRush/closestRival.ts
@@ -1,0 +1,47 @@
+/**
+ * Closest-rival selection for Wheel Rush multiplayer.
+ *
+ * The MP wheel deliberately surfaces a SINGLE rival — the opponent whose score
+ * is nearest to the player's — instead of a full leaderboard. One focused
+ * head-to-head keeps the player chasing a concrete target rather than scanning
+ * a crowded rail. Used by both the header chip and the "points to pass" pill so
+ * the two never reference different people.
+ */
+
+export interface RivalLike {
+  username: string;
+  score: number;
+}
+
+/**
+ * Pick the opponent closest in score to `username`.
+ *
+ * - Excludes the player themselves.
+ * - Primary key: smallest absolute score gap (the neck-and-neck threat).
+ * - Ties break toward the opponent who is AHEAD (the chase target), then by
+ *   higher score, then alphabetically by username so selection is stable.
+ *
+ * @returns the closest rival, or `null` when the player has no opponents.
+ */
+export function selectClosestRival<T extends RivalLike>(
+  leaderboard: T[],
+  username: string,
+): T | null {
+  const others = leaderboard.filter(p => p.username !== username);
+  if (others.length === 0) return null;
+
+  const me = leaderboard.find(p => p.username === username);
+  const myScore = me?.score ?? 0;
+
+  return [...others].sort((a, b) => {
+    const gapA = Math.abs(a.score - myScore);
+    const gapB = Math.abs(b.score - myScore);
+    if (gapA !== gapB) return gapA - gapB;
+    // Equal gap → prefer the opponent ahead of me (someone to overtake).
+    const aheadA = a.score >= myScore ? 0 : 1;
+    const aheadB = b.score >= myScore ? 0 : 1;
+    if (aheadA !== aheadB) return aheadA - aheadB;
+    if (b.score !== a.score) return b.score - a.score;
+    return a.username.localeCompare(b.username);
+  })[0] ?? null;
+}


### PR DESCRIPTION
## What & why

Polish pass on the **Wheel Rush** multiplayer word-wheel mode, driven by a LogRocket replay showing distracting found-word colors, a stray "SAYA" tile on the wheel, and a crowded rival rail.

### 1. Found-words: too distracting + ragged height
The MP found-words chips used full-saturation `bg-neo-lime` / `bg-neo-cyan` / `bg-neo-pink` / `bg-neo-red` fills (eye-searing). They now adopt the **calm daily-challenge visual language** — dark `bg-neo-navy-light` surface, white text, with status encoded by a subtle tinted border + a small per-kind accent on the score. Each chip is a **fixed height** (`h-7`) so the row never looks ragged.

### 2. "Weird words in the circle" (e.g. "SAYA")
Root cause: the wheel letter **`I`** was being rewritten to **"saya"** (Indonesian for the pronoun "I") by the browser's Google-Translate auto-translation walking the text nodes — intermittent, and only for letters that look like words in the target language. Fixed by guarding game text with `translate="no"` + `notranslate`:
- shared `WheelLetter` + `WordTile` (also fixes the **daily** word wheel)
- MP found-word chips and rival name/score in the header + pill

### 3. One rival, the closest
The header showed the **top 3** opponents by score, and a separate pill showed yet another "next rival". Now a single shared `selectClosestRival` helper picks the **one opponent nearest in score** (tie → the one ahead, the chase target). The header chip and the "points to pass" pill both reference that same single rival, so the player is never shown more than one — keeping focus on a concrete head-to-head.

### 4. Stabilize sync
`requestWheelRushState` (reconnect / late-join) re-sent the puzzle and the player's own words but **never the leaderboard**, so opponent scores stayed stale/empty until the next score event. It now also pushes a fresh leaderboard directly to the requesting socket.

## Tests (TDD)
- New pure helper `selectClosestRival` + full unit suite (gap, tie-break, all-behind, stable ordering).
- Updated `WheelRushHeader` test: top-3 → single closest rival.
- New `MyWordsChips` tests: calm dark chips, fixed height, per-kind border, translate guard.
- New `WheelLetter` translate-guard regression ("I" must not become "saya").
- New handler test: reconnect snapshot also emits a fresh `updateLeaderboard`.
- Existing `WheelRushView` pill tests remain green (pill now sourced from the same closest rival, shown only when ahead).

All affected suites pass (323 wheel-related frontend + backend tests), lint clean, `tsc --noEmit` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_012ApdaBevakz9k1uwsjyDxH)_