### PR TITLE
fix(word-wheel): raise orbit radius floor so petals never collapse onto center

### DIFF
--- a/fe-next/components/daily/WordWheelGame.tsx
+++ b/fe-next/components/daily/WordWheelGame.tsx
@@ -646,7 +646,11 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
       const size = Math.min(rect.width, rect.height);
       setWheelRadius(
         shortVp?.matches
-          ? computeWheelRadius(size, 88, 40, 44)
+          // short: variant shrinks the letters (center 64px, outer 48px), so
+          // the floor only needs to clear 32+24=56px — but it MUST clear it, or
+          // the petals collapse onto the center the way the default 40 floor let
+          // them on a cramped landscape wheel.
+          ? computeWheelRadius(size, 88, 56, 44)
           : computeWheelRadius(size, 136),
       );
     };

--- a/fe-next/components/multiplayer/WheelRushView.tsx
+++ b/fe-next/components/multiplayer/WheelRushView.tsx
@@ -122,7 +122,9 @@ export const WheelRushView: React.FC<Props> = ({ socket, username, leaderboard, 
   const [feedback, setFeedback] = useState<{ type: 'ok' | 'err'; msg: string } | null>(null);
   const [wordBuilderShake, setWordBuilderShake] = useState(false);
   const [fogActive, setFogActive] = useState(false);
-  const [wheelRadius, setWheelRadius] = useState(72);
+  // Seed at the center-clearing floor (see computeWheelRadius) so the pre-measure
+  // first paint doesn't briefly collapse the petals onto the center letter.
+  const [wheelRadius, setWheelRadius] = useState(76);
   const [celebration, setCelebration] = useState<WheelCelebration | null>(null);
   const celebrationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Ref-bridged so the once-bound socket onResult closure can reach the latest trigger.

--- a/fe-next/lib/wordWheel/__tests__/wheelGeometry.test.ts
+++ b/fe-next/lib/wordWheel/__tests__/wheelGeometry.test.ts
@@ -15,8 +15,22 @@ describe('computeWheelRadius', () => {
   });
 
   it('never drops below the floor so the wheel stays usable when tiny', () => {
-    expect(computeWheelRadius(120, 136)).toBe(52); // (120-60)/2 = 30 → floored
+    expect(computeWheelRadius(120, 136)).toBe(76); // (120-60)/2 = 30 → floored
     expect(computeWheelRadius(120, 136, 48)).toBe(48); // custom floor
+  });
+
+  it('default floor clears the center letter so petals never overlap on a cramped wheel', () => {
+    // REGRESSION: on height-constrained viewports the container shrinks, so
+    // `(width − allowance)/2` collapses toward the floor. The mobile center
+    // letter is 80px (radius 40) and outer letters 52px (radius 26), so the
+    // orbit must be ≥ 66px or the petals overlap the center (and, at R < 52,
+    // each other). The default floor therefore has to clear that threshold
+    // with a small gap — a 52px floor let the flower collapse into itself.
+    const CENTER_R = 80 / 2;
+    const OUTER_R = 52 / 2;
+    const flooredOnTinyBox = computeWheelRadius(120, 136);
+    expect(flooredOnTinyBox).toBeGreaterThanOrEqual(CENTER_R + OUTER_R); // ≥ 66, no center overlap
+    expect(flooredOnTinyBox).toBeGreaterThanOrEqual(52); // ≥ outer diameter, no petal-petal overlap
   });
 
   it('scales down as the container shrinks (monotonic in width)', () => {
@@ -26,9 +40,9 @@ describe('computeWheelRadius', () => {
   });
 
   it('guards against 0 / negative / NaN widths (pre-measure render)', () => {
-    expect(computeWheelRadius(0, 136)).toBe(52);
-    expect(computeWheelRadius(-10, 136)).toBe(52);
-    expect(computeWheelRadius(Number.NaN, 136)).toBe(52);
+    expect(computeWheelRadius(0, 136)).toBe(76);
+    expect(computeWheelRadius(-10, 136)).toBe(76);
+    expect(computeWheelRadius(Number.NaN, 136)).toBe(76);
   });
 
   it('returns an integer (px transforms should not be sub-pixel)', () => {

--- a/fe-next/lib/wordWheel/wheelGeometry.ts
+++ b/fe-next/lib/wordWheel/wheelGeometry.ts
@@ -21,7 +21,15 @@ export const WHEEL_LETTER_ALLOWANCE_PX = 60;
  *
  * @param containerWidthPx rendered wheel width (getBoundingClientRect)
  * @param maxRadius        upper bound (96 mobile, 136/140 desktop)
- * @param minRadius        lower bound; keeps a tiny wheel usable
+ * @param minRadius        lower bound; must clear the center letter so the
+ *                         petals never collapse onto it on a height-capped
+ *                         viewport. The mobile center letter is 80px (radius 40)
+ *                         and outer letters 52px (radius 26), so the orbit needs
+ *                         ≥66px to avoid overlap; the 76px default adds a small
+ *                         gap. A floor below that let a cramped wheel crush the
+ *                         flower into itself (petals overlapping center + each
+ *                         other). Short/landscape passes a smaller floor to match
+ *                         its shrunken `short:` letters.
  * @param letterAllowance  rim space reserved for one outer letter. Defaults to
  *                         {@link WHEEL_LETTER_ALLOWANCE_PX}; pass a smaller value
  *                         on short/landscape viewports where the `short:` variant
@@ -32,7 +40,7 @@ export const WHEEL_LETTER_ALLOWANCE_PX = 60;
 export function computeWheelRadius(
   containerWidthPx: number,
   maxRadius: number,
-  minRadius = 52,
+  minRadius = 76,
   letterAllowance = WHEEL_LETTER_ALLOWANCE_PX,
 ): number {
   if (!Number.isFinite(containerWidthPx) || containerWidthPx <= 0) {


### PR DESCRIPTION
## Problem

On the daily Word Wheel (and multiplayer Wheel Rush), the outer letter "petals" were rendering too close to each other and to the center letter — collapsing the flower into itself instead of the previously well-spaced layout.

## Root cause

The orbit radius comes from `computeWheelRadius`, which fits the orbit inside the rim with `(containerWidth − letterAllowance) / 2`, floored at `minRadius`. The floor was **52px** (and **40px** on short/landscape) — *below* the geometric clearance the layout actually needs:

- Mobile center letter = 80px (radius **40**), outer letters = 52px (radius **26**) → the orbit must be **≥ 66px** just to avoid overlapping the center, and **≥ 52px** to keep adjacent petals from touching.

The wheel container is height-capped on constrained viewports (`max-h-[max(176px, calc(100cqb-116px))]`). When a phone's flex height-chain produced a small container, `(width − 60)/2` collapsed toward the 52px floor — so the petals overlapped the center and crowded one another.

## Fix

Raise the radius floor so it always clears the center letter:

- `computeWheelRadius` default `minRadius`: **52 → 76** (clears 66px + a small gap)
- Daily short-viewport call floor: **40 → 56** (clears the shrunken `short:` letters: 64px center + 48px outer)
- Seed the multiplayer pre-measure `wheelRadius` at the floor (**72 → 76**) so the first paint doesn't briefly collapse

Roomy viewports are unchanged (the fit formula already yields a larger radius there); only the space-starved case that was collapsing is corrected.

## Testing

- TDD: added a failing geometry test documenting the center-clearance contract, then implemented the fix.
- `wheelGeometry`, `WordWheelGame.*`, `WheelRush*` suites: **165 passing**.
- Typecheck clean on changed files.

https://claude.ai/code/session_01C4GasvMLqfXg6W3xey6DpT