### PR TITLE
refactor(word-wheel): declutter the daily challenge live board

### DIFF
--- a/fe-next/components/daily/WordWheelGame.tsx
+++ b/fe-next/components/daily/WordWheelGame.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { m, AnimatePresence, useReducedMotion } from 'framer-motion';
-import { Clock, Delete, RotateCcw, Sparkles, Flame, TrendingUp, ChevronUp, Check } from 'lucide-react';
+import { Clock, Delete, RotateCcw, Flame, TrendingUp, ChevronUp, Check } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
 import { computeWheelRadius } from '@/lib/wordWheel/wheelGeometry';
@@ -786,7 +786,7 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
             {builtLetters.length === 0 ? (
               <m.span
                 key="placeholder"
-                className="text-neo-white font-neo-display text-base sm:text-lg"
+                className="text-neo-white/55 font-medium text-sm sm:text-base"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
@@ -950,7 +950,7 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
         className="h-[14px] sm:h-[16px] flex items-center justify-center"
       >
         {builtLetters.length > 0 && (
-          <p className="text-neo-white text-[10px] sm:text-xs text-center">
+          <p className="text-neo-white/45 text-[10px] sm:text-xs text-center">
             {t('wordWheel.tapToRemove')} &middot; {t('wordWheel.doubleTapToSubmit')}
           </p>
         )}
@@ -1028,12 +1028,9 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
         ))}
       </div>
 
-      {/* ── Center letter rule hint ── (hidden on short viewports to reclaim
-          vertical room for the wheel; the same rule is shown on the intro/ready
-          screen, so no information is lost mid-game). */}
-      <p className="text-neo-white text-xs text-center short:hidden">
-        {t('wordWheel.centerLetterRule')} &middot; {t('wordWheel.minLetters', { min: '3' })}
-      </p>
+      {/* The center-letter + min-length rule was removed from the live board to
+          cut mid-game clutter — it's still presented on the intro/ready screen
+          and surfaced on demand via the "too short" / "missing center" toasts. */}
 
       {/* ── Action Buttons (inline below wheel, glued via flex cluster) ── */}
       <div
@@ -1073,10 +1070,7 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
           animate={isValidating ? { opacity: [1, 0.6, 1] } : {}}
           transition={isValidating ? { duration: 0.6, repeat: Infinity } : {}}
         >
-          <div className="flex items-center gap-2">
-            <Sparkles className="w-5 h-5" />
-            {t('wordWheel.submit')}
-          </div>
+          {t('wordWheel.submit')}
         </m.button>
 
         {/* Remove last letter */}


### PR DESCRIPTION
## Why

The daily Word Wheel board still felt visually cluttered — several headline-weight text blocks competed with the wheel for attention, plus a decorative icon on the Submit button.

## What changed

`fe-next/components/daily/WordWheelGame.tsx` (presentational only):

- **Removed the persistent center-letter + min-length rule line** below the wheel. The exact same rule is already shown on the intro/ready screen (`WordWheelChallenge.tsx`) and is surfaced on demand via the "too short" / "missing center" toasts, so no information is lost.
- **Muted the build-area placeholder** ("Tap or drag letters…") and the **tap-to-remove hint** — they now read as quiet secondary text instead of headline-weight white, letting the wheel be the clear focal point.
- **Dropped the decorative Sparkles icon** from the Submit button; the inline submit chip already carries the check affordance.

## Layout / safety

- All reserved layout slots (`tap-hint-slot`, `word-wheel-action-bar`, `found-words-slot`, `next-rival-slot`, `combo-slot`) are untouched — no layout shift introduced.
- No string keys, testids, or interaction handlers changed.

## Verification

- `vitest` daily suite: **460 passed** (incl. controls, inline-submit, layout-stability, short-viewport, banner-clearance).
- `tsc --noEmit`: no errors for the edited file.

Before/after is best seen on `/he/daily/word-wheel` (the screenshot that prompted this) — the board now leads with the wheel rather than stacked instructional text.

https://claude.ai/code/session_01RCe3b7jXA3MCTrwf63wgpM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCe3b7jXA3MCTrwf63wgpM)_