### PR TITLE
feat(i18n): offer native language when the browser would auto-translate the UI

### DIFF
--- a/fe-next/__tests__/components/Header.musicControls.test.tsx
+++ b/fe-next/__tests__/components/Header.musicControls.test.tsx
@@ -1,6 +1,6 @@
 import { vi, type Mock, } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Header from '@/components/Header';
 import { LanguageProvider } from '@/contexts/LanguageContext';
@@ -18,6 +18,24 @@ import { ThemeProvider } from '@/utils/ThemeContext';
  * 2. Music controls should appear in the mobile header (visible on < sm screens)
  * 3. Music controls should NOT appear in the mobile menu dropdown
  */
+
+// Silence the app logger. The mounted MusicProvider/AuthProvider kick off
+// async work (dynamic `howler` import, auth/session probes) that resolves
+// AFTER the synchronous test body and logs via `logger`. If that log lands
+// while the vitest worker is closing it throws the flaky
+// `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`
+// (seen intermittently on this heavy multi-provider test, on master too).
+vi.mock('@/utils/logger', () => ({
+    default: {
+        log: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        time: vi.fn(),
+        timeEnd: vi.fn(),
+    },
+}));
 
 // Mock Next.js router
 vi.mock('next/navigation', () => ({
@@ -67,6 +85,17 @@ describe('Header - Music Controls Placement', () => {
     beforeEach(() => {
         // Clear any mocks
         vi.clearAllMocks();
+    });
+
+    afterEach(async () => {
+        // Let provider async effects (dynamic howler import, auth/session
+        // probes, translation load) settle inside act() so their state updates
+        // and any console output happen within the test window — not during
+        // worker teardown, which surfaces as a flaky
+        // "Closing rpc while onUserConsoleLog was pending" error.
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
     });
 
     describe('Desktop View (sm+ screens)', () => {

--- a/fe-next/app/[locale]/layout.tsx
+++ b/fe-next/app/[locale]/layout.tsx
@@ -16,6 +16,7 @@ import DictionaryPrewarmer from '@/components/DictionaryPrewarmer';
 import NativeOAuthInitializer from '@/components/NativeOAuthInitializer';
 import { ToastContainer } from '@/components/ui/EnhancedToast';
 import { OfflineBanner } from '@/components/offline/OfflineBanner';
+import { NativeLanguageBanner } from '@/components/NativeLanguageBanner';
 import { OfflineSyncBridge } from '@/components/offline/OfflineSyncBridge';
 import { getLocalizedSchemaStrings } from '@/utils/seoLocalizedSchema';
 import type { Language } from '@/shared/types/game';
@@ -607,6 +608,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
                 <ConditionalProviders lang={validLocale} initialTranslations={initialTranslations}>
                     {/* VersionChecker needs to be inside providers to access LanguageContext */}
                     <VersionChecker />
+                    <NativeLanguageBanner />
                     <OfflineBanner />
                     <OfflineSyncBridge />
                     <div className="flex-1 flex flex-col min-h-0 relative overflow-x-clip">

--- a/fe-next/components/NativeLanguageBanner.tsx
+++ b/fe-next/components/NativeLanguageBanner.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { m, AnimatePresence } from 'framer-motion';
+import { Languages, X } from 'lucide-react';
+import { useNativeLanguageSuggestion } from '@/hooks/useNativeLanguageSuggestion';
+import { SUGGESTION_COPY } from '@/utils/languageSuggestion';
+
+/**
+ * Offers a one-tap switch to our native translation when the player's browser
+ * prefers a language we ship natively but the app is showing another one
+ * (e.g. a US-based Spanish speaker served English, whom Chrome would otherwise
+ * machine-translate). Copy is rendered in the *target* language.
+ *
+ * The banner is itself `translate="no"` — it is already in the target language
+ * and must not be re-translated by the browser (which would also expose it to
+ * the DOM-mutation crashes the offer exists to avoid).
+ */
+export function NativeLanguageBanner() {
+  const { suggested, accept, dismiss } = useNativeLanguageSuggestion();
+  const copy = suggested ? SUGGESTION_COPY[suggested] : null;
+
+  return (
+    <AnimatePresence>
+      {suggested && copy && (
+        <m.div
+          role="status"
+          aria-live="polite"
+          lang={suggested}
+          translate="no"
+          initial={{ y: -32, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: -32, opacity: 0 }}
+          transition={{ duration: 0.18 }}
+          className="notranslate fixed top-0 inset-x-0 z-50 flex items-center gap-3 bg-neo-cyan text-neo-navy border-b-neo border-neo-navy px-4 py-2 shadow-hard"
+        >
+          <Languages className="size-5 shrink-0" aria-hidden />
+          <div className="flex-1 min-w-0">
+            <span className="font-neo-display text-sm font-bold">{copy.prompt}</span>
+          </div>
+          <button
+            type="button"
+            onClick={accept}
+            className="shrink-0 rounded-neo border-neo border-neo-navy bg-neo-lime hover:bg-neo-lime/80 active:translate-y-px px-3 py-1 font-bold text-sm"
+          >
+            {copy.accept}
+          </button>
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label={copy.dismiss}
+            title={copy.dismiss}
+            className="shrink-0 rounded-neo border-neo border-neo-navy bg-neo-cream/40 hover:bg-neo-cream/60 active:translate-y-px px-2 py-1"
+          >
+            <X className="size-4" aria-hidden />
+          </button>
+        </m.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export default NativeLanguageBanner;

--- a/fe-next/components/__tests__/NativeLanguageBanner.test.tsx
+++ b/fe-next/components/__tests__/NativeLanguageBanner.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NativeLanguageBanner } from '../NativeLanguageBanner';
 
 const mockSetLanguage = vi.fn();
@@ -37,6 +37,12 @@ describe('NativeLanguageBanner', () => {
     mockLanguage = 'en';
     localStorage.clear();
     document.documentElement.className = '';
+  });
+
+  afterEach(() => {
+    // Drop our `navigator.languages` override so it can't leak into whatever
+    // test file vitest runs next in this worker (the prototype getter returns).
+    delete (navigator as { languages?: readonly string[] }).languages;
   });
 
   it('offers the native language when the browser prefers a supported one we are not showing', () => {

--- a/fe-next/components/__tests__/NativeLanguageBanner.test.tsx
+++ b/fe-next/components/__tests__/NativeLanguageBanner.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NativeLanguageBanner } from '../NativeLanguageBanner';
+
+const mockSetLanguage = vi.fn();
+let mockLanguage = 'en';
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguageSafe: () => ({ language: mockLanguage, setLanguage: mockSetLanguage }),
+}));
+
+// framer-motion: render children plainly, drop animation-only props.
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  m: new Proxy(
+    {},
+    {
+      get: () => {
+        return ({ children, ...props }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          const { initial, animate, exit, transition, ...rest } = props;
+          void initial; void animate; void exit; void transition;
+          return <div {...(rest as Record<string, unknown>)}>{children}</div>;
+        };
+      },
+    },
+  ),
+}));
+
+function setBrowserLanguages(langs: string[]) {
+  Object.defineProperty(navigator, 'languages', { get: () => langs, configurable: true });
+}
+
+describe('NativeLanguageBanner', () => {
+  beforeEach(() => {
+    mockSetLanguage.mockReset();
+    mockLanguage = 'en';
+    localStorage.clear();
+    document.documentElement.className = '';
+  });
+
+  it('offers the native language when the browser prefers a supported one we are not showing', () => {
+    // App is English (e.g. forced by a stale boggle_language=en cookie) while
+    // the player's top browser preference is Spanish — Chrome would otherwise
+    // machine-translate. Offer our native Spanish instead.
+    setBrowserLanguages(['es-US', 'es', 'en-US']);
+    render(<NativeLanguageBanner />);
+    // Offer shown in Spanish, in the user's preferred language.
+    expect(screen.getByText('¿Prefieres jugar en Español?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cambiar' })).toBeInTheDocument();
+  });
+
+  it('switches to the native language when the user accepts', () => {
+    setBrowserLanguages(['es-US', 'es', 'en-US']);
+    render(<NativeLanguageBanner />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar' }));
+    expect(mockSetLanguage).toHaveBeenCalledWith('es');
+  });
+
+  it('hides and remembers the dismissal when the user declines', () => {
+    setBrowserLanguages(['es-US', 'es', 'en-US']);
+    const { rerender } = render(<NativeLanguageBanner />);
+    fireEvent.click(screen.getByRole('button', { name: 'No, gracias' }));
+    expect(screen.queryByText('¿Prefieres jugar en Español?')).not.toBeInTheDocument();
+    // Dismissal persists across remounts (no nagging on every load).
+    rerender(<NativeLanguageBanner />);
+    expect(screen.queryByText('¿Prefieres jugar en Español?')).not.toBeInTheDocument();
+    expect(mockSetLanguage).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing when the app is already in the preferred language', () => {
+    mockLanguage = 'es';
+    setBrowserLanguages(['es-MX', 'es']);
+    const { container } = render(<NativeLanguageBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the browser preference is unsupported', () => {
+    setBrowserLanguages(['fr-FR', 'de']);
+    const { container } = render(<NativeLanguageBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('marks itself translate="no" so the browser does not re-translate the offer', () => {
+    setBrowserLanguages(['es-US', 'es', 'en-US']);
+    render(<NativeLanguageBanner />);
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveAttribute('translate', 'no');
+    expect(banner.className).toContain('notranslate');
+  });
+});

--- a/fe-next/hooks/useNativeLanguageSuggestion.ts
+++ b/fe-next/hooks/useNativeLanguageSuggestion.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useLanguageSafe } from '@/contexts/LanguageContext';
+import {
+  detectPreferredLanguage,
+  isBrowserTranslating,
+  resolveSuggestedLanguage,
+  type SuggestionLanguage,
+} from '@/utils/languageSuggestion';
+
+const dismissKey = (lang: string) => `lexiclash_lang_suggestion_dismissed:${lang}`;
+const EXPLICIT_KEY = 'boggle_language_explicit';
+
+// Browser page-translation can kick in a beat after load, so re-evaluate once
+// shortly after mount to catch it (the primary trigger — a differing preferred
+// language with no explicit choice — already fires synchronously on mount).
+const TRANSLATE_RECHECK_MS = 1500;
+
+function readDismissed(lang: SuggestionLanguage): boolean {
+  try {
+    return localStorage.getItem(dismissKey(lang)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function readExplicit(): boolean {
+  try {
+    return localStorage.getItem(EXPLICIT_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decides whether to offer the player our native translation of the language
+ * their browser prefers, and exposes accept/dismiss actions. See
+ * `utils/languageSuggestion.ts` for the reasoning behind the heuristics.
+ */
+export function useNativeLanguageSuggestion(): {
+  suggested: SuggestionLanguage | null;
+  accept: () => void;
+  dismiss: () => void;
+} {
+  const { language, setLanguage } = useLanguageSafe();
+  const [suggested, setSuggested] = useState<SuggestionLanguage | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const evaluate = () => {
+      const preferred = detectPreferredLanguage(navigator.languages);
+      const result = resolveSuggestedLanguage({
+        current: language,
+        preferred,
+        explicit: readExplicit(),
+        dismissed: preferred ? readDismissed(preferred) : false,
+        browserTranslating: isBrowserTranslating(document),
+      });
+      setSuggested(result);
+    };
+
+    evaluate();
+    const timer = window.setTimeout(evaluate, TRANSLATE_RECHECK_MS);
+    return () => window.clearTimeout(timer);
+  }, [language]);
+
+  const accept = useCallback(() => {
+    setSuggested((current) => {
+      if (current) setLanguage(current);
+      return null;
+    });
+  }, [setLanguage]);
+
+  const dismiss = useCallback(() => {
+    setSuggested((current) => {
+      if (current) {
+        try {
+          localStorage.setItem(dismissKey(current), '1');
+        } catch {
+          // ignore (private mode etc.)
+        }
+      }
+      return null;
+    });
+  }, []);
+
+  return { suggested, accept, dismiss };
+}

--- a/fe-next/instrumentation-client.ts
+++ b/fe-next/instrumentation-client.ts
@@ -1,5 +1,12 @@
 import * as Sentry from "@sentry/nextjs";
 import "./sentry.client.config";
+import { installTranslationDomGuard } from "./utils/domTranslationGuard";
+
+// Harden React against DOM mutations from in-browser page translators
+// (Google Translate, Edge), which otherwise crash the app with
+// `NotFoundError: Failed to execute 'removeChild'`. Installed as early as
+// possible on the client, before React hydrates.
+installTranslationDomGuard();
 
 // Required for Sentry to instrument navigations in Next.js 16+
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/fe-next/utils/__tests__/domTranslationGuard.test.ts
+++ b/fe-next/utils/__tests__/domTranslationGuard.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { installTranslationDomGuard } from '../domTranslationGuard';
+
+describe('installTranslationDomGuard', () => {
+  let originalRemoveChild: typeof Node.prototype.removeChild;
+  let originalInsertBefore: typeof Node.prototype.insertBefore;
+
+  beforeEach(() => {
+    originalRemoveChild = Node.prototype.removeChild;
+    originalInsertBefore = Node.prototype.insertBefore;
+  });
+
+  afterEach(() => {
+    Node.prototype.removeChild = originalRemoveChild;
+    Node.prototype.insertBefore = originalInsertBefore;
+  });
+
+  it('removeChild still works normally for genuine children', () => {
+    installTranslationDomGuard();
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    parent.appendChild(child);
+
+    expect(parent.removeChild(child)).toBe(child);
+    expect(parent.contains(child)).toBe(false);
+  });
+
+  it('removeChild no-ops instead of throwing when the node was already detached (browser translate)', () => {
+    installTranslationDomGuard();
+    const parent = document.createElement('div');
+    const orphan = document.createElement('span'); // never appended to parent
+
+    // Without the guard this throws NotFoundError (the React+GoogleTranslate crash).
+    expect(() => parent.removeChild(orphan)).not.toThrow();
+    expect(parent.removeChild(orphan)).toBe(orphan);
+  });
+
+  it('insertBefore still works normally for genuine reference nodes', () => {
+    installTranslationDomGuard();
+    const parent = document.createElement('div');
+    const ref = document.createElement('span');
+    const inserted = document.createElement('b');
+    parent.appendChild(ref);
+
+    expect(parent.insertBefore(inserted, ref)).toBe(inserted);
+    expect(parent.firstChild).toBe(inserted);
+  });
+
+  it('insertBefore falls back to append when the reference node was moved away', () => {
+    installTranslationDomGuard();
+    const parent = document.createElement('div');
+    const inserted = document.createElement('b');
+    const movedRef = document.createElement('span'); // not a child of parent
+
+    expect(() => parent.insertBefore(inserted, movedRef)).not.toThrow();
+    expect(parent.contains(inserted)).toBe(true);
+  });
+
+  it('is idempotent — installing twice does not double-wrap or break behavior', () => {
+    installTranslationDomGuard();
+    installTranslationDomGuard();
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    parent.appendChild(child);
+    expect(parent.removeChild(child)).toBe(child);
+  });
+});

--- a/fe-next/utils/__tests__/languageSuggestion.test.ts
+++ b/fe-next/utils/__tests__/languageSuggestion.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mapToSupportedLanguage,
+  detectPreferredLanguage,
+  resolveSuggestedLanguage,
+  isBrowserTranslating,
+  SUGGESTION_COPY,
+  SUPPORTED_SUGGESTION_LANGUAGES,
+} from '../languageSuggestion';
+
+describe('mapToSupportedLanguage', () => {
+  it('maps a region-qualified tag to its primary supported language', () => {
+    // Given a US-Spanish speaker's tag, When mapped, Then we get 'es'
+    expect(mapToSupportedLanguage('es-MX')).toBe('es');
+    expect(mapToSupportedLanguage('es-US')).toBe('es');
+    expect(mapToSupportedLanguage('en-GB')).toBe('en');
+  });
+
+  it('maps the legacy Hebrew code "iw" to "he"', () => {
+    expect(mapToSupportedLanguage('iw')).toBe('he');
+    expect(mapToSupportedLanguage('iw-IL')).toBe('he');
+  });
+
+  it('returns null for unsupported or empty tags', () => {
+    expect(mapToSupportedLanguage('fr-FR')).toBeNull();
+    expect(mapToSupportedLanguage('de')).toBeNull();
+    expect(mapToSupportedLanguage('')).toBeNull();
+    expect(mapToSupportedLanguage(null)).toBeNull();
+    expect(mapToSupportedLanguage(undefined)).toBeNull();
+  });
+});
+
+describe('detectPreferredLanguage', () => {
+  it('returns the first supported language in the browser preference list', () => {
+    // The first (top-priority) supported preference wins.
+    expect(detectPreferredLanguage(['en-US', 'en', 'es'])).toBe('en');
+    // A Spanish-first speaker (e.g. US Latino) → es, even with region suffix.
+    expect(detectPreferredLanguage(['es-419', 'es', 'en-US'])).toBe('es');
+  });
+
+  it('skips unsupported tags until it finds a supported one', () => {
+    expect(detectPreferredLanguage(['fr-FR', 'de', 'ja'])).toBe('ja');
+  });
+
+  it('returns null when nothing is supported or list is empty', () => {
+    expect(detectPreferredLanguage(['fr', 'de'])).toBeNull();
+    expect(detectPreferredLanguage([])).toBeNull();
+    expect(detectPreferredLanguage(undefined)).toBeNull();
+  });
+});
+
+describe('resolveSuggestedLanguage', () => {
+  const base = { current: 'en' as const, preferred: 'es' as const, explicit: false, dismissed: false, browserTranslating: false };
+
+  it('suggests the native language when it differs and no explicit choice was made', () => {
+    // The screenshot case: app is en, browser prefers es → offer es.
+    expect(resolveSuggestedLanguage(base)).toBe('es');
+  });
+
+  it('does not suggest when the app is already in the preferred language', () => {
+    expect(resolveSuggestedLanguage({ ...base, current: 'es' })).toBeNull();
+  });
+
+  it('does not suggest when there is no supported preference', () => {
+    expect(resolveSuggestedLanguage({ ...base, preferred: null })).toBeNull();
+  });
+
+  it('does not suggest once dismissed for that language', () => {
+    expect(resolveSuggestedLanguage({ ...base, dismissed: true })).toBeNull();
+  });
+
+  it('respects an explicit user choice (no nagging)', () => {
+    expect(resolveSuggestedLanguage({ ...base, explicit: true })).toBeNull();
+  });
+
+  it('overrides an explicit choice when the browser is actively translating', () => {
+    // Strong signal the explicit pick no longer matches what they want to read.
+    expect(resolveSuggestedLanguage({ ...base, explicit: true, browserTranslating: true })).toBe('es');
+  });
+
+  it('still respects an explicit dismissal even under active translation', () => {
+    expect(resolveSuggestedLanguage({ ...base, explicit: true, browserTranslating: true, dismissed: true })).toBeNull();
+  });
+});
+
+describe('isBrowserTranslating', () => {
+  const makeDoc = (setup: (html: HTMLElement) => void): Document => {
+    const doc = document.implementation.createHTMLDocument('t');
+    setup(doc.documentElement);
+    return doc;
+  };
+
+  it('detects Google Translate via the translated-ltr/rtl class on <html>', () => {
+    expect(isBrowserTranslating(makeDoc((html) => html.classList.add('translated-ltr')))).toBe(true);
+    expect(isBrowserTranslating(makeDoc((html) => html.classList.add('translated-rtl')))).toBe(true);
+  });
+
+  it('detects injected Google Translate banner/skiptranslate nodes', () => {
+    expect(
+      isBrowserTranslating(
+        makeDoc((html) => {
+          const el = html.ownerDocument.createElement('div');
+          el.className = 'skiptranslate';
+          html.appendChild(el);
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a normal, untranslated document', () => {
+    expect(isBrowserTranslating(makeDoc(() => {}))).toBe(false);
+    expect(isBrowserTranslating(undefined)).toBe(false);
+  });
+});
+
+describe('SUGGESTION_COPY', () => {
+  it('provides target-language copy for every supported language', () => {
+    for (const lang of SUPPORTED_SUGGESTION_LANGUAGES) {
+      const copy = SUGGESTION_COPY[lang];
+      expect(copy).toBeTruthy();
+      expect(copy.nativeName.length).toBeGreaterThan(0);
+      expect(copy.prompt.length).toBeGreaterThan(0);
+      expect(copy.accept.length).toBeGreaterThan(0);
+      expect(copy.dismiss.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('writes the Spanish prompt in Spanish (so a US Spanish speaker understands it)', () => {
+    expect(SUGGESTION_COPY.es.nativeName).toBe('Español');
+    expect(SUGGESTION_COPY.es.prompt).toMatch(/Español/);
+  });
+});

--- a/fe-next/utils/domTranslationGuard.ts
+++ b/fe-next/utils/domTranslationGuard.ts
@@ -1,0 +1,64 @@
+/**
+ * Defensive guard against third-party DOM mutations from in-browser page
+ * translators (Google Translate, Edge Translator) and similar extensions.
+ *
+ * When a translator swaps text nodes, React's virtual DOM and the real DOM
+ * desync. React then tries to `removeChild`/`insertBefore` a node the
+ * translator has already moved or detached, and the browser throws
+ * `NotFoundError: Failed to execute 'removeChild' on 'Node'` — a hard,
+ * full-page React crash. (Sentry has logged these on translated sessions.)
+ *
+ * This wraps the two offending `Node.prototype` methods so that, when the
+ * target relationship no longer holds, they no-op instead of throwing. It is
+ * the widely-used community mitigation for the React + Google Translate crash.
+ * It changes nothing for genuine parent/child operations.
+ *
+ * The real fix for *why* the page is being translated lives in the native
+ * language suggestion banner — this is the safety net for when the user
+ * keeps the browser translation on regardless.
+ */
+
+// Marker stamped on our wrapper functions. We check the live method for this
+// rather than a separate boolean so idempotency stays correct even if the
+// prototype methods are swapped out from under us.
+const GUARD_MARK = '__lexiclashTranslationGuard';
+
+type MarkedFn = { [GUARD_MARK]?: boolean };
+
+function isGuarded(fn: unknown): boolean {
+  return typeof fn === 'function' && (fn as MarkedFn)[GUARD_MARK] === true;
+}
+
+export function installTranslationDomGuard(): void {
+  if (typeof Node === 'undefined' || !Node.prototype) return;
+
+  if (!isGuarded(Node.prototype.removeChild)) {
+    const originalRemoveChild = Node.prototype.removeChild;
+    const wrappedRemoveChild = function removeChild<T extends Node>(this: Node, child: T): T {
+      if (child.parentNode !== this) {
+        // The translator already detached/moved this node — pretend success.
+        return child;
+      }
+      return originalRemoveChild.call(this, child) as T;
+    };
+    (wrappedRemoveChild as MarkedFn)[GUARD_MARK] = true;
+    Node.prototype.removeChild = wrappedRemoveChild;
+  }
+
+  if (!isGuarded(Node.prototype.insertBefore)) {
+    const originalInsertBefore = Node.prototype.insertBefore;
+    const wrappedInsertBefore = function insertBefore<T extends Node>(
+      this: Node,
+      newNode: T,
+      referenceNode: Node | null,
+    ): T {
+      if (referenceNode && referenceNode.parentNode !== this) {
+        // The reference node was moved by the translator — append instead of throw.
+        return originalInsertBefore.call(this, newNode, null) as T;
+      }
+      return originalInsertBefore.call(this, newNode, referenceNode) as T;
+    };
+    (wrappedInsertBefore as MarkedFn)[GUARD_MARK] = true;
+    Node.prototype.insertBefore = wrappedInsertBefore;
+  }
+}

--- a/fe-next/utils/languageSuggestion.ts
+++ b/fe-next/utils/languageSuggestion.ts
@@ -1,0 +1,123 @@
+/**
+ * Native-language suggestion logic.
+ *
+ * Problem this solves: a player whose top browser language is Spanish is served
+ * our English app anyway — typically because a stale `boggle_language=en` cookie
+ * (or an English deep link) pins the locale ahead of their `Accept-Language`.
+ * Chrome then machine-translates our English UI to Spanish on the fly. The
+ * result is a worse experience than our hand-crafted `es` bundle AND a flag/text
+ * mismatch (real app lang = en → 🇺🇸, visible text = browser-translated Spanish).
+ *
+ * The fix: detect when the browser prefers a language we ship natively and
+ * offer a one-tap switch to *our* translation. Once the page is genuinely in
+ * their language, the browser stops auto-translating (which also avoids the
+ * DOM-mutation React crashes that browser translation causes).
+ *
+ * These functions are intentionally pure (no `navigator`/`document`/storage
+ * access) so they can be unit-tested in isolation; the hook supplies the I/O.
+ */
+import type { Language } from '@/shared/types/game';
+
+/** Locales we ship native, hand-crafted translations for. */
+export const SUPPORTED_SUGGESTION_LANGUAGES = ['en', 'he', 'sv', 'ja', 'es'] as const;
+export type SuggestionLanguage = (typeof SUPPORTED_SUGGESTION_LANGUAGES)[number];
+
+const SUPPORTED = new Set<string>(SUPPORTED_SUGGESTION_LANGUAGES);
+
+/**
+ * Map a BCP-47 language tag (e.g. `es-MX`, `en-GB`, legacy `iw`) to one of the
+ * languages we natively support, or `null` if we don't ship that language.
+ */
+export function mapToSupportedLanguage(tag: string | null | undefined): SuggestionLanguage | null {
+  if (!tag) return null;
+  const primary = tag.toLowerCase().split(/[-_]/)[0];
+  // `iw` is the deprecated ISO code for Hebrew still emitted by some browsers.
+  const normalized = primary === 'iw' ? 'he' : primary;
+  return SUPPORTED.has(normalized) ? (normalized as SuggestionLanguage) : null;
+}
+
+/**
+ * First natively-supported language in the browser's ordered preference list
+ * (`navigator.languages`). Returns `null` when none are supported.
+ */
+export function detectPreferredLanguage(
+  navigatorLanguages: readonly string[] | undefined,
+): SuggestionLanguage | null {
+  if (!navigatorLanguages) return null;
+  for (const tag of navigatorLanguages) {
+    const lang = mapToSupportedLanguage(tag);
+    if (lang) return lang;
+  }
+  return null;
+}
+
+interface SuggestionInput {
+  /** Language the app is currently rendering. */
+  current: Language;
+  /** Natively-supported language the browser prefers (from detectPreferredLanguage). */
+  preferred: SuggestionLanguage | null;
+  /** Whether the user explicitly picked the current language (don't nag). */
+  explicit: boolean;
+  /** Whether the user already dismissed the suggestion for `preferred`. */
+  dismissed: boolean;
+  /** Whether the browser/extension is actively machine-translating the page. */
+  browserTranslating: boolean;
+}
+
+/**
+ * Decide whether to offer switching to the user's native language.
+ * Returns the language to suggest, or `null` to stay silent.
+ */
+export function resolveSuggestedLanguage({
+  current,
+  preferred,
+  explicit,
+  dismissed,
+  browserTranslating,
+}: SuggestionInput): SuggestionLanguage | null {
+  if (!preferred) return null;
+  if (preferred === current) return null; // already in their language
+  if (dismissed) return null; // respect a prior dismissal, always
+  // If they explicitly chose the current language, stay silent — UNLESS the
+  // browser is actively machine-translating, which is strong evidence that the
+  // explicit pick no longer matches what they actually want to read.
+  if (explicit && !browserTranslating) return null;
+  return preferred;
+}
+
+/**
+ * Detect an active in-browser page translation (Google Translate, Edge
+ * Translator, etc.). Google Translate toggles `translated-ltr`/`translated-rtl`
+ * on `<html>` and injects `.skiptranslate`/`.goog-te-*` nodes; Edge stamps
+ * translated text nodes with `_msttexthash`.
+ */
+export function isBrowserTranslating(doc: Document | undefined | null): boolean {
+  if (!doc) return false;
+  const html = doc.documentElement;
+  if (!html) return false;
+  if (html.classList.contains('translated-ltr') || html.classList.contains('translated-rtl')) {
+    return true;
+  }
+  return !!doc.querySelector('.goog-te-banner-frame, .skiptranslate, [_msttexthash]');
+}
+
+/** Copy for the suggestion banner, written *in the target language* so the */
+/** offer is understandable to a speaker of that language. */
+export interface SuggestionCopy {
+  /** Autonym shown to the user (e.g. "Español", "עברית"). */
+  nativeName: string;
+  /** Full prompt, e.g. "¿Prefieres jugar en Español?". */
+  prompt: string;
+  /** Accept button label. */
+  accept: string;
+  /** Dismiss button accessible label. */
+  dismiss: string;
+}
+
+export const SUGGESTION_COPY: Record<SuggestionLanguage, SuggestionCopy> = {
+  en: { nativeName: 'English', prompt: 'Prefer to play in English?', accept: 'Switch', dismiss: 'No thanks' },
+  es: { nativeName: 'Español', prompt: '¿Prefieres jugar en Español?', accept: 'Cambiar', dismiss: 'No, gracias' },
+  he: { nativeName: 'עברית', prompt: 'מעדיפים לשחק בעברית?', accept: 'החלף', dismiss: 'לא תודה' },
+  sv: { nativeName: 'Svenska', prompt: 'Vill du spela på svenska?', accept: 'Byt', dismiss: 'Nej tack' },
+  ja: { nativeName: '日本語', prompt: '日本語でプレイしますか？', accept: '切り替える', dismiss: 'いいえ' },
+};


### PR DESCRIPTION
## Problem

A player whose **top browser language differs from the app's language** (e.g. a US‑based Spanish speaker) can be served our **English** app anyway — typically because a stale `boggle_language=en` cookie (or an English deep link) pins the locale ahead of their `Accept-Language`. Chrome then **machine‑translates** the English UI to Spanish on the fly.

This was the source of the reported screenshot: the language flag showed 🇺🇸 while the UI text was Spanish. The flag was *correct* — the app genuinely ran in English; the Spanish text was **Chrome's auto‑translation overlay**, not our app.

Two real harms:
1. The player gets a worse machine translation of English instead of our hand‑crafted `es` bundle (which we already ship).
2. In‑browser translators mutate the DOM and crash React with `NotFoundError: Failed to execute 'removeChild'` — the codebase already defends game tiles/words with `translate="no"`, but the broader UI was exposed.

## Solution

**1. Native‑language offer banner** (`NativeLanguageBanner` + `useNativeLanguageSuggestion`)
- When the browser's top *supported* preference differs from the current app language (and the user hasn't explicitly chosen it), show a **dismissible** banner offering a one‑tap switch to our native translation.
- Copy is rendered **in the target language** (e.g. "¿Prefieres jugar en Español?") so the speaker understands it.
- Dismissal is **remembered per language** (`localStorage`) — no nagging on every load.
- If active page‑translation is detected, the offer can override an explicit choice (strong signal the page is being translated). Once the user accepts and the page is genuinely in their language, the browser stops auto‑translating.
- Mounted globally in `app/[locale]/layout.tsx` beside `OfflineBanner`.

**2. Defensive crash guard** (`installTranslationDomGuard`)
- Wraps `Node.prototype.removeChild`/`insertBefore` so that, when a translator has already moved/detached the target node, they **no‑op instead of throwing** — the widely‑used mitigation for the React + Google Translate crash.
- Idempotent (marks the live method, not a separate flag) and installed early in `instrumentation-client.ts`, before hydration.

## Notes
- The flag itself was **not** a bug — it correctly reflects the real app language. The fix targets the root cause (browser auto‑translation) rather than the symptom.
- Detection/decision logic is pure and fully unit‑tested.

## Tests
TDD throughout — **29 tests**, all green:
- `utils/__tests__/languageSuggestion.test.ts` — tag mapping, preference detection, suggestion heuristics, translation detection, copy completeness.
- `utils/__tests__/domTranslationGuard.test.ts` — genuine ops still work, orphaned‑node ops no‑op, idempotency.
- `components/__tests__/NativeLanguageBanner.test.tsx` — offer/accept/dismiss‑persist, no‑op when already native / unsupported, `translate="no"` self‑guard.

`tsc --noEmit` and ESLint pass clean on all changed files.

https://claude.ai/code/session_016HmmQanGrV4UV19E2tgaCm

---
_Generated by [Claude Code](https://claude.ai/code/session_016HmmQanGrV4UV19E2tgaCm)_