### PR TITLE
SEO: daily meta tag improvements (2026-06-06)

### DIFF
--- a/docs/seo-daily/2026-06-06.md
+++ b/docs/seo-daily/2026-06-06.md
@@ -1,0 +1,94 @@
+# SEO Daily Report — 2026-06-06
+
+**Data range:** 2026-05-08 → 2026-06-04 (28 days, GSC; Bing API returned 403 — skipped)
+
+---
+
+## Headline Metrics
+
+### Google Search Console (28d)
+
+| Metric | Value |
+|---|---|
+| Total clicks | 63 |
+| Total impressions | 9,541 |
+| Overall CTR | 0.7% |
+| Avg position | 8.5 |
+| Unique queries | 262 |
+| Unique pages ranked | 301 |
+
+**7d vs prior-7d delta:** Not available from single-period pull. Run two separate GSC queries for precise trend data.
+
+### Bing Webmaster
+API returned HTTP 403 — Bing Webmaster key `c13df4f2...` not authorized for `lexiclash.live`. Verify the site is added and verified in Bing Webmaster Tools, then re-add the API key.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+Queries with ≥30 impressions where actual CTR < 70% of expected CTR for their position band.
+
+| Query | Page | Pos | Impressions | Current CTR | Expected CTR | Suggested Fix |
+|---|---|---|---|---|---|---|
+| scrabble online | /es/juego-de-palabras-multijugador | 6.5 | 2,019 | 0.3% | 4% | Shorten title (78→60 chars), action desc |
+| scrabble online gratis | /es/juego-de-palabras-multijugador | 8.5 | 896 | 0.0% | 2% | Same page fix |
+| scrabble en linea | /es/juego-de-palabras-multijugador | 7.6 | 867 | 0.3% | 3% | Same page fix |
+| scrabble online español | /es/juego-de-palabras-multijugador | 8.3 | 808 | 0.1% | 2% | Same page fix |
+| jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 7.4 | 493 | 0.2% | 3% | Same page fix |
+| scrabble online svenska | /sv/swedish-multiplayer-word-game | 7.1 | 387 | 0.0% | 3% | Swedish title/desc (62→56 chars) |
+| scrabble en español online | /es/juego-de-palabras-multijugador | 7.5 | 349 | 0.6% | 3% | Same page fix |
+| scrabble juego online | /es/juego-de-palabras-multijugador | 7.2 | 311 | 0.3% | 3% | Same page fix |
+| jugar scrabble gratis | /es/juego-de-palabras-multijugador | 6.7 | 193 | 0.0% | 4% | Same page fix |
+| jugar scrabble online | /es/juego-de-palabras-multijugador | 8.2 | 235 | 0.0% | 2% | Same page fix |
+
+**Combined potential lift (top 15 queries):** ~209 additional clicks/28d if CTR reaches 50% of expected.
+
+Two distinct pages account for all 34 CTR opportunities: the Spanish multiplayer page and the Swedish multiplayer page. Fixing those two files captures the entire CTR gap.
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+Queries at positions 8–20 with ≥50 impressions — small content/link improvements can push to page 1.
+
+| Query | Page | Pos | Impressions | Clicks | Suggested Action |
+|---|---|---|---|---|---|
+| scrabble online gratis | /es/juego-de-palabras-multijugador | 8.5 | 896 | 0 | Add H2 "Juega Scrabble Online Gratis Sin Registro", internal links from homepage |
+| scrabble online español | /es/juego-de-palabras-multijugador | 8.3 | 808 | 1 | Add H2 "Scrabble Online en Español — Tiempo Real", expand FAQ answer |
+| jugar scrabble online | /es/juego-de-palabras-multijugador | 8.2 | 235 | 0 | Add FAQ entry: "¿Cómo jugar Scrabble online?" |
+| scrabble (en español) - juega gratis en línea | /es/juego-de-palabras-multijugador | 8.0 | 215 | 1 | Meta desc action verb improvement (this PR) |
+| scrabble online gratis en español | /es/juego-de-palabras-multijugador | 8.6 | 206 | 0 | Include phrase in H2 on page |
+| scrabble svenska | /sv/swedish-multiplayer-word-game | 8.6 | 128 | 0 | Add H2 "Spela Scrabble Svenska Online Gratis", this PR title fix |
+| scrabble español online | /es/juego-de-palabras-multijugador | 8.5 | 120 | 1 | Same Spanish page fix |
+| scrabble gratis en español | /es/juego-de-palabras-multijugador | 8.1 | 117 | 0 | Same Spanish page fix |
+| jugar scrabble online gratis | /es/juego-de-palabras-multijugador | 8.0 | 99 | 0 | Same Spanish page fix |
+| scrabble online español multijugador | /es/juego-de-palabras-multijugador | 8.8 | 90 | 2 | Add H2 matching this phrase |
+
+---
+
+## Bing Parity Gaps
+
+Skipped — Bing Webmaster API returned HTTP 403. **Action required:** Log into Bing Webmaster Tools, verify `lexiclash.live`, and generate a new API key.
+
+---
+
+## GEO / AI Visibility Recommendations
+
+The Spanish and Swedish pages already have FAQPage + HowTo JSON-LD schema. Opportunities to expand:
+
+| Query type | Current | Recommended |
+|---|---|---|
+| "scrabble online gratis" | No explicit FAQ entry | Add: Q "¿Es gratis scrabble online?" → A "Sí, 100% gratis. Sin registro, sin descargas. Solo abre el juego y empieza." |
+| "cómo jugar scrabble online" | HowTo schema present | Verify HowTo steps include "Comparte el enlace" as a distinct step with clear `text` |
+| "scrabble svenska regler" | Not present | Add FAQ entry on Swedish page: "Vad är reglerna för Scrabble Online?" with concise answer |
+| "word game multiplayer" (English) | FAQ on homepage | Ensure homepage FAQ includes "Is LexiClash free?" and "How many players?" answers for AI snippet capture |
+
+The FAQ schema on both landing pages is structurally correct. The gap is **answer completeness** — answers under 40 words perform best in AI overviews.
+
+---
+
+## Today's Actions
+
+1. **PR opened:** Meta title shortened on Spanish page (78→60 chars) and Swedish page (62→56 chars); descriptions tightened with action verbs. Estimated +74 clicks/28d on "scrabble online" alone at position 6.5.
+2. **Bing blocked:** Resolve the 403 on Bing Webmaster API — verify the site and regenerate the API key. Once fixed, re-run this script to populate the parity gap table.
+3. **Content sprint (next 5 days):** Add H2 tags to the Spanish page matching "scrabble online gratis" and "scrabble online español" phrases, and one new FAQ entry per page. These are the 15 rank-up queries clustered at position 8–9 — a nudge to page 1 is within reach.

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,12 +27,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Jugar Scrabble en Español Online Gratis — Multijugador Tiempo Real | LexiClash',
-    description: 'Jugar scrabble en español online gratis con amigos en tiempo real — no por turnos. Sin registro, sin descarga. Hasta 50 jugadores. Crea sala en segundos, invita por enlace.',
+    title: 'Scrabble Online Gratis en Español — Multijugador | LexiClash',
+    description: 'Juega Scrabble online gratis en español con amigos — tiempo real, no por turnos. Sin registro ni descarga. Crea sala, invita y empieza en segundos.',
     keywords: 'jugar scrabble en español online gratis, scrabble en español online gratis, scrabble online español, cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Jugar Scrabble en Español Online Gratis — Tiempo Real | LexiClash',
-      description: 'Jugar scrabble en español online gratis — no por turnos. Crea sala, invita por enlace. 100% gratis, sin descargas.',
+      title: 'Scrabble Online Gratis en Español — Multijugador | LexiClash',
+      description: 'Juega Scrabble online gratis en español — tiempo real, no por turnos. Crea sala, invita por enlace. 100% gratis, sin descargas.',
       locale: 'es_ES',
       type: 'website',
       url: pageUrl,
@@ -47,8 +47,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Gratis en Español — Multijugador en Tiempo Real | LexiClash',
-      description: 'Juega scrabble online en tiempo real — no por turnos. Sala con enlace, sin registro. ¡Hasta 50 jugadores!',
+      title: 'Scrabble Online Gratis en Español — Multijugador | LexiClash',
+      description: 'Juega Scrabble online gratis en español — tiempo real, no por turnos. Sin registro. Crea sala, invita y empieza en segundos. ¡Hasta 50 jugadores!',
       images: [`${BASE_URL}/og-image-es-multiplayer.webp`],
     },
     alternates: {

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -16,12 +16,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
-    description: 'Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk, tävla direkt. Gratis, ingen app, ingen registrering.',
+    title: 'Scrabble Online Svenska Gratis — Multiplayer | LexiClash',
+    description: 'Spela Scrabble online på svenska — gratis, ingen app, ingen registrering. Realtid med vänner: skapa rum, bjud in med länk, tävla direkt. Upp till 50 spelare.',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
-      description: 'Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk. Gratis, ingen registrering.',
+      title: 'Scrabble Online Svenska Gratis — Multiplayer | LexiClash',
+      description: 'Spela Scrabble online på svenska i realtid — gratis, ingen registrering. Skapa rum, bjud in med länk och tävla direkt.',
       locale: 'sv_SE',
       type: 'website',
       url: pageUrl,
@@ -36,8 +36,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
-      description: 'Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk, tävla direkt. Gratis.',
+      title: 'Scrabble Online Svenska Gratis — Multiplayer | LexiClash',
+      description: 'Spela Scrabble online på svenska i realtid — gratis, ingen registrering. Skapa rum, bjud in med länk och tävla direkt. Upp till 50 spelare.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },
     alternates: {


### PR DESCRIPTION
## Summary

Daily SEO meta-tag pass targeting the two pages responsible for 100% of the 34 CTR-opportunity queries found in the 2026-05-08→2026-06-04 GSC dataset.

---

## Changes

### 1. `/es/juego-de-palabras-multijugador` — Spanish multiplayer page

**Top query:** `scrabble online` — 2,019 impressions at position 6.5, **0.3% CTR vs 4% expected (+74 clicks/28d potential)**

| | Old | New |
|---|---|---|
| Title (chars) | Jugar Scrabble en Español Online Gratis — Multijugador Tiempo Real \| LexiClash **(78)** | Scrabble Online Gratis en Español — Multijugador \| LexiClash **(60)** |
| Description | Jugar scrabble en español online gratis con amigos en tiempo real — no por turnos. Sin registro, sin descarga. Hasta 50 jugadores. Crea sala en segundos, invita por enlace. **(173 chars)** | Juega Scrabble online gratis en español con amigos — tiempo real, no por turnos. Sin registro ni descarga. Crea sala, invita y empieza en segundos. **(147 chars)** |

**Why:** Title was 78 chars — Google truncates past ~60, producing a clipped snippet. New title leads with exact query `Scrabble Online` and stays within budget. Description opens with action verb `Juega`.

**Queries benefiting:** scrabble online · scrabble en linea · scrabble online gratis · scrabble online español · jugar scrabble en español gratis · scrabble en español online · scrabble juego online (combined ~6,300 impressions/28d)

---

### 2. `/sv/swedish-multiplayer-word-game` — Swedish multiplayer page

**Top query:** `scrabble online svenska` — 387 impressions at position 7.1, **0.0% CTR vs 3% expected (+11 clicks/28d potential)**

| | Old | New |
|---|---|---|
| Title (chars) | Scrabble Online Svenska Gratis — Spela Multiplayer \| LexiClash **(62)** | Scrabble Online Svenska Gratis — Multiplayer \| LexiClash **(56)** |
| Description | Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk, tävla direkt. Gratis, ingen app, ingen registrering. **(135)** | Spela Scrabble online på svenska — gratis, ingen app, ingen registrering. Realtid med vänner: skapa rum, bjud in med länk, tävla direkt. Upp till 50 spelare. **(155)** |

**Why:** Title trimmed 62→56 chars. Description now opens with `Spela` (action verb) and adds player-count social proof.

---

## Expected CTR Uplift

| Page | Impressions/28d | Current CTR | Target CTR | Est. extra clicks/28d |
|---|---|---|---|---|
| Spanish multiplayer | ~6,300 | 0.2% avg | 1.5% (50% of expected) | ~82 |
| Swedish multiplayer | ~625 | 0.1% avg | 1.5% | ~9 |
| **Total** | | | | **~91 clicks/28d** |

---

## Test Plan
- [ ] Verify title ≤60 chars renders untruncated in SERP preview
- [ ] `pnpm build` passes in `fe-next/`
- [ ] Spanish page `<title>` correct in browser
- [ ] Swedish page `<title>` correct in browser
- [ ] Monitor GSC CTR for these queries over next 14 days

https://claude.ai/code/session_01PJ4hQZ2LL6AS5ZhpVokyLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJ4hQZ2LL6AS5ZhpVokyLs)_