### PR TITLE
fix(practice): stop Word Hunt board overflowing into discoveries list

### DIFF
--- a/fe-next/components/practice/PracticeClassicSandbox.tsx
+++ b/fe-next/components/practice/PracticeClassicSandbox.tsx
@@ -196,7 +196,10 @@ export default function PracticeClassicSandbox() {
       <PracticeMistakeCoach kind={coach.active} mode="classic" onClose={coach.close} />
 
       <div className="flex-1 min-h-0 flex items-center justify-center w-full">
-        <div data-testid="practice-board" className="w-full max-w-xs aspect-square">
+        {/* Fill the flex space; `.game-board-frame` clamps the square to the
+            available height (max-height: min(board-size, 100%)). A width-driven
+            `aspect-square` here overflowed downward on short viewports. */}
+        <div data-testid="practice-board" className="w-full h-full">
           <GridComponent
             grid={board}
             interactive

--- a/fe-next/components/practice/PracticeWordHuntSandbox.tsx
+++ b/fe-next/components/practice/PracticeWordHuntSandbox.tsx
@@ -417,7 +417,12 @@ export default function PracticeWordHuntSandbox() {
         </div>
 
         <div className={`flex-1 min-h-0 flex items-center justify-center w-full relative transition-opacity duration-200 ${isVerifying ? 'opacity-50 pointer-events-none' : ''}`}>
-        <div data-testid="practice-board" className="w-full max-w-xs aspect-square mx-auto">
+        {/* Fill the flex space and let `.game-board-frame`'s
+            `max-height: min(board-size, 100%)` clamp the square to the
+            available height — mirrors the live game's <SurvivalGridSection>.
+            A width-driven `aspect-square` here overflowed downward and painted
+            tiles over the discoveries list when vertical room was tight. */}
+        <div data-testid="practice-board" className="w-full h-full">
           <GridComponent
             grid={board}
             interactive

--- a/fe-next/components/practice/__tests__/PracticeWordHuntSandbox.boardSizing.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeWordHuntSandbox.boardSizing.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * PracticeWordHuntSandbox — board sizing / no-clipping regression.
+ *
+ * Bug (2026-06-06): the board wrapper used a *width-driven* `aspect-square`
+ * (`w-full max-w-xs aspect-square`). When the vertical space left by the clue
+ * boxes + tips + discoveries was smaller than the board's width, the square
+ * overflowed DOWNWARD and painted its white tiles over the DiscoveredWordsList
+ * below it ("6 palabras / TIA" bleeding through the grid).
+ *
+ * Fix mirrors the live game's `SurvivalGridSection`: the board wrapper FILLS
+ * the flex container (`w-full h-full`) and lets `.game-board-frame`'s
+ * `max-height: min(board-size, 100%)` clamp the square to the available height,
+ * so it can never overflow its allotted space.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/practice/usePracticeValidator', () => ({
+  usePracticeValidator: () => ({ check: vi.fn().mockResolvedValue({ isValid: true }) }),
+}));
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ language: 'en', t: (k: string) => k }),
+}));
+vi.mock('pixi.js', () => ({
+  Application: class {
+    canvas = document.createElement('canvas');
+    screen = { width: 320, height: 240 };
+    stage = { addChild: vi.fn(), removeChild: vi.fn(), removeChildren: vi.fn() };
+    ticker = { add: vi.fn(), remove: vi.fn() };
+    init = vi.fn().mockResolvedValue(undefined);
+    destroy = vi.fn();
+  },
+  Graphics: class {
+    x = 0;
+    y = 0;
+    alpha = 1;
+    scale = { set: vi.fn() };
+    circle = vi.fn().mockReturnThis();
+    fill = vi.fn().mockReturnThis();
+    clear = vi.fn().mockReturnThis();
+    destroy = vi.fn();
+  },
+}));
+vi.mock('@/components/GridComponent', () => ({
+  default: () => <div data-testid="grid-component-stub" />,
+}));
+
+import PracticeWordHuntSandbox from '../PracticeWordHuntSandbox';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('PracticeWordHuntSandbox — board fits its flex space (no clipping)', () => {
+  it('fills the available height instead of forcing a width-driven square', () => {
+    const { getByTestId } = render(<PracticeWordHuntSandbox />);
+    const board = getByTestId('practice-board');
+
+    // Fills the flex container height so .game-board-frame can clamp to it.
+    expect(board.className).toContain('h-full');
+    expect(board.className).toContain('w-full');
+
+    // Must NOT use a width-driven aspect-square — that overflowed downward and
+    // painted over the discoveries list. The square is enforced by the inner
+    // .game-board-frame CSS, not by the wrapper.
+    expect(board.className).not.toContain('aspect-square');
+  });
+});


### PR DESCRIPTION
## Problem

In **Practice → Word Hunt** the board was overflowing its allotted space and painting its white tiles over the elements below it — the `DiscoveredWordsList` ("6 palabras / TIA") bled *through* the grid, and the board looked clipped/cramped (reported on a narrow viewport).

## Root cause

The board wrapper forced a **width-driven** square:

```tsx
<div data-testid="practice-board" className="w-full max-w-xs aspect-square mx-auto">
```

`aspect-square` makes the element as tall as it is wide. When the vertical space left over (after the clue boxes + goal chip + short-tip row + discoveries) was smaller than the board's width, the square's height exceeded its `flex-1` container and **overflowed downward**, drawing tiles on top of the discoveries list. The inner `.game-board-frame` already has viewport-aware sizing (`--board-size` + `max-height: min(board-size, 100%)`), but its `100%` clamp was tied to the width-driven square wrapper, so it never engaged.

## Fix

Mirror the live game's `SurvivalGridSection`, which has never had this bug: let the wrapper **fill** its flex container and let `.game-board-frame`'s `max-height: min(board-size, 100%)` clamp the square to the actually-available height.

```tsx
<div data-testid="practice-board" className="w-full h-full">
```

Now `100%` resolves to the real `flex-1` height, so the board can never exceed its allotted space — no overflow, no painting over the discoveries. Applied to **both** the Word Hunt and Classic sandboxes (identical anti-pattern).

## Tests

- New regression test `PracticeWordHuntSandbox.boardSizing.test.tsx` (written first, RED → GREEN): asserts the board wrapper fills height (`w-full h-full`) and no longer uses the overflow-prone `aspect-square`.
- Full practice suite green: **359 tests passing** across 55 files.
- Lint clean on changed files.

## Notes

Pushed via the GitHub API because the environment's git proxy rejected the push with HTTP 413.

---
_Generated by [Claude Code](https://claude.ai/code/session_0183FU5yMRyDcJCe6oDTYV5S)_