### PR TITLE
SEO: daily meta tag improvements (2026-06-07)

### DIFF
--- a/docs/seo-daily/2026-06-07.md
+++ b/docs/seo-daily/2026-06-07.md
@@ -1,0 +1,156 @@
+# SEO Daily Report — 2026-06-07
+
+**Data range:** 2026-05-09 to 2026-06-05 (28 days; GSC 2-day lag)
+**Generated:** 2026-06-07
+
+---
+
+## Headline Metrics
+
+### Google Search Console
+
+| Metric | 28d Total | Last 7d | Prior 7d | Delta |
+|---|---|---|---|---|
+| Clicks | 70 | 25 | 18 | **+39%** |
+| Impressions | 12,323 | 6,387 | 3,625 | **+76%** |
+| CTR | 0.57% | 0.39% | 0.50% | −0.11pp |
+| Avg Position | 8.1 | — | — | — |
+
+> **Signal:** Impressions accelerating sharply (+76% WoW) driven by "scrabble online" query surge. CTR has not kept pace — title truncation and weak CTAs are likely culprits.
+
+### Bing Webmaster Tools
+
+> **Not available.** Bing API returned HTTP 403 (API key rejected for this site). Bing section skipped.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+Criteria: impressions ≥ 30, CTR underperforms position benchmark by ≥ 30%.
+
+| # | Query | Page | Position | Impressions | CTR | Expected CTR | Gap | Suggested Fix |
+|---|---|---|---|---|---|---|---|---|
+| 1 | scrabble online | /es/juego-de-palabras-multijugador | 6.4 | 2,860 | 0.2% | 4.0% | **−94%** | Shorten title to ≤60 chars; add action verb CTA in desc |
+| 2 | scrabble online gratis | /es/juego-de-palabras-multijugador | 8.3 | 1,123 | 0.0% | 2.5% | **−100%** | Same page — title/desc fix captures this too |
+| 3 | scrabble en linea | /es/juego-de-palabras-multijugador | 7.3 | 1,090 | 0.3% | 3.0% | **−91%** | Same page — title/desc fix |
+| 4 | scrabble online español | /es/juego-de-palabras-multijugador | 8.0 | 1,071 | 0.1% | 2.5% | **−96%** | Same page — title/desc fix |
+| 5 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 7.1 | 601 | 0.2% | 3.0% | **−94%** | Same page — title/desc fix |
+| 6 | scrabble en español online | /es/juego-de-palabras-multijugador | 7.2 | 464 | 0.4% | 3.0% | **−86%** | Same page |
+| 7 | scrabble online svenska | sv/swedish-multiplayer-word-game | 6.8 | 404 | 0.0% | 3.0% | **−100%** | Swedish page needs dedicated landing page title with "Svenska Scrabble Online" |
+| 8 | scrabble juego online | /es/juego-de-palabras-multijugador | 6.9 | 382 | 0.3% | 3.0% | **−91%** | Same page |
+| 9 | scrabble (en español) - juega gratis en línea | /es/juego-de-palabras-multijugador | 7.8 | 308 | 0.3% | 2.5% | **−87%** | Same page |
+| 10 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.0 | 305 | 0.0% | 2.5% | **−100%** | Same page |
+
+**Root cause for #1–6, 8–10:** Current title is 75 chars (Google truncates at ~60) and lacks urgency CTA. All 9 queries land on the same page — a single title/desc fix has outsized impact.
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+Criteria: avg position 8–20, impressions ≥ 50.
+
+| # | Query | Page | Position | Impressions | Suggested Action |
+|---|---|---|---|---|---|
+| 1 | scrabble online gratis | /es/juego-de-palabras-multijugador | 8.3 | 1,123 | Add H2 "Juega Scrabble Online Gratis" above fold; expand FAQ with "¿Es gratis scrabble online?" |
+| 2 | jugar scrabble online | /es/juego-de-palabras-multijugador | 8.0 | 305 | Internal links from /es/ homepage to this page using anchor "jugar scrabble online" |
+| 3 | scrabble online gratis en español | /es/juego-de-palabras-multijugador | 8.5 | 236 | Add keyword phrase to intro paragraph |
+| 4 | scrabble svenska | sv/swedish-multiplayer-word-game | 8.3 | 173 | Swedish page needs dedicated meta + H1 with "Scrabble Svenska Online Gratis" |
+| 5 | scrabble español online | /es/juego-de-palabras-multijugador | 8.4 | 133 | Covered by title fix |
+| 6 | scrabble espagnol en ligne | /es/juego-de-palabras-multijugador | 8.4 | 79 | French visitors landing on Spanish page — consider hreflang or French landing page |
+| 7 | המילה היומית | /he/hamila-hayomit | 9.2 | 74 | Improve Hebrew page H1 to start with exact query; add DefinedTerm schema answer |
+| 8 | scrabble online en español | /es/juego-de-palabras-multijugador | 9.1 | 59 | Covered by title fix |
+| 9 | מילת היום | /he/hamila-hayomit | 9.9 | 57 | Add "מילת היום" as alt-name in DefinedTerm schema; FAQ answer for this exact query |
+
+---
+
+## Bing Parity Gaps
+
+> Bing API returned HTTP 403. Unable to compute Bing parity gaps.
+> **Action:** Verify Bing Webmaster Tools API key at https://www.bing.com/webmasters — current key may be expired or not authorized for lexiclash.live.
+
+---
+
+## Rising / Falling Queries (Last 7d vs Prior 7d)
+
+### Rising (>30% impression increase)
+
+| Query | Prior 7d | Last 7d | Delta |
+|---|---|---|---|
+| המילה היומית (Hebrew daily word) | 2 | 72 | **+3,500%** |
+| scrable online (typo variant) | 1 | 21 | +2,000% |
+| scrabble on line | 3 | 23 | +667% |
+| scrabble online en español | 6 | 42 | +600% |
+| מילת היום (Hebrew word of day) | 9 | 35 | +289% |
+| jugar scrabble online | 47 | 146 | +211% |
+| ordhjul (Swedish word wheel) | 5 | 15 | +200% |
+| scrabble online | 754 | 2,042 | **+171%** |
+| scrabble gratis español | 4 | 10 | +150% |
+| juego de scrabble en español gratis online | 19 | 46 | +142% |
+
+### Falling (>30% impression decrease)
+
+| Query | Prior 7d | Last 7d | Delta |
+|---|---|---|---|
+| scrabble online svenska | 109 | 57 | −48% |
+| scrabble español online | 47 | 29 | −38% |
+| scrabble svenska online | 16 | 11 | −31% |
+
+---
+
+## GEO / AI Visibility Recommendations
+
+These question-style queries are prime candidates for FAQPage schema and clear answer paragraphs (LLMs and AI Overviews extract structured Q&A).
+
+### Spanish Scrabble Page (`/es/juego-de-palabras-multijugador`)
+
+Add to existing FAQPage schema:
+
+```json
+{
+  "@type": "Question",
+  "name": "¿Cómo jugar Scrabble online gratis en español?",
+  "acceptedAnswer": {
+    "@type": "Answer",
+    "text": "Entra en LexiClash.live, elige Español, crea una sala en 1 clic y comparte el enlace. Sin registro, sin descarga. Hasta 50 jugadores en tiempo real."
+  }
+},
+{
+  "@type": "Question",
+  "name": "¿Cuál es la mejor alternativa a Scrabble online gratis?",
+  "acceptedAnswer": {
+    "@type": "Answer",
+    "text": "LexiClash es una alternativa a Scrabble online gratis en español — multijugador en tiempo real, 10,000+ palabras, sin turnos, sin registro."
+  }
+}
+```
+
+### Hebrew Daily Word Page (`/he/hamila-hayomit`)
+
+This page is exploding (+3,500% for "המילה היומית"). Current FAQ has 6 items. Add:
+
+```json
+{
+  "@type": "Question",
+  "name": "מה זה מילת היום?",
+  "acceptedAnswer": {
+    "@type": "Answer",
+    "text": "מילת היום היא אתגר יומי חינמי של LexiClash — כל יום מילה חדשה לאותו לוח לכל העולם. משחקים ציד מילים וגלגל מילים, משתפים תוצאות, ומתחרים בטבלת מובילים."
+  }
+}
+```
+
+### Home Page (`/es/`) — FAQ addition for rising query
+
+"rueda de palabras online" (new query, 22 impressions last 7d) — add FAQ item to homepage Spanish FAQ schema:
+```
+Q: ¿Qué es la rueda de palabras online?
+A: La Rueda de Palabras de LexiClash es un puzzle diario gratuito: gira letras para encontrar todas las palabras escondidas. Nuevo puzzle cada día, gratis, sin registro.
+```
+
+---
+
+## Today's Actions
+
+- **Action 1 (PR #1 — this report):** Update meta title (75→51 chars) and description on `/es/juego-de-palabras-multijugador` to capture "scrabble online" surge (2,860 impressions, 0.2% CTR → target 2–3%). Estimated uplift: +40–60 clicks/week.
+- **Action 2:** Add 2 FAQ items to `/es/juego-de-palabras-multijugador` targeting "jugar scrabble online gratis" (GEO/AI visibility for AI Overviews).
+- **Action 3:** Improve Hebrew `/he/hamila-hayomit` meta title and FAQ schema — "המילה היומית" is at +3,500% impressions with 0 clicks; capturing even 5% CTR = ~18 clicks/week.

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,12 +27,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Scrabble Online Gratis en Español — Multijugador en Tiempo Real | LexiClash',
-    description: 'Scrabble online gratis en español — sin turnos, tiempo real. Sin registro ni app. Crea sala en 1 clic, invita por enlace. Hasta 50 jugadores.',
+    title: 'Jugar Scrabble Online Gratis en Español | LexiClash',
+    description: 'Juega Scrabble online gratis en español ahora. Sin registro, sin app — multijugador en tiempo real. Crea sala en 1 clic, invita amigos. ¡Empieza ya! →',
     keywords: 'jugar scrabble en español online gratis, scrabble en español online gratis, scrabble online español, cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Scrabble Online Gratis en Español — Multijugador en Tiempo Real | LexiClash',
-      description: 'Scrabble online gratis en español — sin turnos, tiempo real. Crea sala, invita por enlace. Sin registro ni descargas.',
+      title: 'Jugar Scrabble Online Gratis en Español | LexiClash',
+      description: 'Juega Scrabble online gratis en español — sin registro, sin app. Multijugador en tiempo real, crea sala en 1 clic. ¡Empieza ya! →',
       locale: 'es_ES',
       type: 'website',
       url: pageUrl,
@@ -47,8 +47,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Gratis en Español — Multijugador en Tiempo Real | LexiClash',
-      description: 'Juega scrabble online en tiempo real — no por turnos. Sala con enlace, sin registro. ¡Hasta 50 jugadores!',
+      title: 'Jugar Scrabble Online Gratis en Español | LexiClash',
+      description: 'Juega Scrabble online gratis — sin registro, tiempo real. Crea sala en 1 clic. ¡Hasta 50 jugadores! →',
       images: [`${BASE_URL}/og-image-es-multiplayer.webp`],
     },
     alternates: {


### PR DESCRIPTION
## Summary

Meta title and description fixes for `/es/juego-de-palabras-multijugador` — the page receiving 9 of the top 10 CTR-opportunity queries. All three changes are title/description only; no content or component changes.

## Changes

### 1. `<title>` — 75 chars → 51 chars

| | Value |
|---|---|
| **Old** | `Scrabble Online Gratis en Español — Multijugador en Tiempo Real \| LexiClash` |
| **New** | `Jugar Scrabble Online Gratis en Español \| LexiClash` |

Google truncates titles at ~60 chars on desktop. The old title showed as `Scrabble Online Gratis en Español — Multijugador en T…` in SERPs, cutting off before the brand and burying the most relevant terms.

**Expected CTR uplift:** title now fits cleanly; "Jugar" matches the action-intent phrasing of top queries (jugar scrabble online, jugar scrabble en español gratis).

### 2. `<meta name="description">` — added urgency + CTA

| | Value |
|---|---|
| **Old** | `Scrabble online gratis en español — sin turnos, tiempo real. Sin registro ni app. Crea sala en 1 clic, invita por enlace. Hasta 50 jugadores.` |
| **New** | `Juega Scrabble online gratis en español ahora. Sin registro, sin app — multijugador en tiempo real. Crea sala en 1 clic, invita amigos. ¡Empieza ya! →` |

Adds "ahora" (urgency), action verb at start, and "¡Empieza ya! →" conversion CTA. Still ≤155 chars.

### 3. OpenGraph + Twitter card titles/descriptions updated to match.

## Data Behind This

| Query | Impressions (28d) | CTR | Pos | Expected CTR |
|---|---|---|---|---|
| scrabble online | 2,860 | 0.2% | 6.4 | 4.0% |
| scrabble online gratis | 1,123 | 0.0% | 8.3 | 2.5% |
| scrabble en linea | 1,090 | 0.3% | 7.3 | 3.0% |
| scrabble online español | 1,071 | 0.1% | 8.0 | 2.5% |
| jugar scrabble en español gratis | 601 | 0.2% | 7.1 | 3.0% |

Total impressions across affected queries: **~8,100** in 28 days, surging **+171% WoW** on "scrabble online" alone.

Conservative target: 1.5% blended CTR → ~22 additional clicks/week.

## Test Plan
- [ ] Confirm title renders correctly (≤60 chars visible) in a SERP preview tool
- [ ] Confirm description renders without truncation (≤155 chars)
- [ ] Check OG card preview looks correct (title + description)
- [ ] No layout/component regressions (only metadata changed)

Full SEO report: `docs/seo-daily/2026-06-07.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV9EVAyVsgC4mTQtxZwytK)_