### PR TITLE
feat: block player or guest by id or IP (admin moderation)

### DIFF
--- a/fe-next/app/[locale]/admin/blocklist/PageClient.tsx
+++ b/fe-next/app/[locale]/admin/blocklist/PageClient.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Shield } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import Header from '@/components/Header';
+import { Button } from '@/components/ui/button';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useAuth } from '@/contexts/AuthContext';
+import { cn } from '@/lib/utils';
+import { AdminSidebar } from '@/components/admin/sidebar/AdminSidebar';
+import { AdminBottomNav } from '@/components/admin/sidebar/AdminBottomNav';
+import { BlockListManager } from '@/components/admin/blocklist/BlockListManager';
+import { PageLoader } from '@/components/ui/PageLoader';
+import { useAdminAuth } from '@/hooks/useAdminAuth';
+
+export default function BlocklistPageClient() {
+  const router = useRouter();
+  const { t, language } = useLanguage();
+  const isRTL = language === 'he';
+  const { user, profile, isAdmin, loading: authLoading } = useAuth();
+  const { authToken, isLoading: tokenLoading } = useAdminAuth();
+
+  const isProfileLoading = !authLoading && user && !profile;
+
+  if (!authLoading && !isProfileLoading && (!user || !isAdmin)) {
+    return (
+      <div className="flex-1 bg-neo-navy text-neo-white flex items-center justify-center">
+        <div className="text-center">
+          <Shield className="w-16 h-16 text-neo-lime mx-auto mb-4" />
+          <h1 className="text-2xl font-neo-display text-neo-white mb-2">{t('admin.accessRequired')}</h1>
+          <Button onClick={() => router.push(`/${language}`)} variant="outline">{t('common.backToHome')}</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (authLoading || isProfileLoading || tokenLoading || !authToken) {
+    return (
+      <div className="flex-1 bg-neo-navy text-neo-white flex items-center justify-center">
+        <PageLoader size="lg" text={t('common.loading')} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('flex-1 flex flex-col bg-neo-navy w-full overflow-x-hidden min-h-screen', isRTL && 'rtl')}>
+      <Header />
+      <div className="flex flex-1">
+        <AdminSidebar />
+        <main className="flex-1 min-w-0 px-4 py-6 sm:px-6 lg:px-8 pb-20 sm:pb-6">
+          <div className="mb-6">
+            <h1 className="text-2xl font-neo-display text-neo-white">{t('admin.blocklist.title')}</h1>
+            <p className="text-sm text-slate-400 mt-1">{t('admin.blocklist.subtitle')}</p>
+          </div>
+          <BlockListManager authToken={authToken} />
+        </main>
+      </div>
+      <AdminBottomNav />
+    </div>
+  );
+}

--- a/fe-next/app/[locale]/admin/blocklist/page.tsx
+++ b/fe-next/app/[locale]/admin/blocklist/page.tsx
@@ -1,0 +1,5 @@
+import BlocklistPageClient from './PageClient';
+
+export default function BlocklistPage() {
+  return <BlocklistPageClient />;
+}

--- a/fe-next/app/api/admin/blocks/__tests__/parseBlockPayload.test.ts
+++ b/fe-next/app/api/admin/blocks/__tests__/parseBlockPayload.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { parseBlockPayload, BLOCK_TYPES } from '../parseBlockPayload';
+
+describe('parseBlockPayload', () => {
+  it('accepts a valid permanent block and trims the value', () => {
+    const r = parseBlockPayload({ blockType: 'auth_user', value: '  user-1  ', reason: 'cheating' });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.data.block_type).toBe('auth_user');
+      expect(r.data.value).toBe('user-1');
+      expect(r.data.reason).toBe('cheating');
+      expect(r.data.expires_at).toBeNull();
+    }
+  });
+
+  it('rejects an unknown block type', () => {
+    const r = parseBlockPayload({ blockType: 'email', value: 'x' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects an empty value', () => {
+    expect(parseBlockPayload({ blockType: 'ip', value: '   ' }).ok).toBe(false);
+    expect(parseBlockPayload({ blockType: 'ip' }).ok).toBe(false);
+  });
+
+  it('rejects an over-long value', () => {
+    expect(parseBlockPayload({ blockType: 'ip', value: 'x'.repeat(256) }).ok).toBe(false);
+  });
+
+  it('normalizes an empty reason to null', () => {
+    const r = parseBlockPayload({ blockType: 'ip', value: '1.2.3.4', reason: '   ' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data.reason).toBeNull();
+  });
+
+  it('computes expires_at from a positive durationMs', () => {
+    const before = Date.now();
+    const r = parseBlockPayload({ blockType: 'ip', value: '1.2.3.4', durationMs: 3600_000 });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const ts = new Date(r.data.expires_at as string).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before + 3600_000 - 1000);
+    }
+  });
+
+  it('accepts a future expiresAt ISO string', () => {
+    const future = new Date(Date.now() + 86_400_000).toISOString();
+    const r = parseBlockPayload({ blockType: 'guest_session', value: 'sess', expiresAt: future });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data.expires_at).toBe(future);
+  });
+
+  it('rejects an expiresAt in the past', () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    expect(parseBlockPayload({ blockType: 'ip', value: '1.2.3.4', expiresAt: past }).ok).toBe(false);
+  });
+
+  it('rejects an unparseable expiresAt', () => {
+    expect(parseBlockPayload({ blockType: 'ip', value: '1.2.3.4', expiresAt: 'not-a-date' }).ok).toBe(false);
+  });
+
+  it('exposes the three supported block types', () => {
+    expect([...BLOCK_TYPES]).toEqual(['auth_user', 'guest_session', 'ip']);
+  });
+});

--- a/fe-next/app/api/admin/blocks/parseBlockPayload.ts
+++ b/fe-next/app/api/admin/blocks/parseBlockPayload.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure validation/normalization for the admin blocklist create payload.
+ * Kept separate from the route so it can be unit-tested without Next/server deps.
+ */
+
+export const BLOCK_TYPES = ['auth_user', 'guest_session', 'ip'] as const;
+export type BlockType = (typeof BLOCK_TYPES)[number];
+
+const MAX_VALUE_LEN = 255;
+const MAX_REASON_LEN = 500;
+
+export interface ParsedBlock {
+  block_type: BlockType;
+  value: string;
+  reason: string | null;
+  /** ISO string, or null for a permanent block. */
+  expires_at: string | null;
+}
+
+export type ParseResult =
+  | { ok: true; data: ParsedBlock }
+  | { ok: false; error: string };
+
+interface RawBlockPayload {
+  blockType?: unknown;
+  value?: unknown;
+  reason?: unknown;
+  /** ISO string for an explicit expiry. */
+  expiresAt?: unknown;
+  /** Relative duration in ms (alternative to expiresAt). */
+  durationMs?: unknown;
+}
+
+function isBlockType(v: unknown): v is BlockType {
+  return typeof v === 'string' && (BLOCK_TYPES as readonly string[]).includes(v);
+}
+
+export function parseBlockPayload(body: RawBlockPayload): ParseResult {
+  if (!isBlockType(body.blockType)) {
+    return { ok: false, error: `blockType must be one of: ${BLOCK_TYPES.join(', ')}` };
+  }
+
+  const value = typeof body.value === 'string' ? body.value.trim() : '';
+  if (!value) {
+    return { ok: false, error: 'value is required' };
+  }
+  if (value.length > MAX_VALUE_LEN) {
+    return { ok: false, error: `value must be at most ${MAX_VALUE_LEN} characters` };
+  }
+
+  let reason: string | null = null;
+  if (typeof body.reason === 'string') {
+    const trimmed = body.reason.trim().slice(0, MAX_REASON_LEN);
+    reason = trimmed.length ? trimmed : null;
+  }
+
+  let expires_at: string | null = null;
+  if (body.expiresAt != null && body.expiresAt !== '') {
+    if (typeof body.expiresAt !== 'string') {
+      return { ok: false, error: 'expiresAt must be an ISO date string' };
+    }
+    const ts = new Date(body.expiresAt).getTime();
+    if (Number.isNaN(ts)) {
+      return { ok: false, error: 'expiresAt is not a valid date' };
+    }
+    if (ts <= Date.now()) {
+      return { ok: false, error: 'expiresAt must be in the future' };
+    }
+    expires_at = new Date(ts).toISOString();
+  } else if (body.durationMs != null) {
+    const ms = Number(body.durationMs);
+    if (!Number.isFinite(ms) || ms <= 0) {
+      return { ok: false, error: 'durationMs must be a positive number' };
+    }
+    expires_at = new Date(Date.now() + ms).toISOString();
+  }
+
+  return { ok: true, data: { block_type: body.blockType, value, reason, expires_at } };
+}

--- a/fe-next/app/api/admin/blocks/route.ts
+++ b/fe-next/app/api/admin/blocks/route.ts
@@ -1,0 +1,116 @@
+/**
+ * API Route: /api/admin/blocks
+ * Admin moderation blocklist management. Powers the admin "Blocklist" view and
+ * the quick-block buttons in the Players/Guests admin lists.
+ *
+ *   GET    — list blocks (optionally filter by type / active-only)
+ *   POST   — create or refresh a block (upsert on block_type+value)
+ *   DELETE — remove a block by id (?id=...)
+ *
+ * Writes use the service-role client (bypasses RLS); the backend join path
+ * consults a cached view of this table to refuse blocked players/guests/IPs.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyAdminAuth } from '@/lib/auth/adminAuth';
+import { getSupabaseAdmin } from '@/lib/admin/server';
+import { parseBlockPayload, BLOCK_TYPES } from './parseBlockPayload';
+
+const TABLE = 'blocked_entities';
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdminAuth(request);
+  if (!authResult.success) return authResult.response!;
+
+  const supabase = getSupabaseAdmin();
+  if (!supabase) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const typeFilter = searchParams.get('type');
+  const activeOnly = searchParams.get('activeOnly') === 'true';
+
+  let query = supabase
+    .from(TABLE)
+    .select('id, block_type, value, reason, blocked_by, created_at, expires_at')
+    .order('created_at', { ascending: false })
+    .limit(500);
+
+  if (typeFilter && (BLOCK_TYPES as readonly string[]).includes(typeFilter)) {
+    query = query.eq('block_type', typeFilter);
+  }
+  if (activeOnly) {
+    // Permanent (NULL) or not-yet-expired.
+    query = query.or(`expires_at.is.null,expires_at.gt.${new Date().toISOString()}`);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ blocks: data ?? [] });
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await verifyAdminAuth(request);
+  if (!authResult.success) return authResult.response!;
+
+  const supabase = getSupabaseAdmin();
+  if (!supabase) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = parseBlockPayload((body ?? {}) as Record<string, unknown>);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  // Upsert so re-blocking the same target refreshes reason/expiry rather than
+  // erroring on the unique (block_type, value) constraint.
+  const { data, error } = await supabase
+    .from(TABLE)
+    .upsert(
+      { ...parsed.data, blocked_by: authResult.user!.id },
+      { onConflict: 'block_type,value' },
+    )
+    .select('id, block_type, value, reason, blocked_by, created_at, expires_at')
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ block: data }, { status: 201 });
+}
+
+export async function DELETE(request: NextRequest) {
+  const authResult = await verifyAdminAuth(request);
+  if (!authResult.success) return authResult.response!;
+
+  const supabase = getSupabaseAdmin();
+  if (!supabase) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+  if (!id) {
+    return NextResponse.json({ error: 'id is required' }, { status: 400 });
+  }
+
+  const { error } = await supabase.from(TABLE).delete().eq('id', id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/fe-next/backend/handlers/__tests__/playerJoinHandler.block.test.ts
+++ b/fe-next/backend/handlers/__tests__/playerJoinHandler.block.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Player Join Handler — global moderation blocklist enforcement.
+ *
+ * An admin-issued block (auth user id / guest session id / IP) must refuse a
+ * join: the handler emits the typed PLAYER_BLOCKED error and never adds the
+ * user to the game. A non-blocked join proceeds past the block gate.
+ */
+
+import { vi } from 'vitest';
+import { Server, Socket } from 'socket.io';
+import { ErrorCodes } from '../../utils/errorHandler';
+
+const { mockValidatePayload, mockIsBlocked, mockGetGame, mockAddUserToGame } = vi.hoisted(() => ({
+  mockValidatePayload: vi.fn(),
+  mockIsBlocked: vi.fn(),
+  mockGetGame: vi.fn(),
+  mockAddUserToGame: vi.fn(),
+}));
+
+vi.mock('../../modules/gameStateManager', () => ({
+  getGame: mockGetGame,
+  getAuthUserConnection: vi.fn(),
+  getSocketIdByUsername: vi.fn().mockReturnValue(undefined),
+  addUserToGame: mockAddUserToGame,
+  updateUserSocketId: vi.fn(),
+  removeUserFromGame: vi.fn(),
+  getGameUsers: vi.fn().mockReturnValue([]),
+  getActiveRooms: vi.fn().mockReturnValue([]),
+  isRoomEmpty: vi.fn(),
+  restoreGameFromRedis: vi.fn(),
+  updateHostSocketId: vi.fn(),
+  getLeaderboard: vi.fn().mockReturnValue([]),
+  getTournamentIdFromGame: vi.fn(),
+  getGameSpectators: vi.fn().mockReturnValue([]),
+  addSpectatorToGame: vi.fn(),
+  upgradeSpectatorToPlayer: vi.fn(),
+  deleteGame: vi.fn(),
+  transferHost: vi.fn(),
+  getNextEligibleHost: vi.fn(),
+  clearSocketMappingsForLeave: vi.fn(),
+  isSpectator: vi.fn(),
+}));
+
+vi.mock('../../utils/socketHelpers', () => ({
+  broadcastToRoom: vi.fn(),
+  broadcastToRoomExceptSender: vi.fn(),
+  broadcastActiveRooms: vi.fn(),
+  getGameRoom: vi.fn((code: string) => `game:${code}`),
+  joinRoom: vi.fn(),
+  leaveRoom: vi.fn(),
+  LOBBY_ROOM: 'lobby',
+  safeEmit: vi.fn(),
+  getSocketById: vi.fn(),
+  disconnectSocket: vi.fn(),
+  isSocketMigrating: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../utils/rateLimiter', () => ({
+  checkRateLimit: vi.fn().mockReturnValue(true),
+  getIpFromSocket: vi.fn().mockReturnValue('203.0.113.7'),
+  default: { checkRateLimit: vi.fn().mockReturnValue(true) },
+}));
+
+vi.mock('../../modules/blockListManager', () => ({ isBlocked: mockIsBlocked }));
+
+vi.mock('../../modules/lobbyAutoStart', () => ({ cancelAutoStartCountdown: vi.fn() }));
+vi.mock('../../utils/timerManager', () => ({
+  default: { clearGameTimer: vi.fn(), clearTimer: vi.fn() }, clearGameTimer: vi.fn(),
+}));
+vi.mock('../../utils/gameStartCoordinator', () => ({ default: { cancel: vi.fn(), handlePlayerDisconnect: vi.fn() } }));
+vi.mock('../../services/gameLifecycle/gameTimer.js', () => ({ startGameTimer: vi.fn(), resumeGameTimerIfMissing: vi.fn() }));
+vi.mock('../../services/gameLifecycle/gameTimer', () => ({ startGameTimer: vi.fn(), resumeGameTimerIfMissing: vi.fn() }));
+vi.mock('../../modules/botManager', () => ({ cleanupGameBots: vi.fn() }));
+vi.mock('../../utils/gameUtils', () => ({
+  generateRandomAvatar: vi.fn().mockReturnValue({ color: 'blue', icon: 'cat' }),
+}));
+vi.mock('../../utils/socketValidation', () => ({
+  validatePayload: mockValidatePayload,
+  joinGameSchema: {},
+}));
+vi.mock('../../utils/consts', () => ({ MAX_PLAYERS_PER_ROOM: 8 }));
+vi.mock('../../utils/gameStateMachine', () => ({
+  isInProgress: vi.fn().mockReturnValue(false),
+  canJoinFreely: vi.fn().mockReturnValue(true),
+  shouldSendGameState: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../modules/notificationService', () => ({
+  notifyPlayerJoined: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../playerReconnectHandler', () => ({
+  handleReconnection: vi.fn(),
+  handleLateJoin: vi.fn(),
+  handleTournamentJoin: vi.fn(),
+  handleExistingAuthConnectionJoin: vi.fn().mockResolvedValue({ handled: false }),
+}));
+vi.mock('../playerDataInit', () => ({ ensurePlayerState: vi.fn().mockResolvedValue(undefined) }));
+
+import { registerPlayerJoinHandlers } from '../playerJoinHandler';
+
+function captureJoinHandler() {
+  const listeners: Record<string, (...args: unknown[]) => unknown> = {};
+  const socket = {
+    id: 'blk-socket-1',
+    emit: vi.fn(),
+    join: vi.fn(),
+    leave: vi.fn(),
+    data: {},
+    handshake: { address: '203.0.113.7', headers: {} },
+    on: vi.fn((event: string, cb: (...args: unknown[]) => unknown) => { listeners[event] = cb; }),
+  } as unknown as Socket;
+  const io = { emit: vi.fn(), to: vi.fn().mockReturnThis() } as unknown as Server;
+  registerPlayerJoinHandlers(io, socket);
+  return { socket, join: listeners['join'] };
+}
+
+describe('PlayerJoinHandler — moderation blocklist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGame.mockReturnValue({
+      gameCode: 'ABC123',
+      roomName: 'Room',
+      language: 'en',
+      gameState: 'waiting',
+      users: {},
+    });
+    mockValidatePayload.mockImplementation((_schema: unknown, data: unknown) => ({ success: true, data }));
+  });
+
+  it('refuses a blocked join with PLAYER_BLOCKED and does not add the user', async () => {
+    mockIsBlocked.mockResolvedValue({ blockType: 'ip', value: '203.0.113.7', reason: 'abuse' });
+
+    const { socket, join } = captureJoinHandler();
+    await join({ gameCode: 'ABC123', username: 'Eve' });
+
+    const errorCall = (socket.emit as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[0] === 'error');
+    expect(errorCall).toBeDefined();
+    expect(errorCall![1]).toMatchObject({ code: ErrorCodes.PLAYER_BLOCKED, message: 'abuse' });
+    expect(mockAddUserToGame).not.toHaveBeenCalled();
+  });
+
+  it('lets a non-blocked join proceed past the block gate', async () => {
+    mockIsBlocked.mockResolvedValue(null);
+
+    const { socket, join } = captureJoinHandler();
+    await join({ gameCode: 'ABC123', username: 'Alice' });
+
+    const errorCall = (socket.emit as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[0] === 'error' && c[1]?.code === ErrorCodes.PLAYER_BLOCKED,
+    );
+    expect(errorCall).toBeUndefined();
+    expect(mockAddUserToGame).toHaveBeenCalled();
+  });
+});

--- a/fe-next/backend/handlers/__tests__/playerJoinHandler.lateJoin.test.ts
+++ b/fe-next/backend/handlers/__tests__/playerJoinHandler.lateJoin.test.ts
@@ -73,7 +73,12 @@ vi.mock('../../utils/errorHandler', async () => {
 
 vi.mock('../../utils/rateLimiter', () => ({
   checkRateLimit: vi.fn().mockReturnValue(true),
+  getIpFromSocket: vi.fn().mockReturnValue('127.0.0.1'),
   default: { checkRateLimit: vi.fn().mockReturnValue(true) },
+}));
+
+vi.mock('../../modules/blockListManager', () => ({
+  isBlocked: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('../../utils/timerManager', () => ({

--- a/fe-next/backend/handlers/playerJoinHandler.ts
+++ b/fe-next/backend/handlers/playerJoinHandler.ts
@@ -36,7 +36,8 @@ import {
 
 import { cancelAutoStartCountdown } from '../modules/lobbyAutoStart.js';
 import { emitError, ErrorCodes } from '../utils/errorHandler.js';
-import { checkRateLimit } from '../utils/rateLimiter.js';
+import { checkRateLimit, getIpFromSocket } from '../utils/rateLimiter.js';
+import { isBlocked } from '../modules/blockListManager.js';
 import timerManager, { clearGameTimer } from '../utils/timerManager.js';
 import { cleanupGameBots } from '../modules/botManager.js';
 import gameStartCoordinator from '../utils/gameStartCoordinator.js';
@@ -161,6 +162,23 @@ function registerPlayerJoinHandlers(io: Server, socket: Socket): void {
     // Block kicked players from re-joining
     if (game.kickedPlayers?.has(username)) {
       emitError(socket, ErrorCodes.PLAYER_KICKED, { message: 'You have been kicked from this room' });
+      return;
+    }
+
+    // Global moderation blocklist (admin-issued): refuse the verified player
+    // (auth user id), the guest (guest session id), or any client behind a
+    // blocked IP. Checked here — before reconnection/late-join — so a blocked
+    // user cannot reclaim a slot or rejoin under a new name.
+    const blockMatch = await isBlocked({
+      authUserId,
+      guestSessionId,
+      ip: getIpFromSocket(socket),
+    });
+    if (blockMatch) {
+      logger.warn('SOCKET', `Blocked ${blockMatch.blockType} attempted to join ${gameCode} as ${username}`);
+      emitError(socket, ErrorCodes.PLAYER_BLOCKED, {
+        message: blockMatch.reason || 'You have been blocked from playing.',
+      });
       return;
     }
 

--- a/fe-next/backend/modules/__tests__/blockListManager.test.ts
+++ b/fe-next/backend/modules/__tests__/blockListManager.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  refreshBlockList,
+  isBlockedSync,
+  isBlocked,
+  __resetBlockListForTest,
+} from '../blockListManager';
+
+const { selectMock } = vi.hoisted(() => ({ selectMock: vi.fn() }));
+
+vi.mock('../supabase', () => ({
+  getSupabase: vi.fn(() => ({
+    from: vi.fn(() => ({ select: selectMock })),
+  })),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const future = () => new Date(Date.now() + 60_000).toISOString();
+const past = () => new Date(Date.now() - 60_000).toISOString();
+
+describe('blockListManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetBlockListForTest();
+  });
+
+  it('loads blocks from supabase into the cache on refresh', async () => {
+    selectMock.mockResolvedValue({
+      data: [
+        { block_type: 'auth_user', value: 'user-1', reason: 'cheating', expires_at: null },
+      ],
+      error: null,
+    });
+
+    await refreshBlockList();
+
+    expect(isBlockedSync({ authUserId: 'user-1' })).toEqual({
+      blockType: 'auth_user',
+      value: 'user-1',
+      reason: 'cheating',
+    });
+  });
+
+  it('returns null when the identifier is not blocked', async () => {
+    selectMock.mockResolvedValue({ data: [], error: null });
+    await refreshBlockList();
+
+    expect(isBlockedSync({ authUserId: 'nobody', guestSessionId: 'g', ip: '1.2.3.4' })).toBeNull();
+  });
+
+  it('matches a blocked guest session id and a blocked ip', async () => {
+    selectMock.mockResolvedValue({
+      data: [
+        { block_type: 'guest_session', value: 'sess-9', reason: null, expires_at: future() },
+        { block_type: 'ip', value: '203.0.113.7', reason: 'abuse', expires_at: null },
+      ],
+      error: null,
+    });
+    await refreshBlockList();
+
+    expect(isBlockedSync({ guestSessionId: 'sess-9' })?.blockType).toBe('guest_session');
+    expect(isBlockedSync({ ip: '203.0.113.7' })?.blockType).toBe('ip');
+  });
+
+  it('ignores an expired block (expires_at in the past)', async () => {
+    selectMock.mockResolvedValue({
+      data: [{ block_type: 'auth_user', value: 'user-2', reason: null, expires_at: past() }],
+      error: null,
+    });
+    await refreshBlockList();
+
+    expect(isBlockedSync({ authUserId: 'user-2' })).toBeNull();
+  });
+
+  it('treats empty / missing identifiers as not blocked', async () => {
+    selectMock.mockResolvedValue({
+      data: [{ block_type: 'ip', value: '', reason: null, expires_at: null }],
+      error: null,
+    });
+    await refreshBlockList();
+
+    expect(isBlockedSync({})).toBeNull();
+    expect(isBlockedSync({ ip: '' })).toBeNull();
+  });
+
+  it('isBlocked refreshes from the DB when the cache is stale', async () => {
+    selectMock.mockResolvedValue({
+      data: [{ block_type: 'ip', value: '198.51.100.5', reason: null, expires_at: null }],
+      error: null,
+    });
+
+    const match = await isBlocked({ ip: '198.51.100.5' });
+
+    expect(selectMock).toHaveBeenCalled();
+    expect(match?.blockType).toBe('ip');
+  });
+
+  it('leaves the existing cache intact when the DB read errors', async () => {
+    selectMock.mockResolvedValueOnce({
+      data: [{ block_type: 'auth_user', value: 'user-3', reason: null, expires_at: null }],
+      error: null,
+    });
+    await refreshBlockList();
+
+    selectMock.mockResolvedValueOnce({ data: null, error: { message: 'boom' } });
+    await refreshBlockList();
+
+    expect(isBlockedSync({ authUserId: 'user-3' })?.value).toBe('user-3');
+  });
+});

--- a/fe-next/backend/modules/blockListManager.ts
+++ b/fe-next/backend/modules/blockListManager.ts
@@ -1,0 +1,174 @@
+/**
+ * Block List Manager
+ *
+ * In-memory, short-TTL cache of the admin moderation blocklist
+ * (`blocked_entities` table). The realtime game-join path consults this to
+ * refuse entry to a blocked registered player (auth user id), a blocked guest
+ * (guest session id), or any client behind a blocked IP.
+ *
+ * Why a cache (not a per-join DB read): `join` is a hot socket event. A direct
+ * Supabase round-trip on every join would add 50–200 ms of latency to a path
+ * that fires constantly. Instead we load the (small) blocklist once and refresh
+ * it on a 30 s TTL, so a freshly-issued block takes effect within ~30 s while
+ * the join path stays in-memory-fast. Expired blocks are also filtered inline
+ * on every check, so time-boxed blocks lapse precisely without waiting for a
+ * refresh.
+ *
+ * Writes happen elsewhere (the service-role admin API). This module is
+ * read-only against the DB. NEVER subscribe this table to supabase_realtime —
+ * see .claude/rules/50-supabase-perf.md.
+ */
+
+import { getSupabase } from './supabase';
+import logger from '../utils/logger';
+
+export type BlockType = 'auth_user' | 'guest_session' | 'ip';
+
+export interface BlockCheckInput {
+  authUserId?: string | null;
+  guestSessionId?: string | null;
+  ip?: string | null;
+}
+
+export interface BlockMatch {
+  blockType: BlockType;
+  value: string;
+  reason: string | null;
+}
+
+interface CacheEntry {
+  reason: string | null;
+  /** epoch ms; null = permanent. */
+  expiresAt: number | null;
+}
+
+const TABLE = 'blocked_entities';
+const REFRESH_TTL_MS = 30_000;
+
+const cache: Record<BlockType, Map<string, CacheEntry>> = {
+  auth_user: new Map(),
+  guest_session: new Map(),
+  ip: new Map(),
+};
+
+let lastLoadedAt = 0;
+let inFlight: Promise<void> | null = null;
+let autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Reload the full blocklist from the DB into the in-memory cache. Best-effort:
+ * on a DB error the previous cache is left intact (fail-open — a transient DB
+ * blip must not start letting blocked users through OR start rejecting
+ * everyone; it simply keeps serving the last known-good list).
+ */
+export async function refreshBlockList(): Promise<void> {
+  const client = getSupabase();
+  if (!client) return;
+
+  const { data, error } = await client
+    .from(TABLE)
+    .select('block_type, value, reason, expires_at');
+
+  if (error) {
+    logger.warn('BLOCKLIST', `Failed to refresh blocklist: ${error.message}`);
+    return;
+  }
+
+  const next: Record<BlockType, Map<string, CacheEntry>> = {
+    auth_user: new Map(),
+    guest_session: new Map(),
+    ip: new Map(),
+  };
+
+  for (const row of data || []) {
+    const type = row.block_type as BlockType;
+    const value = String(row.value ?? '');
+    if (!next[type] || !value) continue;
+    const expiresAt = row.expires_at ? new Date(row.expires_at).getTime() : null;
+    next[type].set(value, { reason: row.reason ?? null, expiresAt });
+  }
+
+  cache.auth_user = next.auth_user;
+  cache.guest_session = next.guest_session;
+  cache.ip = next.ip;
+  lastLoadedAt = Date.now();
+}
+
+function lookup(type: BlockType, value?: string | null): BlockMatch | null {
+  if (!value) return null;
+  const entry = cache[type].get(value);
+  if (!entry) return null;
+  // Inline expiry guard so time-boxed blocks lapse exactly on time, regardless
+  // of when the next refresh runs. Evict lazily to keep the map lean.
+  if (entry.expiresAt !== null && entry.expiresAt <= Date.now()) {
+    cache[type].delete(value);
+    return null;
+  }
+  return { blockType: type, value, reason: entry.reason };
+}
+
+/**
+ * Synchronous block check against the current cache. Returns the first match
+ * (auth user → guest session → IP) or null. Does NOT touch the DB.
+ */
+export function isBlockedSync(input: BlockCheckInput): BlockMatch | null {
+  return (
+    lookup('auth_user', input.authUserId) ||
+    lookup('guest_session', input.guestSessionId) ||
+    lookup('ip', input.ip)
+  );
+}
+
+async function ensureFresh(): Promise<void> {
+  if (Date.now() - lastLoadedAt < REFRESH_TTL_MS) return;
+  // Coalesce concurrent refreshes (many joins can race the TTL boundary).
+  if (inFlight) {
+    await inFlight;
+    return;
+  }
+  inFlight = refreshBlockList().finally(() => {
+    inFlight = null;
+  });
+  await inFlight;
+}
+
+/**
+ * Async block check used by the join path: refreshes the cache if stale, then
+ * performs the in-memory lookup.
+ */
+export async function isBlocked(input: BlockCheckInput): Promise<BlockMatch | null> {
+  // Skip the (possibly DB-touching) freshness check entirely when there is
+  // nothing to look up.
+  if (!input.authUserId && !input.guestSessionId && !input.ip) return null;
+  await ensureFresh();
+  return isBlockedSync(input);
+}
+
+/**
+ * Start the background refresh loop. Called once at server startup so the
+ * cache is warm and stays current even on an idle server.
+ */
+export function startBlockListAutoRefresh(): void {
+  if (autoRefreshTimer) return;
+  void refreshBlockList();
+  autoRefreshTimer = setInterval(() => {
+    void refreshBlockList();
+  }, REFRESH_TTL_MS);
+  if (typeof autoRefreshTimer.unref === 'function') autoRefreshTimer.unref();
+}
+
+export function stopBlockListAutoRefresh(): void {
+  if (autoRefreshTimer) {
+    clearInterval(autoRefreshTimer);
+    autoRefreshTimer = null;
+  }
+}
+
+/** Test-only: clear cache + freshness so each test starts clean. */
+export function __resetBlockListForTest(): void {
+  cache.auth_user.clear();
+  cache.guest_session.clear();
+  cache.ip.clear();
+  lastLoadedAt = 0;
+  inFlight = null;
+}

--- a/fe-next/backend/socketHandlers.ts
+++ b/fe-next/backend/socketHandlers.ts
@@ -24,6 +24,7 @@ const {
 
 const { loadCommunityWords } = require('./modules/communityWordManager');
 const { cleanupEmptyRooms } = require('./modules/gameStateManager');
+const { startBlockListAutoRefresh } = require('./modules/blockListManager');
 const { initRateLimit, resetRateLimit, isIpBlocked, isIpBlockedAsync, RateLimiter } = require('./utils/rateLimiter');
 import logger from './utils/logger';
 
@@ -42,6 +43,10 @@ function initializeSocketHandlers(io: Server): void {
 
   // Start connection health check
   startConnectionHealthCheck(io);
+
+  // Warm + keep the admin moderation blocklist cache fresh (used by the
+  // join path to refuse blocked players/guests/IPs).
+  startBlockListAutoRefresh();
 
   // Set up periodic cleanup of empty rooms (tracked for shutdown)
   if (_emptyRoomCleanupTimer) clearInterval(_emptyRoomCleanupTimer);

--- a/fe-next/backend/utils/errorHandler.ts
+++ b/fe-next/backend/utils/errorHandler.ts
@@ -78,6 +78,7 @@ export const ErrorCodes = {
   PLAYER_NOT_HOST: 'PLAYER_NOT_HOST',
   PLAYER_ALREADY_IN_GAME: 'PLAYER_ALREADY_IN_GAME',
   PLAYER_KICKED: 'PLAYER_KICKED',
+  PLAYER_BLOCKED: 'PLAYER_BLOCKED',
   PLAYER_USERNAME_TAKEN: 'PLAYER_USERNAME_TAKEN',
   PLAYER_INVALID_USERNAME: 'PLAYER_INVALID_USERNAME',
 
@@ -187,6 +188,11 @@ export const ErrorRegistry: Record<string, ErrorRegistryEntry> = {
   },
   [ErrorCodes.PLAYER_KICKED]: {
     message: 'You have been removed from the game',
+    severity: ErrorSeverity.LOW,
+    httpStatus: 403
+  },
+  [ErrorCodes.PLAYER_BLOCKED]: {
+    message: 'You have been blocked from playing',
     severity: ErrorSeverity.LOW,
     httpStatus: 403
   },

--- a/fe-next/components/admin/GuestManager.tsx
+++ b/fe-next/components/admin/GuestManager.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Search, ChevronLeft, ChevronRight, Smartphone, Monitor,
-  CheckCircle2, XCircle, Globe, Clock, Trophy, Gamepad2, Target,
+  CheckCircle2, XCircle, Globe, Clock, Trophy, Gamepad2, Target, Ban,
 } from 'lucide-react';
 import Link from 'next/link';
 import toast from 'react-hot-toast';
@@ -156,6 +156,27 @@ export function GuestManager({ authToken }: { authToken: string }) {
   useEffect(() => {
     setPage(1);
   }, [resetPageEffect]);
+
+  const [blockingId, setBlockingId] = useState<string | null>(null);
+
+  // Block a guest by their session id so the realtime join path refuses them.
+  const handleBlockGuest = useCallback(async (sessionId: string) => {
+    if (blockingId || !window.confirm(`Block guest ${sessionId.slice(0, 8)} from joining games?`)) return;
+    setBlockingId(sessionId);
+    try {
+      const res = await fetch('/api/admin/blocks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
+        body: JSON.stringify({ blockType: 'guest_session', value: sessionId, reason: 'Blocked by admin' }),
+      });
+      if (!res.ok) throw new Error('Failed');
+      toast.success('Guest blocked');
+    } catch {
+      toast.error('Failed to block guest');
+    } finally {
+      setBlockingId(null);
+    }
+  }, [authToken, blockingId]);
 
   const guests = data?.guests || [];
   const stats = data?.stats;
@@ -367,6 +388,17 @@ export function GuestManager({ authToken }: { authToken: string }) {
                         <Stat label="Longest" value={g.longest_word} highlight="text-amber-500" />
                       )}
                     </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleBlockGuest(g.session_id)}
+                      disabled={blockingId === g.session_id}
+                      className="text-red-600 border-red-300 hover:bg-red-50 dark:hover:bg-red-900/20 flex-shrink-0 self-start lg:self-center"
+                      title="Block this guest from joining games"
+                    >
+                      <Ban className="w-4 h-4 me-1" />
+                      Block
+                    </Button>
                   </div>
                 </CardContent>
               </Card>

--- a/fe-next/components/admin/PlayerCard.tsx
+++ b/fe-next/components/admin/PlayerCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Calendar, Gift, Bomb, ExternalLink } from 'lucide-react';
+import { Calendar, Gift, Bomb, ExternalLink, Ban } from 'lucide-react';
 import Link from 'next/link';
 import { postHogPersonUrl } from '@/lib/admin/postHogLinks';
 import { Button } from '@/components/ui/button';
@@ -17,7 +17,9 @@ interface PlayerCardProps {
   onToggleSelect: (id: string) => void;
   onGift: (player: Player) => void;
   onToggleBlast: (player: Player) => void;
+  onBlock: (player: Player) => void;
   blastLoading: boolean;
+  blockLoading: boolean;
   curatorAssignments: CuratorAssignmentRow[];
   onAssignCurator: (player: Player, language: string, tier: number) => void;
   onRevokeCurator: (player: Player, language: string) => void;
@@ -36,7 +38,9 @@ export function PlayerCard({
   onToggleSelect,
   onGift,
   onToggleBlast,
+  onBlock,
   blastLoading,
+  blockLoading,
   curatorAssignments,
   onAssignCurator,
   onRevokeCurator,
@@ -123,6 +127,17 @@ export function PlayerCard({
               >
                 <Bomb className="w-4 h-4 me-1" />
                 {player.blast_access ? 'Blast ✓' : 'Blast'}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onBlock(player)}
+                disabled={blockLoading}
+                className="text-red-600 border-red-300 hover:bg-red-50 dark:hover:bg-red-900/20"
+                title="Block this player from joining games"
+              >
+                <Ban className="w-4 h-4 me-1" />
+                Block
               </Button>
             </div>
           </div>

--- a/fe-next/components/admin/PlayerManager.tsx
+++ b/fe-next/components/admin/PlayerManager.tsx
@@ -76,6 +76,28 @@ export function PlayerManager({ authToken }: { authToken: string }) {
   const selectedPlayers = players.filter((p) => selectedIds.has(p.id));
 
   const [blastAccessLoading, setBlastAccessLoading] = useState<string | null>(null);
+  const [blockLoading, setBlockLoading] = useState<string | null>(null);
+
+  // Block a registered player by their auth user id so the realtime join path
+  // refuses them. Permanent until lifted from the admin Blocklist view.
+  const handleBlockPlayer = useCallback(async (player: Player) => {
+    const name = player.display_name || player.username;
+    if (blockLoading || !window.confirm(`Block ${name} from joining games?`)) return;
+    setBlockLoading(player.id);
+    try {
+      const response = await fetch('/api/admin/blocks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
+        body: JSON.stringify({ blockType: 'auth_user', value: player.id, reason: `Blocked by admin: ${name}` }),
+      });
+      if (!response.ok) throw new Error('Failed');
+      toast.success(`Blocked ${name}`);
+    } catch {
+      toast.error('Failed to block player');
+    } finally {
+      setBlockLoading(null);
+    }
+  }, [authToken, blockLoading]);
 
   const handleToggleBlastAccess = useCallback(async (player: Player) => {
     setBlastAccessLoading(player.id);
@@ -340,7 +362,9 @@ export function PlayerManager({ authToken }: { authToken: string }) {
               onToggleSelect={toggleSelect}
               onGift={(p) => openGiftDialog([p])}
               onToggleBlast={handleToggleBlastAccess}
+              onBlock={handleBlockPlayer}
               blastLoading={blastAccessLoading === player.id}
+              blockLoading={blockLoading === player.id}
               curatorAssignments={curatorMap[player.id] ?? []}
               onAssignCurator={handleAssignCurator}
               onRevokeCurator={handleRevokeCurator}

--- a/fe-next/components/admin/blocklist/BlockListManager.tsx
+++ b/fe-next/components/admin/blocklist/BlockListManager.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Ban, Trash2, ShieldOff, User, UserRound, Globe } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { Loader } from '@/components/ui/Loader';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+type BlockType = 'auth_user' | 'guest_session' | 'ip';
+
+interface BlockRow {
+  id: string;
+  block_type: BlockType;
+  value: string;
+  reason: string | null;
+  blocked_by: string | null;
+  created_at: string;
+  expires_at: string | null;
+}
+
+const DURATIONS: { key: string; ms: number | null }[] = [
+  { key: 'permanent', ms: null },
+  { key: '1h', ms: 60 * 60 * 1000 },
+  { key: '24h', ms: 24 * 60 * 60 * 1000 },
+  { key: '7d', ms: 7 * 24 * 60 * 60 * 1000 },
+  { key: '30d', ms: 30 * 24 * 60 * 60 * 1000 },
+];
+
+const TYPE_META: Record<BlockType, { icon: React.ReactNode; labelKey: string }> = {
+  auth_user: { icon: <User className="w-3.5 h-3.5" />, labelKey: 'admin.blocklist.type.authUser' },
+  guest_session: { icon: <UserRound className="w-3.5 h-3.5" />, labelKey: 'admin.blocklist.type.guest' },
+  ip: { icon: <Globe className="w-3.5 h-3.5" />, labelKey: 'admin.blocklist.type.ip' },
+};
+
+export function BlockListManager({ authToken }: { authToken: string }) {
+  const { t } = useLanguage();
+  const [blocks, setBlocks] = useState<BlockRow[] | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+
+  const [blockType, setBlockType] = useState<BlockType>('auth_user');
+  const [value, setValue] = useState('');
+  const [reason, setReason] = useState('');
+  const [duration, setDuration] = useState<string>('permanent');
+
+  const authHeaders = useCallback(
+    (json = false): Record<string, string> => ({
+      Authorization: `Bearer ${authToken}`,
+      ...(json ? { 'Content-Type': 'application/json' } : {}),
+    }),
+    [authToken],
+  );
+
+  const fetchBlocks = useCallback(async () => {
+    try {
+      const res = await fetch('/api/admin/blocks?activeOnly=true', { headers: authHeaders() });
+      if (!res.ok) throw new Error('Failed to load blocks');
+      const json = await res.json();
+      setBlocks(json.blocks ?? []);
+    } catch {
+      setBlocks([]);
+    }
+  }, [authHeaders]);
+
+  useEffect(() => { fetchBlocks(); }, [fetchBlocks]);
+
+  const handleCreate = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      const ms = DURATIONS.find((d) => d.key === duration)?.ms ?? null;
+      const res = await fetch('/api/admin/blocks', {
+        method: 'POST',
+        headers: authHeaders(true),
+        body: JSON.stringify({
+          blockType,
+          value: trimmed,
+          reason: reason.trim() || undefined,
+          durationMs: ms ?? undefined,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error || `Failed (HTTP ${res.status})`);
+      }
+      toast.success(t('admin.blocklist.blockedToast'));
+      setValue('');
+      setReason('');
+      fetchBlocks();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to block');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [authHeaders, blockType, value, reason, duration, submitting, fetchBlocks, t]);
+
+  const handleRemove = useCallback(async (id: string) => {
+    if (removingId) return;
+    setRemovingId(id);
+    try {
+      const res = await fetch(`/api/admin/blocks?id=${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+        headers: authHeaders(),
+      });
+      if (!res.ok) throw new Error('Failed to unblock');
+      setBlocks((prev) => prev?.filter((b) => b.id !== id) ?? []);
+      toast.success(t('admin.blocklist.unblockedToast'));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to unblock');
+    } finally {
+      setRemovingId(null);
+    }
+  }, [authHeaders, removingId, t]);
+
+  return (
+    <div className="space-y-6">
+      {/* Create block form */}
+      <Card>
+        <CardContent className="p-4">
+          <form onSubmit={handleCreate} className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-slate-400 uppercase">{t('admin.blocklist.typeLabel')}</label>
+              <Select value={blockType} onValueChange={(v) => setBlockType(v as BlockType)}>
+                <SelectTrigger className="w-[180px]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="auth_user">{t('admin.blocklist.type.authUser')}</SelectItem>
+                  <SelectItem value="guest_session">{t('admin.blocklist.type.guest')}</SelectItem>
+                  <SelectItem value="ip">{t('admin.blocklist.type.ip')}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex flex-col gap-1 flex-1 min-w-[200px]">
+              <label className="text-xs text-slate-400 uppercase">{t('admin.blocklist.valueLabel')}</label>
+              <Input
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                placeholder={t('admin.blocklist.valuePlaceholder')}
+              />
+            </div>
+            <div className="flex flex-col gap-1 flex-1 min-w-[160px]">
+              <label className="text-xs text-slate-400 uppercase">{t('admin.blocklist.reasonLabel')}</label>
+              <Input
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder={t('admin.blocklist.reasonPlaceholder')}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-slate-400 uppercase">{t('admin.blocklist.durationLabel')}</label>
+              <Select value={duration} onValueChange={setDuration}>
+                <SelectTrigger className="w-[150px]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {DURATIONS.map((d) => (
+                    <SelectItem key={d.key} value={d.key}>{t(`admin.blocklist.duration.${d.key}`)}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button type="submit" disabled={submitting || !value.trim()} className="bg-red-600 hover:bg-red-700 text-white">
+              <Ban className="w-4 h-4 me-1" />
+              {t('admin.blocklist.blockButton')}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {/* Active blocks list */}
+      {blocks === null ? (
+        <div className="flex justify-center py-12"><Loader size="md" /></div>
+      ) : blocks.length === 0 ? (
+        <div className="text-center py-12 text-slate-500 flex flex-col items-center gap-2">
+          <ShieldOff className="w-8 h-8 opacity-50" />
+          {t('admin.blocklist.empty')}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {blocks.map((b) => {
+            const meta = TYPE_META[b.block_type];
+            return (
+              <Card key={b.id} className="hover:shadow-md transition-shadow">
+                <CardContent className="p-3 flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-slate-600/30 text-slate-300">
+                        {meta.icon}
+                        {t(meta.labelKey)}
+                      </span>
+                      <span className="font-mono font-bold truncate">{b.value}</span>
+                    </div>
+                    <div className="text-xs text-slate-500 mt-1 flex flex-wrap gap-x-3">
+                      {b.reason && <span>{b.reason}</span>}
+                      <span>{t('admin.blocklist.addedOn')} {new Date(b.created_at).toLocaleDateString()}</span>
+                      <span>
+                        {b.expires_at
+                          ? `${t('admin.blocklist.expires')} ${new Date(b.expires_at).toLocaleString()}`
+                          : t('admin.blocklist.duration.permanent')}
+                      </span>
+                    </div>
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleRemove(b.id)}
+                    disabled={removingId === b.id}
+                    className="text-emerald-600 border-emerald-300 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 flex-shrink-0"
+                  >
+                    <Trash2 className="w-4 h-4 me-1" />
+                    {t('admin.blocklist.unblockButton')}
+                  </Button>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/fe-next/components/admin/sidebar/adminNavIcons.ts
+++ b/fe-next/components/admin/sidebar/adminNavIcons.ts
@@ -21,6 +21,7 @@ import {
   Languages,
   GraduationCap,
   UserRound,
+  Ban,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -43,6 +44,7 @@ export const ADMIN_NAV_ICONS: Record<string, LucideIcon> = {
   Languages,
   GraduationCap,
   UserRound,
+  Ban,
 };
 
 /** Safe lookup with a sensible fallback so an unknown key never crashes. */

--- a/fe-next/lib/admin/__tests__/adminNav.test.ts
+++ b/fe-next/lib/admin/__tests__/adminNav.test.ts
@@ -72,9 +72,9 @@ describe('ADMIN_BUCKET_CHILDREN', () => {
     );
   });
 
-  it('people bucket bundles players, guests, teacher-access', () => {
+  it('people bucket bundles players, guests, teacher-access, blocklist', () => {
     const keys = ADMIN_BUCKET_CHILDREN.people.map((l) => l.key);
-    expect(keys).toEqual(['players', 'guests', 'teacher-access']);
+    expect(keys).toEqual(['players', 'guests', 'teacher-access', 'blocklist']);
   });
 });
 

--- a/fe-next/lib/admin/adminNav.ts
+++ b/fe-next/lib/admin/adminNav.ts
@@ -81,7 +81,7 @@ export const ADMIN_PRIMARY_TABS: AdminNavBucket[] = [
     labelKey: 'admin.sidebar.people',
     iconKey: 'Users',
     defaultPath: '/players',
-    ownedPrefixes: ['/players', '/guests', '/teacher-access'],
+    ownedPrefixes: ['/players', '/guests', '/teacher-access', '/blocklist'],
   },
   {
     key: 'more',
@@ -144,6 +144,7 @@ export const ADMIN_BUCKET_CHILDREN: Record<string, AdminNavLeaf[]> = {
     { key: 'players', labelKey: 'admin.sidebar.players', iconKey: 'Users', defaultPath: '/players' },
     { key: 'guests', labelKey: 'admin.nav.guests', iconKey: 'UserRound', defaultPath: '/guests' },
     { key: 'teacher-access', labelKey: 'admin.nav.teacherAccess', iconKey: 'GraduationCap', defaultPath: '/teacher-access' },
+    { key: 'blocklist', labelKey: 'admin.sidebar.blocklist', iconKey: 'Ban', defaultPath: '/blocklist' },
   ],
 };
 

--- a/fe-next/supabase/migrations/20260608120000_blocked_entities.sql
+++ b/fe-next/supabase/migrations/20260608120000_blocked_entities.sql
@@ -1,0 +1,53 @@
+-- =============================================
+-- PLAYER / GUEST BLOCKLIST — admin moderation: block by auth user id,
+-- guest session id, or IP address.
+-- Migration: 20260608120000_blocked_entities
+--
+-- A single, uniform blocklist that the realtime game-join path consults to
+-- refuse entry to a blocked registered player (auth user id), a blocked guest
+-- (guest session id), or any client behind a blocked IP. Each block is
+-- optionally time-boxed (expires_at) or permanent (expires_at IS NULL).
+--
+-- Writes are admin-only via the service-role API (/api/admin/blocks); admins
+-- may READ the list under RLS. The backend enforcement layer caches this table
+-- in memory and refreshes on a short TTL — it never subscribes to it.
+--
+-- NOT added to supabase_realtime (no consumer) — see .claude/rules/50-supabase-perf.md.
+-- =============================================
+
+CREATE TABLE IF NOT EXISTS public.blocked_entities (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- What kind of identifier `value` holds.
+  block_type  TEXT NOT NULL CHECK (block_type IN ('auth_user','guest_session','ip')),
+  -- The identifier itself: an auth.users id, a guest session id, or an IP string.
+  value       TEXT NOT NULL CHECK (length(value) BETWEEN 1 AND 255),
+  reason      TEXT,
+  -- Admin who created the block (kept for audit; survives admin deletion).
+  blocked_by  UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- NULL = permanent. A future timestamp time-boxes the block.
+  expires_at  TIMESTAMPTZ
+);
+
+-- One row per (type, value): re-blocking the same target upserts onto this,
+-- refreshing the reason / expiry rather than stacking duplicate rows. This is
+-- also the point-lookup index the cache-refresh + admin list queries use.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_blocked_entities_type_value
+  ON public.blocked_entities (block_type, value);
+
+-- Supports the periodic purge of expired rows (expires_at < now()).
+CREATE INDEX IF NOT EXISTS idx_blocked_entities_expires_at
+  ON public.blocked_entities (expires_at)
+  WHERE expires_at IS NOT NULL;
+
+ALTER TABLE public.blocked_entities ENABLE ROW LEVEL SECURITY;
+COMMENT ON TABLE public.blocked_entities IS
+  'Admin moderation blocklist. Refuses game-join for a blocked auth_user / guest_session / ip. expires_at NULL = permanent. Writes via service-role API; admins read under RLS. Not in supabase_realtime.';
+
+-- Admins read the blocklist (admin UI). All writes go through the service-role
+-- API, which bypasses RLS — so no INSERT/UPDATE/DELETE policy is granted here.
+-- Reuses the existing is_admin_user() SECURITY DEFINER helper.
+DROP POLICY IF EXISTS "admins read blocklist" ON public.blocked_entities;
+CREATE POLICY "admins read blocklist"
+  ON public.blocked_entities FOR SELECT
+  USING (public.is_admin_user());

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -13186,9 +13186,39 @@ const en = {
       "people": "People",
       "more": "More",
       "moderation": "Moderation",
+      "blocklist": "Blocklist",
       "overview": "Overview",
       "players": "Players",
       "system": "System"
+    },
+    "blocklist": {
+      "title": "Blocklist",
+      "subtitle": "Block a player, guest, or IP from joining games.",
+      "typeLabel": "Type",
+      "valueLabel": "Identifier",
+      "valuePlaceholder": "User ID, guest session ID, or IP",
+      "reasonLabel": "Reason",
+      "reasonPlaceholder": "Optional",
+      "durationLabel": "Duration",
+      "blockButton": "Block",
+      "unblockButton": "Unblock",
+      "blockedToast": "Block added",
+      "unblockedToast": "Block removed",
+      "empty": "No active blocks.",
+      "addedOn": "Added",
+      "expires": "Expires",
+      "type": {
+        "authUser": "Player",
+        "guest": "Guest",
+        "ip": "IP address"
+      },
+      "duration": {
+        "permanent": "Permanent",
+        "1h": "1 hour",
+        "24h": "24 hours",
+        "7d": "7 days",
+        "30d": "30 days"
+      }
     },
     "system": {
       "down": "Down",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -7336,6 +7336,7 @@ const es = {
       "overview": "Resumen",
       "analytics": "Análisis",
       "moderation": "Moderación",
+      "blocklist": "Lista de bloqueos",
       "content": "Contenido",
       "puzzleReview": "Revisión de acertijos",
       "people": "Personas",
@@ -7344,6 +7345,35 @@ const es = {
       "guests": "Invitados",
       "system": "Sistema",
       "wordCraft": "WordCraft"
+    },
+    "blocklist": {
+      "title": "Lista de bloqueos",
+      "subtitle": "Bloquea a un jugador, invitado o IP para que no se una a las partidas.",
+      "typeLabel": "Tipo",
+      "valueLabel": "Identificador",
+      "valuePlaceholder": "ID de usuario, ID de sesión de invitado o IP",
+      "reasonLabel": "Motivo",
+      "reasonPlaceholder": "Opcional",
+      "durationLabel": "Duración",
+      "blockButton": "Bloquear",
+      "unblockButton": "Desbloquear",
+      "blockedToast": "Bloqueo añadido",
+      "unblockedToast": "Bloqueo eliminado",
+      "empty": "No hay bloqueos activos.",
+      "addedOn": "Añadido",
+      "expires": "Expira",
+      "type": {
+        "authUser": "Jugador",
+        "guest": "Invitado",
+        "ip": "Dirección IP"
+      },
+      "duration": {
+        "permanent": "Permanente",
+        "1h": "1 hora",
+        "24h": "24 horas",
+        "7d": "7 días",
+        "30d": "30 días"
+      }
     },
     "invalidWords": {
       "title": "Revisión de Palabras Inválidas",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -7368,6 +7368,7 @@ const he = {
       "overview": "סקירה",
       "analytics": "אנליטיקה",
       "moderation": "מודרציה",
+      "blocklist": "רשימת חסומים",
       "content": "תוכן",
       "puzzleReview": "סקירת חידות",
       "people": "אנשים",
@@ -7376,6 +7377,35 @@ const he = {
       "guests": "אורחים",
       "system": "מערכת",
       "wordCraft": "וורדקראפט"
+    },
+    "blocklist": {
+      "title": "רשימת חסומים",
+      "subtitle": "חסום שחקן, אורח או כתובת IP מהצטרפות למשחקים.",
+      "typeLabel": "סוג",
+      "valueLabel": "מזהה",
+      "valuePlaceholder": "מזהה משתמש, מזהה אורח או כתובת IP",
+      "reasonLabel": "סיבה",
+      "reasonPlaceholder": "אופציונלי",
+      "durationLabel": "משך",
+      "blockButton": "חסום",
+      "unblockButton": "בטל חסימה",
+      "blockedToast": "החסימה נוספה",
+      "unblockedToast": "החסימה הוסרה",
+      "empty": "אין חסימות פעילות.",
+      "addedOn": "נוסף",
+      "expires": "פג בתאריך",
+      "type": {
+        "authUser": "שחקן",
+        "guest": "אורח",
+        "ip": "כתובת IP"
+      },
+      "duration": {
+        "permanent": "קבוע",
+        "1h": "שעה",
+        "24h": "24 שעות",
+        "7d": "7 ימים",
+        "30d": "30 ימים"
+      }
     },
     "kpi": {
       "dau": "משתמשים פעילים יומיים",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -7412,6 +7412,7 @@ const ja = {
       "overview": "概要",
       "analytics": "分析",
       "moderation": "モデレーション",
+      "blocklist": "ブロックリスト",
       "content": "コンテンツ",
       "puzzleReview": "パズルレビュー",
       "people": "ユーザー",
@@ -7420,6 +7421,35 @@ const ja = {
       "guests": "ゲスト",
       "system": "システム",
       "wordCraft": "ワードクラフト"
+    },
+    "blocklist": {
+      "title": "ブロックリスト",
+      "subtitle": "プレイヤー、ゲスト、またはIPのゲーム参加をブロックします。",
+      "typeLabel": "種類",
+      "valueLabel": "識別子",
+      "valuePlaceholder": "ユーザーID、ゲストセッションID、またはIP",
+      "reasonLabel": "理由",
+      "reasonPlaceholder": "任意",
+      "durationLabel": "期間",
+      "blockButton": "ブロック",
+      "unblockButton": "解除",
+      "blockedToast": "ブロックを追加しました",
+      "unblockedToast": "ブロックを解除しました",
+      "empty": "有効なブロックはありません。",
+      "addedOn": "追加日",
+      "expires": "期限",
+      "type": {
+        "authUser": "プレイヤー",
+        "guest": "ゲスト",
+        "ip": "IPアドレス"
+      },
+      "duration": {
+        "permanent": "無期限",
+        "1h": "1時間",
+        "24h": "24時間",
+        "7d": "7日間",
+        "30d": "30日間"
+      }
     },
     "invalidWords": {
       "title": "無効な単語の確認",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -7392,6 +7392,7 @@ const sv = {
       "overview": "Översikt",
       "analytics": "Analys",
       "moderation": "Moderering",
+      "blocklist": "Blockeringslista",
       "content": "Innehåll",
       "puzzleReview": "Pusselgranskning",
       "people": "Personer",
@@ -7400,6 +7401,35 @@ const sv = {
       "guests": "Gäster",
       "system": "System",
       "wordCraft": "WordCraft"
+    },
+    "blocklist": {
+      "title": "Blockeringslista",
+      "subtitle": "Blockera en spelare, gäst eller IP-adress från att gå med i spel.",
+      "typeLabel": "Typ",
+      "valueLabel": "Identifierare",
+      "valuePlaceholder": "Användar-ID, gästsessions-ID eller IP",
+      "reasonLabel": "Orsak",
+      "reasonPlaceholder": "Valfritt",
+      "durationLabel": "Varaktighet",
+      "blockButton": "Blockera",
+      "unblockButton": "Avblockera",
+      "blockedToast": "Blockering tillagd",
+      "unblockedToast": "Blockering borttagen",
+      "empty": "Inga aktiva blockeringar.",
+      "addedOn": "Tillagd",
+      "expires": "Upphör",
+      "type": {
+        "authUser": "Spelare",
+        "guest": "Gäst",
+        "ip": "IP-adress"
+      },
+      "duration": {
+        "permanent": "Permanent",
+        "1h": "1 timme",
+        "24h": "24 timmar",
+        "7d": "7 dagar",
+        "30d": "30 dagar"
+      }
     },
     "invalidWords": {
       "title": "Granskning av Ogiltiga Ord",


### PR DESCRIPTION
Add an admin moderation blocklist that refuses game entry to a registered
player (auth user id), a guest (guest session id), or any client behind a
given IP — with an optional expiry (temporary or permanent).

Backend
- New blocked_entities table (migration) with RLS: admins read, writes via
  service-role API. Not added to supabase_realtime (no consumer).
- blockListManager: in-memory, 30s-TTL cache of the blocklist with inline
  expiry guard; warmed + refreshed on server startup. Avoids a per-join DB
  round-trip on the hot join path.
- Enforce in playerJoinHandler before reconnection/late-join via a new
  PLAYER_BLOCKED error code, using the verified auth id, guest session id,
  and client IP.

Admin API (/api/admin/blocks)
- GET list (active-only / by type), POST upsert-block, DELETE unblock.
- Pure parseBlockPayload validator (type, value, reason, expiry/duration).

Admin UI
- New /admin/blocklist page + BlockListManager (create + manage blocks).
- Quick "Block" buttons on the Players and Guests admin lists.
- Sidebar nav entry under People; translations for en/he/sv/ja/es.

Tests (TDD): blockListManager (7), join-handler enforcement (2),
parseBlockPayload (10); updated existing join + adminNav tests for the new
dependency/IA.