### PR TITLE
fix(mp): solo-confirm popup no longer auto-opens before host clicks Start

### DIFF
--- a/fe-next/host/HostView.tsx
+++ b/fe-next/host/HostView.tsx
@@ -712,6 +712,7 @@ const HostView: React.FC<HostViewProps> = memo(({
           highlightedCells={animation.highlightedCells}
           tableData={runtime.tableData}
           onStartGame={actions.startGame}
+          onAutoStartWithBots={actions.confirmSoloStart}
           onExitRoom={actions.handleExitRoom}
           onCancelTournament={actions.handleCancelTournamentDialog}
           onRegenerateBoard={actions.regenerateBoard}

--- a/fe-next/host/__tests__/HostPreGameView.quickPlay.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.quickPlay.test.tsx
@@ -112,6 +112,7 @@ const baseProps = {
   highlightedCells: [],
   tableData: [['A', 'B'], ['C', 'D']],
   onStartGame: vi.fn(),
+  onAutoStartWithBots: vi.fn(),
   onExitRoom: vi.fn(),
   onCancelTournament: vi.fn(),
   onRegenerateBoard: vi.fn(),
@@ -143,7 +144,10 @@ describe('HostPreGameView Quick Play / bot auto-fill', () => {
     expect(addBots).toBeUndefined();
     expect(setAutoFill).toBeDefined();
     expect(setAutoFill![1]).toEqual({ enabled: true, targetCount: 3 });
-    expect(baseProps.onStartGame).toHaveBeenCalled();
+    // Auto-fill rescue starts directly with bots — never via the solo-confirm
+    // popup path (onStartGame → startGame → setShowSoloConfirm).
+    expect(baseProps.onAutoStartWithBots).toHaveBeenCalled();
+    expect(baseProps.onStartGame).not.toHaveBeenCalled();
   });
 
   it('starts bot countdown immediately when isQuickPlay=true and alone', () => {
@@ -155,6 +159,7 @@ describe('HostPreGameView Quick Play / bot auto-fill', () => {
     const setAutoFill = emitMock.mock.calls.find(([evt]) => evt === 'setAutoFill');
     expect(setAutoFill).toBeDefined();
     expect(setAutoFill![1]).toEqual({ enabled: true, targetCount: 3 });
-    expect(baseProps.onStartGame).toHaveBeenCalled();
+    expect(baseProps.onAutoStartWithBots).toHaveBeenCalled();
+    expect(baseProps.onStartGame).not.toHaveBeenCalled();
   });
 });

--- a/fe-next/host/__tests__/HostPreGameView.soloHostStart.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.soloHostStart.test.tsx
@@ -121,6 +121,7 @@ const baseProps = {
   highlightedCells: [],
   tableData: [['A', 'B'], ['C', 'D']],
   onStartGame: vi.fn(),
+  onAutoStartWithBots: vi.fn(),
   onExitRoom: vi.fn(),
   onCancelTournament: vi.fn(),
   onRegenerateBoard: vi.fn(),
@@ -207,7 +208,11 @@ describe('HostPreGameView passive bot auto-fill timer (alone host)', () => {
 
     const setAutoFill = emitMock.mock.calls.find(([evt]) => evt === 'setAutoFill');
     expect(setAutoFill).toBeDefined();
-    expect(baseProps.onStartGame).toHaveBeenCalled();
+    // Passive rescue must start DIRECTLY with bots — NOT via the solo-confirm
+    // popup path (onStartGame → startGame → setShowSoloConfirm). An abandoned
+    // host never clicks a modal, so a popup here would strand the lobby forever.
+    expect(baseProps.onAutoStartWithBots).toHaveBeenCalled();
+    expect(baseProps.onStartGame).not.toHaveBeenCalled();
   });
 
   it('does NOT auto-fill via the timer in a PRIVATE (invite/classroom) room', () => {

--- a/fe-next/host/components/HostPreGameView.tsx
+++ b/fe-next/host/components/HostPreGameView.tsx
@@ -98,6 +98,14 @@ interface HostPreGameViewProps {
   highlightedCells: { row: number; col: number }[];
   tableData: LetterGrid;
   onStartGame: () => void;
+  /**
+   * Start the game DIRECTLY with bot opponents, bypassing the solo-confirm
+   * popup. Used by the automatic rescue paths (passive alone-timer + Quick
+   * Play countdown) where there is no user click to gate the modal on — an
+   * abandoned host would never dismiss a popup, stranding the lobby. Falls
+   * back to `onStartGame` when not provided.
+   */
+  onAutoStartWithBots?: () => void;
   onExitRoom: () => void;
   onCancelTournament: () => void;
   onRegenerateBoard?: () => void;
@@ -134,6 +142,7 @@ function HostPreGameView({
   autoStartSecondsLeft = null,
   onCancelAutoStart,
   onStartGame,
+  onAutoStartWithBots,
   onExitRoom,
   tournamentCreating,
   lessonData,
@@ -302,13 +311,22 @@ function HostPreGameView({
     };
   }, [humanGuestCount, isQuickPlay, isPrivate]);
 
+  // Automatic rescue start (passive alone-timer + Quick Play countdown). Routes
+  // through onAutoStartWithBots so the game starts DIRECTLY with bots instead of
+  // re-prompting the solo-confirm popup (onStartGame → startGame →
+  // setShowSoloConfirm). A modal here pops up with no user click and an
+  // abandoned host never dismisses it, stranding the lobby.
+  const startWithBots = useCallback(() => {
+    (onAutoStartWithBots ?? onStartGame)();
+  }, [onAutoStartWithBots, onStartGame]);
+
   useEffect(() => {
     if (botCountdown === null) return;
     if (botCountdown <= 0) {
       // setAutoFill is the backend's bot-fill primitive; the prior 'addBots'
       // event had no server handler so silently dropped (bots never spawned).
       socket?.emit('setAutoFill', { enabled: true, targetCount: 3 });
-      onStartGame();
+      startWithBots();
       setBotCountdown(null);
       return;
     }
@@ -318,7 +336,7 @@ function HostPreGameView({
     return () => {
       if (countdownIntervalRef.current) clearInterval(countdownIntervalRef.current);
     };
-  }, [botCountdown, socket, gameCode, onStartGame]);
+  }, [botCountdown, socket, gameCode, startWithBots]);
 
   const handleRoomLanguageChange = useCallback((newLang: Language) => {
     socket?.emit('changeRoomLanguage', { gameCode, language: newLang });


### PR DESCRIPTION
The 'Invite Friends / Play with Bots' modal popped up on its own in the
host lobby. Root cause: the passive alone-timer and Quick Play bot-fill
countdowns called onStartGame() (-> startGame -> setShowSoloConfirm) with
no user click. An abandoned host never dismisses a modal, so the rescue
that was meant to auto-start the lobby instead stranded it behind a popup.

- Add onAutoStartWithBots prop; the automatic bot-fill countdowns now
  start DIRECTLY with bots via confirmSoloStart, bypassing the modal.
- Explicit Start-button clicks keep the popup (the intended Invite CTA).
- Update soloHostStart + quickPlay tests to assert the rescue path starts
  via onAutoStartWithBots and never via the popup path (onStartGame).