### PR TITLE
fix(word-hunt): compact MP layout on wide-but-short viewports

### DIFF
--- a/fe-next/components/daily/survival/SurvivalClueBoxes.tsx
+++ b/fe-next/components/daily/survival/SurvivalClueBoxes.tsx
@@ -24,6 +24,37 @@ export interface SurvivalClueBoxesProps {
   t: (key: string) => string;
   /** Formed word currently equals target length — submitting will consume a try. */
   matchesTargetLength?: boolean;
+  /**
+   * Force the short-landscape compact treatment (small tiles, tight spacing,
+   * collapsed reserved slots) regardless of the `max-height:560px` media query.
+   * Word Hunt MP sets this on wide-but-short viewports (e.g. 1530×695) where the
+   * grid would otherwise be squished by the full-size clue boxes. SP daily
+   * survival never passes it, so its behaviour is unchanged.
+   */
+  compact?: boolean;
+}
+
+/**
+ * Clue-tile size classes, keyed by word length. `compact` returns small fixed
+ * sizes (mirroring the `max-height:560px` values) so a tight column on a wide
+ * screen gets the same breathing room a short phone already does. The default
+ * branch keeps the responsive sizes for normal play.
+ */
+function tileSizeClass(wordLength: number, compact?: boolean): string {
+  if (compact) {
+    return wordLength <= 4
+      ? 'w-7 h-7 text-xs rounded border shadow-none'
+      : wordLength <= 8
+        ? 'w-6 h-6 text-[10px] rounded border shadow-none'
+        : 'w-5 h-5 text-[9px] rounded border shadow-none';
+  }
+  return wordLength <= 4
+    ? 'w-11 h-11 sm:w-12 sm:h-12 text-lg sm:text-xl [@media(max-height:560px)]:w-7 [@media(max-height:560px)]:h-7 [@media(max-height:560px)]:text-xs [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none'
+    : wordLength <= 6
+      ? 'w-10 h-10 sm:w-11 sm:h-11 text-base sm:text-lg [@media(max-height:560px)]:w-6 [@media(max-height:560px)]:h-6 [@media(max-height:560px)]:text-[10px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none'
+      : wordLength <= 8
+        ? 'w-9 h-9 sm:w-10 sm:h-10 text-sm sm:text-base [@media(max-height:560px)]:w-6 [@media(max-height:560px)]:h-6 [@media(max-height:560px)]:text-[10px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none'
+        : 'w-8 h-8 sm:w-9 sm:h-9 text-xs sm:text-sm [@media(max-height:560px)]:w-5 [@media(max-height:560px)]:h-5 [@media(max-height:560px)]:text-[9px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none';
 }
 
 /**
@@ -43,6 +74,7 @@ export const SurvivalClueBoxes = forwardRef<HTMLDivElement, SurvivalClueBoxesPro
   gameDir,
   t,
   matchesTargetLength = false,
+  compact = false,
 }, ref) => {
   if (!currentHint) return null;
 
@@ -54,9 +86,11 @@ export const SurvivalClueBoxes = forwardRef<HTMLDivElement, SurvivalClueBoxesPro
       initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
       className={cn(
-        "mx-auto max-w-3xl w-full px-3 py-2 mb-0.5 rounded-neo-lg transition-all duration-300",
-        "[@media(max-height:560px)]:py-px [@media(max-height:560px)]:px-1.5 [@media(max-height:560px)]:mb-0 [@media(max-height:560px)]:border [@media(max-height:560px)]:rounded-md",
-        "bg-neo-navy/30 dark:bg-neo-navy/50 border-2 border-neo-black/20",
+        "mx-auto max-w-3xl w-full transition-all duration-300",
+        "bg-neo-navy/30 dark:bg-neo-navy/50 border-neo-black/20",
+        compact
+          ? "px-1.5 py-px mb-0 border rounded-md"
+          : "px-3 py-2 mb-0.5 border-2 rounded-neo-lg [@media(max-height:560px)]:py-px [@media(max-height:560px)]:px-1.5 [@media(max-height:560px)]:mb-0 [@media(max-height:560px)]:border [@media(max-height:560px)]:rounded-md",
         showFeedbackOverlay
           ? "clue-feedback-active clue-container-attention animate-pulse ring-2 ring-neo-lime/60"
           : showMatchWarning
@@ -72,7 +106,12 @@ export const SurvivalClueBoxes = forwardRef<HTMLDivElement, SurvivalClueBoxesPro
           is hidden anyway. Mirrors the legend row's min-h reservation. */}
       <div
         data-testid="match-target-warning-slot"
-        className="min-h-[1.5rem] sm:min-h-[1.75rem] mb-1 [@media(max-height:560px)]:hidden [@media(max-height:560px)]:min-h-0 [@media(max-height:560px)]:mb-0 flex items-center justify-center"
+        className={cn(
+          "flex items-center justify-center",
+          compact
+            ? "hidden min-h-0 mb-0"
+            : "min-h-[1.5rem] sm:min-h-[1.75rem] mb-1 [@media(max-height:560px)]:hidden [@media(max-height:560px)]:min-h-0 [@media(max-height:560px)]:mb-0",
+        )}
       >
         {showMatchWarning && (
           <span
@@ -90,9 +129,10 @@ export const SurvivalClueBoxes = forwardRef<HTMLDivElement, SurvivalClueBoxesPro
         const targetAttempts = attempts.filter(a => !a.isDiscovery).length;
         const triesRemaining = MAX_ATTEMPTS - targetAttempts;
         return (
-          <div className="text-center mb-2 [@media(max-height:560px)]:mb-0.5">
+          <div className={cn("text-center", compact ? "mb-0.5" : "mb-2 [@media(max-height:560px)]:mb-0.5")}>
             <span className={cn(
-              "text-xl sm:text-2xl font-black [@media(max-height:560px)]:text-sm",
+              "font-black",
+              compact ? "text-sm" : "text-xl sm:text-2xl [@media(max-height:560px)]:text-sm",
               triesRemaining <= 2
                 ? "text-neo-red"
                 : triesRemaining <= 4
@@ -117,6 +157,7 @@ export const SurvivalClueBoxes = forwardRef<HTMLDivElement, SurvivalClueBoxesPro
               feedback={latestAttemptFeedback}
               targetWordLength={targetWord.length}
               skipAnimations={skipAnimations}
+              compact={compact}
             />
           ) : (
             <HintBoxes
@@ -125,13 +166,17 @@ export const SurvivalClueBoxes = forwardRef<HTMLDivElement, SurvivalClueBoxesPro
               accumulatedClues={accumulatedClues}
               revealedLetters={revealedLetters}
               attempts={attempts}
+              compact={compact}
             />
           )}
         </AdaptiveAnimatePresence>
       </div>
 
       {/* Legend / Known letters indicator. Floor collapses on short landscape so the grid keeps room. */}
-      <div className="min-h-[40px] sm:min-h-[44px] [@media(max-height:560px)]:min-h-0 flex flex-col justify-center">
+      <div className={cn(
+        "flex flex-col justify-center",
+        compact ? "min-h-0" : "min-h-[40px] sm:min-h-[44px] [@media(max-height:560px)]:min-h-0",
+      )}>
         <AdaptiveAnimatePresence mode="sync">
           {showFeedbackOverlay && latestAttemptFeedback ? (
             <FeedbackLegend t={t} />
@@ -182,9 +227,10 @@ interface FeedbackOverlayProps {
   feedback: LetterFeedback[];
   targetWordLength: number;
   skipAnimations: boolean;
+  compact?: boolean;
 }
 
-const FeedbackOverlay: React.FC<FeedbackOverlayProps> = ({ feedback, targetWordLength, skipAnimations }) => {
+const FeedbackOverlay: React.FC<FeedbackOverlayProps> = ({ feedback, targetWordLength, skipAnimations, compact }) => {
   // Gray letters flash briefly then fade to '?' after a delay
   const [grayFaded, setGrayFaded] = useState(false);
 
@@ -196,13 +242,7 @@ const FeedbackOverlay: React.FC<FeedbackOverlayProps> = ({ feedback, targetWordL
   // Normalize feedback to match target word length
   const normalizedFeedback = normalizeToTargetLength(feedback, targetWordLength);
   const wordLength = normalizedFeedback.length;
-  const sizeClass = wordLength <= 4
-    ? "w-11 h-11 sm:w-12 sm:h-12 text-lg sm:text-xl [@media(max-height:560px)]:w-7 [@media(max-height:560px)]:h-7 [@media(max-height:560px)]:text-xs [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none"
-    : wordLength <= 6
-      ? "w-10 h-10 sm:w-11 sm:h-11 text-base sm:text-lg [@media(max-height:560px)]:w-6 [@media(max-height:560px)]:h-6 [@media(max-height:560px)]:text-[10px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none"
-      : wordLength <= 8
-        ? "w-9 h-9 sm:w-10 sm:h-10 text-sm sm:text-base [@media(max-height:560px)]:w-6 [@media(max-height:560px)]:h-6 [@media(max-height:560px)]:text-[10px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none"
-        : "w-8 h-8 sm:w-9 sm:h-9 text-xs sm:text-sm [@media(max-height:560px)]:w-5 [@media(max-height:560px)]:h-5 [@media(max-height:560px)]:text-[9px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none";
+  const sizeClass = tileSizeClass(wordLength, compact);
 
   return (
     <AdaptiveMotion.div
@@ -254,6 +294,7 @@ interface HintBoxesProps {
   accumulatedClues: Map<number, AccumulatedClue>;
   revealedLetters: Set<number>;
   attempts: TargetAttempt[];
+  compact?: boolean;
 }
 
 const HintBoxes: React.FC<HintBoxesProps> = ({
@@ -262,6 +303,7 @@ const HintBoxes: React.FC<HintBoxesProps> = ({
   accumulatedClues,
   revealedLetters,
   attempts,
+  compact,
 }) => {
   const hintChars = currentHint.hint.split(' ').filter(c => c !== '');
   const wordLength = hintChars.length;
@@ -276,13 +318,7 @@ const HintBoxes: React.FC<HintBoxesProps> = ({
     () => computeYellowState(attempts, letterCounts, accumulatedClues),
     [attempts, letterCounts, accumulatedClues]
   );
-  const sizeClass = wordLength <= 4
-    ? "w-11 h-11 sm:w-12 sm:h-12 text-lg sm:text-xl [@media(max-height:560px)]:w-7 [@media(max-height:560px)]:h-7 [@media(max-height:560px)]:text-xs [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none"
-    : wordLength <= 6
-      ? "w-10 h-10 sm:w-11 sm:h-11 text-base sm:text-lg [@media(max-height:560px)]:w-6 [@media(max-height:560px)]:h-6 [@media(max-height:560px)]:text-[10px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none"
-      : wordLength <= 8
-        ? "w-9 h-9 sm:w-10 sm:h-10 text-sm sm:text-base [@media(max-height:560px)]:w-6 [@media(max-height:560px)]:h-6 [@media(max-height:560px)]:text-[10px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none"
-        : "w-8 h-8 sm:w-9 sm:h-9 text-xs sm:text-sm [@media(max-height:560px)]:w-5 [@media(max-height:560px)]:h-5 [@media(max-height:560px)]:text-[9px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none";
+  const sizeClass = tileSizeClass(wordLength, compact);
 
   return (
     <AdaptiveMotion.div

--- a/fe-next/components/daily/survival/__tests__/SurvivalClueBoxes.compact.test.tsx
+++ b/fe-next/components/daily/survival/__tests__/SurvivalClueBoxes.compact.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Short-landscape compaction for the Word Hunt MP clue boxes.
+ *
+ * BUG: at wide-but-short viewports (e.g. 1530×695) the vertical compaction
+ * only kicked in at `max-height:560px`, so the full-size clue boxes ate the
+ * column height and squished the grid — the board felt cluttered and selected
+ * tiles (which scale up) overlapped their neighbours.
+ *
+ * FIX: WordHuntGameLayout detects the wide-short band and passes `compact`,
+ * which forces the small tile + tight-spacing treatment regardless of the
+ * `max-height:560px` media query. SP daily survival never passes `compact`,
+ * so its behaviour is unchanged.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SurvivalClueBoxes } from '../SurvivalClueBoxes';
+import type { AccumulatedClue } from '../types';
+
+vi.mock('framer-motion', () => ({
+  m: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
+      const { initial, animate, exit, transition, whileHover, whileTap, ...domProps } = props;
+      return <div {...domProps}>{children}</div>;
+    },
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+describe('SurvivalClueBoxes - compact (short landscape)', () => {
+  const baseProps = {
+    currentHint: { level: 0, hint: '_ _ _ _ _', revealed: 0, unlockCost: 0 },
+    targetWord: '?????',
+    attempts: [],
+    accumulatedClues: new Map<number, AccumulatedClue>(),
+    revealedLetters: new Set<number>(),
+    knownLetters: new Set<string>(),
+    latestAttemptFeedback: null,
+    showFeedbackOverlay: false,
+    isClueGaining: false,
+    skipAnimations: true,
+    gameDir: 'ltr' as const,
+    t: (key: string) => key,
+  };
+
+  it('renders small clue tiles (no large w-10/w-11 sizing) when compact', () => {
+    render(<SurvivalClueBoxes {...baseProps} compact />);
+    const tiles = screen.getAllByText('?');
+    expect(tiles.length).toBeGreaterThan(0);
+    for (const tile of tiles) {
+      expect(tile.className).not.toContain('w-10');
+      expect(tile.className).not.toContain('w-11');
+    }
+  });
+
+  it('keeps the large clue tiles when not compact (SP default)', () => {
+    render(<SurvivalClueBoxes {...baseProps} />);
+    const tiles = screen.getAllByText('?');
+    // 5-letter word → w-10 base size in the default (non-compact) branch.
+    expect(tiles.some((el) => el.className.includes('w-10'))).toBe(true);
+  });
+
+  it('collapses the reserved warning slot when compact', () => {
+    render(<SurvivalClueBoxes {...baseProps} compact />);
+    const slot = screen.getByTestId('match-target-warning-slot');
+    expect(slot.className).toContain('hidden');
+  });
+});

--- a/fe-next/components/wordhunt/WordHuntGameLayout.tsx
+++ b/fe-next/components/wordhunt/WordHuntGameLayout.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { memo } from 'react';
+import { cn } from '@/lib/utils';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { SurvivalClueBoxes } from '@/components/daily/survival/SurvivalClueBoxes';
 import { SurvivalLifeBar } from '@/components/daily/survival/SurvivalLifeBar';
 import { SurvivalGridSection } from '@/components/daily/survival/SurvivalGridSection';
@@ -131,21 +133,37 @@ export const WordHuntGameLayout = memo<WordHuntGameLayoutProps>(({
   t,
   gameDir,
 }) => {
+  // Wide-but-short viewports (e.g. 1530×695) run the row layout (≥720px) but
+  // have too little height for the full-size chrome — the clue boxes + header
+  // crowd the grid until it's squished and selected tiles overlap. In that band
+  // we force the compact treatment so the board keeps its room. The min-width
+  // guard scopes this to the sidebar layout; portrait phones keep their own
+  // `max-height:560px` tuning.
+  const shortLandscape = useMediaQuery('(min-width: 720px) and (max-height: 760px)');
+
   return (
     <div className="flex-1 flex flex-col min-[720px]:flex-row min-h-0 overflow-x-hidden overflow-y-auto" translate="no">
       {/* Main game area — capped width on wider screens, with vertical rhythm between sections */}
-      <div className="flex-1 flex flex-col min-h-0 overflow-y-auto overflow-x-hidden w-full max-w-3xl mx-auto gap-1.5 md:gap-2 [@media(max-height:560px)]:gap-0.5">
+      <div className={cn(
+        'flex-1 flex flex-col min-h-0 overflow-y-auto overflow-x-hidden w-full max-w-3xl mx-auto',
+        shortLandscape ? 'gap-0.5' : 'gap-1.5 md:gap-2 [@media(max-height:560px)]:gap-0.5',
+      )}>
         {/* Score + Quit — compact */}
         <WordHuntMPHeader
           score={score}
           onQuit={onQuit}
           onShowHelp={onShowHelp}
           t={t}
+          compact={shortLandscape}
         />
 
         {/* Clue Boxes — tight vertical padding; on short landscape collapse outer padding too.
             Skeleton placeholder while server target metadata is in flight (recovery race). */}
-        <div className={`px-2 [@media(max-height:560px)]:px-1 flex-shrink-0${wrongGuessShake ? ' animate-neo-shake' : ''}`}>
+        <div className={cn(
+          'flex-shrink-0',
+          shortLandscape ? 'px-1' : 'px-2 [@media(max-height:560px)]:px-1',
+          wrongGuessShake && 'animate-neo-shake',
+        )}>
           {targetLength > 0 ? (
             <SurvivalClueBoxes
               currentHint={currentHint}
@@ -161,6 +179,7 @@ export const WordHuntGameLayout = memo<WordHuntGameLayoutProps>(({
               gameDir={gameDir}
               t={t}
               matchesTargetLength={matchesTargetLength}
+              compact={shortLandscape}
             />
           ) : (
             <ClueTilesSkeleton t={t} />
@@ -171,7 +190,7 @@ export const WordHuntGameLayout = memo<WordHuntGameLayoutProps>(({
             card vanishes in 8s, leaving players thinking they must spell the
             hidden word; this one-liner stays so it's always clear that ANY
             valid word heals and only matching the target wins. */}
-        {targetLength > 0 && (
+        {targetLength > 0 && !shortLandscape && (
           <p
             data-testid="wh-heal-hint"
             className="shrink-0 px-2 text-center text-[11px] sm:text-xs font-neo-body text-neo-white leading-tight"

--- a/fe-next/components/wordhunt/WordHuntMPHeader.tsx
+++ b/fe-next/components/wordhunt/WordHuntMPHeader.tsx
@@ -2,27 +2,46 @@
 
 import { memo } from 'react';
 import { X, HelpCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 export interface WordHuntMPHeaderProps {
   score: number;
   onQuit: () => void;
   t: (key: string) => string;
   onShowHelp?: () => void;
+  /**
+   * Force the short-landscape compact treatment (small buttons + score chip)
+   * regardless of the `max-height:560px` media query. WordHuntGameLayout sets
+   * this on wide-but-short viewports (e.g. 1530×695) where the row layout is
+   * active but height is tight, so the chrome stops crowding the grid.
+   */
+  compact?: boolean;
 }
+
+// Icon button size — `compact` collapses it without waiting on the media query.
+const iconBtnSize = (compact?: boolean) =>
+  compact ? 'w-8 h-8' : 'w-10 h-10 [@media(max-height:560px)]:w-8 [@media(max-height:560px)]:h-8';
 
 export const WordHuntMPHeader = memo<WordHuntMPHeaderProps>(({
   score,
   onQuit,
   t,
   onShowHelp,
+  compact,
 }) => {
   return (
-    <div className="flex items-center justify-between px-2 py-0.5 [@media(max-height:560px)]:py-0 gap-2">
+    <div className={cn(
+      'flex items-center justify-between px-2 gap-2',
+      compact ? 'py-0' : 'py-0.5 [@media(max-height:560px)]:py-0',
+    )}>
       {/* Help button or spacer for layout balance */}
       {onShowHelp ? (
         <button
           onClick={onShowHelp}
-          className="w-10 h-10 [@media(max-height:560px)]:w-8 [@media(max-height:560px)]:h-8 flex items-center justify-center rounded-neo border-3 border-neo-black bg-neo-navy-light text-neo-white shadow-hard-sm hover:text-neo-white hover:shadow-hard active:shadow-hard-pressed transition-all"
+          className={cn(
+            iconBtnSize(compact),
+            'flex items-center justify-center rounded-neo border-3 border-neo-black bg-neo-navy-light text-neo-white shadow-hard-sm hover:text-neo-white hover:shadow-hard active:shadow-hard-pressed transition-all',
+          )}
           aria-label={t('wordHuntRules.quickTipsTitle')}
           data-testid="wh-help-button"
         >
@@ -34,8 +53,14 @@ export const WordHuntMPHeader = memo<WordHuntMPHeaderProps>(({
 
       {/* Score Badge */}
       <div className="flex-1 flex justify-center">
-        <div className="bg-neo-navy border-3 border-neo-black rounded-neo px-4 py-1.5 [@media(max-height:560px)]:px-2 [@media(max-height:560px)]:py-0 shadow-hard-sm">
-          <span className="text-2xl [@media(max-height:560px)]:text-base font-black font-neo-display text-neo-yellow tabular-nums">
+        <div className={cn(
+          'bg-neo-navy border-3 border-neo-black rounded-neo shadow-hard-sm',
+          compact ? 'px-2 py-0' : 'px-4 py-1.5 [@media(max-height:560px)]:px-2 [@media(max-height:560px)]:py-0',
+        )}>
+          <span className={cn(
+            'font-black font-neo-display text-neo-yellow tabular-nums',
+            compact ? 'text-base' : 'text-2xl [@media(max-height:560px)]:text-base',
+          )}>
             {score}
           </span>
         </div>
@@ -44,7 +69,10 @@ export const WordHuntMPHeader = memo<WordHuntMPHeaderProps>(({
       {/* Quit Button */}
       <button
         onClick={onQuit}
-        className="w-10 h-10 [@media(max-height:560px)]:w-8 [@media(max-height:560px)]:h-8 flex items-center justify-center rounded-neo border-3 border-neo-black bg-neo-red text-neo-white shadow-hard-sm hover:shadow-hard active:shadow-hard-pressed transition-shadow"
+        className={cn(
+          iconBtnSize(compact),
+          'flex items-center justify-center rounded-neo border-3 border-neo-black bg-neo-red text-neo-white shadow-hard-sm hover:shadow-hard active:shadow-hard-pressed transition-shadow',
+        )}
         aria-label={t('common.quit')}
       >
         <X size={20} strokeWidth={3} />

--- a/fe-next/components/wordhunt/__tests__/WordHuntGameLayout.shortLandscape.test.tsx
+++ b/fe-next/components/wordhunt/__tests__/WordHuntGameLayout.shortLandscape.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Short-landscape (wide-but-short) layout behaviour for Word Hunt MP.
+ *
+ * At viewports like 1530×695 the row layout is active (≥720px wide) but the
+ * height is too small for the full-size chrome, which squished the grid and
+ * made the board feel cluttered with overlapping tiles. In that band the
+ * layout drops the redundant "any word heals" one-liner and threads `compact`
+ * to the clue boxes / header so the grid keeps its room.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { WordHuntGameLayout } from '../WordHuntGameLayout';
+
+vi.mock('../WordHuntMPHeader', () => ({ WordHuntMPHeader: () => <div data-testid="mp-header" /> }));
+vi.mock('../WordHuntMPLeaderboard', () => ({ WordHuntMPLeaderboard: () => <div data-testid="mp-leaderboard" /> }));
+vi.mock('../WordHuntGameOverOverlay', () => ({ WordHuntGameOverOverlay: () => null }));
+vi.mock('@/components/daily/survival/SurvivalLifeBar', () => ({ SurvivalLifeBar: () => <div data-testid="life-bar" /> }));
+vi.mock('@/components/daily/survival/SurvivalGridSection', () => ({ SurvivalGridSection: () => <div data-testid="grid-section" /> }));
+vi.mock('@/components/daily/survival/SurvivalClueBoxes', () => ({
+  SurvivalClueBoxes: ({ compact }: { compact?: boolean }) => (
+    <div data-testid="real-clue-boxes" data-compact={compact ? 'true' : 'false'} />
+  ),
+}));
+
+const baseProps = {
+  score: 0,
+  onQuit: () => {},
+  targetLength: 5,
+  currentHint: { hint: '_ _ _ _ _', level: 0, unlockCost: 0 },
+  attempts: [],
+  accumulatedClues: new Map(),
+  knownLetters: new Set<string>(),
+  latestAttemptFeedback: null,
+  showFeedbackOverlay: false,
+  lifePoints: 100,
+  isGameOver: false,
+  targetFound: false,
+  isLifeGaining: false,
+  lifeGainAmount: null,
+  isClueGaining: false,
+  grid: [['A']] as never,
+  onWordSubmit: () => {},
+  onWordChange: () => {},
+  playerLives: {},
+  eliminatedPlayers: [],
+  leaderboard: [],
+  currentUsername: 'me',
+  t: (k: string) => k,
+  gameDir: 'ltr' as const,
+};
+
+function setMatchMedia(matchesShortLandscape: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes('max-height') ? matchesShortLandscape : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+}
+
+describe('WordHuntGameLayout short-landscape adaptation', () => {
+  it('keeps the heal hint and full clue boxes on tall viewports', () => {
+    setMatchMedia(false);
+    render(<WordHuntGameLayout {...baseProps} />);
+    expect(screen.getByTestId('wh-heal-hint')).toBeInTheDocument();
+    expect(screen.getByTestId('real-clue-boxes')).toHaveAttribute('data-compact', 'false');
+  });
+
+  it('drops the heal hint and compacts the clue boxes on wide-short viewports', () => {
+    setMatchMedia(true);
+    render(<WordHuntGameLayout {...baseProps} />);
+    expect(screen.queryByTestId('wh-heal-hint')).not.toBeInTheDocument();
+    expect(screen.getByTestId('real-clue-boxes')).toHaveAttribute('data-compact', 'true');
+  });
+});

--- a/fe-next/components/wordhunt/__tests__/WordHuntMPHeader.test.tsx
+++ b/fe-next/components/wordhunt/__tests__/WordHuntMPHeader.test.tsx
@@ -67,4 +67,17 @@ describe('WordHuntMPHeader', () => {
     render(<WordHuntMPHeader {...defaultProps} />);
     expect(screen.queryByTestId('wh-help-button')).not.toBeInTheDocument();
   });
+
+  it('uses full-size quit button by default', () => {
+    render(<WordHuntMPHeader {...defaultProps} />);
+    const quitBtn = screen.getByLabelText('common.quit');
+    expect(quitBtn.className).toContain('w-10');
+  });
+
+  it('shrinks the quit button when compact (short landscape)', () => {
+    render(<WordHuntMPHeader {...defaultProps} compact />);
+    const quitBtn = screen.getByLabelText('common.quit');
+    expect(quitBtn.className).not.toContain('w-10');
+    expect(quitBtn.className).toContain('w-8');
+  });
 });


### PR DESCRIPTION
At wide-but-short viewports (e.g. 1530x695) the Word Hunt MP row layout is
active (>=720px) but vertical compaction only triggered at max-height:560px,
so the full-size header + clue boxes + heal hint crowded the column and
squished the grid — the board felt cluttered and selected tiles (which scale
up to 1.15x) overlapped their neighbours.

WordHuntGameLayout now detects the wide-short band via
(min-width:720px) and (max-height:760px) and threads a compact flag to the
header and clue boxes, drops the redundant heal-hint one-liner, and tightens
gaps so the grid keeps its room. SP daily survival never passes compact, so
its behaviour is unchanged.

Also dedupes the duplicated clue-tile sizeClass into a shared tileSizeClass
helper.

https://claude.ai/code/session_01Lq5MG53dGPdPFzk54py62z