### PR TITLE
fix(onboarding): let users edit name on mobile keyboards in QuickProfileSetup

### DIFF
--- a/fe-next/components/onboarding/QuickProfileSetup.tsx
+++ b/fe-next/components/onboarding/QuickProfileSetup.tsx
@@ -9,6 +9,7 @@ import Avatar from '@/components/Avatar';
 import AvatarBuilderModal from '@/components/avatar/AvatarBuilderModal';
 import InviteContextBanner from './InviteContextBanner';
 import { suggestPlayerName } from '@/utils/onboardingNameSuggestions';
+import { useImeText } from '@/hooks/useImeText';
 import { cn } from '@/lib/utils';
 
 interface QuickProfileSetupProps {
@@ -37,13 +38,23 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
   if (initialSuggestionRef.current === '') {
     initialSuggestionRef.current = suggestPlayerName(language);
   }
-  const [name, setName] = useState(initialSuggestionRef.current);
+  // IME-resilient input. Mobile keyboards (Android GBoard, RTL/Hebrew, swipe &
+  // autocorrect) buffer composition and commit text WITHOUT firing React's
+  // synthetic onChange. A naive `value={name}` controlled input then keeps
+  // forcing the DOM back to the stale suggestion — so the user "can't change
+  // their name". The hook mirrors the live DOM value via onInput/compositionEnd.
+  const {
+    ref: inputRef,
+    value: name,
+    getValue: getLiveName,
+    setValue: setName,
+    inputProps,
+  } = useImeText<HTMLInputElement>({ maxLength: 20, initialValue: initialSuggestionRef.current });
   const [avatar, setAvatar] = useState<CustomAvatarConfig>(getRandomAvatarConfig);
   const [isBuilderOpen, setIsBuilderOpen] = useState(false);
   const [avatarKey, setAvatarKey] = useState(0);
   const [showShake, setShowShake] = useState(false);
   const [justValidated, setJustValidated] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
   const previouslyValidRef = useRef(false);
 
   const trimmedName = name.trim();
@@ -81,17 +92,12 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
   }, []);
 
   const handleSubmit = useCallback(() => {
-    // Read from DOM as source of truth — mobile IME/autofill sometimes
-    // commits text without firing React's synthetic onChange, so `name`
-    // state may lag the actual input value (classic "need to add a space
-    // before it works" symptom).
-    const domValue = inputRef.current?.value ?? name;
-    const liveTrimmed = domValue.trim();
+    // getLiveName() reads the DOM ref directly (and trims/caps) as the source of
+    // truth — React state can still lag mid-composition on mobile keyboards.
+    const liveTrimmed = getLiveName();
     const liveCount = Array.from(liveTrimmed).length;
     const liveValid =
       liveCount >= 1 && liveCount <= 20 && /^[\p{L}\p{N}\s._-]+$/u.test(liveTrimmed);
-
-    if (domValue !== name) setName(domValue);
 
     if (!liveValid) {
       setShowShake(true);
@@ -101,7 +107,7 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
     }
     const nameEdited = liveTrimmed !== initialSuggestionRef.current.trim();
     onComplete(liveTrimmed, avatar, nameEdited);
-  }, [name, avatar, onComplete]);
+  }, [getLiveName, inputRef, avatar, onComplete]);
 
   const staggerChild = {
     hidden: { opacity: 0, y: 20 },
@@ -234,11 +240,9 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
             transition={{ duration: justValidated ? 0.5 : 0.4, ease: 'easeOut' }}
           >
             <input
+              {...inputProps}
               id="profile-name"
-              ref={inputRef}
               type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter' && isNameValid) handleSubmit(); }}
               placeholder={t('onboarding.name.placeholder')}
               autoFocus
@@ -283,6 +287,7 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
           initial="hidden"
           animate="visible"
           onClick={handleSubmit}
+          aria-disabled={!isNameValid}
           whileHover={isNameValid ? { scale: 1.02, y: -2 } : {}}
           whileTap={isNameValid ? { scale: 0.98, y: 2 } : {}}
           className={cn(

--- a/fe-next/components/onboarding/__tests__/QuickProfileSetup.test.tsx
+++ b/fe-next/components/onboarding/__tests__/QuickProfileSetup.test.tsx
@@ -101,6 +101,12 @@ vi.mock('@/shared/types/customAvatar', () => ({
   }),
 }));
 
+// Mock the locale-aware name suggester so the initial value (and thus the
+// character counter) is deterministic across tests.
+vi.mock('@/utils/onboardingNameSuggestions', () => ({
+  suggestPlayerName: () => 'StartName', // 9 chars
+}));
+
 // Mock InviteContextBanner
 vi.mock('@/components/onboarding/InviteContextBanner', () => ({
   __esModule: true,
@@ -177,6 +183,35 @@ describe('QuickProfileSetup', () => {
     expect(defaultProps.onComplete).toHaveBeenCalledTimes(1);
     const args = defaultProps.onComplete.mock.calls[0];
     expect(args[2]).toBe(false);
+  });
+
+  describe('mobile IME / virtual keyboard resilience', () => {
+    // Regression: on Android GBoard (incl. Spanish/Hebrew autocorrect & swipe
+    // typing) the keyboard buffers composition and commits text WITHOUT firing
+    // React's synthetic onChange. A naive `value={name}` controlled input then
+    // keeps forcing the DOM back to the stale suggestion, so the user "can't
+    // change their name". The field must mirror the live DOM value.
+
+    it('reflects text committed via compositionEnd even when onChange never fires', () => {
+      render(<QuickProfileSetup {...defaultProps} />);
+      const input = screen.getByRole('textbox') as HTMLInputElement;
+      // Initial suggestion 'StartName' => 9 chars.
+      expect(screen.getByText('9/20')).toBeInTheDocument();
+
+      // Override the value setter so React's change tracker can't observe it
+      // (this is exactly what a real mobile IME does), then fire only
+      // compositionEnd — no synthetic onChange.
+      Object.defineProperty(input, 'value', {
+        configurable: true,
+        writable: true,
+        value: 'Bouncy Wolf', // 11 chars
+      });
+      fireEvent.compositionEnd(input, { data: 'Bouncy Wolf' });
+
+      // The visible counter is driven by React state — it must update, proving
+      // the field accepted the change.
+      expect(screen.getByText('11/20')).toBeInTheDocument();
+    });
   });
 
   describe('avatar builder integration', () => {


### PR DESCRIPTION
The name field in the FTUE / join-a-friend profile card used a naive
controlled input (value + onChange only). Android GBoard, RTL/Hebrew and
swipe/autocorrect keyboards buffer composition and commit text WITHOUT
firing React's synthetic onChange, so the controlled value kept snapping
the DOM back to the stale suggestion — the user could not change their
name.

Adopt the existing useImeText hook (already proven in RoomChat /
MessageComposer) to mirror the live DOM value via onInput/compositionEnd,
read the DOM at submit time, and mark the CTA aria-disabled so a tap
still flushes the IME buffer.