### PR TITLE
fix(friends): make async "challenge a friend" flow actually start a game

### DIFF
--- a/fe-next/app/[locale]/friend-challenge/[id]/FriendChallengeLandingClient.tsx
+++ b/fe-next/app/[locale]/friend-challenge/[id]/FriendChallengeLandingClient.tsx
@@ -97,7 +97,9 @@ export default function FriendChallengeLandingClient({ locale, challenge, viewer
       // ignore storage quota
     }
     neoSuccessToast(t('friends.challenges.accepted'));
-    router.push(`/${locale}/?friendChallenge=${challenge.id}`);
+    // Launch the same-length solo board so the friend can beat the target; the
+    // producer hook submits their result (PUT phase=challenged) on game-end.
+    router.push(`/${locale}/singleplayer?autoStart=challenge`);
   }, [challenge, locale, router, t]);
 
   const onDecline = useCallback(async () => {
@@ -267,7 +269,7 @@ export default function FriendChallengeLandingClient({ locale, challenge, viewer
               } catch {
                 /* ignore */
               }
-              router.push(`/${locale}/?friendChallenge=${challenge.id}`);
+              router.push(`/${locale}/singleplayer?autoStart=challenge`);
             }}
             className={cn(
               'w-full py-3 rounded-neo border-neo-thick border-neo-black shadow-hard',

--- a/fe-next/components/friends/FriendsList.tsx
+++ b/fe-next/components/friends/FriendsList.tsx
@@ -334,7 +334,9 @@ const FriendsList: React.FC<FriendsListProps> = ({
       }
       toast.success(t('friends.challenges.async.playInstruction'));
       setChallengeFriend(null);
-      router.push(`/${language}/?asyncChallenge=new`);
+      // Drop the challenger straight into a solo timed board so they can play
+      // and lock their target score; the producer hook POSTs on game-end.
+      router.push(`/${language}/singleplayer?autoStart=challenge`);
       return;
     }
 

--- a/fe-next/components/singleplayer/__tests__/SinglePlayerView.challengeAutoStart.test.tsx
+++ b/fe-next/components/singleplayer/__tests__/SinglePlayerView.challengeAutoStart.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * SinglePlayerView autoStart=challenge Tests
+ *
+ * The async friend-challenge flow routes BOTH sides (challenger via
+ * `pendingAsyncChallenge`, accepting friend via `pendingFriendChallenge`) to
+ * /singleplayer?autoStart=challenge so the player can actually COMPLETE a board.
+ * Previously the flow routed to /?asyncChallenge=new / /?friendChallenge=, which
+ * no code read — the player was stranded on the landing page and the producer
+ * hook never fired.
+ *
+ * Spec: fe-next/docs/specs/2026-05-13-friend-challenge-async-design.md
+ */
+
+import { act } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+let mockSearchParams = new Map<string, string>();
+const mockRouterPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush, replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => ({ get: (key: string) => mockSearchParams.get(key) || null }),
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (key: string) => key, language: 'en', dir: 'ltr' }),
+}));
+
+const mockSetIsInGame = vi.fn();
+vi.mock('@/contexts/NavigationContext', () => ({
+  useHideNavigation: () => mockSetIsInGame,
+}));
+
+vi.mock('@/contexts/MusicContext', () => ({
+  useMusic: () => ({
+    unlockAudio: vi.fn(),
+    playBackgroundMusic: vi.fn(),
+    stopBackgroundMusic: vi.fn(),
+    isPlaying: false,
+  }),
+}));
+
+vi.mock('@/hooks/useGameMusic', () => ({ useGameMusic: vi.fn() }));
+vi.mock('@/hooks/usePullToRefresh', () => ({
+  usePullToRefresh: () => ({
+    pullToRefreshHandlers: {},
+    pullState: { pullDistance: 0, isRefreshing: false },
+  }),
+}));
+vi.mock('@/utils/contextualGuidanceStorage', () => ({
+  shouldShowGuidance: vi.fn().mockReturnValue(false),
+  markGuidanceShown: vi.fn(),
+}));
+vi.mock('@/hooks/useFeatureUnlockNotifications', () => ({
+  useFeatureUnlockNotifications: vi.fn(),
+}));
+vi.mock('@/utils/playerStats', () => ({
+  recordGameResult: vi.fn().mockReturnValue({ isNewHighScore: false, previousBest: null, isNewAllTimeBest: false }),
+  getConfigRecord: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../SinglePlayerGame', () => {
+  const MockSinglePlayerGame = () => <div data-testid="game">Game</div>;
+  MockSinglePlayerGame.displayName = 'MockSinglePlayerGame';
+  return { default: MockSinglePlayerGame };
+});
+vi.mock('../SinglePlayerResults', () => {
+  const MockSinglePlayerResults = () => <div data-testid="results">Results</div>;
+  MockSinglePlayerResults.displayName = 'MockSinglePlayerResults';
+  return { default: MockSinglePlayerResults };
+});
+vi.mock('../PreGameTutorial', () => {
+  const MockPreGameTutorial = () => <div data-testid="pre-game-tutorial">Tutorial</div>;
+  MockPreGameTutorial.displayName = 'MockPreGameTutorial';
+  return { default: MockPreGameTutorial };
+});
+vi.mock('@/components/AutoHideHeader', () => {
+  const MockAutoHideHeader = () => null;
+  MockAutoHideHeader.displayName = 'MockAutoHideHeader';
+  return { default: MockAutoHideHeader };
+});
+vi.mock('@/components/ui/PullToRefreshIndicator', () => ({
+  PullToRefreshIndicator: () => null,
+}));
+vi.mock('../highScoreManager', () => ({
+  getHighScore: vi.fn().mockReturnValue(null),
+  getAllTimeBest: vi.fn().mockReturnValue(null),
+}));
+vi.mock('@/utils/playerProgressStorage', () => ({
+  incrementTrainingGames: vi.fn(),
+}));
+
+const getDefaultPreset = vi.fn();
+const getMinWordLength = vi.fn().mockReturnValue(3);
+vi.mock('../presetConfig', () => ({
+  getMinWordLength: (lang: string, diff: string) => getMinWordLength(lang, diff),
+  getDefaultPreset: (mode: string) => getDefaultPreset(mode),
+  getPresetById: vi.fn().mockReturnValue(null),
+}));
+
+import SinglePlayerView from '../SinglePlayerView';
+
+describe('SinglePlayerView - autoStart=challenge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new Map();
+    sessionStorage.clear();
+  });
+
+  it('starts the game immediately for the challenger (pendingAsyncChallenge)', async () => {
+    // GIVEN the dialog stashed the challenger config and routed here
+    mockSearchParams.set('autoStart', 'challenge');
+    sessionStorage.setItem(
+      'pendingAsyncChallenge',
+      JSON.stringify({
+        friendUserId: 'friend-1',
+        gameMode: 'classic',
+        language: 'en',
+        durationSeconds: 90,
+        createdAt: Date.now(),
+      }),
+    );
+
+    // WHEN the page renders
+    await act(async () => {
+      render(<SinglePlayerView />);
+    });
+
+    // THEN it drops straight into a board (no landing-page dead end)
+    await waitFor(() => {
+      expect(screen.getByTestId('game')).toBeInTheDocument();
+    });
+    // AND it does NOT spin up a bot game
+    expect(getDefaultPreset).not.toHaveBeenCalledWith('solo-bots');
+  });
+
+  it('starts the game for the accepting friend (pendingFriendChallenge)', async () => {
+    // GIVEN the friend accepted and the landing page stashed their config
+    mockSearchParams.set('autoStart', 'challenge');
+    sessionStorage.setItem(
+      'pendingFriendChallenge',
+      JSON.stringify({
+        id: 'ch-1',
+        gameMode: 'classic',
+        language: 'en',
+        durationSeconds: 60,
+        targetScore: 120,
+      }),
+    );
+
+    // WHEN the page renders
+    await act(async () => {
+      render(<SinglePlayerView />);
+    });
+
+    // THEN it launches a board so they can beat the target
+    await waitFor(() => {
+      expect(screen.getByTestId('game')).toBeInTheDocument();
+    });
+  });
+
+  it('still starts a board when no stashed config is present (defaults)', async () => {
+    // GIVEN autoStart=challenge with no sessionStorage (e.g. reload)
+    mockSearchParams.set('autoStart', 'challenge');
+
+    // WHEN the page renders
+    await act(async () => {
+      render(<SinglePlayerView />);
+    });
+
+    // THEN it falls back to a default timed board rather than erroring
+    await waitFor(() => {
+      expect(screen.getByTestId('game')).toBeInTheDocument();
+    });
+  });
+});

--- a/fe-next/components/singleplayer/useSinglePlayerConfig.ts
+++ b/fe-next/components/singleplayer/useSinglePlayerConfig.ts
@@ -241,6 +241,51 @@ export function useSinglePlayerConfig({ searchParams }: UseSinglePlayerConfigOpt
     }
   }, [presetParam, autoStart, phase, uiLanguage]);
 
+  // Auto-start async friend-challenge game (autoStart=challenge).
+  // Both sides of the async flow land here: the challenger (config stashed under
+  // `pendingAsyncChallenge` by the dialog) plays first to lock a target score,
+  // and the accepting friend (`pendingFriendChallenge`) plays to beat it. We
+  // launch a solo, no-bots, timed board using the stashed duration + language so
+  // the player can actually COMPLETE the challenge. The producer hook in
+  // SinglePlayerResults fires the POST/PUT on game-end.
+  useEffect(() => {
+    if (autoStart !== 'challenge' || hasAutoStartedRef.current) return;
+    if (typeof window === 'undefined') return;
+    hasAutoStartedRef.current = true;
+
+    let durationSeconds = 120;
+    let challengeLang: string = uiLanguage;
+    try {
+      const raw =
+        sessionStorage.getItem('pendingAsyncChallenge') ||
+        sessionStorage.getItem('pendingFriendChallenge');
+      if (raw) {
+        const cfg = JSON.parse(raw) as { durationSeconds?: number; language?: string };
+        if (typeof cfg.durationSeconds === 'number' && cfg.durationSeconds > 0) {
+          durationSeconds = cfg.durationSeconds;
+        }
+        if (typeof cfg.language === 'string' && cfg.language) {
+          challengeLang = cfg.language;
+        }
+      }
+    } catch {
+      // Fall back to defaults if the stashed config is unreadable.
+    }
+
+    const minWordLength = getMinWordLength(challengeLang, 'MEDIUM');
+    setGameState(prev => ({
+      ...prev,
+      mode: 'challenge',
+      difficulty: 'MEDIUM',
+      timerSeconds: durationSeconds,
+      bots: [],
+      language: challengeLang as Language,
+      grid: null,
+      minWordLength,
+    }));
+    setPhase('playing');
+  }, [autoStart, uiLanguage]);
+
   // Auto-load MP handoff board (Phase 3.7) — same grid used in MP game
   useEffect(() => {
     if (!mpHandoff || hasAutoStartedRef.current) return;

--- a/fe-next/hooks/__tests__/useAsyncChallengeProducer.test.tsx
+++ b/fe-next/hooks/__tests__/useAsyncChallengeProducer.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * useAsyncChallengeProducer — challenger POST flow
+ *
+ * Covers the bug where the challenger picks a dialog mode (classic/blitz/
+ * survival) that the async-challenge API + DB constraint reject
+ * (only classic/blast/word-hunt are valid). The producer must normalize the
+ * mode to a valid API value before POSTing, otherwise blitz/survival silently
+ * 400 and the challenge never reaches the friend.
+ *
+ * Spec: fe-next/docs/specs/2026-05-13-friend-challenge-async-design.md
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { normalizeAsyncGameMode, useAsyncChallengeProducer } from '../useAsyncChallengeProducer';
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (k: string) => k }),
+}));
+
+describe('normalizeAsyncGameMode', () => {
+  it('keeps valid API modes unchanged', () => {
+    expect(normalizeAsyncGameMode('classic')).toBe('classic');
+    expect(normalizeAsyncGameMode('blast')).toBe('blast');
+    expect(normalizeAsyncGameMode('word-hunt')).toBe('word-hunt');
+  });
+
+  it('maps dialog-only modes the API rejects to classic', () => {
+    // GIVEN dialog modes that the async API + DB CHECK constraint reject
+    expect(normalizeAsyncGameMode('blitz')).toBe('classic');
+    expect(normalizeAsyncGameMode('survival')).toBe('classic');
+  });
+
+  it('falls back to classic for missing/unknown values', () => {
+    expect(normalizeAsyncGameMode(undefined)).toBe('classic');
+    expect(normalizeAsyncGameMode('')).toBe('classic');
+    expect(normalizeAsyncGameMode('nonsense')).toBe('classic');
+  });
+});
+
+describe('useAsyncChallengeProducer — POST normalizes gameMode', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('POSTs a valid API gameMode even when the stashed mode is survival', async () => {
+    // GIVEN a challenger config stashed by the dialog with an unsupported mode
+    sessionStorage.setItem(
+      'pendingAsyncChallenge',
+      JSON.stringify({
+        friendUserId: 'friend-1',
+        friendUsername: 'Bob',
+        gameMode: 'survival',
+        language: 'en',
+        durationSeconds: 120,
+        createdAt: Date.now(),
+      }),
+    );
+
+    // WHEN the producer fires after a game ends
+    renderHook(() =>
+      useAsyncChallengeProducer({
+        enabled: true,
+        score: 100,
+        words: ['cat'],
+        letterGrid: [['a', 'b'], ['c', 'd']],
+        gridSize: 4,
+      }),
+    );
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    // THEN the POST body carries a constraint-valid mode (not 'survival')
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.gameMode).toBe('classic');
+  });
+});

--- a/fe-next/hooks/useAsyncChallengeProducer.ts
+++ b/fe-next/hooks/useAsyncChallengeProducer.ts
@@ -62,6 +62,19 @@ const KEY_CHALLENGER = 'pendingAsyncChallenge';
 const KEY_CHALLENGED = 'pendingFriendChallenge';
 const MAX_CONFIG_AGE_MS = 60 * 60 * 1000; // 1 hour
 
+/**
+ * Modes the async-challenge API + DB CHECK constraint accept
+ * (`async_board_challenges.game_mode IN ('classic','blast','word-hunt')`).
+ * The challenge dialog offers `classic|blitz|survival` as timer/flavor labels,
+ * so blitz/survival would 400 on POST. Async challenges run on a classic board,
+ * so anything outside the valid set collapses to 'classic'.
+ */
+const VALID_API_MODES: readonly string[] = ['classic', 'blast', 'word-hunt'];
+
+export function normalizeAsyncGameMode(mode: string | undefined): string {
+  return mode && VALID_API_MODES.includes(mode) ? mode : 'classic';
+}
+
 function readChallengerConfig(): ChallengerConfig | null {
   if (typeof window === 'undefined') return null;
   try {
@@ -119,7 +132,7 @@ export function useAsyncChallengeProducer(input: AsyncChallengeProducerInput): v
       firedRef.current = true;
       const body = {
         friendUserId: challengerCfg.friendUserId,
-        gameMode: challengerCfg.gameMode,
+        gameMode: normalizeAsyncGameMode(challengerCfg.gameMode),
         language: challengerCfg.language,
         durationSeconds: challengerCfg.durationSeconds,
         letterGrid: input.letterGrid,


### PR DESCRIPTION
The async ("Beat my score") challenge flow was broken at both entry
points: the challenger was routed to /?asyncChallenge=new and the
accepting friend to /?friendChallenge=<id>, but no code read either
param. Both players landed on the marketing page, no board ever
started, and the producer hook in SinglePlayerResults never fired — so
the challenge was never sent or completed.

- Route both sides to /singleplayer?autoStart=challenge so the player
  immediately plays a solo timed board and completes their score.
- useSinglePlayerConfig: handle autoStart=challenge, reading the stashed
  pendingAsyncChallenge / pendingFriendChallenge config for timer +
  language (falls back to defaults if absent).
- Normalize the POSTed gameMode to the API/DB-valid set
  (classic|blast|word-hunt); the dialog's blitz/survival picks were
  silently 400ing on the challenge create.

Tests: producer mode-normalization + autoStart=challenge launch for
both challenger and accepting friend.