### PR TITLE
fix(onboarding): prevent stuck black backdrop when homepage FTUE chunk fails to load

### DIFF
--- a/fe-next/app/[locale]/PageClient.tsx
+++ b/fe-next/app/[locale]/PageClient.tsx
@@ -3,6 +3,8 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
+import { Loader2 } from 'lucide-react';
+import { retryImport } from '@/utils/retryImport';
 import { hasCompletedOnboarding, hasSupabaseSession, savePendingRoomInvite, hasPendingRoomInvite } from '@/utils/onboardingStorage';
 import { trackInviteLanded, trackInviteRedirectFired } from '@/utils/growthTracking';
 import { isOnboardingAllowedRoute } from '@/lib/onboarding/allowedRoutes';
@@ -20,11 +22,20 @@ const sanitizeHostName = (raw: string): string => {
   return raw.replace(HOST_NAME_ALLOWED, '').trim().slice(0, 24);
 };
 
+// `retryImport` hardens the lazy chunk load: a flaky network or a stale chunk
+// hash after a deploy used to leave the bare-navy `loading` fallback on screen
+// forever — reported as "black backdrop, no popup" on the homepage. The loading
+// fallback now shows a spinner so a slow load reads as loading, not a stuck screen.
 const OnboardingFlow = dynamic(
-  () => import('@/components/onboarding/OnboardingFlow'),
+  retryImport(() => import('@/components/onboarding/OnboardingFlow')),
   {
     ssr: false,
-    loading: () => <div className="fixed inset-0 bg-neo-navy z-50" />,
+    loading: () => (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-neo-navy" role="status" aria-live="polite">
+        <Loader2 className="h-12 w-12 animate-spin text-neo-yellow" aria-hidden />
+        <span className="sr-only">Loading…</span>
+      </div>
+    ),
   }
 );
 

--- a/fe-next/utils/retryImport.test.ts
+++ b/fe-next/utils/retryImport.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { retryImport } from './retryImport';
+
+describe('retryImport', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    try {
+      sessionStorage.clear();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves with the module when the factory succeeds on the first try', async () => {
+    const mod = { default: 'Component' };
+    const factory = vi.fn().mockResolvedValue(mod);
+
+    const wrapped = retryImport(factory);
+    await expect(wrapped()).resolves.toBe(mod);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a transient failure and then resolves', async () => {
+    const mod = { default: 'Component' };
+    const factory = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network blip'))
+      .mockResolvedValueOnce(mod);
+
+    const wrapped = retryImport(factory, { retries: 2, interval: 100 });
+    const promise = wrapped();
+
+    // Let the first (failed) attempt settle, then fire the backoff timer.
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(promise).resolves.toBe(mod);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects after exhausting retries on a non-chunk error', async () => {
+    const err = new Error('boom');
+    const factory = vi.fn().mockRejectedValue(err);
+    const reload = vi.fn();
+
+    const wrapped = retryImport(factory, { retries: 1, interval: 50, reload });
+    const promise = wrapped();
+    const assertion = expect(promise).rejects.toBe(err);
+
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+
+    expect(factory).toHaveBeenCalledTimes(2); // initial + 1 retry
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads once when a chunk-load error persists after retries', async () => {
+    const chunkErr = new Error('Loading chunk 42 failed.');
+    chunkErr.name = 'ChunkLoadError';
+    const factory = vi.fn().mockRejectedValue(chunkErr);
+    const reload = vi.fn();
+
+    const wrapped = retryImport(factory, { retries: 1, interval: 50, reload });
+    // Promise stays pending on purpose (page reloads), so don't await it.
+    wrapped().catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload twice within the guard window', async () => {
+    const chunkErr = new Error('Loading chunk 7 failed.');
+    chunkErr.name = 'ChunkLoadError';
+    const factory = vi.fn().mockRejectedValue(chunkErr);
+    const reload = vi.fn();
+
+    const wrapped = retryImport(factory, { retries: 0, interval: 10, reload });
+
+    wrapped().catch(() => {});
+    await vi.advanceTimersByTimeAsync(10);
+    wrapped().catch(() => {});
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/fe-next/utils/retryImport.ts
+++ b/fe-next/utils/retryImport.ts
@@ -1,0 +1,97 @@
+import logger from '@/utils/logger';
+
+/**
+ * Hardens a dynamic `import()` against transient chunk-load failures.
+ *
+ * Why: code-split chunks (e.g. the homepage FTUE `OnboardingFlow`) are fetched
+ * lazily. A flaky network — or, classically, a stale chunk hash after a new
+ * deploy while the tab was open — makes the `import()` reject with a
+ * `ChunkLoadError`. With `next/dynamic` that leaves the `loading` fallback on
+ * screen forever: a full-screen backdrop with no content. Users reported it as
+ * "black backdrop, no popup" on the homepage.
+ *
+ * Strategy: retry the import a few times with backoff (covers a momentary
+ * blip), and if a chunk error still persists, force a single guarded reload to
+ * pull the fresh asset manifest (covers the post-deploy stale-hash case). The
+ * reload guard prevents an infinite reload loop.
+ */
+
+const RELOAD_GUARD_KEY = 'chunk_reload_at';
+const RELOAD_GUARD_WINDOW_MS = 10_000;
+
+function isChunkLoadError(err: unknown): boolean {
+  const name = (err as { name?: string } | null)?.name;
+  const message = (err as { message?: string } | null)?.message ?? '';
+  return (
+    name === 'ChunkLoadError' ||
+    /Loading chunk \S+ failed/i.test(message) ||
+    /Loading CSS chunk/i.test(message) ||
+    /Failed to fetch dynamically imported module/i.test(message) ||
+    /error loading dynamically imported module/i.test(message)
+  );
+}
+
+/** Allow at most one reload per window so a permanently-broken chunk can't loop. */
+function shouldReloadOnce(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const last = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) || '0');
+    if (Number.isFinite(last) && Date.now() - last < RELOAD_GUARD_WINDOW_MS) {
+      return false;
+    }
+    sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+    return true;
+  } catch {
+    // sessionStorage unavailable (private mode / SSR) — don't risk a reload loop.
+    return false;
+  }
+}
+
+export interface RetryImportOptions {
+  /** Number of retries after the first attempt (default 2). */
+  retries?: number;
+  /** Initial backoff in ms; doubles each retry (default 300). */
+  interval?: number;
+  /** Injectable reload hook (defaults to `window.location.reload`). For tests. */
+  reload?: () => void;
+}
+
+/**
+ * Wrap a dynamic-import factory so it retries on failure. The returned function
+ * is drop-in compatible with `next/dynamic(factory, ...)` and `React.lazy`.
+ */
+export function retryImport<T>(
+  factory: () => Promise<T>,
+  options: RetryImportOptions = {},
+): () => Promise<T> {
+  const retries = options.retries ?? 2;
+  const interval = options.interval ?? 300;
+  const reload =
+    options.reload ??
+    (() => {
+      if (typeof window !== 'undefined') window.location.reload();
+    });
+
+  return () =>
+    new Promise<T>((resolve, reject) => {
+      const attempt = (remaining: number, delay: number): void => {
+        factory()
+          .then(resolve)
+          .catch((err: unknown) => {
+            if (remaining > 0) {
+              setTimeout(() => attempt(remaining - 1, delay * 2), delay);
+              return;
+            }
+            // Retries exhausted. A stale-chunk error is unrecoverable in place;
+            // reload once to fetch the new manifest. Otherwise surface the error.
+            if (isChunkLoadError(err) && shouldReloadOnce()) {
+              logger.warn('retryImport: chunk load failed after retries, reloading', err);
+              reload();
+              return; // page reloads — leave the promise pending.
+            }
+            reject(err);
+          });
+      };
+      attempt(retries, interval);
+    });
+}


### PR DESCRIPTION
The homepage lazy-loads OnboardingFlow via next/dynamic with a bare
full-screen navy loading fallback and no chunk-load error handling. A flaky
network or a stale chunk hash after a deploy made the import() reject (or hang),
leaving the dark fallback on screen forever with no popup — most visible to
non-default-locale users (e.g. Hebrew) whose extra locale chunks add load.

- Add retryImport(): retries a failed dynamic import with backoff and, on a
  persistent ChunkLoadError, triggers a single guarded reload to fetch the fresh
  asset manifest so it can never stay stuck.
- Wrap the OnboardingFlow import with retryImport and replace the bare navy
  fallback with a spinner so a slow load reads as loading, not a frozen screen.

https://claude.ai/code/session_01SFdZognGN4b5wWr3y5vkD3