### PR TITLE
fix(host): anchor lobby emote trigger as a fixed floating button

### DIFF
--- a/fe-next/host/__tests__/HostPreGameView.lobbyReactions.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.lobbyReactions.test.tsx
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import HostPreGameView from '../components/HostPreGameView';
 
 const emitMock = vi.fn();
@@ -151,5 +151,17 @@ describe('HostPreGameView lobby emote (LobbyReactions send tray)', () => {
     const props = lobbyReactionsProps.at(-1);
     expect(props).toBeDefined();
     expect(props!.receiveOnly).toBeFalsy();
+  });
+
+  it('anchors the emote trigger as a fixed floating button, not an in-flow orphan', () => {
+    // The trigger used to render bare at the end of the root div, dropping into
+    // document flow below the sticky start bar — a lone emoji floating bottom-left
+    // that broke the layout. It must be a deliberate fixed-position FAB instead.
+    render(<HostPreGameView {...baseProps} />);
+
+    const fab = screen.getByTestId('host-lobby-emote-fab');
+    expect(fab.className).toContain('fixed');
+    // Mirrors the chat bubble (bottom corner), so the two FABs frame the start bar.
+    expect(fab.className).toMatch(/bottom-/);
   });
 });

--- a/fe-next/host/components/HostPreGameView.tsx
+++ b/fe-next/host/components/HostPreGameView.tsx
@@ -730,8 +730,16 @@ function HostPreGameView({
       <ChatBubble gameCode={gameCode} username={username} isHost t={t} />
       {/* The host is a present person on their own device (true cast-to-TV is the
           separate tv-broadcast/ components), so they can fling emoji whether they
-          play or just run the scoreboard — same ambient delight as every player. */}
-      <LobbyReactions username={username} />
+          play or just run the scoreboard — same ambient delight as every player.
+          Anchor the trigger as a fixed floating button mirroring the chat bubble on
+          the opposite (start) corner — otherwise it drops into document flow and
+          orphans as a lone emoji below the sticky start bar, breaking the layout. */}
+      <div
+        data-testid="host-lobby-emote-fab"
+        className="fixed bottom-20 start-4 lg:bottom-6 lg:start-6 z-40"
+      >
+        <LobbyReactions username={username} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
The host lobby emote trigger (LobbyReactions send tray) rendered bare at
the end of the root div, so it fell into normal document flow and orphaned
as a lone 😊 emoji bottom-left, below the sticky start bar — breaking the
layout.

Wrap it in a fixed-position container that mirrors the chat bubble on the
opposite (start) corner, so the two floating buttons frame the start bar
symmetrically. Uses logical start-* insets for RTL parity with the chat
bubble's end-* insets.