### PR TITLE
fix(blast): dock MP timer into HUD top row + label score column

### DIFF
--- a/fe-next/components/blast/legacy/BlastHUD.tsx
+++ b/fe-next/components/blast/legacy/BlastHUD.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { X, HelpCircle, Shield, Bomb, Zap, Sparkles } from 'lucide-react';
+import { X, HelpCircle, Shield, Bomb, Zap, Sparkles, Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatTimeMMSS } from '@/shared/utils/timeFormatting';
+import { computeTimerUrgency } from '@/lib/cosy/timerUrgency';
+import { useSuppressTimerUrgency } from '@/contexts/AccessibilityContext';
 import { BlastComboStreakBadge } from './BlastComboStreakBadge';
 import type { ComboStreakState } from './hooks/useBlastComboStreak';
 
@@ -56,6 +59,65 @@ function useAnimatedScore(target: number) {
   return { display, pulse };
 }
 
+/**
+ * Compact countdown pill for the HUD top row (multiplayer only).
+ *
+ * MP Blast used to float a large CircularTimer in its own band below the HUD,
+ * which crowded the board and read as a detached element. Since the wave chip
+ * is hidden in MP, the top-row left slot is empty — so we dock the timer there
+ * instead: balanced chrome, the board reclaims that vertical space, and the
+ * countdown sits beside the rest of the stats where players already look.
+ *
+ * Urgency escalates the colour (cyan → yellow → red) and pulses when critical,
+ * mirroring CircularTimer. Calm/Cosy mode suppresses the escalation.
+ */
+function BlastHUDTimer({
+  remainingTime,
+  totalTime,
+  t,
+}: {
+  remainingTime: number;
+  totalTime: number;
+  t: (key: string) => string | undefined;
+}) {
+  const suppressUrgency = useSuppressTimerUrgency();
+  const { state } = computeTimerUrgency(remainingTime, suppressUrgency);
+  const danger = state === 'veryLow' || state === 'critical';
+
+  const colorClass =
+    state === 'critical' || state === 'veryLow'
+      ? 'border-neo-red/70 text-neo-red'
+      : state === 'low'
+        ? 'border-neo-yellow/70 text-neo-yellow'
+        : 'border-neo-cyan/50 text-neo-cyan';
+
+  return (
+    <div
+      data-testid="blast-mp-timer"
+      data-urgency={state}
+      role="timer"
+      aria-label={`${t('blast.time') ?? 'Time'}: ${formatTimeMMSS(Math.max(0, Math.round(remainingTime)))}`}
+      className={cn(
+        'shrink-0 inline-flex items-center gap-1.5 rounded-lg border-2 bg-black/25 px-2 py-0.5',
+        colorClass,
+        danger && 'blast-heartbeat',
+      )}
+      style={NO_TEXT_SHADOW_STYLE}
+      title={`${totalTime}s ${t('blast.time') ?? 'Time'}`}
+    >
+      <Clock className="h-3.5 w-3.5 shrink-0" strokeWidth={3} />
+      <div className="flex flex-col items-start leading-none">
+        <span className="text-[8px] font-black uppercase tracking-[0.18em] opacity-70">
+          {t('blast.time') ?? 'Time'}
+        </span>
+        <span className="text-sm font-black tabular-nums leading-tight">
+          {formatTimeMMSS(Math.max(0, Math.round(remainingTime)))}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 interface BlastHUDProps {
   score: number;
   wordsFoundCount: number;
@@ -81,6 +143,11 @@ interface BlastHUDProps {
   hintSlot?: React.ReactNode;
   /** Whether this is multiplayer mode (timer-era, no waves). Hides wave chip in MP. */
   isMultiplayer?: boolean;
+  /** MP countdown — seconds remaining. Rendered as a compact pill in the top row
+   *  (the slot the wave chip would occupy in SP). Omitted in single-player. */
+  remainingTime?: number | null;
+  /** MP round length in seconds — drives the urgency calc + a11y label. */
+  totalTime?: number;
   t: (key: string) => string | undefined;
 }
 
@@ -107,8 +174,12 @@ export function BlastHUD({
   ddaBoostActive = false,
   hintSlot,
   isMultiplayer = false,
+  remainingTime = null,
+  totalTime,
   t,
 }: BlastHUDProps) {
+  const showTimer =
+    isMultiplayer && remainingTime !== null && remainingTime !== undefined && (totalTime ?? 0) > 0;
   const clearPct = totalTiles > 0 ? Math.round((tilesCleared / totalTiles) * 100) : 0;
   const isFiniteMoves = isFinite(totalMoves);
   const goalMet = clearPct >= BLAST_WAVE_GOAL_PCT;
@@ -133,6 +204,11 @@ export function BlastHUD({
       {/* Top row: wave + buff slot + controls. Min-h fixed so chip toggles never reflow. */}
       <div className="flex items-center justify-between px-3 py-1.5 pt-safe min-h-[36px]">
         <div className="flex items-center gap-2 min-w-0">
+          {/* MP countdown — docked into the top row where the wave chip would
+              sit in SP, so the board no longer shares space with a floating timer. */}
+          {showTimer && (
+            <BlastHUDTimer remainingTime={remainingTime as number} totalTime={totalTime as number} t={t} />
+          )}
           {/* Wave chip — hidden in MP (timer-era, no waves) */}
           {!isMultiplayer && (
             <span
@@ -209,20 +285,29 @@ export function BlastHUD({
           Each cell uses fixed basis/min-width so digit growth or chip toggles
           don't shove neighbours around. */}
       <div className="flex items-stretch px-3 py-2 gap-3">
-        {/* Score — fixed minimum width room for 5 digits */}
+        {/* Score — fixed minimum width room for 5 digits. Labelled so the lone
+            star + number reads unambiguously as the player's score. */}
         <div
-          className="flex items-center gap-1.5 basis-1/3 min-w-0"
+          className="flex flex-col justify-center basis-1/3 min-w-0"
           aria-label={`${t('blast.score')}: ${animatedScore}`}
         >
-          <span className="text-amber-400 text-base shrink-0">★</span>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="text-amber-400 text-base shrink-0">★</span>
+            <span
+              className={cn(
+                'text-2xl font-black tabular-nums truncate transition-transform duration-150 text-neo-white origin-left',
+                scorePulse && 'scale-[1.15]',
+              )}
+              style={{ minWidth: '5ch' }}
+            >
+              {animatedScore.toLocaleString()}
+            </span>
+          </div>
           <span
-            className={cn(
-              'text-2xl font-black tabular-nums truncate transition-transform duration-150 text-neo-white',
-              scorePulse && 'scale-[1.15]',
-            )}
-            style={{ minWidth: '5ch' }}
+            data-testid="blast-score-label"
+            className="text-[9px] font-bold uppercase tracking-wider text-white/70 leading-none mt-0.5"
           >
-            {animatedScore.toLocaleString()}
+            {t('blast.score')}
           </span>
         </div>
 

--- a/fe-next/components/blast/legacy/BlastStage.tsx
+++ b/fe-next/components/blast/legacy/BlastStage.tsx
@@ -3,7 +3,6 @@
 import { memo, useRef, useState, useEffect, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { Shuffle, AlertTriangle, Lightbulb } from 'lucide-react';
-import CircularTimer from '@/components/CircularTimer';
 const BlastTileGuide = dynamic(() => import('./BlastTileGuide'), { ssr: false });
 import { AdaptiveMotion, AdaptiveAnimatePresence } from '@/components/motion/AdaptiveMotion';
 import { Button } from '@/components/ui/button';
@@ -280,6 +279,8 @@ export const BlastStage = memo(function BlastStage({
         ddaBoostActive={ddaBoostActive}
         hintSlot={hintSlot}
         isMultiplayer={isMultiplayer}
+        remainingTime={remainingTime}
+        totalTime={totalTime}
         t={t}
       />
       <BlastObjectiveBanner objectives={objectiveProgress} t={t} />
@@ -289,12 +290,8 @@ export const BlastStage = memo(function BlastStage({
         </div>
       )}
       {hintToast}
-      {/* Multiplayer timer — shown to players only */}
-      {remainingTime !== null && remainingTime !== undefined && totalTime !== undefined && totalTime > 0 && (
-        <div className="flex justify-center mt-2">
-          <CircularTimer remainingTime={remainingTime} totalTime={totalTime} size="sm" />
-        </div>
-      )}
+      {/* MP countdown now lives inline in the HUD top row (see BlastHUD); it no
+          longer floats here above the board, which kept crowding the grid. */}
       </div>
 
       {/* 1b. Live leaderboard strip (MP only) — mobile only; desktop uses the

--- a/fe-next/components/blast/legacy/__tests__/BlastHUD.test.tsx
+++ b/fe-next/components/blast/legacy/__tests__/BlastHUD.test.tsx
@@ -88,6 +88,41 @@ describe('BlastHUD — score/moves/wave smoke', () => {
   });
 });
 
+describe('BlastHUD — multiplayer timer (consolidated into HUD)', () => {
+  // The MP countdown used to float in a separate band below the HUD, crowding
+  // the board. It now lives inline in the HUD top row (the slot that's empty in
+  // MP since the wave chip is hidden), so the board gets its full height back.
+  const mpProps = { ...baseProps, isMultiplayer: true, totalMoves: Infinity };
+
+  it('renders the inline timer in MP showing MM:SS', () => {
+    render(<BlastHUD {...mpProps} remainingTime={55} totalTime={90} />);
+    const timer = screen.getByTestId('blast-mp-timer');
+    expect(timer.textContent).toContain('0:55');
+  });
+
+  it('does not render the inline timer in single-player (no timer props)', () => {
+    render(<BlastHUD {...baseProps} />);
+    expect(screen.queryByTestId('blast-mp-timer')).toBeNull();
+  });
+
+  it('flags danger urgency when time is low', () => {
+    render(<BlastHUD {...mpProps} remainingTime={4} totalTime={90} />);
+    expect(screen.getByTestId('blast-mp-timer').getAttribute('data-urgency')).toBe('critical');
+  });
+
+  it('stays calm (normal urgency) with plenty of time left', () => {
+    render(<BlastHUD {...mpProps} remainingTime={55} totalTime={90} />);
+    expect(screen.getByTestId('blast-mp-timer').getAttribute('data-urgency')).toBe('normal');
+  });
+});
+
+describe('BlastHUD — labelled stat columns (clarity)', () => {
+  it('labels the score column so the star number reads as SCORE', () => {
+    render(<BlastHUD {...baseProps} score={1234} />);
+    expect(screen.getByTestId('blast-score-label')).toBeDefined();
+  });
+});
+
 describe('BlastHUD — Lucky Boost (DDA visibility)', () => {
   it('hides the Lucky Boost chip when ddaBoostActive=false', () => {
     render(<BlastHUD {...baseProps} ddaBoostActive={false} />);

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -9723,6 +9723,7 @@ const en = {
     "celebrateAgain": "Celebrate again",
     "best": "Best",
     "movesLeft": "Moves",
+    "time": "Time",
     "you": "YOU",
     "live": "LIVE",
     "luckyBoost": "Lucky Boost",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -10090,6 +10090,7 @@ const es = {
     "celebrateAgain": "Celebrar de nuevo",
     "best": "Mejor",
     "movesLeft": "Movimientos",
+    "time": "Tiempo",
     "you": "TÚ",
     "live": "EN VIVO",
     "luckyBoost": "Bonus de Suerte",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -10263,6 +10263,7 @@ const he = {
     "celebrateAgain": "חגוג שוב",
     "best": "שיא",
     "movesLeft": "מהלכים",
+    "time": "זמן",
     "you": "את/ה",
     "live": "חי",
     "luckyBoost": "בונוס מזל",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -10074,6 +10074,7 @@ const ja = {
     "celebrateAgain": "また祝おう",
     "best": "ベスト",
     "movesLeft": "残り手数",
+    "time": "残り時間",
     "you": "あなた",
     "live": "ライブ",
     "luckyBoost": "ラッキーブースト",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -10103,6 +10103,7 @@ const sv = {
     "celebrateAgain": "Fira igen",
     "best": "Bäst",
     "movesLeft": "Drag",
+    "time": "Tid",
     "you": "DU",
     "live": "LIVE",
     "luckyBoost": "Tursam boost",


### PR DESCRIPTION
Blast MP layout read as cramped/unclear: the countdown floated in its own
band directly above the board (crowding the grid), the HUD top row sat empty
on the left in MP (wave chip is hidden there), and the lone "★ 0" gave no hint
it was the player's own score.

- New compact BlastHUDTimer pill docked into the top-row slot the wave chip
  vacates in MP. Shows MM:SS + a TIME label, escalates colour cyan→yellow→red
  with a heartbeat at critical, and respects Calm/Cosy urgency suppression.
- Remove the floating CircularTimer band from BlastStage in MP so the board
  reclaims that vertical space; pass remainingTime/totalTime to BlastHUD.
- Label the score column ("SCORE") so the star + number reads unambiguously.
- blast.time i18n added across en/he/sv/ja/es.

5 new TDD cases, full blast legacy suite green (609), typecheck clean.