### PR TITLE
feat(mp): single live leaderboard with at-a-glance standing cue

### DIFF
--- a/fe-next/components/game/in-game/components/GameLeaderboard.tsx
+++ b/fe-next/components/game/in-game/components/GameLeaderboard.tsx
@@ -10,6 +10,7 @@ import { getAvatarTrait } from '@/lib/avatar/avatarPersonality';
 import PlayerProfileTooltip from '@/components/ui/PlayerProfileTooltip';
 import PresenceIndicator from '@/components/PresenceIndicator';
 import { getRankStyle, getRankIconString } from '@/utils/rankingStyles';
+import { cn } from '@/lib/utils';
 import type { ExtendedLeaderboardPlayer as LeaderboardPlayer } from '@/shared/types/view';
 import type { TranslationFn } from '../types';
 
@@ -19,6 +20,9 @@ interface GameLeaderboardProps {
   isHost: boolean;
   t: TranslationFn;
   dir: 'rtl' | 'ltr';
+  /** Tighter rendering for the mobile in-game split view (smaller border, no
+   *  slide-in). Defaults to the full desktop sidebar styling. */
+  compact?: boolean;
 }
 
 interface MemoizedLeaderboardPlayer extends LeaderboardPlayer {
@@ -214,9 +218,26 @@ export const GameLeaderboard = memo<GameLeaderboardProps>(function GameLeaderboa
   isHost,
   t,
   dir,
+  compact = false,
 }) {
   // Track previous scores and ranks for change detection
   const prevDataRef = useRef<Map<string, { rank: number; score: number }>>(new Map());
+
+  // "Your standing" cue — the single live leaderboard now carries the
+  // motivational signal the old race-track panel used to: am I leading (and by
+  // how much), or how many points do I need to pass the player right above me.
+  // `leaderboard` arrives pre-sorted (rank === index), so neighbours are direct.
+  const youStanding = useMemo(() => {
+    const myIndex = leaderboard.findIndex((p) => p.username === username);
+    if (myIndex === -1 || leaderboard.length < 2) return null;
+    if (myIndex === 0) {
+      const gap = leaderboard[0].score - (leaderboard[1]?.score ?? 0);
+      return { leading: true as const, gap };
+    }
+    const target = leaderboard[myIndex - 1];
+    const toCatch = Math.max(1, target.score - leaderboard[myIndex].score + 1);
+    return { leading: false as const, toCatch };
+  }, [leaderboard, username]);
 
   const memoizedLeaderboard: MemoizedLeaderboardPlayer[] = useMemo(
     () =>
@@ -253,24 +274,57 @@ export const GameLeaderboard = memo<GameLeaderboardProps>(function GameLeaderboa
 
   return (
     <AdaptiveMotion.div
-      className="bg-neo-cream text-neo-black border-4 border-neo-black rounded-neo-lg shadow-hard-lg flex flex-col overflow-hidden max-h-[45vh] lg:max-h-[50vh] lg:shrink relative"
-      initial={{ x: 50, opacity: 0 }}
-      animate={{ x: 0, opacity: 1 }}
-      transition={{ delay: 0.2 }}
+      className={cn(
+        'bg-neo-cream text-neo-black border-neo-black rounded-neo-lg shadow-hard-lg flex flex-col overflow-hidden relative',
+        compact ? 'border-3' : 'border-4 max-h-[45vh] lg:max-h-[50vh] lg:shrink',
+      )}
+      initial={compact ? false : { x: 50, opacity: 0 }}
+      animate={compact ? undefined : { x: 0, opacity: 1 }}
+      transition={compact ? undefined : { delay: 0.2 }}
     >
       {/* Header */}
-      <div className="py-2.5 px-4 border-b-4 border-neo-black bg-neo-pink text-white">
-        <h3 className="flex items-center gap-2 text-neo-white text-sm uppercase tracking-widest font-black">
-          <Trophy className="w-4 h-4 text-neo-lime" />
-          {t('playerView.leaderboard')}
-          <span className="ms-auto text-[10px] font-bold text-neo-white tabular-nums">
-            {leaderboard.length} {leaderboard.length === 1 ? 'player' : 'players'}
+      <div className={cn('border-b-4 border-neo-black bg-neo-pink text-white', compact ? 'py-1.5 px-3' : 'py-2.5 px-4')}>
+        <h3 className={cn('flex items-center gap-2 text-neo-white uppercase tracking-widest font-black', compact ? 'text-xs' : 'text-sm')}>
+          <Trophy className="w-4 h-4 text-neo-lime shrink-0" />
+          <span className="truncate">{t('playerView.leaderboard')}</span>
+          <span className="ms-auto text-[10px] font-bold text-neo-white tabular-nums whitespace-nowrap shrink-0">
+            {t('mp.rivals.playersCount', { n: leaderboard.length })}
           </span>
         </h3>
       </div>
 
+      {/* Your standing — leading by N / N points to catch the player above. */}
+      {youStanding && (
+        <div
+          data-testid="leaderboard-you-status"
+          className={cn(
+            'flex items-center justify-center gap-1.5 px-3 py-1 border-b-2 border-neo-black font-black uppercase tracking-wide',
+            compact ? 'text-[10px]' : 'text-xs',
+            youStanding.leading ? 'bg-neo-lime text-neo-black' : 'bg-neo-cyan/15 text-neo-black',
+          )}
+        >
+          {youStanding.leading ? (
+            <>
+              <Flame className="w-3.5 h-3.5 text-neo-pink shrink-0" />
+              <span>{t('leaderboard.leading')}</span>
+              {youStanding.gap > 0 && (
+                <span className="tabular-nums text-neo-black/70">
+                  +{youStanding.gap} {t('leaderboard.ahead')}
+                </span>
+              )}
+            </>
+          ) : (
+            <>
+              <TrendingUp className="w-3.5 h-3.5 text-neo-cyan shrink-0" />
+              <span className="tabular-nums">+{youStanding.toCatch}</span>
+              <span>{t('leaderboard.toCatch')}</span>
+            </>
+          )}
+        </div>
+      )}
+
       {/* Content */}
-      <div className="overflow-y-auto flex-1 p-2.5 custom-scrollbar">
+      <div className={cn('p-2.5', compact ? 'overflow-y-auto custom-scrollbar' : 'overflow-y-auto flex-1 custom-scrollbar')}>
         <div className="space-y-1.5" role="list">
           {memoizedLeaderboard.map((player) => {
             const change = changes.get(player.username);

--- a/fe-next/components/game/in-game/components/PortraitLayout.tsx
+++ b/fe-next/components/game/in-game/components/PortraitLayout.tsx
@@ -14,8 +14,6 @@ import RoomChat from '@/components/RoomChat';
 import { type WordFeedback } from '../../WordFormingArea';
 import { WordFormingAreaConnected } from './WordFormingAreaConnected';
 import { ComboDisplayConnected } from '../../ComboDisplayConnected';
-import CompactLeaderboard from '../../CompactLeaderboard';
-import { useBlastComboSync } from '@/hooks/gameState/store';
 import { shouldShowKeyboardTrails } from '../../keyboardTrailsUtils';
 import { KeyboardInlineHint } from '@/components/keyboard';
 import { WordsRemaining } from '@/player/components/in-game/WordsRemaining';
@@ -239,9 +237,6 @@ export const PortraitLayout = memo<PortraitLayoutProps>(function PortraitLayout(
   onTimerState,
   inDesktopShell = false,
 }) {
-  // Combo event for leaderboard badges (from Zustand blastComboSync)
-  const blastComboSync = useBlastComboSync();
-
   // Derive avatar map from leaderboard for WordHunt player lives.
   // Use deferred so socket-burst leaderboard updates don't recompute mid-drag.
   const playerAvatars = useMemo(() => {
@@ -259,18 +254,6 @@ export const PortraitLayout = memo<PortraitLayoutProps>(function PortraitLayout(
     () => foundWords.filter((fw) => fw.isValid !== false && fw.word.length >= 5).length,
     [foundWords],
   );
-  const compactLeaderboardPlayers = useMemo(
-    () => deferredLeaderboard.map((p) => ({
-      username: p.username,
-      score: p.score,
-      rank: 0,
-      avatarImage: p.avatar?.avatarImage,
-      customAvatar: p.avatar?.customAvatar,
-      inputMethod: p.username === username && isTypingMode ? 'keyboard' as const : null,
-    })),
-    [deferredLeaderboard, username, isTypingMode],
-  );
-
   // Track floating score animation
   const [floatingScore, setFloatingScore] = useState<number | null>(null);
   const [isFireRoundScore, setIsFireRoundScore] = useState(false);
@@ -675,17 +658,19 @@ export const PortraitLayout = memo<PortraitLayoutProps>(function PortraitLayout(
             </div>
           )}
 
-          {/* Mobile: Split-view with compact leaderboard + words.
+          {/* Mobile: Split-view with the single live leaderboard + words.
               Leaderboard only when there are other players; word list always shows while playing
               so single-player users can see their progress. */}
           {isPlaying && !gameplayFocusMode && (
             <div className="block lg:hidden mt-0.5 md:mt-1 space-y-0.5 max-w-md mx-auto md:space-y-1 shrink overflow-y-auto min-h-0 max-h-[120px] sm:max-h-[140px] medium-short:max-h-[88px] short:max-h-[80px] scrollbar-thin">
-              {deferredLeaderboard && deferredLeaderboard.length > 0 && (
-                <CompactLeaderboard
-                  players={compactLeaderboardPlayers}
-                  currentUsername={username}
+              {deferredLeaderboard && deferredLeaderboard.length > 1 && (
+                <GameLeaderboard
+                  leaderboard={deferredLeaderboard}
+                  username={username}
+                  isHost={isHost}
                   t={t}
-                  comboEvent={blastComboSync}
+                  dir={dir}
+                  compact
                 />
               )}
               <GameWordList foundWords={foundWords} minWordLength={minWordLength} t={t} compact />
@@ -703,15 +688,9 @@ export const PortraitLayout = memo<PortraitLayoutProps>(function PortraitLayout(
             standings: desktop players were previously blind to who was winning. */}
         {((deferredLeaderboard && deferredLeaderboard.length > 1) || !gameplayFocusMode) && (
           <div className="hidden lg:flex lg:flex-col lg:w-56 xl:w-64 2xl:w-72 gap-2 shrink-0 min-h-0 overflow-y-auto">
-            {/* Live race-track leaderboard with avatars (multiplayer only) */}
-            {deferredLeaderboard && deferredLeaderboard.length > 1 && (
-              <CompactLeaderboard
-                players={compactLeaderboardPlayers}
-                currentUsername={username}
-                t={t}
-                comboEvent={blastComboSync}
-              />
-            )}
+            {/* Single live leaderboard — ranked standings with a "your standing"
+                cue (leading by N / N points to catch). Replaces the previous
+                duplicate race-track + standings stack. */}
             {deferredLeaderboard && deferredLeaderboard.length > 0 && (
               <GameLeaderboard
                 leaderboard={deferredLeaderboard}

--- a/fe-next/components/game/in-game/components/__tests__/GameLeaderboard.youStatus.test.tsx
+++ b/fe-next/components/game/in-game/components/__tests__/GameLeaderboard.youStatus.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * GameLeaderboard — "your standing" status strip
+ *
+ * The MP view now keeps a single live leaderboard (the ranked standings).
+ * To preserve the motivational "live race" cue that the old CompactLeaderboard
+ * provided, GameLeaderboard surfaces a compact strip telling the current
+ * player whether they are leading (and by how much) or how many points they
+ * need to catch the player directly above them.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { GameLeaderboard } from '../GameLeaderboard';
+import type { ExtendedLeaderboardPlayer } from '@/shared/types/view';
+
+vi.mock('@/components/motion/AdaptiveMotion', () => ({
+  AdaptiveMotion: {
+    div: ({ children, className }: React.PropsWithChildren<{ className?: string }>) => (
+      <div className={className}>{children}</div>
+    ),
+  },
+}));
+
+vi.mock('@/components/Avatar', () => ({
+  default: ({ size }: { size: string }) => <div data-testid="avatar" data-size={size} />,
+}));
+
+vi.mock('@/components/ui/PlayerProfileTooltip', () => ({
+  default: ({ children }: React.PropsWithChildren) => <div data-testid="profile-tooltip">{children}</div>,
+}));
+
+vi.mock('@/components/PresenceIndicator', () => ({
+  default: ({ status }: { status: string }) => <div data-testid="presence-indicator" data-status={status} />,
+}));
+
+const mockT = (key: string, params?: Record<string, string | number>) =>
+  params ? `${key}:${JSON.stringify(params)}` : key;
+
+function player(over: Partial<ExtendedLeaderboardPlayer> & { username: string; score: number }): ExtendedLeaderboardPlayer {
+  return {
+    wordCount: 0,
+    isHost: false,
+    avatar: undefined,
+    presenceStatus: 'active' as const,
+    isWindowFocused: true,
+    isBot: false,
+    disconnected: false,
+    comboLevel: 0,
+    ...over,
+  } as ExtendedLeaderboardPlayer;
+}
+
+describe('GameLeaderboard — your standing strip', () => {
+  it('shows the "leading" cue with the gap to second place when the player is #1', () => {
+    const leaderboard = [player({ username: 'Me', score: 50 }), player({ username: 'Rival', score: 30 })];
+
+    render(<GameLeaderboard leaderboard={leaderboard} username="Me" isHost={false} t={mockT} dir="ltr" />);
+
+    const strip = screen.getByTestId('leaderboard-you-status');
+    expect(strip).toHaveTextContent('leaderboard.leading');
+    // +20 ahead of second place
+    expect(strip).toHaveTextContent('+20');
+    expect(strip).toHaveTextContent('leaderboard.ahead');
+  });
+
+  it('shows the points needed to catch the player directly above when not leading', () => {
+    const leaderboard = [player({ username: 'Leader', score: 40 }), player({ username: 'Me', score: 25 })];
+
+    render(<GameLeaderboard leaderboard={leaderboard} username="Me" isHost={false} t={mockT} dir="ltr" />);
+
+    const strip = screen.getByTestId('leaderboard-you-status');
+    // need 40 - 25 + 1 = 16 points to pass
+    expect(strip).toHaveTextContent('+16');
+    expect(strip).toHaveTextContent('leaderboard.toCatch');
+  });
+
+  it('does NOT render the status strip in a solo leaderboard', () => {
+    const leaderboard = [player({ username: 'Me', score: 10 })];
+
+    render(<GameLeaderboard leaderboard={leaderboard} username="Me" isHost={false} t={mockT} dir="ltr" />);
+
+    expect(screen.queryByTestId('leaderboard-you-status')).not.toBeInTheDocument();
+  });
+
+  it('does NOT render the status strip when the current player is not on the board', () => {
+    const leaderboard = [player({ username: 'A', score: 10 }), player({ username: 'B', score: 5 })];
+
+    render(<GameLeaderboard leaderboard={leaderboard} username="Spectator" isHost={false} t={mockT} dir="ltr" />);
+
+    expect(screen.queryByTestId('leaderboard-you-status')).not.toBeInTheDocument();
+  });
+
+  it('localizes the player count in the header instead of hardcoding English', () => {
+    const leaderboard = [player({ username: 'A', score: 10 }), player({ username: 'B', score: 5 })];
+
+    render(<GameLeaderboard leaderboard={leaderboard} username="A" isHost={false} t={mockT} dir="ltr" />);
+
+    // Uses the shared, already-translated players-count key (with interpolation)
+    expect(screen.getByText(/mp\.rivals\.playersCount/)).toBeInTheDocument();
+    expect(screen.queryByText(/\bplayers\b/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
The multiplayer in-game view stacked two redundant leaderboards showing
the same players — the "Carrera en Vivo" race-track (CompactLeaderboard)
and the "Clasificación" ranked standings (GameLeaderboard). Keep only the
ranked standings as the single live leaderboard and make it clearer at a
glance:

- Remove CompactLeaderboard from PortraitLayout (mobile + desktop); the
  mobile split-view now uses the same GameLeaderboard via a new `compact`
  variant, so MP shows one consistent leaderboard everywhere.
- Fold the motivational race cue into GameLeaderboard: a "your standing"
  strip showing "Leading +N" or "+N to catch" the player directly above.
- Localize the header player count (was hardcoded English "players") via
  the shared mp.rivals.playersCount key.

Drops the now-unused blastComboSync wiring and compactLeaderboardPlayers
memo from PortraitLayout.