### PR TITLE
fix(landing): right-size oversized cube art on the modes bento

### DIFF
--- a/fe-next/lib/landing/__tests__/modeMeta.test.ts
+++ b/fe-next/lib/landing/__tests__/modeMeta.test.ts
@@ -51,14 +51,16 @@ describe('MODE_META — parity with control renderCard', () => {
     expect(genIcon, `${key} genIcon lives under /modes/cubes/`).toMatch(/^\/modes\/cubes\/.+\.png$/);
   });
 
-  // The kawaii cube stickers are not framed consistently: blast/daily/arena/adventure
-  // bleed their FX to the edges, while practice/connections/brainGym/wordCraft float
-  // small + centered in a big navy margin. `imgScale` (a per-asset CSS scale applied
-  // in the Cube) grows ONLY the small ones so every tile reads full-bleed — scaling the
-  // already-bleeding ones would clip their explosion/sunburst art, so they stay unset.
+  // The kawaii cube stickers are not framed consistently. Two groups stay at
+  // natural framing (no imgScale): arena/blast/adventure bleed their FX to the
+  // edges, and brainGym's character is already large — the brain + dumbbell +
+  // feet span ~75% of the tile, so any upscale clips it (top brain / bottom feet).
+  // Only practice/connections/wordCraft float small + centered in a big navy
+  // margin; `imgScale` (a per-asset CSS scale applied in the Cube) grows ONLY
+  // those so every tile reads full-bleed without cropping art.
   describe('imgScale — per-asset framing normalisation', () => {
-    const FLOATY = ['practice', 'connections', 'brainGym', 'wordCraft'] as const;
-    const BLEED = ['arena', 'blast', 'adventure'] as const;
+    const FLOATY = ['practice', 'connections', 'wordCraft'] as const;
+    const NATURAL = ['arena', 'blast', 'adventure', 'brainGym'] as const;
 
     it.each(FLOATY)('small-framed mode %s scales its art up (>1)', (key) => {
       const { imgScale } = MODE_META[key];
@@ -67,8 +69,8 @@ describe('MODE_META — parity with control renderCard', () => {
       expect(imgScale, `${key} imgScale sane`).toBeLessThanOrEqual(1.8);
     });
 
-    it.each(BLEED)('edge-bleeding mode %s is left at natural framing (no imgScale)', (key) => {
-      // undefined or exactly 1 both mean "no scale" — never >1 (would clip FX)
+    it.each(NATURAL)('large/edge-bleeding mode %s is left at natural framing (no imgScale)', (key) => {
+      // undefined or exactly 1 both mean "no scale" — never >1 (would clip FX / character)
       expect(MODE_META[key].imgScale ?? 1).toBe(1);
     });
   });

--- a/fe-next/lib/landing/modeMeta.ts
+++ b/fe-next/lib/landing/modeMeta.ts
@@ -84,12 +84,14 @@ export const MODE_META: Record<string, ModeMetaEntry> = {
   brainGym: {
     titleKey: 'landing.brainTraining', descKey: 'landing.brainTrainingDesc', path: '/brain',
     Icon: Brain, variant: 'purple', modeImage: '/modes/practice.png', genIcon: '/modes/cubes/braingym.png',
-    imgScale: 1.4, // taller char (~53% / tall) → gentler scale so the brain stays in-frame
+    // No imgScale: the character is already large-framed (brain + dumbbell + feet
+    // span ~75% of the tile). Upscaling clipped the brain at the top edge and the
+    // feet at the bottom, reading oversized — natural framing matches the other tiles.
   },
   wordCraft: {
     titleKey: 'wordcraft.modeTitle', descKey: 'wordcraft.modeDesc', path: '/word-craft',
     Icon: Layers, variant: 'orange', badge: 'NEW', modeImage: '/modes/word-craft.png', genIcon: '/modes/cubes/wordcraft.png',
-    imgScale: 1.45, // ~55% framed → fill
+    imgScale: 1.1, // hammer + anvil already fill ~60% → a gentle bump to match wordForge, not overgrow
   },
   crossword: {
     titleKey: 'crossword.name', descKey: 'crossword.tagline', path: '/crossword',


### PR DESCRIPTION
brainGym and wordCraft cube stickers rendered noticeably larger than the
rest of the modes grid. Both were over-scaled via imgScale:

- brainGym (1.4): its character is already large-framed (brain + dumbbell
  + feet span ~75% of the tile), so the upscale clipped the brain at the
  top edge and feet at the bottom. Dropped to natural framing.
- wordCraft (1.45): art already fills ~60%; lowered to 1.1 so it matches
  its blacksmith analog (wordForge) instead of overgrowing.

Reclassifies brainGym from the floaty/small-framed set to the
natural-framing set in modeMeta tests.