### PR TITLE
fix(emails): legible CTA in dark mode + hide non-public crossword mode

### DIFF
--- a/fe-next/__tests__/reengagement-v2.test.ts
+++ b/fe-next/__tests__/reengagement-v2.test.ts
@@ -426,4 +426,23 @@ describe('ReengagementEmailV2 — secondary cube-image mode grid', () => {
       expect(html).not.toContain(emoji);
     }
   });
+
+  it('excludes the not-yet-public crossword mode from the secondary grid', async () => {
+    const modes = getWelcomeEmailModes('en', BASE);
+    const html = await render(ReengagementEmailV2({ ...baseProps, modes }));
+    expect(modes.some((m) => m.key === 'crossword')).toBe(false);
+    expect(html).not.toContain('/modes/cubes/crossword.png');
+  });
+});
+
+describe('ReengagementEmailV2 — Gmail dark-mode-safe CTA colour', () => {
+  it('never uses pure #000000 (Gmail dark mode would invert the lime CTA text to white)', async () => {
+    const html = await renderHtml();
+    expect(html.toLowerCase()).not.toContain('#000000');
+  });
+
+  it('paints the dark CTA elements in an off-black that survives dark-mode inversion', async () => {
+    const html = await renderHtml();
+    expect(html.toLowerCase()).toContain('#0a0a0a');
+  });
 });

--- a/fe-next/emails/reengagement-v2.tsx
+++ b/fe-next/emails/reengagement-v2.tsx
@@ -250,7 +250,10 @@ const C = {
   dim: '#6b6b85',
   pink: '#FF1493',
   lime: '#A8E600',
-  black: '#000000',
+  // Off-black, NOT pure #000000: Gmail (Android) dark mode force-swaps pure
+  // #000000 → #FFFFFF, which flipped the lime CTA's text + border + hard-shadow
+  // white (illegible on lime). An off-black reads identically but is left alone.
+  black: '#0A0A0A',
   divider: '#2a2a48',
 } as const;
 

--- a/fe-next/emails/welcome.tsx
+++ b/fe-next/emails/welcome.tsx
@@ -149,14 +149,17 @@ const C = {
   bg: '#1a1a2e',
   card: '#252545',
   cardInner: '#1e1e3a',
-  border: '#000000',
+  // Off-black, NOT pure #000000: Gmail (Android) dark mode force-swaps pure
+  // #000000 → #FFFFFF, which flipped the lime CTA's text + border + hard-shadow
+  // white (illegible on lime). An off-black reads identically but is left alone.
+  border: '#0A0A0A',
   footer: '#666666',
   lime: '#A8E600',
   pink: '#FF1493',
   cyan: '#5CE0D6',
   purple: '#8B5CF6',
   white: '#FFFFFF',
-  black: '#000000',
+  black: '#0A0A0A',
   grayDark: '#374151',
   grayLight: '#9CA3AF',
   // Uniform tile chrome — one quiet edge for every mode. The cube art carries

--- a/fe-next/lib/email/__tests__/welcomeModes.test.ts
+++ b/fe-next/lib/email/__tests__/welcomeModes.test.ts
@@ -7,7 +7,8 @@ const BASE = 'https://www.lexiclash.live';
 describe('getWelcomeEmailModes — dynamic public mode list for the welcome email', () => {
   it('includes only public modes available to all players', () => {
     const keys = getWelcomeEmailModes('en', BASE).map((m) => m.key);
-    // Exactly the promoted public set (matches landing FEATURED_MODES minus admin/adventure)
+    // Exactly the promoted public set (matches landing FEATURED_MODES minus
+    // admin/adventure, and minus crossword — not yet public to all players).
     expect(keys).toEqual([
       'arena',
       'daily',
@@ -15,9 +16,13 @@ describe('getWelcomeEmailModes — dynamic public mode list for the welcome emai
       'connections',
       'wordCraft',
       'brainGym',
-      'crossword',
       'practice',
     ]);
+  });
+
+  it('excludes crossword (not yet public to all players)', () => {
+    const keys = new Set(getWelcomeEmailModes('en', BASE).map((m) => m.key));
+    expect(keys.has('crossword')).toBe(false);
   });
 
   it('excludes every admin-gated mode', () => {
@@ -74,7 +79,8 @@ describe('getWelcomeEmailModes — dynamic public mode list for the welcome emai
   });
 
   it('exposes a stable public order constant', () => {
-    expect(PUBLIC_WELCOME_MODE_ORDER.length).toBe(8);
+    expect(PUBLIC_WELCOME_MODE_ORDER.length).toBe(7);
+    expect(PUBLIC_WELCOME_MODE_ORDER).not.toContain('crossword');
   });
 });
 

--- a/fe-next/lib/email/__tests__/welcomeRender.test.tsx
+++ b/fe-next/lib/email/__tests__/welcomeRender.test.tsx
@@ -71,4 +71,24 @@ describe('WelcomeEmail — dynamic cube-image mode grid', () => {
     expect(out).toContain(`${BASE}/he/multiplayer`);
     expect(modes.every((m) => m.href.includes('/he/'))).toBe(true);
   });
+
+  it('never uses pure #000000 (Gmail dark-mode inverts it to white, killing the CTA)', async () => {
+    // Gmail (Android) dark mode force-swaps pure #000000 → #FFFFFF. That turned
+    // the lime CTA's dark text + border + hard-shadow white (unreadable on lime).
+    // The whole email uses an off-black instead so dark mode leaves it alone.
+    const out = await renderHtml('en').html;
+    expect(out.toLowerCase()).not.toContain('#000000');
+  });
+
+  it('paints the CTA label in a dark off-black so it reads on the bright lime button', async () => {
+    const out = await renderHtml('en').html;
+    expect(out.toLowerCase()).toContain('#0a0a0a');
+  });
+
+  it('excludes the not-yet-public crossword mode from the grid', async () => {
+    const { modes, html } = renderHtml('en');
+    const out = await html;
+    expect(modes.some((m) => m.key === 'crossword')).toBe(false);
+    expect(out).not.toContain('/modes/cubes/crossword.png');
+  });
 });

--- a/fe-next/lib/email/welcomeModes.ts
+++ b/fe-next/lib/email/welcomeModes.ts
@@ -13,6 +13,9 @@
  *  - `adventure` is omitted: it is a public route but the landing intentionally
  *    keeps it out of FEATURED_MODES (and it is mid-rework), so the email mirrors
  *    the landing's promoted public set rather than every reachable route.
+ *  - `crossword` (תשבץ) is omitted: it is not yet public to all players, so it
+ *    must not be promoted in the welcome / re-engagement emails until it ships
+ *    broadly. Re-add it here when it goes fully public.
  *
  * Titles come from the registry's i18n keys (localized via `translateKey`).
  * Taglines are curated per-language email copy (tighter than the landing descs,
@@ -33,8 +36,8 @@ export interface WelcomeEmailMode {
 
 /**
  * The promoted public set, in email order. Mirrors the landing FEATURED_MODES
- * minus admin-gated modes and minus `adventure`. `daily` leads after arena as
- * the habit hook.
+ * minus admin-gated modes, minus `adventure`, and minus `crossword` (not yet
+ * public to all players). `daily` leads after arena as the habit hook.
  */
 export const PUBLIC_WELCOME_MODE_ORDER = [
   'arena',
@@ -43,7 +46,6 @@ export const PUBLIC_WELCOME_MODE_ORDER = [
   'connections',
   'wordCraft',
   'brainGym',
-  'crossword',
   'practice',
 ] as const;
 


### PR DESCRIPTION
Two issues in the welcome + re-engagement (v2) emails:

1. CTA text rendered white on the bright lime button. Gmail (Android)
   dark mode force-swaps pure #000000 -> #FFFFFF, which flipped the lime
   CTA's dark text, border and hard-shadow to white (illegible on lime).
   Switch the dark palette tokens from #000000 to an off-black (#0A0A0A)
   that reads identically but escapes dark-mode inversion.

2. The crossword (תשבץ) mode is not yet public to all players, so drop it
   from PUBLIC_WELCOME_MODE_ORDER — it no longer shows in the welcome or
   re-engagement email mode grids. Re-add when it ships broadly.

Tests updated/added (TDD): welcomeModes, welcomeRender, reengagement-v2.

https://claude.ai/code/session_01CQfpt1QeJ719Dd3Cos5gjo