### PR TITLE
fix(results): stop native WebView white flash from scroll-effect GPU layers

### DIFF
--- a/fe-next/components/results/ResultsScrollEffects.tsx
+++ b/fe-next/components/results/ResultsScrollEffects.tsx
@@ -10,9 +10,28 @@ import {
 } from 'framer-motion';
 import gsap from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import { Capacitor } from '@capacitor/core';
 
 if (typeof window !== 'undefined') {
   gsap.registerPlugin(ScrollTrigger);
+}
+
+/**
+ * Inside the native Capacitor WebView these decorative scroll effects must NOT
+ * run. Each promotes a persistent GPU compositor layer via `will-change:
+ * transform` / `translate3d(0,0,0)` (parallax + hero tilt) or `will-change:
+ * height` (rail). On the Android System WebView a freshly-promoted layer paints
+ * an UNINITIALISED WHITE backing for a frame or two before the element's content
+ * composites onto it — and because the hero-tilt layer wraps the whole results
+ * body, that white wash lands "over" many components on entry (the reported
+ * "white bg flashing over the result/pre-result components"). They were added
+ * 2026-06-13; before that the page had no such layers and did not flash. The
+ * effects are pure garnish, so we drop them on native and keep them on web
+ * (where layer init does not flash). Caller is `ssr:false`, so a sync check is
+ * hydration-safe.
+ */
+function isNativeApp(): boolean {
+  return typeof window !== 'undefined' && Capacitor.isNativePlatform();
 }
 
 function useIsSmallViewport(): boolean {
@@ -60,9 +79,11 @@ export const ResultsParallaxBackdrop: React.FC<ParallaxBackdropProps> = ({
   const isSmall = useIsSmallViewport();
   const backRef = useRef<HTMLDivElement | null>(null);
   const midRef = useRef<HTMLDivElement | null>(null);
+  // Native WebView paints promoted layers white before they composite — skip.
+  const active = enabled && !isNativeApp();
 
   useEffect(() => {
-    if (reducedMotion || !enabled) return;
+    if (reducedMotion || !active) return;
     const scroller = scrollRef.current;
     const back = backRef.current;
     const mid = midRef.current;
@@ -96,9 +117,9 @@ export const ResultsParallaxBackdrop: React.FC<ParallaxBackdropProps> = ({
         tw.kill();
       });
     };
-  }, [scrollRef, intensity, isSmall, reducedMotion, enabled]);
+  }, [scrollRef, intensity, isSmall, reducedMotion, active]);
 
-  if (reducedMotion || !enabled) return null;
+  if (reducedMotion || !active) return null;
 
   return (
     <div className="absolute inset-0 pointer-events-none overflow-hidden z-0" aria-hidden="true">
@@ -197,9 +218,12 @@ export const ResultsHeroTilt: React.FC<HeroTiltProps> = ({
 }) => {
   const reducedMotion = useReducedMotion();
   const innerRef = useRef<HTMLDivElement>(null);
+  // Native WebView paints this `will-change:transform` layer white on creation
+  // (it wraps the whole results body) — render a plain div there instead.
+  const active = enabled && !isNativeApp();
 
   useEffect(() => {
-    if (reducedMotion || !enabled) return;
+    if (reducedMotion || !active) return;
     const scroller = scrollRef.current;
     const target = innerRef.current;
     if (!scroller || !target) return;
@@ -219,9 +243,9 @@ export const ResultsHeroTilt: React.FC<HeroTiltProps> = ({
       tw.scrollTrigger?.kill();
       tw.kill();
     };
-  }, [scrollRef, reducedMotion, enabled]);
+  }, [scrollRef, reducedMotion, active]);
 
-  if (reducedMotion || !enabled) {
+  if (reducedMotion || !active) {
     return <div className={className}>{children}</div>;
   }
 
@@ -260,8 +284,10 @@ export const ResultsScrollProgressRail: React.FC<ScrollProgressRailProps> = ({
   const { scrollYProgress } = useScroll({ container: scrollRef as React.RefObject<HTMLElement> });
   const smoothed = useSpring(scrollYProgress, { stiffness: 220, damping: 30, mass: 0.4 });
   const height = useTransform(smoothed, [0, 1], ['0%', '100%']);
+  // Native WebView flashes the promoted `will-change:height` layer white — skip.
+  const active = enabled && !isNativeApp();
 
-  if (reducedMotion || !enabled) return null;
+  if (reducedMotion || !active) return null;
 
   return (
     <m.div

--- a/fe-next/components/results/__tests__/ResultsScrollEffects.test.tsx
+++ b/fe-next/components/results/__tests__/ResultsScrollEffects.test.tsx
@@ -14,7 +14,17 @@ vi.mock('gsap', () => ({
 }));
 vi.mock('gsap/ScrollTrigger', () => ({ ScrollTrigger: {} }));
 
-import { ResultsParallaxBackdrop } from '../ResultsScrollEffects';
+// Native detection — flip per-test to assert the GPU-layer scroll effects are
+// inert inside the Capacitor WebView (where promoted `will-change`/`translate3d`
+// layers paint an uninitialised white backing before they composite).
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: vi.fn(() => false) },
+}));
+
+import { Capacitor } from '@capacitor/core';
+import { ResultsParallaxBackdrop, ResultsHeroTilt, ResultsScrollProgressRail } from '../ResultsScrollEffects';
+
+const mockIsNative = vi.mocked(Capacitor.isNativePlatform);
 
 function Harness({ enabled }: { enabled?: boolean }) {
   const ref = useRef<HTMLDivElement>(null);
@@ -25,7 +35,28 @@ function Harness({ enabled }: { enabled?: boolean }) {
   );
 }
 
+function TiltHarness({ enabled }: { enabled?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div data-testid="harness" ref={ref}>
+      <ResultsHeroTilt scrollRef={ref} enabled={enabled}>
+        <span>child</span>
+      </ResultsHeroTilt>
+    </div>
+  );
+}
+
+function RailHarness({ enabled }: { enabled?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div data-testid="harness" ref={ref}>
+      <ResultsScrollProgressRail scrollRef={ref} enabled={enabled} />
+    </div>
+  );
+}
+
 beforeEach(() => {
+  mockIsNative.mockReturnValue(false);
   window.matchMedia = ((q: string) => ({
     matches: false,
     media: q,
@@ -49,6 +80,46 @@ describe('ResultsParallaxBackdrop', () => {
 
   it('runs no effect layers when disabled (the CSS-hidden tree must stay inert)', () => {
     const { container } = render(<Harness enabled={false} />);
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('renders the parallax layer on web (enabled)', () => {
+    const { container } = render(<Harness />);
+    expect(container.querySelector('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it('renders NO GPU layer on native — the promoted layer flashes white in the WebView', () => {
+    mockIsNative.mockReturnValue(true);
+    const { container } = render(<Harness />);
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+    // No will-change/translate3d hardware-layer hints leak into the DOM.
+    expect(container.innerHTML).not.toMatch(/will-change|translate3d/i);
+  });
+});
+
+describe('ResultsHeroTilt', () => {
+  it('promotes a will-change layer on web', () => {
+    const { container } = render(<TiltHarness />);
+    expect(container.querySelector('[style*="will-change"]')).not.toBeNull();
+  });
+
+  it('renders children with NO will-change layer on native (no white flash)', () => {
+    mockIsNative.mockReturnValue(true);
+    const { container, getByText } = render(<TiltHarness />);
+    expect(getByText('child')).toBeTruthy();
+    expect(container.querySelector('[style*="will-change"]')).toBeNull();
+  });
+});
+
+describe('ResultsScrollProgressRail', () => {
+  it('renders the rail on web', () => {
+    const { container } = render(<RailHarness />);
+    expect(container.querySelector('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it('renders nothing on native (no promoted layer to flash white)', () => {
+    mockIsNative.mockReturnValue(true);
+    const { container } = render(<RailHarness />);
     expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
   });
 });


### PR DESCRIPTION
Root cause of the "white bg flashing over the result / pre-result components"
on the installed app: the cinematic results scroll effects added 2026-06-13
(ResultsHeroTilt, ResultsParallaxBackdrop, ResultsScrollProgressRail) each
force a persistent GPU compositor layer via `will-change: transform` /
`translate3d(0,0,0)` (or `will-change: height`). On the Android System WebView
a freshly-promoted layer paints an UNINITIALISED WHITE backing for a frame or
two before the element's content composites onto it. ResultsHeroTilt wraps the
whole results body, so that white wash lands "over" many components on entry —
exactly the user's report ("it changes, affects a lot of components, like
something rendered behind"), and it shows briefly then resolves to content.
Before 2026-06-13 the page had no such layers and did not flash.

These effects are pure decoration, so gate them off inside the native Capacitor
WebView (where layer init flashes white) while keeping them on web (where it
does not). The caller is `ssr:false`, so the sync `Capacitor.isNativePlatform()`
check is hydration-safe.

TDD: added native-path specs to ResultsScrollEffects.test.tsx asserting the
three effects emit no will-change/translate3d layer on native. tsc clean,
eslint clean, 18 results specs pass.