### PR TITLE
fix(fanfare): drop will-change GPU-layer hints on native to stop white flash

### DIFF
--- a/fe-next/components/mascot/MascotCelebrationVideo.tsx
+++ b/fe-next/components/mascot/MascotCelebrationVideo.tsx
@@ -1,8 +1,26 @@
 'use client';
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { Capacitor } from '@capacitor/core';
 import { MascotHaloGlow, type HaloIntensity, type HaloTone } from './MascotHaloGlow';
 import { pickCelebrationSrc } from '@/lib/results/celebrationVariant';
+
+/**
+ * The celebration's animated garnish (edge glow, title, sparkles) hints
+ * `will-change` so the browser promotes each to its own GPU compositor layer up
+ * front. On the native Capacitor (Android System) WebView a freshly-promoted
+ * layer paints an UNINITIALISED WHITE backing for a frame or two before the
+ * element composites onto it — and because the edge glow sits directly over the
+ * mascot video, that white wash reads as "the fanfare flashes white". Dropping
+ * the hint on native keeps the animations (transform / opacity / box-shadow all
+ * still tween) but defers layer promotion to the first animated frame, by which
+ * point real content has painted, so there is no white flash. Web keeps the
+ * hint (it does not flash there). The fanfare's caller is `ssr:false`, so this
+ * sync platform check is hydration-safe.
+ */
+function isNativeApp(): boolean {
+  return typeof window !== 'undefined' && Capacitor.isNativePlatform();
+}
 
 export type MascotCelebrationKind =
   | 'champion'        // MP 1st place
@@ -181,6 +199,8 @@ export const MascotCelebrationVideo = memo(function MascotCelebrationVideo({
   forceSrc,
 }: MascotCelebrationVideoProps) {
   const variant = VARIANTS[kind];
+  // On native the eager GPU-layer promotion flashes white; drop the hint there.
+  const native = isNativeApp();
   // Pick a clip ONCE per mount. The results page re-renders frequently
   // (countdowns, score reveals); seeding from a mount-time random keeps the
   // same clip for the life of this celebration instead of reshuffling.
@@ -344,7 +364,7 @@ export const MascotCelebrationVideo = memo(function MascotCelebrationVideo({
               textShadow: `0 0 18px ${glowPrimary}99, 0 0 36px ${glowSecondary}66`,
               filter: `drop-shadow(0 4px 0 rgba(0,0,0,0.85)) drop-shadow(0 0 12px ${glowPrimary}cc)`,
               animation: `lcMcvTitleIn 540ms cubic-bezier(0.34, 1.56, 0.64, 1) both, lcMcvTitleWobble 2.4s ease-in-out 0.6s infinite`,
-              willChange: 'transform, opacity',
+              willChange: native ? undefined : 'transform, opacity',
             }}
           >
             {displayedTitle}
@@ -373,7 +393,7 @@ export const MascotCelebrationVideo = memo(function MascotCelebrationVideo({
                   ['--lc-fx' as string]: `${s.floatX}px`,
                   ['--lc-fy' as string]: `${s.floatY}px`,
                   animation: `${sparkleKey} 1.9s ease-in-out ${s.delay}s infinite`,
-                  willChange: 'transform, opacity',
+                  willChange: native ? undefined : 'transform, opacity',
                 }}
               />
             );
@@ -412,7 +432,7 @@ export const MascotCelebrationVideo = memo(function MascotCelebrationVideo({
                   borderRadius: '24px',
                   pointerEvents: 'none',
                   animation: `${edgeGlowKey} 1.8s ease-in-out infinite`,
-                  willChange: 'box-shadow',
+                  willChange: native ? undefined : 'box-shadow',
                 }}
               />
             </div>

--- a/fe-next/components/mascot/__tests__/MascotCelebrationVideo.test.tsx
+++ b/fe-next/components/mascot/__tests__/MascotCelebrationVideo.test.tsx
@@ -1,6 +1,19 @@
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Native detection — flip per-test to assert the celebration's animated overlay
+// layers do NOT force a GPU compositor layer (`will-change`) inside the
+// Capacitor WebView, where a freshly-promoted layer paints an uninitialised
+// WHITE backing for a frame before content composites (the "fanfare flashes
+// white" report). On web the hint stays (no flash there).
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: vi.fn(() => false) },
+}));
+
+import { Capacitor } from '@capacitor/core';
 import { MascotCelebrationVideo } from '../MascotCelebrationVideo';
+
+const mockIsNative = vi.mocked(Capacitor.isNativePlatform);
 
 function mockReducedMotion(matches: boolean) {
   Object.defineProperty(window, 'matchMedia', {
@@ -22,6 +35,7 @@ describe('MascotCelebrationVideo', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockReducedMotion(false);
+    mockIsNative.mockReturnValue(false);
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -159,6 +173,38 @@ describe('MascotCelebrationVideo', () => {
     render(<MascotCelebrationVideo kind="streak" />);
     const sparkles = screen.getAllByTestId('mascot-celebration-sparkle');
     expect(sparkles.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('promotes the edge-glow / title / sparkle layers with will-change on web', () => {
+    render(<MascotCelebrationVideo kind="champion" />);
+    expect(screen.getByTestId('mascot-celebration-edge-glow').style.willChange).toBe('box-shadow');
+    expect(screen.getByTestId('mascot-celebration-title').style.willChange).toBe('transform, opacity');
+    for (const sparkle of screen.getAllByTestId('mascot-celebration-sparkle')) {
+      expect(sparkle.style.willChange).toBe('transform, opacity');
+    }
+  });
+
+  it('emits NO will-change layer on native — the promoted layer flashes white in the WebView', () => {
+    // Root cause of "the fanfare flashes white" on the installed app: each of
+    // these decorative layers (edge-glow box-shadow, title, sparkles) forces a
+    // persistent GPU compositor layer via `will-change`. The Android System
+    // WebView paints a freshly-promoted layer with an uninitialised white backing
+    // for a frame or two before the element composites — the edge glow sits
+    // directly over the video, so that white wash lands on the celebration.
+    // Drop the hint on native (keep the animation); promotion then defers to the
+    // first animated frame, after content has painted, so no white flash.
+    mockIsNative.mockReturnValue(true);
+    const { container } = render(<MascotCelebrationVideo kind="champion" />);
+    expect(screen.getByTestId('mascot-celebration-edge-glow').style.willChange).toBe('');
+    expect(screen.getByTestId('mascot-celebration-title').style.willChange).toBe('');
+    for (const sparkle of screen.getAllByTestId('mascot-celebration-sparkle')) {
+      expect(sparkle.style.willChange).toBe('');
+    }
+    // No will-change hint leaks into the markup at all.
+    expect(container.innerHTML).not.toMatch(/will-change/i);
+    // The celebration content still renders (we keep the juice, drop the flash).
+    expect(screen.getByTestId('mascot-celebration-edge-glow')).toBeInTheDocument();
+    expect(screen.getAllByTestId('mascot-celebration-sparkle').length).toBeGreaterThanOrEqual(6);
   });
 
   it('uses a knight-family video for the "explorer" first-visit-today kind (supports variety clips)', () => {


### PR DESCRIPTION
The mascot celebration's animated garnish (edge-glow overlay, title,
sparkles) hinted will-change, eagerly promoting each to its own GPU
compositor layer at mount. On the native Capacitor (Android System)
WebView a freshly-promoted layer paints an uninitialised WHITE backing
for a frame or two before the element composites onto it. The edge glow
sits directly over the mascot video, so that white wash reads as the
fanfare flashing white — the same layer-init flash class fixed for the
results-page scroll effects in 75911dc, now on the pre-result fanfare.

Drop the hint on native only (Capacitor.isNativePlatform()); web keeps it
(no flash there). Animations still tween — promotion just defers to the
first animated frame, after real content has painted. Caller is ssr:false
so the sync platform check is hydration-safe.

TDD: added native-path spec asserting no will-change leaks on native plus
a web spec asserting the hints stay. 19/19 mascot specs pass.