### PR TITLE
fix(playerStyle): don't reopen style popup when account already has a style

### DIFF
--- a/fe-next/lib/playerStyle/shouldShowStylePopup.test.ts
+++ b/fe-next/lib/playerStyle/shouldShowStylePopup.test.ts
@@ -59,6 +59,20 @@ describe('shouldShowStylePopup', () => {
     ).toBe(false);
   });
 
+  it('never shows once the account already has a style, even if auth reads false transiently', () => {
+    // The chosen style on `profiles.player_style` must suppress the popup in
+    // EITHER auth state, not only the authenticated branch. During session
+    // restore / token refresh / cross-tab sync `isAuthenticated` can briefly
+    // read false while the profile object still holds the chosen style (the same
+    // value the "current" badge renders from). If the profileStyle check only
+    // lived in the authed branch, the gate would fall into the guest branch,
+    // ignore the chosen style, and re-open the popup over a user who already
+    // picked — the exact "modal opened after I chose my style" report.
+    expect(shouldShowStylePopup({ ...base, isAuthenticated: false, profileStyle: 'hasidic' })).toBe(
+      false,
+    );
+  });
+
   describe('authenticated', () => {
     const authed = { ...base, isAuthenticated: true };
     it('shows once when the popup was never shown and no style chosen', () => {

--- a/fe-next/lib/playerStyle/shouldShowStylePopup.ts
+++ b/fe-next/lib/playerStyle/shouldShowStylePopup.ts
@@ -19,7 +19,12 @@ export interface StylePopupGateInput {
   profileLoaded: boolean;
   /** profiles.player_style_modal_shown_at (authed). */
   profileShownAt: string | null;
-  /** profiles.player_style (authed) — already chose a style elsewhere. */
+  /**
+   * profiles.player_style — already chose a style on the account. Suppresses the
+   * popup in EITHER auth state (a transient `isAuthenticated === false` during
+   * session restore must not route a user who already picked through the guest
+   * branch and re-prompt them).
+   */
   profileStyle: string | null;
   /** localStorage one-time flag (guest). */
   guestShown: boolean;
@@ -62,10 +67,18 @@ export function shouldShowStylePopup(input: StylePopupGateInput): boolean {
   // Catches the authed gap where `profileStyle` lags behind the local choice
   // (guest picked in FTUE then logged in, or the profile sync hasn't landed).
   if (input.localStyleChosen) return false;
+  // Already picked a style on the ACCOUNT → never prompt, in either auth state.
+  // Global (not just the authed branch): during session restore / token refresh
+  // / cross-tab sync `isAuthenticated` can read false for a tick while the
+  // profile object still holds the chosen style — the same value the "current"
+  // badge renders from. If this lived only in the authed branch, that tick would
+  // fall into the guest branch, ignore the chosen style, and re-open the popup
+  // over a user who already picked ("modal opened after I chose my style").
+  if (input.profileStyle) return false;
 
   if (input.isAuthenticated) {
     if (!input.profileLoaded) return false; // profile not fetched yet → don't guess
-    return !input.profileShownAt && !input.profileStyle;
+    return !input.profileShownAt;
   }
   return input.guestOnboardingDone && !input.guestShown;
 }


### PR DESCRIPTION
The chosen-style suppression for profiles.player_style lived only inside the
authenticated branch of shouldShowStylePopup. During session restore / token
refresh / cross-tab sync, isAuthenticated can read false for a tick while the
profile object still holds the chosen style (the same value the 'current' badge
renders from). That tick fell into the guest branch, which ignores profileStyle,
and re-opened the one-time popup over a user who had already picked their style.

Hoist the profileStyle check to a global short-circuit so a chosen style in
either persistence layer (localStorage or account) suppresses the popup in
either auth state.