### PR TITLE
fix(results): gate per-section reveal off native to stop the post-fanfare white flashes

### DIFF
--- a/fe-next/components/results/ResultsScrollEffects.tsx
+++ b/fe-next/components/results/ResultsScrollEffects.tsx
@@ -168,8 +168,17 @@ export const ResultsSectionReveal: React.FC<SectionRevealProps> = ({
   const reducedMotion = useReducedMotion();
   const ref = useRef<HTMLDivElement>(null);
 
-  if (reducedMotion) {
-    return <div ref={ref} className={className}>{children}</div>;
+  // Drop the reveal on native (same as reduced-motion). Framer-motion promotes
+  // each animating `m.div` to its own GPU compositor layer as it scrolls into
+  // view, and on the Android System WebView a freshly-promoted layer paints an
+  // UNINITIALISED WHITE backing for a frame before it composites. EVERY results
+  // section is wrapped in this reveal, so that surfaced as the page "flashing
+  // white" section-by-section — the hero/podium right as the fanfare hands off,
+  // then each section as the user scrolls. This is the same layer-init flash
+  // class already gated off native for the sibling scroll effects (Parallax /
+  // HeroTilt / ProgressRail in this file); SectionReveal was the one left behind.
+  if (reducedMotion || isNativeApp()) {
+    return <div ref={ref} className={className} data-testid="results-section-reveal-static">{children}</div>;
   }
 
   const xFrom = index % 2 === 0 ? -10 : 10;
@@ -180,6 +189,7 @@ export const ResultsSectionReveal: React.FC<SectionRevealProps> = ({
     <m.div
       ref={ref}
       className={className}
+      data-testid="results-section-reveal-motion"
       initial={{ opacity: 0, y: 22, x: xFrom, rotate: rotateFrom }}
       whileInView={{ opacity: 1, y: 0, x: 0, rotate: 0 }}
       viewport={{ once: true, amount: 0.15, margin: '0px 0px -8% 0px' }}

--- a/fe-next/components/results/__tests__/ResultsScrollEffects.test.tsx
+++ b/fe-next/components/results/__tests__/ResultsScrollEffects.test.tsx
@@ -22,7 +22,12 @@ vi.mock('@capacitor/core', () => ({
 }));
 
 import { Capacitor } from '@capacitor/core';
-import { ResultsParallaxBackdrop, ResultsHeroTilt, ResultsScrollProgressRail } from '../ResultsScrollEffects';
+import {
+  ResultsParallaxBackdrop,
+  ResultsHeroTilt,
+  ResultsScrollProgressRail,
+  ResultsSectionReveal,
+} from '../ResultsScrollEffects';
 
 const mockIsNative = vi.mocked(Capacitor.isNativePlatform);
 
@@ -108,6 +113,34 @@ describe('ResultsHeroTilt', () => {
     const { container, getByText } = render(<TiltHarness />);
     expect(getByText('child')).toBeTruthy();
     expect(container.querySelector('[style*="will-change"]')).toBeNull();
+  });
+});
+
+describe('ResultsSectionReveal', () => {
+  it('animates the section on web (framer-motion m.div reveal)', () => {
+    const { queryByTestId, getByText } = render(
+      <ResultsSectionReveal index={0}>
+        <span>section</span>
+      </ResultsSectionReveal>,
+    );
+    expect(getByText('section')).toBeTruthy();
+    expect(queryByTestId('results-section-reveal-motion')).not.toBeNull();
+    expect(queryByTestId('results-section-reveal-static')).toBeNull();
+  });
+
+  it('renders a plain static div on native — every section is wrapped in this reveal, and framer-motion promotes each m.div to its own GPU layer that the WebView paints white on creation (the results "flashing white" after the fanfare)', () => {
+    mockIsNative.mockReturnValue(true);
+    const { container, queryByTestId, getByText } = render(
+      <ResultsSectionReveal index={0}>
+        <span>section</span>
+      </ResultsSectionReveal>,
+    );
+    // Content still renders — we drop the animation, not the section.
+    expect(getByText('section')).toBeTruthy();
+    expect(queryByTestId('results-section-reveal-static')).not.toBeNull();
+    expect(queryByTestId('results-section-reveal-motion')).toBeNull();
+    // No transform / will-change hardware-layer hint leaks into the markup.
+    expect(container.innerHTML).not.toMatch(/will-change|transform|translate/i);
   });
 });
 


### PR DESCRIPTION
Root cause of "still lots of flashing whites since the fanfare in MP and
after that": ResultsSectionReveal — which wraps EVERY results section
(hero/podium + every stat/CTA section, both the mobile and desktop trees)
— still ran its framer-motion `m.div` reveal on native. Framer-motion
promotes each animating element to its own GPU compositor layer as it
scrolls into view, and on the Android System WebView a freshly-promoted
layer paints an UNINITIALISED WHITE backing for a frame or two before the
element composites onto it. So the hero/podium flashed white the instant
the fanfare handed off, then each section flashed white as the user
scrolled — exactly the report.

This is the same layer-init flash class already gated off native for the
three sibling scroll effects in this file (ResultsParallaxBackdrop,
ResultsHeroTilt, ResultsScrollProgressRail) in 75911dc / 96356b6 —
SectionReveal was the one component left behind, and it is the most
pervasive one because every section passes through it.

Fix: render the plain static div on native (the existing reduced-motion
path), so no compositor layer is promoted and nothing flashes. Web keeps
the reveal (it does not flash there). `isNativeApp()` is the same
hydration-safe sync Capacitor check the siblings use; caller is ssr:false.

TDD: added web + native specs for ResultsSectionReveal to
ResultsScrollEffects.test.tsx (10/10 pass; 504 results+mascot specs green,
tsc + eslint clean).

https://claude.ai/code/session_0123r9TNzDgYKwKQQ8sX4FqP