### PR TITLE
fix(audio): stop Blast Mode BGM stacking duplicate Howler instances across waves

### DIFF
--- a/fe-next/contexts/MusicContext.tsx
+++ b/fe-next/contexts/MusicContext.tsx
@@ -135,6 +135,14 @@ export function MusicProvider({ children }: MusicProviderProps): React.ReactElem
   const fadeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const currentTrackRef = useRef<TrackKey | null>(null);
   const isTransitioningRef = useRef(false);
+  // Deferred fade-out stops, keyed by track. A bare `setTimeout(() => howl.stop())`
+  // is fire-and-forget: it nulls currentHowlRef synchronously but leaves the Howl
+  // PLAYING until it fires ~1s later. If the same track is re-entered inside that
+  // window (every Blast wave remounts <BlastGame>), play() lands on a still-playing
+  // Howl and Howler spawns a SECOND concurrent sound — the echo that stacks per
+  // wave until the tab freezes. Tracking the timers lets us cancel a pending stop
+  // before restarting a track so exactly one instance per Howl can ever exist.
+  const pendingStopsRef = useRef<Map<TrackKey, ReturnType<typeof setTimeout>>>(new Map());
   const isMutedRef = useRef(isMuted);
   const volumeRef = useRef(volume);
 
@@ -191,11 +199,38 @@ export function MusicProvider({ children }: MusicProviderProps): React.ReactElem
     return howl;
   }, []);
 
+  /** Cancel a track's pending deferred stop, if any. */
+  const cancelPendingStop = useCallback((key: TrackKey) => {
+    const pending = pendingStopsRef.current.get(key);
+    if (pending) {
+      clearTimeout(pending);
+      pendingStopsRef.current.delete(key);
+    }
+  }, []);
+
+  /**
+   * Stop `howl` after `ms`, tracking the timer so it can be cancelled if the
+   * track is re-entered before it fires. Replaces bare `setTimeout(stop)` calls
+   * that otherwise leave a Howl playing past the point where currentHowlRef has
+   * already been reassigned — the window in which a duplicate play() echoes.
+   */
+  const scheduleStop = useCallback((key: TrackKey, howl: Howl, ms: number) => {
+    cancelPendingStop(key);
+    const id = setTimeout(() => {
+      pendingStopsRef.current.delete(key);
+      howl.stop();
+    }, ms);
+    pendingStopsRef.current.set(key, id);
+  }, [cancelPendingStop]);
+
   // Cleanup on unmount
   useEffect(() => {
     const howls = howlsRef.current;
     const fadeTimeout = fadeTimeoutRef.current;
+    const pendingStops = pendingStopsRef.current;
     return () => {
+      pendingStops.forEach(clearTimeout);
+      pendingStops.clear();
       Object.values(howls).forEach(howl => howl.unload());
       if (fadeTimeout) clearTimeout(fadeTimeout);
     };
@@ -300,8 +335,9 @@ export function MusicProvider({ children }: MusicProviderProps): React.ReactElem
       if (key !== trackKey) {
         if (howl.playing()) {
           howl.fade(howl.volume(), 0, fadeOutMs);
-          setTimeout(() => howl.stop(), fadeOutMs);
+          scheduleStop(key as TrackKey, howl, fadeOutMs);
         } else {
+          cancelPendingStop(key as TrackKey);
           howl.stop();
         }
       }
@@ -311,6 +347,15 @@ export function MusicProvider({ children }: MusicProviderProps): React.ReactElem
       oldHowl.stop();
     }
 
+    // Single-instance guard: collapse any lingering playback of THIS track before
+    // (re)starting it. We only reach here when we genuinely intend to start the
+    // track (the same-track-already-playing case short-circuits above), so a
+    // still-playing Howl here is a zombie from a deferred fade-out — calling
+    // play() on it would spawn a second concurrent Howler sound (the echo).
+    // Cancelling the pending stop also keeps a stale timer from silencing the
+    // instance we're about to start.
+    cancelPendingStop(trackKey);
+    newHowl.stop();
     newHowl.volume(0);
     newHowl.play();
 
@@ -348,7 +393,7 @@ export function MusicProvider({ children }: MusicProviderProps): React.ReactElem
         fadeToTrackRef.current?.(pendingTrack, pendingFadeOut, pendingFadeIn);
       }
     }, Math.max(fadeOutMs, fadeInMs));
-  }, [getOrCreateHowl, windowFocusedRef, pausedByVisibilityRef, pausedByBlurRef]);
+  }, [getOrCreateHowl, scheduleStop, cancelPendingStop, windowFocusedRef, pausedByVisibilityRef, pausedByBlurRef]);
 
   useEffect(() => { fadeToTrackRef.current = fadeToTrack; }, [fadeToTrack]);
 
@@ -423,11 +468,12 @@ export function MusicProvider({ children }: MusicProviderProps): React.ReactElem
   // auto-unlock listener. A backup effect here caused double-play.
 
   const stopMusic = useCallback((fadeOutMs = 1000) => {
-    Object.values(howlsRef.current).forEach(howl => {
+    Object.entries(howlsRef.current).forEach(([key, howl]) => {
       if (howl.playing()) {
         howl.fade(howl.volume(), 0, fadeOutMs);
-        setTimeout(() => howl.stop(), fadeOutMs);
+        scheduleStop(key as TrackKey, howl, fadeOutMs);
       } else {
+        cancelPendingStop(key as TrackKey);
         howl.stop();
       }
     });
@@ -435,7 +481,7 @@ export function MusicProvider({ children }: MusicProviderProps): React.ReactElem
     currentTrackRef.current = null;
     setCurrentTrack(null);
     setIsPlaying(false);
-  }, []);
+  }, [scheduleStop, cancelPendingStop]);
 
   const setVolume = useCallback((newVolume: number) => {
     const clampedVolume = Math.max(0, Math.min(1, newVolume));

--- a/fe-next/contexts/__tests__/MusicContext.blastWaveNoDuplicate.test.tsx
+++ b/fe-next/contexts/__tests__/MusicContext.blastWaveNoDuplicate.test.tsx
@@ -1,0 +1,163 @@
+import { vi, type MockedClass } from 'vitest';
+/**
+ * Regression test for the Blast Mode ("מצב פיצוץ") background-music leak.
+ *
+ * BUG: Blast Mode's <BlastGame> remounts on every wave transition. On mount it
+ * calls fadeToTrack(TRACKS.BLAST); on unmount it calls stopMusic(). stopMusic()
+ * nulls currentTrack/currentHowl SYNCHRONOUSLY but defers the real howl.stop()
+ * by fadeOutMs via an untracked setTimeout. The next mount's fadeToTrack(BLAST)
+ * therefore finds currentTrackRef === null, BYPASSES its de-dup guard, and calls
+ * play() on the SAME cached blast Howl while its previous instance is still
+ * playing. Howler spawns a second concurrent sound — the "echo" — and instances
+ * stack with every wave, driving the CPU/memory climb that freezes the game.
+ *
+ * INVARIANT: a single Howl must never have more than one concurrent active
+ * playback. Re-entering a track must collapse to exactly one instance, and a
+ * stale deferred stop must not silence the freshly started instance.
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { MusicProvider, useMusic } from '../MusicContext';
+import { Howl } from 'howler';
+
+// Track concurrent active playbacks per Howl instance. play() with no id while
+// already playing models Howler spawning a NEW concurrent sound; stop() (no id)
+// collapses all instances; pause() halts without destroying.
+vi.mock('howler', () => {
+  const mockHowl = vi.fn().mockImplementation((options) => {
+    const instance = {
+      _options: options,
+      _instanceId: options.src?.[0] || 'unknown',
+      _state: 'unloaded',
+      _active: 0, // concurrent active playbacks
+      _maxActive: 0, // high-water mark — the assertion target
+      _volume: options.volume || 0,
+
+      state: vi.fn(function (this: any) { return this._state; }),
+
+      load: vi.fn(function (this: any) {
+        this._state = 'loading';
+        setTimeout(() => {
+          this._state = 'loaded';
+          options.onload?.();
+        }, 10);
+        return this;
+      }),
+
+      play: vi.fn(function (this: any) {
+        // Howler: play() with no id while already playing spawns a NEW instance.
+        this._active += 1;
+        this._maxActive = Math.max(this._maxActive, this._active);
+        this._state = 'loaded';
+        return this._active;
+      }),
+
+      playing: vi.fn(function (this: any) { return this._active > 0; }),
+
+      pause: vi.fn(function (this: any) {
+        if (this._active > 0) this._active -= 1;
+        return this;
+      }),
+
+      stop: vi.fn(function (this: any) {
+        this._active = 0; // stop() with no id collapses all instances
+        return this;
+      }),
+
+      volume: vi.fn(function (this: any, vol?: number) {
+        if (vol !== undefined) { this._volume = vol; return this; }
+        return this._volume;
+      }),
+
+      fade: vi.fn(function (this: any, _from: number, to: number, duration: number) {
+        setTimeout(() => { this._volume = to; }, duration / 10);
+        return this;
+      }),
+
+      seek: vi.fn(function (this: any) { return 0; }),
+      unload: vi.fn(function (this: any) { this._state = 'unloaded'; this._active = 0; return this; }),
+      once: vi.fn(function (this: any) { return this; }),
+    };
+    return instance;
+  });
+
+  return {
+    Howl: mockHowl,
+    Howler: {
+      ctx: { state: 'running', resume: vi.fn().mockResolvedValue(undefined), suspend: vi.fn() },
+    },
+  };
+});
+
+vi.mock('@/utils/logger', () => ({
+  __esModule: true,
+  default: { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/audio/audioLoader', async () => {
+  const { Howl } = await import('howler');
+  return {
+    createLazyHowl: vi.fn((src: string | string[], options?: any) =>
+      Howl({ src: Array.isArray(src) ? src : [src], preload: false, html5: true, ...options }),
+    ),
+    preloadAudioOnDemand: vi.fn(() => Promise.resolve()),
+    ensureHowl: vi.fn().mockResolvedValue(vi.fn()),
+  };
+});
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function getBlastHowl(): any {
+  const HowlCtor = Howl as MockedClass<typeof Howl>;
+  return HowlCtor.mock.results.find(
+    (r) => r.type === 'return' && (r.value as any)?._options?.src?.[0] === '/music/blast_mode.mp3',
+  )?.value;
+}
+
+describe('MusicContext — Blast wave-transition has no duplicate BGM instances', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(document, 'hasFocus', { writable: true, value: vi.fn(() => true) });
+    Object.defineProperty(document, 'visibilityState', { writable: true, value: 'visible' });
+  });
+
+  it('never stacks two concurrent blast instances across an unmount→remount cycle', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <MusicProvider>{children}</MusicProvider>
+    );
+    const { result } = renderHook(() => useMusic(), { wrapper });
+
+    act(() => {
+      result.current.unlockAudio();
+      result.current.setVolume(0.5);
+    });
+
+    // Wave 1 mount: start blast BGM. Small fades so isTransitioning clears fast.
+    await act(async () => {
+      result.current.fadeToTrack(result.current.TRACKS.BLAST, 100, 100);
+      await wait(200);
+    });
+
+    const blast = getBlastHowl();
+    expect(blast).toBeDefined();
+    expect(blast.playing()).toBe(true);
+    expect(blast._maxActive).toBe(1);
+
+    // Wave 1 → wave 2 transition: BlastGame unmounts (stopMusic) then the new
+    // BlastGame mounts (fadeToTrack BLAST) BEFORE stopMusic's deferred stop fires.
+    await act(async () => {
+      result.current.stopMusic(); // default 1000ms deferred stop
+      result.current.fadeToTrack(result.current.TRACKS.BLAST, 100, 100);
+      await wait(200); // still well within the 1000ms deferred-stop window
+    });
+
+    // INVARIANT: re-entering blast must collapse to a single instance, never echo.
+    expect(blast._maxActive).toBe(1);
+    expect(blast.playing()).toBe(true);
+
+    // The stale deferred stop from stopMusic must NOT silence the new instance.
+    await act(async () => { await wait(1100); });
+    expect(blast.playing()).toBe(true);
+  });
+});


### PR DESCRIPTION
Blast Mode remounts <BlastGame> on every wave transition; mount calls
fadeToTrack(BLAST), unmount calls stopMusic(). stopMusic() nulled
currentHowlRef/currentTrackRef synchronously but deferred the real
howl.stop() ~1s via an untracked setTimeout. The next mount's
fadeToTrack(BLAST) then found currentTrackRef === null, bypassed its
de-dup guard, and called play() on the still-playing cached blast Howl —
Howler spawns a second concurrent sound. Instances stacked per wave
(echo) and the silent zombie loops became audible on any volume/mute
change, driving the CPU/memory climb that froze the game.

Fix: enforce a single instance per Howl. Track deferred fade-out stops
by track so they can be cancelled, and before (re)starting a track in
fadeToTrack, cancel its pending stop and stop() it first so play() always
lands on a clean Howl. stopMusic() now uses the same tracked stops.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ApqZwAFAZoNiR6kfa83ueu