### PR TITLE
fix(education): restore anon INSERT on teacher access requests + seed Anthony Rettig

### DIFF
--- a/docs/nightly/triage-queue.md
+++ b/docs/nightly/triage-queue.md
@@ -694,8 +694,8 @@ Both `exp-mp-quickplay-wait-v1` and `exp-invite-arrival-clarity-v1` were wired o
 
 - [Supabase] RLS always-true INSERT on `teacher_access_requests`
   - first/last seen: advisor (ongoing)
-  - status: shipped (migration `fix_teacher_access_requests_insert_rls`)
-  - why: `tar_insert_any` WITH CHECK=true allowed anon inserts (spam vector); replaced with `auth.uid() IS NOT NULL`
+  - status: REVERTED — do NOT auth-gate this INSERT (migration `20260617120000_restore_teacher_access_anon_insert`)
+  - why: the 2026-06-14 "fix" (`fix_teacher_access_requests_insert_rls`, replaced WITH CHECK=true with `auth.uid() IS NOT NULL`) BROKE the public apply form. Prospective teachers submit /education/access while signed OUT (they have no account yet), so requiring auth.uid() made every submission fail RLS → 500 → "Something went wrong" in the UI. always-true INSERT here is an ACCEPTED exception (same class as web_vitals anon telemetry); spam is mitigated at the app layer (route rate limit + future captcha), not by gating a public form behind a login it cannot have. Encoded in `lib/education/__tests__/rls.test.ts` ("anon CAN insert"). Advisor will keep flagging — leave as-is.
   - recommended owner: review-by-eod
 
 - [Sentry] TypeError: null.clear in WordWheelPixiRing (JAVASCRIPT-NEXTJS-1CW)

--- a/fe-next/supabase/migrations/20260617120000_restore_teacher_access_anon_insert.sql
+++ b/fe-next/supabase/migrations/20260617120000_restore_teacher_access_anon_insert.sql
@@ -1,0 +1,44 @@
+-- =============================================
+-- FIX: restore anonymous INSERT on teacher_access_requests.
+-- Migration: 20260617120000_restore_teacher_access_anon_insert
+--
+-- WHAT BROKE
+-- The public "Apply for free teacher access" form (/education/access ->
+-- POST /api/education/access-request) is submitted by prospective teachers who
+-- are NOT signed in — the whole point of the gate is that they apply BEFORE
+-- having an account. The original schema (20260609120000) correctly modelled
+-- this with:
+--     CREATE POLICY tar_insert_any ON public.teacher_access_requests
+--       FOR INSERT WITH CHECK (true);
+--
+-- On 2026-06-14 a nightly Supabase-advisor triage lane treated the always-true
+-- INSERT as a spam vector and shipped (ad-hoc, via the Supabase MCP — never as a
+-- committed migration) `fix_teacher_access_requests_insert_rls`, which DROPPED
+-- tar_insert_any and created `tar_insert_authenticated` WITH CHECK
+-- (auth.uid() IS NOT NULL). 20260615030000 then rewrote it to
+-- WITH CHECK ((select auth.uid()) IS NOT NULL).
+--
+-- Effect: anonymous applicants can no longer INSERT, so the apply form's insert
+-- fails under RLS, the route returns 500 ("insert failed: ..."), and the UI
+-- shows the generic "Something went wrong" submit error. Reported by an
+-- applicant (Anthony Rettig, anthony.r.rettig@mcpsmd.net) who could not submit.
+--
+-- THE FIX
+-- A public apply form is anonymous BY DESIGN, so the INSERT policy cannot
+-- require auth — restoring WITH CHECK (true) is the correct model, matching the
+-- committed RLS test (lib/education/__tests__/rls.test.ts: "anon CAN insert").
+-- This is an accepted always-true-INSERT exception, same class as web_vitals
+-- anonymous telemetry; spam is mitigated at the application layer (the route's
+-- per-email rate limit + future captcha), not by gating the public form behind
+-- a login it cannot have. Idempotent: safe no-op where already correct.
+-- =============================================
+
+-- Remove the auth-gated policy shipped by the spam triage (both historical
+-- names, in case either is the one present in a given environment).
+DROP POLICY IF EXISTS tar_insert_authenticated ON public.teacher_access_requests;
+DROP POLICY IF EXISTS tar_insert_any ON public.teacher_access_requests;
+
+-- Restore the public apply-form INSERT: anyone may submit a request.
+CREATE POLICY tar_insert_any
+  ON public.teacher_access_requests FOR INSERT
+  WITH CHECK (true);

--- a/fe-next/supabase/migrations/20260617120100_seed_teacher_access_anthony_rettig.sql
+++ b/fe-next/supabase/migrations/20260617120100_seed_teacher_access_anthony_rettig.sql
@@ -1,0 +1,42 @@
+-- =============================================
+-- SEED: pending teacher-access request for Anthony Rettig.
+-- Migration: 20260617120100_seed_teacher_access_anthony_rettig
+--
+-- WHY
+-- This applicant hit the "Something went wrong" submit error caused by the
+-- broken anon-INSERT RLS policy (fixed in 20260617120000), so their request
+-- never landed in the table and never reached the admin queue. This backfills
+-- the request they tried to submit so an admin can approve it in the dashboard
+-- at /admin/teacher-access. user_id is NULL (anonymous applicant), so the
+-- approve route writes their email to teacher_access_allowlist; the role
+-- upgrade then happens via the post-signup consume bridge when they sign up
+-- with this email.
+--
+-- Values transcribed from the applicant's submission:
+--   name:    Anthony Rettig
+--   email:   anthony.r.rettig@mcpsmd.net
+--   role:    teacher
+--   school:  Baker Middle School
+--   country: United States
+--   use:     Site Word Builder
+--
+-- Idempotent: only inserts if no row for this email already exists, so re-runs
+-- (or a later real submission via the now-fixed form) will not create a dup.
+-- =============================================
+
+INSERT INTO public.teacher_access_requests
+  (user_id, email, full_name, school_or_org, country, role, locale, use_case, status)
+SELECT
+  NULL,
+  'anthony.r.rettig@mcpsmd.net',
+  'Anthony Rettig',
+  'Baker Middle School',
+  'United States',
+  'teacher',
+  'en',
+  'Site Word Builder',
+  'pending'
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.teacher_access_requests
+  WHERE email = 'anthony.r.rettig@mcpsmd.net'
+);


### PR DESCRIPTION
The public "Apply for free teacher access" form is submitted by prospective
teachers who are signed OUT (they have no account yet). The original schema
modelled this with an always-true INSERT policy, but a 2026-06-14 advisor-triage
"fix" (fix_teacher_access_requests_insert_rls) auth-gated it
(WITH CHECK auth.uid() IS NOT NULL), so every anonymous submission began failing
RLS -> route 500 -> "Something went wrong" in the UI.

- 20260617120000: revert to WITH CHECK (true) for the public apply form; this is
  an accepted always-true-INSERT exception (spam handled at the app layer), and
  matches the committed RLS test ("anon CAN insert").
- 20260617120100: backfill the pending request for the applicant who hit the
  error (Anthony Rettig, anthony.r.rettig@mcpsmd.net) so it appears in the admin
  queue and can be approved (idempotent, user_id NULL -> allowlist on approve).
- triage-queue: mark the auth-gating as REVERTED so the nightly lane stops
  re-applying it.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UxVd7aSxzzgJxaDdbCJoU2