### PR TITLE
SEO: daily meta tag improvements (2026-06-18)

### DIFF
--- a/docs/seo-daily/2026-06-18.md
+++ b/docs/seo-daily/2026-06-18.md
@@ -1,0 +1,156 @@
+# SEO Daily Report — 2026-06-18
+
+Data window: 2026-05-20 → 2026-06-16 (28 days, GSC 2-day lag applied)
+
+---
+
+## Headline Metrics
+
+### Google Search Console
+
+| Metric | 28-day total |
+|---|---|
+| Total clicks | 189 |
+| Total impressions | 29,600 |
+| Avg CTR | 0.64% |
+| Avg position | 6.6 |
+| Unique queries | 617 |
+| Unique pages | 338 |
+
+> 7d-vs-prior-7d delta: Not computable — GSC data returned as 28-day rollup only (no daily dimension available in this pull). See tomorrow's run for trend data.
+
+### Bing
+
+Bing API blocked by network egress policy (`ssl.bing.com` not allowlisted). Bing section skipped. Add `ssl.bing.com` to the environment's outbound allowlist to enable.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+All top-10 opportunities point to two pages. Fixing either page = fixing multiple queries at once.
+
+| # | Query | Page | Pos | Impr | CTR | Exp CTR | Gap | Fix |
+|---|---|---|---|---|---|---|---|---|
+| 1 | scrabble online | /es/juego-de-palabras-multijugador | 5.4 | 8,512 | 0.35% | 4.0% | −3.65pp | Title + desc → **DONE in this PR** |
+| 2 | scrabble online español | /es/juego-de-palabras-multijugador | 6.6 | 2,502 | 0.36% | 3.0% | −2.64pp | Same page → **DONE in this PR** |
+| 3 | scrabble online gratis | /es/juego-de-palabras-multijugador | 7.3 | 2,289 | 0.17% | 2.5% | −2.33pp | Same page → **DONE in this PR** |
+| 4 | scrabble en linea | /es/juego-de-palabras-multijugador | 6.4 | 2,111 | 0.24% | 3.0% | −2.76pp | Same page → **DONE in this PR** |
+| 5 | scrabble en español online | /es/juego-de-palabras-multijugador | 6.1 | 1,120 | 0.45% | 3.0% | −2.55pp | Same page → **DONE in this PR** |
+| 6 | scrabble juego online | /es/juego-de-palabras-multijugador | 5.5 | 904 | 0.33% | 4.0% | −3.67pp | Same page → **DONE in this PR** |
+| 7 | scrabble (en español) - juega gratis en línea | /es/juego-de-palabras-multijugador | 7.3 | 904 | 0.22% | 2.5% | −2.28pp | Same page → **DONE in this PR** |
+| 8 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 5.8 | 896 | 0.67% | 4.0% | −3.33pp | Same page → **DONE in this PR** |
+| 9 | scrabble svenska | /sv/swedish-multiplayer-word-game | 7.1 | 653 | 0.15% | 2.5% | −2.35pp | Title + desc → **DONE in this PR** |
+| 10 | jugar scrabble online | /es/juego-de-palabras-multijugador | 7.1 | 609 | 0.00% | 2.5% | −2.50pp | Same page → **DONE in this PR** |
+
+**Conservative click uplift estimate (25% gap close, top 10):** +158 clicks/28d vs current 189 — an ~84% increase.
+
+**Root cause of low CTR:** Multiple queries show 0.00% CTR at positions 5–8. Likely compounded by:
+1. Title was 79 chars (truncated by Google, losing key differentiators)
+2. Description was 172 chars (truncated mid-sentence, poor visual close)
+3. "LexiClash" brand unknown to Spanish Scrabble searchers — user intent mismatch signal
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+Only 2 queries qualify (pos 8–20, ≥50 impressions). Both point to the Hebrew daily page.
+
+| # | Query | Page | Pos | Impr | CTR | Suggested action |
+|---|---|---|---|---|---|---|
+| 1 | המילה היומית | /he/daily | 8.2 | 350 | 0.00% | Add FAQPage schema; add H2 with exact phrase "המילה היומית"; internal links from blog posts |
+| 2 | מילת היום | /he/daily | 8.9 | 195 | 0.00% | Same page — H2 with "מילת היום" + schema covers both queries |
+
+The Hebrew daily page is just off page 1. One content+schema pass could push both queries onto page 1 (worth ~60 clicks/28d at position ≤5).
+
+---
+
+## Bing Parity Gaps
+
+Skipped — Bing API unreachable (network egress policy). Enable `ssl.bing.com` egress to re-enable.
+
+---
+
+## GEO / AI Visibility Recommendations
+
+Top AI-generated queries observed in GSC (structured persona queries from Google SGE/AI Overviews):
+
+| Query (truncated) | Impr | Pos | Action |
+|---|---|---|---|
+| "…what are the most popular word-based games people play online?" | 25 | 2.2 | Already ranking well — add FAQPage schema to surfaced page to lock in AI citation |
+| "…what are the best free word games you can play in a browser right now?" | 20 | 1.9 | Same — FAQPage with clear Q&A pairs |
+| "…which browser word games are best for building vocabulary over time?" | 16 | 2.6 | Same |
+| best word games 2026 | 12 | 5.4 | Needs explicit answer paragraph: "The best free browser word game in 2026 is…" |
+
+**FAQPage schema candidates (Hebrew daily page — rank-up support):**
+
+```json
+{
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "מה זה המילה היומית?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "המילה היומית של LexiClash היא פאזל מילים יומי חינמי שמשחקים כולם בעולם על אותו לוח. כל יום בחצות מתחלפת המילה."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "איך משחקים במילת היום?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "מוצאים מילים בלוח האותיות, צוברים נקודות ומשתפים תוצאות. המשחק חינמי וללא צורך בהרשמה."
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Meta Tag Changes — This PR
+
+### 1. Spanish multiplayer page (`/es/juego-de-palabras-multijugador`)
+
+**Title**
+
+| | Value | Chars |
+|---|---|---|
+| Before | `Jugar Scrabble en Español Online Gratis — Multijugador Tiempo Real \| LexiClash` | 79 ❌ |
+| After | `Jugar Scrabble Online en Español Gratis \| LexiClash` | 51 ✓ |
+
+**Description**
+
+| | Value | Chars |
+|---|---|---|
+| Before | `Jugar scrabble en español online gratis con amigos en tiempo real — no por turnos. Sin registro, sin descarga. Hasta 50 jugadores. Crea sala en segundos, invita por enlace.` | 172 ❌ |
+| After | `Juega scrabble en español gratis — tiempo real, sin turnos. Crea sala en 10 s, invita con enlace. Sin registro, sin descarga. ¡Hasta 50 jugadores!` | 146 ✓ |
+
+Rationale: Title was being truncated at ~60 chars by Google, cutting off key differentiators. New title leads with action verb "Jugar" matching search intent, fits within 60 chars. Description trimmed below 155 chars so it renders complete in SERPs.
+
+### 2. Swedish multiplayer page (`/sv/swedish-multiplayer-word-game`)
+
+**Title**
+
+| | Value | Chars |
+|---|---|---|
+| Before | `Scrabble Online Svenska Gratis — Spela Multiplayer \| LexiClash` | 62 ❌ |
+| After | `Spela Scrabble Online på Svenska Gratis \| LexiClash` | 51 ✓ |
+
+**Description**
+
+| | Value | Chars |
+|---|---|---|
+| Before | `Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk, tävla direkt. Gratis, ingen app, ingen registrering.` | 135 ✓ |
+| After | `Spela scrabble svenska gratis i realtid — inte tur för tur. Bjud in vänner med länk, starta direkt. Ingen nedladdning, ingen registrering.` | 139 ✓ |
+
+Rationale: Title was 62 chars (2 over limit). New title leads with "Spela" (play) to match action intent, includes exact phrase "scrabble svenska" (top query, 653 impr). Description now opens with the exact query phrase.
+
+---
+
+## Today's Actions
+
+1. **PR opened** — meta tag fixes for Spanish and Swedish multiplayer pages. Both titles were over 60 chars and descriptions over 155 chars causing Google to truncate them in SERPs, suppressing CTR. Conservative +158 clicks/28d uplift if 25% of the gap is recovered.
+2. **Next session priority** — add FAQPage schema to `/he/daily` to push "המילה היומית" (350 impr, pos 8.2) and "מילת היום" (195 impr, pos 8.9) onto page 1. No body rewrite needed — schema addition only.
+3. **Infrastructure** — enable `ssl.bing.com` in network egress policy to unblock Bing Webmaster API for parity analysis.

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,11 +27,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Jugar Scrabble en Español Online Gratis — Multijugador Tiempo Real | LexiClash',
-    description: 'Jugar scrabble en español online gratis con amigos en tiempo real — no por turnos. Sin registro, sin descarga. Hasta 50 jugadores. Crea sala en segundos, invita por enlace.',
+    title: 'Jugar Scrabble Online en Español Gratis | LexiClash',
+    description: 'Juega scrabble en español gratis — tiempo real, sin turnos. Crea sala en 10 s, invita con enlace. Sin registro, sin descarga. ¡Hasta 50 jugadores!',
     keywords: 'jugar scrabble en español online gratis, scrabble en español online gratis, scrabble online español, cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Jugar Scrabble en Español Online Gratis — Tiempo Real | LexiClash',
+      title: 'Jugar Scrabble Online en Español Gratis | LexiClash',
       description: 'Jugar scrabble en español online gratis — no por turnos. Crea sala, invita por enlace. 100% gratis, sin descargas.',
       locale: 'es_ES',
       type: 'website',
@@ -47,7 +47,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Gratis en Español — Multijugador en Tiempo Real | LexiClash',
+      title: 'Jugar Scrabble Online en Español Gratis | LexiClash',
       description: 'Juega scrabble online en tiempo real — no por turnos. Sala con enlace, sin registro. ¡Hasta 50 jugadores!',
       images: [`${BASE_URL}/og-image-es-multiplayer.webp`],
     },

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -16,11 +16,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
-    description: 'Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk, tävla direkt. Gratis, ingen app, ingen registrering.',
+    title: 'Spela Scrabble Online på Svenska Gratis | LexiClash',
+    description: 'Spela scrabble svenska gratis i realtid — inte tur för tur. Bjud in vänner med länk, starta direkt. Ingen nedladdning, ingen registrering.',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Spela Scrabble Online på Svenska Gratis | LexiClash',
       description: 'Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk. Gratis, ingen registrering.',
       locale: 'sv_SE',
       type: 'website',
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash',
+      title: 'Spela Scrabble Online på Svenska Gratis | LexiClash',
       description: 'Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk, tävla direkt. Gratis.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },


### PR DESCRIPTION
## Summary

Fixes over-length meta titles and descriptions on the two highest-traffic landing pages, where SERP truncation is suppressing CTR across 10+ queries with 29k combined impressions/28d.

| File | Query (top) | Impr | CTR now | CTR expected | Problem |
|---|---|---|---|---|---|
| `/es/juego-de-palabras-multijugador/page.tsx` | scrabble online | 8,512 | 0.35% | 4.0% | Title was **79 chars** (truncated), desc **172 chars** (truncated mid-sentence) |
| `/sv/swedish-multiplayer-word-game/page.tsx` | scrabble svenska | 653 | 0.15% | 2.5% | Title was **62 chars** (2 over limit) |

## Changes

### Spanish page (`/es/juego-de-palabras-multijugador`)

**Title**
- Before: `Jugar Scrabble en Español Online Gratis — Multijugador Tiempo Real | LexiClash` (79 chars ❌)
- After: `Jugar Scrabble Online en Español Gratis | LexiClash` (51 chars ✓)

**Description**
- Before: `Jugar scrabble en español online gratis con amigos en tiempo real — no por turnos. Sin registro, sin descarga. Hasta 50 jugadores. Crea sala en segundos, invita por enlace.` (172 chars ❌)
- After: `Juega scrabble en español gratis — tiempo real, sin turnos. Crea sala en 10 s, invita con enlace. Sin registro, sin descarga. ¡Hasta 50 jugadores!` (146 chars ✓)

Expected CTR uplift: if 25% of the gap closes → **+~140 clicks/28d** on this page alone (currently gets ~30 clicks from 16k impressions on Scrabble queries).

### Swedish page (`/sv/swedish-multiplayer-word-game`)

**Title**
- Before: `Scrabble Online Svenska Gratis — Spela Multiplayer | LexiClash` (62 chars ❌)
- After: `Spela Scrabble Online på Svenska Gratis | LexiClash` (51 chars ✓)

**Description**
- Before: `Scrabble på svenska i realtid — inte tur och ordning. Skapa rum, bjud in med länk, tävla direkt. Gratis, ingen app, ingen registrering.` (135 chars ✓ — kept but improved)
- After: `Spela scrabble svenska gratis i realtid — inte tur för tur. Bjud in vänner med länk, starta direkt. Ingen nedladdning, ingen registrering.` (139 chars ✓)

Expected CTR uplift: if 25% of gap closes → **+~18 clicks/28d**.

## What's NOT in this PR (next steps)

- `/he/daily` — "המילה היומית" (350 impr, pos 8.2) and "מילת היום" (195 impr, pos 8.9) just off page 1. Needs FAQPage schema addition + H2 with exact phrases. Body content change — out of scope for meta-only PR.
- Bing parity analysis — blocked by network egress (`ssl.bing.com` not allowlisted).

Full analysis: `docs/seo-daily/2026-06-18.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDADkrFJESxshgC6Pvuttj)_