### PR TITLE
feat(seo): reciprocal cross-links across multiplayer/free word-game landings

### DIFF
--- a/fe-next/app/[locale]/__tests__/landingHub.crosslink.test.tsx
+++ b/fe-next/app/[locale]/__tests__/landingHub.crosslink.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import MultiplayerOnline from '../multiplayer-word-game-online/page';
+import WordGamesFree from '../word-games-online-free/page';
+import WithFriends from '../online-word-games-with-friends/page';
+
+// The "multiplayer / free word game" landing pages each carry substantive, differentiated
+// content. To read as an INTENTIONAL content hub (not isolated SEO doorways), each must
+// reciprocally cross-link the other two siblings. (AdSense "low value content" recovery —
+// docs/2026-06-04-adsense-approval-plan.md: additive internal linking, not page removal.)
+
+const SIBLINGS = {
+  multiplayerOnline: 'multiplayer-word-game-online',
+  wordGamesFree: 'word-games-online-free',
+  withFriends: 'online-word-games-with-friends',
+} as const;
+
+async function hrefsOf(Page: (p: { params: Promise<{ locale: string }> }) => Promise<React.ReactElement>) {
+  const { container } = render(await Page({ params: Promise.resolve({ locale: 'en' }) }));
+  return Array.from(container.querySelectorAll('a')).map((a) => a.getAttribute('href') || '');
+}
+
+describe('multiplayer/free-word-game landing hub — reciprocal cross-linking', () => {
+  it('multiplayer-word-game-online links to both siblings', async () => {
+    const hrefs = await hrefsOf(MultiplayerOnline);
+    expect(hrefs.some((h) => h.includes(SIBLINGS.wordGamesFree))).toBe(true);
+    expect(hrefs.some((h) => h.includes(SIBLINGS.withFriends))).toBe(true);
+  });
+
+  it('word-games-online-free links to both siblings', async () => {
+    const hrefs = await hrefsOf(WordGamesFree);
+    expect(hrefs.some((h) => h.includes(SIBLINGS.multiplayerOnline))).toBe(true);
+    expect(hrefs.some((h) => h.includes(SIBLINGS.withFriends))).toBe(true);
+  });
+
+  it('online-word-games-with-friends links to both siblings', async () => {
+    const hrefs = await hrefsOf(WithFriends);
+    expect(hrefs.some((h) => h.includes(SIBLINGS.multiplayerOnline))).toBe(true);
+    expect(hrefs.some((h) => h.includes(SIBLINGS.wordGamesFree))).toBe(true);
+  });
+});

--- a/fe-next/app/[locale]/multiplayer-word-game-online/page.tsx
+++ b/fe-next/app/[locale]/multiplayer-word-game-online/page.tsx
@@ -218,6 +218,14 @@ export default async function MultiplayerWordGameOnlinePage({ params }: PageProp
               <h3 className="font-bold text-neo-pink">vs Words With Friends</h3>
               <p className="mt-1 text-xs text-neo-gray-200">Real-time, not turn-based</p>
             </Link>
+            <Link href={`/${validLocale}/online-word-games-with-friends`} className="rounded-neo border-3 border-neo-gray-400/40 bg-neo-navy/50 p-4 shadow-hard transition-all hover:border-neo-lime/40">
+              <h3 className="font-bold text-neo-lime">Word Games With Friends</h3>
+              <p className="mt-1 text-xs text-neo-gray-200">Create a room, share the link, play together</p>
+            </Link>
+            <Link href={`/${validLocale}/word-games-online-free`} className="rounded-neo border-3 border-neo-gray-400/40 bg-neo-navy/50 p-4 shadow-hard transition-all hover:border-neo-cyan/40">
+              <h3 className="font-bold text-neo-cyan">Word Games Online Free</h3>
+              <p className="mt-1 text-xs text-neo-gray-200">7+ free modes — no download, no signup</p>
+            </Link>
           </div>
         </section>
 

--- a/fe-next/app/[locale]/online-word-games-with-friends/page.tsx
+++ b/fe-next/app/[locale]/online-word-games-with-friends/page.tsx
@@ -186,6 +186,14 @@ export default async function OnlineWordGamesWithFriendsPage({ params }: PagePro
               <h3 className="font-bold text-neo-pink">Best Word Games 2026</h3>
               <p className="mt-1 text-xs text-neo-gray-200">Complete comparison guide</p>
             </Link>
+            <Link href={`/${locale}/multiplayer-word-game-online`} className="rounded-neo border-3 border-neo-gray-400/40 bg-neo-navy/50 p-4 shadow-hard transition-all hover:border-neo-lime/40">
+              <h3 className="font-bold text-neo-lime">Multiplayer Word Game Online</h3>
+              <p className="mt-1 text-xs text-neo-gray-200">Real-time Scrabble alternative — play live</p>
+            </Link>
+            <Link href={`/${locale}/word-games-online-free`} className="rounded-neo border-3 border-neo-gray-400/40 bg-neo-navy/50 p-4 shadow-hard transition-all hover:border-neo-cyan/40">
+              <h3 className="font-bold text-neo-cyan">Word Games Online Free</h3>
+              <p className="mt-1 text-xs text-neo-gray-200">7+ free modes — no download, no signup</p>
+            </Link>
           </div>
         </section>
 

--- a/fe-next/app/[locale]/word-games-online-free/page.tsx
+++ b/fe-next/app/[locale]/word-games-online-free/page.tsx
@@ -154,6 +154,24 @@ export default async function WordGamesOnlineFreePage({ params }: PageProps) {
         </section>
 
         <section className="mb-12">
+          <h2 className="mb-4 font-neo-display text-2xl font-bold sm:text-3xl">Explore More Word Games</h2>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <Link href={`/${locale}/multiplayer-word-game-online`} className="rounded-neo border-3 border-neo-gray-400/40 bg-neo-navy/50 p-4 shadow-hard transition-all hover:border-neo-lime/40">
+              <h3 className="font-bold text-neo-lime">Multiplayer Word Game Online</h3>
+              <p className="mt-1 text-xs text-neo-gray-200">Real-time Scrabble alternative — play live against friends</p>
+            </Link>
+            <Link href={`/${locale}/online-word-games-with-friends`} className="rounded-neo border-3 border-neo-gray-400/40 bg-neo-navy/50 p-4 shadow-hard transition-all hover:border-neo-cyan/40">
+              <h3 className="font-bold text-neo-cyan">Word Games With Friends</h3>
+              <p className="mt-1 text-xs text-neo-gray-200">Create a room, share the link, play together</p>
+            </Link>
+            <Link href={`/${locale}/play-boggle-online-free`} className="rounded-neo border-3 border-neo-gray-400/40 bg-neo-navy/50 p-4 shadow-hard transition-all hover:border-neo-pink/40">
+              <h3 className="font-bold text-neo-pink">Play Boggle Free</h3>
+              <p className="mt-1 text-xs text-neo-gray-200">No download, instant browser play</p>
+            </Link>
+          </div>
+        </section>
+
+        <section className="mb-12">
           <h2 className="font-neo-display text-2xl font-bold sm:text-3xl">Start Playing Free Word Games Now</h2>
           <p className="mt-4 text-neo-gray-200">
             No more searching for word games online free — LexiClash has everything. Multiplayer word battles,


### PR DESCRIPTION
The "multiplayer word game" landing pages each carry substantive, differentiated
content but weren't fully cross-linked — word-games-online-free had no related
section, and the other two didn't link their siblings. Adding reciprocal internal
links makes the cluster read as an intentional content hub rather than isolated
SEO doorways, supporting the AdSense "low value content" recovery
(docs/2026-06-04-adsense-approval-plan.md — additive linking, not page removal).

TDD: app/[locale]/__tests__/landingHub.crosslink.test.tsx asserts each of the
three siblings links to the other two. lint0 / tsc0.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018CnbZEqd91n9LMS13zJF83