### PR TITLE
feat(word-tower): declutter notifications, slim wheel + deck, daily letters

### DIFF
--- a/fe-next/components/wordTower/WordTowerGame.tsx
+++ b/fe-next/components/wordTower/WordTowerGame.tsx
@@ -74,7 +74,12 @@ export function WordTowerGame() {
       return () => { cancelled = true; };
     }
 
-    const opts = { gameCode: 'solo', playerId: 'solo', language };
+    // Day-seeded wheel: the gameCode carries the UTC date so the letter ring is
+    // FRESH every calendar day (a new set of letters daily, NYT-Spelling-Bee
+    // style) while the endless climb itself persists across days. Stable within
+    // the day, so reloads keep the same letters. (Step toward folding the daily
+    // letter set into the broader daily-challenges flow.)
+    const opts = { gameCode: `solo-${utcDateKey()}`, playerId: 'solo', language };
     fetch('/api/word-tower/progress')
       .then((r) => (r.ok ? r.json() : Promise.resolve({ progress: null })))
       .then((d) => {

--- a/fe-next/components/wordTower/WordTowerHud.test.tsx
+++ b/fe-next/components/wordTower/WordTowerHud.test.tsx
@@ -1,27 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, act, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { WordTowerHud, type WordTowerHudProps } from './WordTowerHud';
 
 // jsdom lacks ResizeObserver (the deck-height effect needs it).
 beforeEach(() => {
   vi.stubGlobal('ResizeObserver', class { observe() {} unobserve() {} disconnect() {} });
-  vi.useFakeTimers();
 });
-afterEach(() => { vi.useRealTimers(); cleanup(); vi.unstubAllGlobals(); });
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
 
 const baseProps = (over: Partial<WordTowerHudProps> = {}): WordTowerHudProps => ({
-  anchorLetter: 'A',
-  tray: ['B', 'C', 'D'],
+  anchorLetter: '',
+  tray: ['C', 'A', 'T', 'S'],
   selected: [],
   word: '',
   heightM: 12,
-  personalBestM: 0,
   combo: 1,
   scramblesLeft: 3,
-  floorsCount: 4,
   possibleWords: null,
   clueWord: null,
-  biomeId: 'city',
   lastError: null,
   errorKey: 0,
   lastResult: null,
@@ -36,30 +32,31 @@ const baseProps = (over: Partial<WordTowerHudProps> = {}): WordTowerHudProps => 
   ...over,
 });
 
-describe('WordTowerHud reward popup', () => {
-  it('stays hidden before any word is built (resultKey 0)', () => {
+describe('WordTowerHud deck', () => {
+  it('renders the tray tools (scramble + backspace)', () => {
     render(<WordTowerHud {...baseProps()} />);
-    expect(screen.queryByText(/\+.*m/)).toBeNull();
+    expect(screen.getByLabelText('wordTower.hud.scramble')).toBeTruthy();
+    expect(screen.getByLabelText('wordTower.hud.backspace')).toBeTruthy();
   });
 
-  it('shows the reward on an accepted word, then auto-hides (no longer "always visible")', () => {
-    const props = baseProps({ resultKey: 1, lastResult: { tier: 'tall', meters: 5, accepted: true } as never });
-    render(<WordTowerHud {...props} />);
-    act(() => { vi.advanceTimersByTime(10); });
-    expect(screen.getByText(/\+5\.0\s*m/)).toBeTruthy();
-    // It must NOT linger forever — the bug was it stayed on screen between words.
-    act(() => { vi.advanceTimersByTime(3000); });
-    expect(screen.queryByText(/\+5\.0\s*m/)).toBeNull();
+  it('keeps the BUILD action OUT of the bottom deck while no word is spelled', () => {
+    // The redundant bottom BUILD button was removed — building now lives in the
+    // wheel centre, which only surfaces a build control once a word is ready.
+    render(<WordTowerHud {...baseProps({ word: '', selected: [] })} />);
+    expect(screen.queryByLabelText('wordTower.hud.build')).toBeNull();
   });
 
-  it('reappears when the next word is built (fresh resultKey re-reveals)', () => {
-    const { rerender } = render(
-      <WordTowerHud {...baseProps({ resultKey: 1, lastResult: { tier: 'none', meters: 3, accepted: true } as never })} />,
-    );
-    act(() => { vi.advanceTimersByTime(3000); });
-    expect(screen.queryByText(/\+3\.0\s*m/)).toBeNull();
-    rerender(<WordTowerHud {...baseProps({ resultKey: 2, lastResult: { tier: 'none', meters: 7, accepted: true } as never })} />);
-    act(() => { vi.advanceTimersByTime(10); });
-    expect(screen.getByText(/\+7\.0\s*m/)).toBeTruthy();
+  it('surfaces the BUILD control (in the wheel centre) once a 3+ letter word is spelled', () => {
+    const onSubmit = vi.fn();
+    render(<WordTowerHud {...baseProps({ word: 'CAT', selected: [0, 1, 2], onSubmit })} />);
+    const build = screen.getByLabelText('wordTower.hud.build');
+    expect(build).toBeTruthy();
+    fireEvent.click(build);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the error line on a rejected word', () => {
+    render(<WordTowerHud {...baseProps({ lastError: 'not_in_dictionary', errorKey: 1 })} />);
+    expect(screen.getByText('wordTower.error.not_in_dictionary')).toBeTruthy();
   });
 });

--- a/fe-next/components/wordTower/WordTowerHud.tsx
+++ b/fe-next/components/wordTower/WordTowerHud.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Delete, Shuffle, ArrowUp, Lightbulb, ChevronDown, ChevronUp, RotateCw, ChevronsDown } from 'lucide-react';
+import { Delete, Shuffle, Lightbulb, ChevronDown, ChevronUp, RotateCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { type ApplyResult, type ValidationError } from '@/lib/wordTower/wordTowerManager';
 import { WordTowerWheel } from './WordTowerWheel';
@@ -130,12 +130,12 @@ export function WordTowerHud(props: WordTowerHudProps) {
       <div
         ref={deckRef}
         className={cn(
-          'pointer-events-auto space-y-1.5 rounded-t-neo border-t-neo-thick border-black px-4 pt-1 shadow-[0_-3px_0_rgba(0,0,0,0.5)] backdrop-blur-md transition-colors duration-200',
+          'pointer-events-auto space-y-1 rounded-t-neo border-t-neo-thick border-black px-4 pt-0.5 shadow-[0_-3px_0_rgba(0,0,0,0.5)] backdrop-blur-md transition-colors duration-200',
           isPlacing
             ? 'bg-gradient-to-b from-neo-lime/15 via-neo-navy/95 to-neo-navy/95'
             : 'bg-neo-navy/95',
           deckOpen
-            ? 'pb-[calc(env(safe-area-inset-bottom)+0.85rem)]'
+            ? 'pb-[calc(env(safe-area-inset-bottom)+0.55rem)]'
             : 'pb-[calc(env(safe-area-inset-bottom)+0.4rem)]',
         )}
       >
@@ -219,8 +219,11 @@ export function WordTowerHud(props: WordTowerHudProps) {
           />
         </div>
 
-        {/* Actions */}
-        <div className="mx-auto flex max-w-md items-center gap-2">
+        {/* Actions — only the two tray TOOLS live here now. The BUILD / DROP CTA
+            moved INTO the wheel's centre hub (build a word → tap the centre to
+            lift it → tap again to drop), so the redundant bottom build button is
+            gone and the deck is shorter. Disabled while a word is in flight. */}
+        <div className="mx-auto flex max-w-md items-center justify-center gap-3">
           <button
             type="button"
             onClick={onScramble}
@@ -240,34 +243,6 @@ export function WordTowerHud(props: WordTowerHudProps) {
           >
             <Delete className="h-5 w-5" />
           </button>
-          {/* Primary CTA — Build flips to Drop in-place when a word is in flight */}
-          {isPlacing ? (
-            <button
-              type="button"
-              onClick={onCraneDrop}
-              aria-label={t('wordTower.crane.tapToDrop')}
-              className="relative flex flex-1 items-center justify-center gap-2 overflow-hidden rounded-neo border-neo-thick border-black bg-gradient-to-b from-neo-lime-light to-neo-lime py-3 font-neo-display text-lg font-black uppercase tracking-wide text-black shadow-hard animate-neo-pop active:translate-y-0.5 active:shadow-hard-pressed"
-            >
-              <ChevronsDown className="h-5 w-5 animate-bounce" />
-              {t('wordTower.crane.tapToDrop')}
-              <ChevronsDown className="h-5 w-5 animate-bounce" />
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={onSubmit}
-              disabled={!canSubmit}
-              className={cn(
-                'flex flex-1 items-center justify-center gap-2 rounded-neo border-neo-thick border-black py-2.5 font-neo-display text-lg font-bold text-black shadow-hard disabled:opacity-40 active:translate-y-0.5 active:shadow-hard-pressed',
-                canSubmit
-                  ? 'bg-gradient-to-b from-neo-cyan-light to-neo-cyan ring-2 ring-neo-cyan/40 ring-offset-2 ring-offset-neo-navy'
-                  : 'bg-neo-cyan',
-              )}
-            >
-              <ArrowUp className="h-5 w-5" />
-              {t('wordTower.hud.build')}
-            </button>
-          )}
         </div>
         </div>
         )}

--- a/fe-next/components/wordTower/WordTowerNextRivalChip.tsx
+++ b/fe-next/components/wordTower/WordTowerNextRivalChip.tsx
@@ -1,8 +1,14 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { ChevronUp } from 'lucide-react';
 import Avatar from '@/components/Avatar';
 import { nearestRivalAbove, type RivalMarker } from '@/lib/wordTower/rivals';
+
+/** How long the chase chip stays up after a new target appears before it
+ *  auto-hides — long enough to register the goal, short enough that it never
+ *  "sticks" permanently on screen. */
+const CHASE_CHIP_MS = 6000;
 
 interface Props {
   rivals: RivalMarker[];
@@ -22,7 +28,21 @@ interface Props {
  */
 export function WordTowerNextRivalChip({ rivals, viewerHeightM, reducedMotion, t, dir }: Props) {
   const target = nearestRivalAbove(viewerHeightM, rivals);
-  if (!target) return null;
+  const targetId = target?.id ?? null;
+
+  // Flash the chase goal when the target CHANGES (you climb past one → the next
+  // becomes the goal), then auto-hide. Keyed on the target id so it re-appears
+  // for each new rival but never lingers indefinitely — the founder's "these
+  // notifications stay stuck" fix.
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    if (targetId == null) return;
+    setVisible(true);
+    const id = setTimeout(() => setVisible(false), CHASE_CHIP_MS);
+    return () => clearTimeout(id);
+  }, [targetId]);
+
+  if (!target || !visible) return null;
 
   return (
     <div

--- a/fe-next/components/wordTower/WordTowerPlay.tsx
+++ b/fe-next/components/wordTower/WordTowerPlay.tsx
@@ -62,6 +62,11 @@ import { WordTowerStatHud } from './WordTowerStatHud';
 import { getTowerArchitectTier } from '@/lib/wordTower/architectTier';
 import { WordTowerNextRivalChip } from './WordTowerNextRivalChip';
 
+/** How long a transient celebration toast holds before it auto-dismisses. Kept
+ *  short + uniform so banners clear quickly and never pile up / "stick" on
+ *  screen (founder: the toasts were staying up too long). */
+const TOAST_MS = 1300;
+
 /** Verdict-pop colour by band — mirrors the swinging-beam tint families. */
 const VERDICT_TONE_CLASS: Record<VerdictTone, string> = {
   lime: 'bg-neo-lime text-neo-black',
@@ -198,7 +203,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
     prevZone.current = biomeId;
     setZoneText(t(`wordTower.biome.${biomeId}`));
   }, [biomeId]); // eslint-disable-line react-hooks/exhaustive-deps
-  useAutoDismiss(zoneText, () => setZoneText(null), 2000);
+  useAutoDismiss(zoneText, () => setZoneText(null), TOAST_MS);
 
   // Witty milestone toast on crossing a height landmark.
   const [milestoneText, setMilestoneText] = useState<string | null>(null);
@@ -214,7 +219,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
     haptics.success();
     playLevelUpSound();
   }, [game.heightM]); // eslint-disable-line react-hooks/exhaustive-deps
-  useAutoDismiss(milestoneText, () => setMilestoneText(null), 2000);
+  useAutoDismiss(milestoneText, () => setMilestoneText(null), TOAST_MS);
 
   // Landmark flyby — cosy "you passed X" beat. Defers to a zone or milestone at the same height.
   const [landmarkText, setLandmarkText] = useState<string | null>(null);
@@ -229,7 +234,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
     setLandmarkText(`${hit.icon} ${t(hit.key)}`);
     playHintRevealSound();
   }, [game.heightM]); // eslint-disable-line react-hooks/exhaustive-deps
-  useAutoDismiss(landmarkText, () => setLandmarkText(null), 2000);
+  useAutoDismiss(landmarkText, () => setLandmarkText(null), TOAST_MS);
 
   // Achievements — unlock once (persisted in localStorage), pop a trophy toast.
   const achUnlocked = useRef<Set<string>>(new Set());
@@ -253,7 +258,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
     try { localStorage.setItem('wt-achievements', JSON.stringify([...achUnlocked.current])); } catch { /* */ }
     setAchToast(fresh[fresh.length - 1]); // show the most impressive of the batch
   }, [game.heightM, game.floors.length, game.longestWord, game.longestCombo, rivals]);
-  useAutoDismiss(achToast, () => setAchToast(null), 2000);
+  useAutoDismiss(achToast, () => setAchToast(null), TOAST_MS);
 
   // Roguelike perk draft — daily-run only. Boons fold into one modifier object
   // the crane + hazard sites read. Segregated from the endless board (daily gates
@@ -337,7 +342,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
     setSkinUnlock(fresh);
     setSkinIdRef.current(fresh.id); // wear the reward immediately
   }, [personalBest]);
-  useAutoDismiss(skinUnlock, () => setSkinUnlock(null), 2000);
+  useAutoDismiss(skinUnlock, () => setSkinUnlock(null), TOAST_MS);
 
   // Unmistakable verdict pop — one big, band-coloured beat on every drop telling
   // the player exactly how they did + the metres gained. Keyed off the placement
@@ -365,7 +370,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
   // Dismiss via the shared hook (keyed on the verdict's own resultKey) rather than
   // an inline timer, so the lifespan is owned in ONE place and can never be reset
   // by an unrelated re-render — the same robustness the other banners already use.
-  useAutoDismiss(verdict?.key, () => setVerdict(null), 2000);
+  useAutoDismiss(verdict?.key, () => setVerdict(null), TOAST_MS);
 
   // Combo-milestone fanfare — a one-shot "×5 ON FIRE!" beat the moment the combo
   // crosses 3/5/10/20. Keyed off resultKey so it fires on the placing tick only.
@@ -378,7 +383,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
     haptics.success();
     playComboMilestoneSound(hit.combo);
   }, [tower.state.resultKey]); // eslint-disable-line react-hooks/exhaustive-deps
-  useAutoDismiss(comboFx?.key, () => setComboFx(null), 2000);
+  useAutoDismiss(comboFx?.key, () => setComboFx(null), TOAST_MS);
 
   // Surprise pop — the variable-reward beat. A per-word deterministic roll
   // (towerSurprise.ts) occasionally grants bonus height / scrambles / an updraft
@@ -393,7 +398,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
     surpriseSoundFns[TOWER_SURPRISE_META[s.event].sound]();
     haptics.levelComplete();
   }, [tower.state.resultKey]); // eslint-disable-line react-hooks/exhaustive-deps
-  useAutoDismiss(surpriseFx?.key, () => setSurpriseFx(null), 2000);
+  useAutoDismiss(surpriseFx?.key, () => setSurpriseFx(null), TOAST_MS);
 
   // Rival ghosts are leaderboard records to climb past (read-only). The old
   // solo "wrecking-ball" sabotage was a fake, local-only effect against these
@@ -433,7 +438,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
     haptics.bossHit();
     playErrorSound();
   }, [tower.state.hazardKey]); // eslint-disable-line react-hooks/exhaustive-deps
-  useAutoDismiss(hazardText, () => setHazardText(null), 2000);
+  useAutoDismiss(hazardText, () => setHazardText(null), TOAST_MS);
 
   // CLUTCH SAVE banner — a clean drop pulled the tower back from a critical lean.
   // The biggest single beat in the climb (a fumble instead routes through the
@@ -443,7 +448,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
     if (!crane.clutch || crane.clutch.outcome !== 'save') return;
     setClutchText(t('wordTower.clutch.save'));
   }, [crane.clutch?.key]); // eslint-disable-line react-hooks/exhaustive-deps
-  useAutoDismiss(clutchText, () => setClutchText(null), 2000);
+  useAutoDismiss(clutchText, () => setClutchText(null), TOAST_MS);
 
   // Hide the global bottom nav for the duration of gameplay (full-screen mode).
   const setIsInGame = useHideNavigation();
@@ -514,7 +519,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
     setNewBestText(t('wordTower.daily.newBest'));
     onNewDailyBest?.(game.heightM);
   }, [daily, newBestShown, personalBestM, game.heightM, onNewDailyBest]); // eslint-disable-line react-hooks/exhaustive-deps
-  useAutoDismiss(newBestText, () => setNewBestText(null), 2000);
+  useAutoDismiss(newBestText, () => setNewBestText(null), TOAST_MS);
   useEffect(() => { if (game.heightM > 0) save(); }, [biomeId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Cool EXIT for every compliment/message: after its ~2s hold the source

--- a/fe-next/components/wordTower/WordTowerWheel.tsx
+++ b/fe-next/components/wordTower/WordTowerWheel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef } from 'react';
-import { ChevronsDown } from 'lucide-react';
+import { ChevronsDown, ArrowUp } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useWheelDragSpell } from '@/hooks/useWheelDragSpell';
 
@@ -99,7 +99,7 @@ export function WordTowerWheel({
 
   return (
     <div
-      className="relative mx-auto aspect-square w-full max-w-[300px] touch-none select-none"
+      className="relative mx-auto aspect-square w-full max-w-[230px] touch-none select-none"
       onPointerDown={onDown}
       onPointerMove={placing ? undefined : handlePointerMove}
       onPointerUp={placing ? undefined : handlePointerUp}
@@ -231,7 +231,11 @@ export function WordTowerWheel({
         </div>
       </div>
 
-      {/* Centre hub — word preview while spelling, DROP control while placing. */}
+      {/* Centre hub — the single action surface. While spelling it is the BUILD
+          button (lifts the spelled word to the crane); once a word is held it
+          morphs into the DROP control. The old bottom BUILD button is gone — the
+          action lives where the player's eyes already are (centre of the wheel),
+          and a drag-release still auto-builds via onSubmit. */}
       <div className="absolute left-1/2 top-1/2 z-20 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center">
         {placing ? (
           <button
@@ -239,19 +243,32 @@ export function WordTowerWheel({
             onClick={onDrop}
             aria-label={t('wordTower.crane.steer')}
             className={cn(
-              'pointer-events-auto flex h-20 w-20 flex-col items-center justify-center rounded-full border-neo-thick border-black bg-gradient-to-b from-neo-lime-light to-neo-lime font-neo-display text-[11px] font-black uppercase leading-tight text-black shadow-hard active:translate-y-0.5',
+              'pointer-events-auto flex h-[72px] w-[72px] flex-col items-center justify-center rounded-full border-neo-thick border-black bg-gradient-to-b from-neo-lime-light to-neo-lime font-neo-display text-[11px] font-black uppercase leading-tight text-black shadow-hard active:translate-y-0.5',
               !reducedMotion && 'animate-neo-pop',
             )}
           >
             <ChevronsDown className={cn('h-6 w-6', !reducedMotion && 'animate-bounce')} />
             {t('wordTower.crane.steer')}
           </button>
+        ) : canBuild ? (
+          <button
+            type="button"
+            onClick={onSubmit}
+            aria-label={t('wordTower.hud.build')}
+            className={cn(
+              'pointer-events-auto flex h-[72px] min-w-[72px] max-w-[78%] flex-col items-center justify-center gap-0.5 rounded-full border-neo-thick border-black bg-gradient-to-b from-neo-cyan-light to-neo-cyan px-3 font-neo-display font-black uppercase leading-none text-black shadow-hard active:translate-y-0.5',
+              !reducedMotion && 'animate-neo-pop',
+            )}
+          >
+            <span className="max-w-full truncate text-base tracking-wide">{word}</span>
+            <span className="flex items-center gap-0.5 text-[9px] tracking-[0.15em]">
+              <ArrowUp className="h-3 w-3" />
+              {t('wordTower.hud.build')}
+            </span>
+          </button>
         ) : (
           <div
-            className={cn(
-              'flex h-[34%] min-h-[44px] min-w-[44px] max-w-[60%] items-center justify-center rounded-full border-neo border-black/40 bg-neo-navy/70 px-3 text-center font-neo-display text-xl font-black uppercase tracking-wide text-neo-white backdrop-blur-sm',
-              word.length > 0 && canBuild && 'ring-2 ring-neo-cyan/50',
-            )}
+            className="flex h-[34%] min-h-[44px] min-w-[44px] max-w-[60%] items-center justify-center rounded-full border-neo border-black/40 bg-neo-navy/70 px-3 text-center font-neo-display text-xl font-black uppercase tracking-wide text-neo-white backdrop-blur-sm"
           >
             {word.length > 0
               ? word

--- a/fe-next/components/wordTower/__tests__/WordTowerHud.test.tsx
+++ b/fe-next/components/wordTower/__tests__/WordTowerHud.test.tsx
@@ -45,9 +45,11 @@ describe('WordTowerHud — golden-letter mutator highlight', () => {
 });
 
 describe('WordTowerHud', () => {
-  it('disables Build until the word is 3+ letters', () => {
+  it('reveals the Build control (wheel centre) only once the word is 3+ letters', () => {
+    // The redundant bottom Build button is gone; building lives in the wheel
+    // centre, which only surfaces the control once a buildable word is spelled.
     const { rerender } = render(<WordTowerHud {...makeProps({ word: 'CA' })} />);
-    expect(screen.getByRole('button', { name: /wordTower\.hud\.build/ })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /wordTower\.hud\.build/ })).toBeNull();
     rerender(<WordTowerHud {...makeProps({ word: 'CAT' })} />);
     expect(screen.getByRole('button', { name: /wordTower\.hud\.build/ })).toBeEnabled();
   });
@@ -78,20 +80,22 @@ describe('WordTowerHud', () => {
     expect(onDeckHeight).toHaveBeenCalled();
   });
 
-  it('swaps Build → Drop CTA at the SAME position when a word is pending placement', () => {
+  it('swaps the wheel-centre Build → Drop control when a word is pending placement', () => {
     const onSubmit = vi.fn();
     const onCraneDrop = vi.fn();
     const { rerender } = render(
       <WordTowerHud {...makeProps({ word: 'CAT', onSubmit, onCraneDrop })} />,
     );
-    expect(screen.queryByRole('button', { name: /wordTower\.crane\.tapToDrop/ })).toBeNull();
+    // Spelling a word: the wheel centre is the Build control, no Drop yet.
+    expect(screen.queryByRole('button', { name: /wordTower\.crane\.steer/ })).toBeNull();
     expect(screen.getByRole('button', { name: /wordTower\.hud\.build/ })).toBeEnabled();
 
     rerender(
       <WordTowerHud {...makeProps({ word: 'CAT', pendingWord: 'CCAT', onSubmit, onCraneDrop })} />,
     );
+    // Word in flight: the same centre morphs into the Drop control.
     expect(screen.queryByRole('button', { name: /wordTower\.hud\.build/ })).toBeNull();
-    const dropBtn = screen.getByRole('button', { name: /wordTower\.crane\.tapToDrop/ });
+    const dropBtn = screen.getByRole('button', { name: /wordTower\.crane\.steer/ });
     fireEvent.click(dropBtn);
     expect(onCraneDrop).toHaveBeenCalledTimes(1);
     expect(onSubmit).not.toHaveBeenCalled();


### PR DESCRIPTION
- Notifications: shorten transient toast hold (2000ms → 1300ms) and make the
  persistent "next rival" chase chip auto-hide after 6s (re-shows per new
  target) so banners no longer stick on screen.
- Wheel: shrink the ring (max-w 300 → 230px) and move the BUILD action into the
  wheel's centre hub — spell a word → tap centre to build → tap to drop.
  Drag-release still auto-builds. Removes the redundant bottom BUILD button and
  shortens the control deck.
- Daily letters: seed the endless wheel by the UTC date so each calendar day
  serves a fresh fixed set of letters (stable within the day). Step toward
  folding the daily letter set into the daily-challenges flow.
- Tests: refresh the stale HUD reward-popup test to the current component and
  cover the build-action-moved-to-wheel-centre behaviour.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nz9k9LS3cSuGfzbeRu28k2