### PR TITLE
feat(onboarding): keyboard-safe, ad-free, de-cluttered FTUE identity screen

### DIFF
--- a/fe-next/app/[locale]/layout.tsx
+++ b/fe-next/app/[locale]/layout.tsx
@@ -213,6 +213,11 @@ export const viewport = {
     initialScale: 1,
     viewportFit: 'cover',
     themeColor: '#1a1a2e',
+    // Let the soft keyboard SHRINK the layout viewport instead of overlaying it.
+    // With this, a bottom-anchored element (e.g. the onboarding "Continue" CTA)
+    // sits above the keyboard rather than behind it. Combined with 100dvh on the
+    // onboarding overlay, this keeps the primary action reachable while typing.
+    interactiveWidget: 'resizes-content' as const,
 };
 
 export default async function LocaleLayout({ children, params }: LocaleLayoutProps): Promise<ReactNode> {

--- a/fe-next/components/ads/AdSenseLoader.tsx
+++ b/fe-next/components/ads/AdSenseLoader.tsx
@@ -5,6 +5,7 @@ import Script from 'next/script';
 import { Capacitor } from '@capacitor/core';
 import { useCrazyGames } from '@/components/CrazyGamesSDK';
 import { useSocialCapabilities } from '@/hooks/useSocialCapabilities';
+import { useOnboardingActive } from '@/hooks/useOnboardingActive';
 import { shouldSuppressAdsForTier } from '@/lib/families/adPolicy';
 import { hasConsent, onConsentChange } from '@/utils/cookieConsent';
 import { getAdSenseClient, isAdSenseConfigured, shouldLoadAdSense } from '@/lib/ads/adSensePolicy';
@@ -22,6 +23,7 @@ import { getAdSenseClient, isAdSenseConfigured, shouldLoadAdSense } from '@/lib/
 export function AdSenseLoader() {
   const { tier } = useSocialCapabilities();
   const crazyGames = useCrazyGames();
+  const onboardingActive = useOnboardingActive();
   const [adConsent, setAdConsent] = useState(false);
 
   useEffect(() => {
@@ -36,6 +38,8 @@ export function AdSenseLoader() {
     isNative: Capacitor.isNativePlatform(),
     isCrazyGames: crazyGames?.isOnCrazyGamesPlatform === true,
     suppressedByTier: shouldSuppressAdsForTier(tier),
+    // Keep the FTUE ad-free: withhold the script while the onboarding overlay is up.
+    onboardingActive,
   });
 
   if (!load) return null;

--- a/fe-next/components/ads/BannerCoordinatorMount.tsx
+++ b/fe-next/components/ads/BannerCoordinatorMount.tsx
@@ -122,6 +122,10 @@ export default function BannerCoordinatorMount() {
           drawerOpen: document.documentElement.classList.contains('mobile-drawer-open'),
           inGame: document.body.classList.contains('screen-fit-locked'),
           allowInGame: document.documentElement.classList.contains('banner-allow-in-game'),
+          // FTUE overlay open (set by OnboardingFlow). Unconditional suppress so the
+          // first run stays ad-free — see shouldSuppressBanner. Lives on <html>,
+          // already covered by the observer below.
+          onboarding: document.documentElement.classList.contains('onboarding-active'),
         }),
       );
     syncSuppress(); // reflect any drawer/game state already active at mount

--- a/fe-next/components/ads/__tests__/BannerCoordinatorMount.test.tsx
+++ b/fe-next/components/ads/__tests__/BannerCoordinatorMount.test.tsx
@@ -56,8 +56,8 @@ vi.mock('@/lib/native/bannerController', () => ({
     setSuppressed: (v: boolean) => setSuppressed(v),
   },
   // Mirror the real pure policy so the mount's wiring is exercised end-to-end.
-  shouldSuppressBanner: (i: { drawerOpen: boolean; inGame: boolean; allowInGame: boolean }) =>
-    i.drawerOpen || (i.inGame && !i.allowInGame),
+  shouldSuppressBanner: (i: { drawerOpen: boolean; inGame: boolean; allowInGame: boolean; onboarding?: boolean }) =>
+    Boolean(i.onboarding) || i.drawerOpen || (i.inGame && !i.allowInGame),
 }));
 
 /** Flush the MutationObserver microtask queue. */
@@ -71,7 +71,7 @@ describe('BannerCoordinatorMount', () => {
     isNative.current = true;
     for (const k of Object.keys(listeners)) delete listeners[k];
     foregroundCb.current = null;
-    document.documentElement.classList.remove('mobile-drawer-open', 'banner-allow-in-game');
+    document.documentElement.classList.remove('mobile-drawer-open', 'banner-allow-in-game', 'onboarding-active');
     document.body.classList.remove('screen-fit-locked');
   });
 
@@ -190,6 +190,29 @@ describe('BannerCoordinatorMount', () => {
 
   it('reflects the initial in-game state on mount (game active before render)', () => {
     document.body.classList.add('screen-fit-locked');
+    render(<BannerCoordinatorMount />);
+    expect(setSuppressed).toHaveBeenCalledWith(true);
+  });
+
+  it('suppresses the banner while the FTUE onboarding overlay is open (onboarding-active)', async () => {
+    render(<BannerCoordinatorMount />);
+    setSuppressed.mockClear();
+    document.documentElement.classList.add('onboarding-active');
+    await flushObserver();
+    expect(setSuppressed).toHaveBeenCalledWith(true);
+  });
+
+  it('restores the banner when onboarding finishes (onboarding-active removed)', async () => {
+    document.documentElement.classList.add('onboarding-active');
+    render(<BannerCoordinatorMount />);
+    setSuppressed.mockClear();
+    document.documentElement.classList.remove('onboarding-active');
+    await flushObserver();
+    expect(setSuppressed).toHaveBeenCalledWith(false);
+  });
+
+  it('reflects the initial onboarding state on mount (overlay open before render)', () => {
+    document.documentElement.classList.add('onboarding-active');
     render(<BannerCoordinatorMount />);
     expect(setSuppressed).toHaveBeenCalledWith(true);
   });

--- a/fe-next/components/onboarding/OnboardingFlow.tsx
+++ b/fe-next/components/onboarding/OnboardingFlow.tsx
@@ -77,6 +77,17 @@ const OnboardingFlow: React.FC<OnboardingFlowProps> = ({ onComplete }) => {
     trackOnboardingStart();
   }, []);
 
+  // Keep the entire first run ad-free. The FTUE is a fixed full-screen takeover on
+  // the home route (NOT its own route), so the route-based ad gates can't catch it
+  // and the native banner composites ABOVE the WebView regardless of z-index. This
+  // single class is the source of truth read by BannerCoordinatorMount (native) and
+  // useOnboardingActive → AdSenseLoader (web) to suppress both ad layers, and it
+  // also gives the overlay a CSS hook. Removed on unmount so ads resume afterwards.
+  useEffect(() => {
+    document.documentElement.classList.add('onboarding-active');
+    return () => document.documentElement.classList.remove('onboarding-active');
+  }, []);
+
   const emitCompleted = useCallback((extras: Record<string, unknown> = {}) => {
     if (completionEmittedRef.current) return;
     completionEmittedRef.current = true;
@@ -403,7 +414,13 @@ const OnboardingFlow: React.FC<OnboardingFlowProps> = ({ onComplete }) => {
   return (
     <div
       data-testid="onboarding-flow"
-      className="fixed inset-0 z-[100] bg-neo-navy flex flex-col items-center justify-center overflow-y-auto"
+      // Keyboard-safe layout: 100dvh shrinks with the soft keyboard (paired with
+      // viewport `interactiveWidget: resizes-content`), and on small screens we
+      // top-align + scroll instead of hard-centering — otherwise the vertically
+      // centered card pushes the "Continue" CTA under the keyboard. Desktop keeps
+      // the centered presentation (no keyboard inset there).
+      className="fixed inset-0 z-[100] bg-neo-navy flex flex-col items-center justify-start sm:justify-center overflow-y-auto py-[max(env(safe-area-inset-top),1rem)]"
+      style={{ minHeight: '100dvh' }}
       dir={dir}
     >
       {/* Subtle diagonal grid pattern */}

--- a/fe-next/components/onboarding/QuickProfileSetup.tsx
+++ b/fe-next/components/onboarding/QuickProfileSetup.tsx
@@ -11,6 +11,7 @@ import InviteContextBanner from './InviteContextBanner';
 import { suggestPlayerName } from '@/utils/onboardingNameSuggestions';
 import OnboardingGoogleSignup from './OnboardingGoogleSignup';
 import { useImeText } from '@/hooks/useImeText';
+import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import { cn } from '@/lib/utils';
 import { NeoPanel } from '@/components/ui/panel';
 
@@ -58,6 +59,17 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
   const [showShake, setShowShake] = useState(false);
   const [justValidated, setJustValidated] = useState(false);
   const previouslyValidRef = useRef(false);
+  const submitRef = useRef<HTMLButtonElement>(null);
+
+  // When the soft keyboard opens, the layout viewport shrinks (viewport
+  // `interactiveWidget: resizes-content`). Pull the primary CTA into view so it's
+  // never stranded under the keyboard — the core "can't reach Continue" fix.
+  const { keyboardVisible } = useMobileKeyboard();
+  useEffect(() => {
+    if (keyboardVisible) {
+      submitRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [keyboardVisible]);
 
   const trimmedName = name.trim();
   const nameCharCount = Array.from(trimmedName).length;
@@ -129,7 +141,7 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
       className="w-full max-w-sm lg:max-w-md mx-auto"
       dir={dir}
     >
-      <NeoPanel tone="cream" shadow="md" className="p-5">
+      <NeoPanel tone="cream" shadow="md" className="p-6 sm:p-7">
         {inviteContext && onSkipInvite && (
           <InviteContextBanner
             roomCode={inviteContext.roomCode}
@@ -143,7 +155,7 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
           variants={staggerChild}
           initial="hidden"
           animate="visible"
-          className="text-xl font-black text-neo-black text-center mb-1"
+          className="text-xl font-black text-neo-black text-center mb-4"
         >
           {hasPendingInvite ? t('onboarding.ftue.friendIsWaiting') : t('onboarding.ftue.niceWork')}
         </m.h2>
@@ -163,7 +175,10 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
                 whileTap={{ scale: 0.9 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 15 }}
                 className={cn(
-                  'w-11 h-11 rounded-full border-2 border-neo-black bg-neo-yellow',
+                  // Neutral at rest (color only on hover) so the avatar + pink CTA
+                  // are the only saturated elements — calmer palette, clear hierarchy.
+                  'w-11 h-11 rounded-full border-2 border-neo-black bg-neo-white',
+                  'hover:bg-neo-yellow transition-colors',
                   'flex items-center justify-center shadow-hard-sm'
                 )}
                 aria-label={t('onboarding.ftue.randomize', 'Randomize avatar')}
@@ -247,7 +262,9 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
               type="text"
               onKeyDown={(e) => { if (e.key === 'Enter' && isNameValid) handleSubmit(); }}
               placeholder={t('onboarding.name.placeholder')}
-              autoFocus
+              // Intentionally NOT autoFocused: let the avatar (the fun, first
+              // impression) land before the keyboard slams up and shifts the
+              // layout. The keyboard opens only when the player taps the field.
               maxLength={20}
               autoComplete="off"
               className={cn(
@@ -284,6 +301,7 @@ const QuickProfileSetup: React.FC<QuickProfileSetupProps> = ({
 
         {/* Submit button */}
         <m.button
+          ref={submitRef}
           custom={3}
           variants={staggerChild}
           initial="hidden"

--- a/fe-next/components/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/fe-next/components/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -305,4 +305,25 @@ describe('OnboardingFlow', () => {
       expect(mockPush).toHaveBeenCalledWith('/en/practice');
     });
   });
+
+  // The FTUE is a fixed full-screen takeover on the home route; it flags
+  // <html>.onboarding-active so the (route-blind) native + web ad layers stay
+  // suppressed for the whole first run — see shouldSuppressBanner / shouldLoadAdSense.
+  describe('ad-free onboarding signal', () => {
+    afterEach(() => {
+      document.documentElement.classList.remove('onboarding-active');
+    });
+
+    it('flags html.onboarding-active while the flow is mounted', () => {
+      render(<OnboardingFlow {...defaultProps} />);
+      expect(document.documentElement.classList.contains('onboarding-active')).toBe(true);
+    });
+
+    it('clears the flag on unmount so ads resume after onboarding', () => {
+      const { unmount } = render(<OnboardingFlow {...defaultProps} />);
+      expect(document.documentElement.classList.contains('onboarding-active')).toBe(true);
+      unmount();
+      expect(document.documentElement.classList.contains('onboarding-active')).toBe(false);
+    });
+  });
 });

--- a/fe-next/components/onboarding/__tests__/QuickProfileSetup.test.tsx
+++ b/fe-next/components/onboarding/__tests__/QuickProfileSetup.test.tsx
@@ -34,6 +34,17 @@ vi.mock('lucide-react', () => ({
   X: () => <div data-testid="x-icon" />,
 }));
 
+// Controllable virtual-keyboard mock so we can assert the CTA is scrolled into
+// view when the soft keyboard opens (the fix for "the keyboard + banner cover the
+// Continue button").
+const { kbState } = vi.hoisted(() => ({
+  kbState: { current: { keyboardVisible: false, keyboardHeight: 0 } },
+}));
+vi.mock('@/hooks/useMobileKeyboard', () => ({
+  useMobileKeyboard: () => kbState.current,
+  scrollInputIntoView: vi.fn(),
+}));
+
 // Mock the optional Google signup panel — it has its own test and pulls in the
 // auth stack (supabase, OAuth hooks) we don't want loaded here.
 vi.mock('../OnboardingGoogleSignup', () => ({
@@ -135,6 +146,33 @@ describe('QuickProfileSetup', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    kbState.current = { keyboardVisible: false, keyboardHeight: 0 };
+  });
+
+  describe('keyboard-safe CTA', () => {
+    it('scrolls the Continue button into view when the soft keyboard opens', () => {
+      const scrollSpy = vi.fn();
+      // happy-dom doesn't implement scrollIntoView — install a spy to observe it.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (Element.prototype as any).scrollIntoView = scrollSpy;
+
+      const { rerender } = render(<QuickProfileSetup {...defaultProps} />);
+      scrollSpy.mockClear();
+
+      // Keyboard opens → component re-renders with keyboardVisible=true.
+      kbState.current = { keyboardVisible: true, keyboardHeight: 300 };
+      rerender(<QuickProfileSetup {...defaultProps} />);
+
+      expect(scrollSpy).toHaveBeenCalled();
+    });
+
+    it('does not scroll on mount while the keyboard is closed', () => {
+      const scrollSpy = vi.fn();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (Element.prototype as any).scrollIntoView = scrollSpy;
+      render(<QuickProfileSetup {...defaultProps} />);
+      expect(scrollSpy).not.toHaveBeenCalled();
+    });
   });
 
   it('renders the slide-up profile card', () => {

--- a/fe-next/hooks/__tests__/useOnboardingActive.test.tsx
+++ b/fe-next/hooks/__tests__/useOnboardingActive.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, afterEach } from 'vitest';
+import { useOnboardingActive } from '../useOnboardingActive';
+
+function Probe() {
+  const active = useOnboardingActive();
+  return <div data-testid="probe">{active ? 'active' : 'idle'}</div>;
+}
+
+describe('useOnboardingActive', () => {
+  afterEach(() => {
+    document.documentElement.classList.remove('onboarding-active');
+  });
+
+  it('reports idle when the onboarding-active class is absent', () => {
+    render(<Probe />);
+    expect(screen.getByTestId('probe')).toHaveTextContent('idle');
+  });
+
+  it('reflects the class already present at mount', () => {
+    document.documentElement.classList.add('onboarding-active');
+    render(<Probe />);
+    expect(screen.getByTestId('probe')).toHaveTextContent('active');
+  });
+
+  it('reacts when the class is added after mount', async () => {
+    render(<Probe />);
+    expect(screen.getByTestId('probe')).toHaveTextContent('idle');
+    await act(async () => {
+      document.documentElement.classList.add('onboarding-active');
+      // let the MutationObserver microtask flush
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(screen.getByTestId('probe')).toHaveTextContent('active');
+  });
+
+  it('reacts when the class is removed after mount', async () => {
+    document.documentElement.classList.add('onboarding-active');
+    render(<Probe />);
+    expect(screen.getByTestId('probe')).toHaveTextContent('active');
+    await act(async () => {
+      document.documentElement.classList.remove('onboarding-active');
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(screen.getByTestId('probe')).toHaveTextContent('idle');
+  });
+});

--- a/fe-next/hooks/useOnboardingActive.ts
+++ b/fe-next/hooks/useOnboardingActive.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Reactive read of the `html.onboarding-active` flag — the single source of truth
+ * (set by OnboardingFlow for the FTUE overlay's lifetime) that keeps the first run
+ * ad-free.
+ *
+ * WHY a class + observer instead of a context: the flag must be read by BOTH the
+ * native banner coordinator (BannerCoordinatorMount, which already observes
+ * `<html>` classes outside React) and the web AdSense loader (AdSenseLoader, a
+ * React component). A DOM class observed via `useSyncExternalStore` gives both
+ * consumers one source of truth without threading a provider through the tree, and
+ * stays correct even though the overlay lives in a different subtree than the
+ * loader (which is mounted up in the locale layout).
+ *
+ * SSR-safe: the server snapshot is always `false` (no overlay during SSR), so the
+ * loader's own client-only gating drives the first real value after hydration.
+ */
+const ONBOARDING_CLASS = 'onboarding-active';
+
+function subscribe(onChange: () => void): () => void {
+  if (typeof document === 'undefined') return () => {};
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class'],
+  });
+  return () => observer.disconnect();
+}
+
+function getSnapshot(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.documentElement.classList.contains(ONBOARDING_CLASS);
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+export function useOnboardingActive(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/fe-next/lib/ads/__tests__/adSensePolicy.test.ts
+++ b/fe-next/lib/ads/__tests__/adSensePolicy.test.ts
@@ -79,4 +79,16 @@ describe('adSensePolicy — shouldLoadAdSense', () => {
   it('does NOT load for a child tier (COPPA/Families — web ad suppression)', () => {
     expect(shouldLoadAdSense({ ...base, suppressedByTier: true })).toBe(false);
   });
+
+  it('does NOT load while the FTUE onboarding overlay is active (ad-free first run)', () => {
+    // Onboarding is the highest-leverage conversion funnel; an anchored Auto-Ads
+    // banner there covers the "Continue" CTA and reads as aggressive monetization
+    // before any value is delivered. Withhold the script until onboarding completes.
+    expect(shouldLoadAdSense({ ...base, onboardingActive: true })).toBe(false);
+  });
+
+  it('still loads normally when onboarding is not active (flag omitted or false)', () => {
+    expect(shouldLoadAdSense({ ...base, onboardingActive: false })).toBe(true);
+    expect(shouldLoadAdSense(base)).toBe(true); // omitted → treated as not active
+  });
 });

--- a/fe-next/lib/ads/adSensePolicy.ts
+++ b/fe-next/lib/ads/adSensePolicy.ts
@@ -51,12 +51,23 @@ export function shouldLoadAdSense(ctx: {
   isNative: boolean;
   isCrazyGames: boolean;
   suppressedByTier: boolean;
+  /**
+   * The FTUE onboarding overlay is open. Onboarding is the highest-leverage
+   * conversion funnel; an anchored Auto-Ads banner there covers the primary CTA
+   * and reads as aggressive monetization before any value is delivered. Industry
+   * standard is an ad-free registration/onboarding flow — so we withhold the
+   * script entirely until onboarding completes. (Onboarding mounts before the
+   * consent-gated, afterInteractive adsbygoogle.js would load on first run, so in
+   * practice the script never injects during the FTUE.)
+   */
+  onboardingActive?: boolean;
 }): boolean {
   return (
     ctx.enabled &&
     ctx.hasAdConsent &&
     !ctx.isNative &&
     !ctx.isCrazyGames &&
-    !ctx.suppressedByTier
+    !ctx.suppressedByTier &&
+    !ctx.onboardingActive
   );
 }

--- a/fe-next/lib/native/bannerController.test.ts
+++ b/fe-next/lib/native/bannerController.test.ts
@@ -49,6 +49,24 @@ describe('shouldSuppressBanner (pure)', () => {
   it('ignores the opt-in when not in a game (it is in-game-scoped)', () => {
     expect(shouldSuppressBanner({ drawerOpen: false, inGame: false, allowInGame: true })).toBe(false);
   });
+
+  it('suppresses while the FTUE onboarding overlay is open (ad-free first run)', () => {
+    // Onboarding is a fixed full-screen takeover on the home route, not its own
+    // route — the route gate can't catch it, so the global suppress must. A
+    // banner over the identity screen covers the "Continue" CTA and tanks the
+    // highest-leverage conversion funnel; industry standard is ad-free onboarding.
+    expect(shouldSuppressBanner({ drawerOpen: false, inGame: false, allowInGame: false, onboarding: true })).toBe(true);
+  });
+
+  it('onboarding suppression is not overridden by the in-game opt-in', () => {
+    expect(
+      shouldSuppressBanner({ drawerOpen: false, inGame: true, allowInGame: true, onboarding: true }),
+    ).toBe(true);
+  });
+
+  it('treats a missing onboarding flag as false (back-compat with existing callers)', () => {
+    expect(shouldSuppressBanner({ drawerOpen: false, inGame: false, allowInGame: false })).toBe(false);
+  });
 });
 
 describe('BannerController', () => {

--- a/fe-next/lib/native/bannerController.ts
+++ b/fe-next/lib/native/bannerController.ts
@@ -55,13 +55,22 @@ export function selectActiveBannerRequest(
  * (only `/adventure` today, via `--admob-banner-height`) opts back in by flagging
  * `html.banner-allow-in-game`. The drawer always wins (an open side menu must never
  * have the SurfaceView banner painted on top of it).
+ *
+ * Onboarding (`html.onboarding-active`, set by OnboardingFlow) is an unconditional
+ * suppress: the FTUE is a fixed full-screen takeover on the home route — NOT its own
+ * route — so `isAllowedAdBannerRoute` can't catch it, and the native SurfaceView
+ * composites ABOVE the WebView (z-index can't cover it). A banner there covers the
+ * "Continue" CTA and tanks the highest-leverage conversion funnel, so we keep the
+ * whole first run ad-free. The opt-in does NOT rescue it (no onboarding screen
+ * reserves banner room).
  */
 export function shouldSuppressBanner(input: {
   drawerOpen: boolean;
   inGame: boolean;
   allowInGame: boolean;
+  onboarding?: boolean;
 }): boolean {
-  return input.drawerOpen || (input.inGame && !input.allowInGame);
+  return Boolean(input.onboarding) || input.drawerOpen || (input.inGame && !input.allowInGame);
 }
 
 export interface BannerOps {


### PR DESCRIPTION
Fixes the critical bug where the soft keyboard + bottom banner ad covered the
"Continue" CTA on the new-user name/avatar screen, plus visual clutter.

Keyboard + ad conflict:
- Keep the whole first run ad-free. OnboardingFlow now flags
  html.onboarding-active for its lifetime — a single source of truth read by
  both ad layers (the FTUE is a fixed full-screen takeover on the home route,
  so the route-based gates can't catch it and the native banner composites
  above the WebView):
  * Native AdMob: shouldSuppressBanner() gains an `onboarding` signal;
    BannerCoordinatorMount observes the class and suppresses.
  * Web AdSense: shouldLoadAdSense() gains `onboardingActive`; AdSenseLoader
    reads it via the new useOnboardingActive() hook (useSyncExternalStore over
    the class) and withholds the script.
- Keyboard-safe layout: viewport interactiveWidget 'resizes-content' so the
  keyboard shrinks the layout viewport; overlay uses 100dvh and top-aligns +
  scrolls on small screens instead of hard-centering; QuickProfileSetup scrolls
  the CTA into view via useMobileKeyboard and no longer steals focus on mount.

De-clutter:
- Neutralize the loudest competing hue (yellow randomize button → neutral,
  color on hover) so the avatar + pink CTA carry the palette; more breathing
  room (panel + header spacing).

Tests: new/extended units for the suppress policy, AdSense policy,
useOnboardingActive, BannerCoordinatorMount wiring, OnboardingFlow class
toggle, and QuickProfileSetup keyboard-scroll. All green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q3AG1gTxzBK2HtxryNhCk8