### PR TITLE
fix(ads): reserve bottom-stack space for AdSense anchors that aren't ins.adsbygoogle-noablate

### DIFF
--- a/fe-next/components/ads/WebAnchorAdObserver.tsx
+++ b/fe-next/components/ads/WebAnchorAdObserver.tsx
@@ -55,15 +55,26 @@ export default function WebAnchorAdObserver() {
 
     window.addEventListener('resize', schedule);
     window.addEventListener('orientationchange', schedule);
+    window.addEventListener('load', schedule);
+
+    // AdSense can finish painting the anchor AFTER DOM mutations settle — the ad
+    // iframe loads late with no further mutation the observers can see, so the
+    // single initial measure reads 0 and nothing reserves the band. Nudge a few
+    // re-measures on a settle curve to catch the late paint.
+    const settleTimers = [300, 1000, 2500, 5000].map((ms) =>
+      window.setTimeout(schedule, ms),
+    );
 
     apply();
 
     return () => {
       if (rafId) cancelAnimationFrame(rafId);
+      settleTimers.forEach((id) => window.clearTimeout(id));
       mo.disconnect();
       ro?.disconnect();
       window.removeEventListener('resize', schedule);
       window.removeEventListener('orientationchange', schedule);
+      window.removeEventListener('load', schedule);
       root.style.setProperty('--web-anchor-ad-height', '0px');
       root.classList.remove('has-web-anchor-ad');
     };

--- a/fe-next/components/ads/__tests__/webAnchorAdHeight.test.ts
+++ b/fe-next/components/ads/__tests__/webAnchorAdHeight.test.ts
@@ -80,4 +80,114 @@ describe('measureWebAnchorHeight', () => {
     makeAnchor({ className: 'adsbygoogle', status: 'displayed', height: 64, bottom: 800 });
     expect(measureWebAnchorHeight(window)).toBe(64);
   });
+
+  /**
+   * Fallback: Google Auto-Ads frequently renders the bottom anchor as a
+   * `position: fixed` WRAPPER (e.g. `<div id="aswift_..._anchor">`) holding an
+   * iframe — NOT an `ins.adsbygoogle-noablate`. The narrow <ins> selector misses
+   * it, so the band must also be discovered by walking from the ad frame/ins up
+   * to its nearest fixed/sticky ancestor and measuring that.
+   */
+  function makeWrappedAd(opts: {
+    inner: 'iframe' | 'ins';
+    innerAttrs?: Record<string, string>;
+    wrapperPosition?: string; // computed position of the pinned ancestor
+    height: number;
+    bottom?: number; // viewport-relative bottom of the WRAPPER
+  }): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.style.position = opts.wrapperPosition ?? 'fixed';
+    const bottom = opts.bottom ?? window.innerHeight;
+    wrapper.getBoundingClientRect = () =>
+      ({
+        height: opts.height,
+        width: 360,
+        top: bottom - opts.height,
+        bottom,
+        left: 0,
+        right: 360,
+        x: 0,
+        y: bottom - opts.height,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    const inner = document.createElement(opts.inner);
+    for (const [k, v] of Object.entries(opts.innerAttrs ?? {})) {
+      inner.setAttribute(k, v);
+    }
+    // The inner ad node is statically positioned inside the pinned wrapper; its
+    // own rect would NOT register as bottom-pinned, so the walk-up must measure
+    // the wrapper. Give it a non-bottom rect to prove that.
+    inner.getBoundingClientRect = () =>
+      ({
+        height: opts.height,
+        width: 360,
+        top: 0,
+        bottom: opts.height,
+        left: 0,
+        right: 360,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    wrapper.appendChild(inner);
+    document.body.appendChild(wrapper);
+    return wrapper;
+  }
+
+  // Non-navigable srcs that still match the `src*="googleads"` selector — avoids
+  // happy-dom issuing a real network fetch for the iframe.
+  const GOOGLEADS_SRC = 'data:text/html,googleads';
+
+  it('detects an iframe ad whose fixed wrapper is pinned to the bottom', () => {
+    makeWrappedAd({
+      inner: 'iframe',
+      innerAttrs: { src: GOOGLEADS_SRC },
+      height: 90,
+      bottom: 800,
+    });
+    expect(measureWebAnchorHeight(window)).toBe(90);
+  });
+
+  it('detects a plain ins.adsbygoogle (no anchor class/status) in a fixed bottom wrapper', () => {
+    makeWrappedAd({
+      inner: 'ins',
+      innerAttrs: { class: 'adsbygoogle' },
+      height: 70,
+      bottom: 800,
+    });
+    expect(measureWebAnchorHeight(window)).toBe(70);
+  });
+
+  it('detects an aswift-named iframe (Google ad frame) in a fixed bottom wrapper', () => {
+    makeWrappedAd({
+      inner: 'iframe',
+      innerAttrs: { name: 'aswift_3', src: 'about:blank' },
+      height: 60,
+      bottom: 800,
+    });
+    expect(measureWebAnchorHeight(window)).toBe(60);
+  });
+
+  it('ignores a fixed ad wrapper that is NOT pinned to the bottom (top anchor)', () => {
+    makeWrappedAd({
+      inner: 'iframe',
+      innerAttrs: { src: GOOGLEADS_SRC },
+      height: 90,
+      bottom: 90, // pinned to the TOP, not the bottom
+    });
+    expect(measureWebAnchorHeight(window)).toBe(0);
+  });
+
+  it('ignores an ad frame with no fixed/sticky ancestor (in-flow unit)', () => {
+    makeWrappedAd({
+      inner: 'iframe',
+      innerAttrs: { src: GOOGLEADS_SRC },
+      wrapperPosition: 'static',
+      height: 250,
+      bottom: 800,
+    });
+    expect(measureWebAnchorHeight(window)).toBe(0);
+  });
 });

--- a/fe-next/components/ads/webAnchorAdHeight.ts
+++ b/fe-next/components/ads/webAnchorAdHeight.ts
@@ -27,22 +27,59 @@ export const WEB_ANCHOR_MAX_HEIGHT = 120;
 // bottom:0, but sub-pixel rounding / safe-area can shift them a hair.
 const BOTTOM_TOLERANCE = 6;
 
+// Fallback discovery: Google Auto-Ads does not always render the anchor as an
+// `ins.adsbygoogle-noablate`. It frequently wraps an ad iframe in a
+// `position: fixed` container (e.g. `<div id="aswift_..._anchor">`) that the
+// narrow <ins> selectors miss. These match the ad FRAME/ins; we then walk up to
+// the pinned ancestor and measure that band.
+const AD_FRAME_SELECTORS =
+  'ins.adsbygoogle, iframe[src*="googleads"], iframe[src*="doubleclick"], iframe[src*="googlesyndication"], iframe[name^="aswift"]';
+
+// Returns the height (px) of `el` only if its rect overlays the viewport bottom.
+// An in-flow ad scrolls with the page and never covers fixed bottom CTAs, so it
+// must not be reserved against.
+function bottomPinnedHeight(rect: DOMRect, win: Window): number {
+  if (rect.height <= 0) return 0;
+  if (rect.bottom < win.innerHeight - BOTTOM_TOLERANCE) return 0;
+  return rect.height;
+}
+
+// Google pins the WRAPPER (position: fixed/sticky); the <ins>/<iframe> inside is
+// statically positioned, so its own rect is not bottom-pinned. Walk up to the
+// nearest fixed/sticky ancestor and measure that band.
+function fixedBottomBand(el: HTMLElement, win: Window): number {
+  let node: HTMLElement | null = el;
+  while (node && node !== win.document.body) {
+    const position = win.getComputedStyle(node).position;
+    if (position === 'fixed' || position === 'sticky') {
+      return bottomPinnedHeight(node.getBoundingClientRect(), win);
+    }
+    node = node.parentElement;
+  }
+  return 0;
+}
+
 export function measureWebAnchorHeight(win: Window): number {
   const doc = win.document;
   if (!doc?.body) return 0;
 
-  const nodes = doc.querySelectorAll<HTMLElement>(ANCHOR_SELECTORS);
   let band = 0;
-  nodes.forEach((el) => {
+
+  // Fast path: the known AdSense anchor <ins> markup (measured in place).
+  doc.querySelectorAll<HTMLElement>(ANCHOR_SELECTORS).forEach((el) => {
     if (el.getAttribute('data-anchor-status') === 'dismissed') return;
-    const rect = el.getBoundingClientRect();
-    if (rect.height <= 0) return;
-    // Only count it if it actually overlays the viewport bottom — an in-flow ad
-    // unit scrolls with the page and never covers fixed bottom CTAs, so it must
-    // not be reserved against.
-    if (rect.bottom < win.innerHeight - BOTTOM_TOLERANCE) return;
-    band = Math.max(band, rect.height);
+    band = Math.max(band, bottomPinnedHeight(el.getBoundingClientRect(), win));
   });
+
+  // Fallback: any Google ad frame/ins whose fixed/sticky wrapper is pinned to
+  // the viewport bottom. Catches Auto-Ads anchors that aren't an
+  // `ins.adsbygoogle-noablate` (Google varies the injected DOM).
+  if (band === 0) {
+    doc.querySelectorAll<HTMLElement>(AD_FRAME_SELECTORS).forEach((el) => {
+      if (el.getAttribute('data-anchor-status') === 'dismissed') return;
+      band = Math.max(band, fixedBottomBand(el, win));
+    });
+  }
 
   return Math.min(Math.round(band), WEB_ANCHOR_MAX_HEIGHT);
 }


### PR DESCRIPTION
The daily-challenge Play button (and other bottom CTAs) hid behind the web
AdSense Auto-Ads anchor band. The measurement chain was correct
(--web-anchor-ad-height -> --bottom-stack-height -> pb-bottom-stack +
scroll-padding-bottom) but measureWebAnchorHeight only matched
`ins.adsbygoogle-noablate` / `ins.adsbygoogle[data-anchor-status]`. Google's
Auto-Ads frequently renders the anchor as a position:fixed WRAPPER holding an
ad iframe, which that selector misses — so --web-anchor-ad-height stayed 0px,
has-web-anchor-ad was never set, and no space was reserved.

- webAnchorAdHeight: add a fallback that finds any Google ad frame/ins
  (ins.adsbygoogle, googleads/doubleclick/googlesyndication iframes,
  aswift-named frames), walks up to its nearest fixed/sticky ancestor, and
  measures that band when it is pinned to the viewport bottom. Keeps the fast
  <ins> path; honours data-anchor-status="dismissed"; reuses the 120px clamp.
- WebAnchorAdObserver: add load listener + settle re-measures (300/1000/2500/
  5000ms) so a late-painting ad iframe (loads after mutations settle) is caught.
- Tests: cover wrapped iframe/ins anchors, aswift frames, top-pinned and
  in-flow (no fixed ancestor) negatives.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rqg9kqX3Et2HWKTJzybjjM