### PR TITLE
feat(word-tower): declutter toasts, slim wheel/deck, full crane word, greener drops

### DIFF
--- a/fe-next/components/wordTower/WordTowerCrane.tsx
+++ b/fe-next/components/wordTower/WordTowerCrane.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/lib/wordTower/cranePlacement';
 import { releaseFx } from '@/lib/wordTower/craneReleaseFx';
 import { swayAngleAt, swayNormalizedOffset, effectiveDropError } from '@/lib/wordTower/towerSway';
-import { craneBeamBricks } from '@/lib/wordTower/craneBeamDisplay';
+import { craneBeamBricks, craneBeamTilePx } from '@/lib/wordTower/craneBeamDisplay';
 import { pendulumTargetDeg, stepPendulum, REST_PENDULUM, type PendulumState } from '@/lib/wordTower/cranePendulum';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { applyHebrewFinalLetters } from '@/shared/utils/wordNormalization';
@@ -71,10 +71,11 @@ const BAND_SHADOW: Record<PlacementQuality, string> = {
   miss: 'rgba(255,51,102,0.4)',
 };
 
-/** Per-letter tile size for the held girder. The word is carried as a VERTICAL
- *  column of square bricks — the exact orientation it settles into in the tower
- *  (pos 0 = base at the bottom) — so the carried payload reads as the same shape
- *  it becomes once placed. */
+/** Default per-letter tile size for the held girder (short words). The word is
+ *  carried as a VERTICAL column of square bricks — the exact orientation it
+ *  settles into in the tower (pos 0 = base at the bottom) — so the carried
+ *  payload reads as the same shape it becomes once placed. Longer words shrink
+ *  the bricks (craneBeamTilePx) so the FULL word still fits the bay. */
 const CRANE_BEAM_TILE_PX = 38;
 /** How far the trolley carriage slides along the jib (px from centre). */
 const TROLLEY_RANGE_PX = 110;
@@ -215,12 +216,15 @@ const WordTowerCrane = forwardRef<WordTowerCraneHandle, WordTowerCraneProps>(fun
   const onSweetSpot = aiming && liveBand === 'perfect';
   // Hebrew: show the word-final letter in its sofit form and lay the beam RTL.
   const beamWord = language === 'he' ? applyHebrewFinalLetters(word) : word;
-  // Carry at most 3 bricks — a long word built a girder so tall it ran off the
-  // top of the bay and crowded the HUD. The full word lives in the builder slot
-  // below; the carried payload only needs to READ as a stack of blocks. Any
-  // remainder is surfaced as a small "+N" badge so the size is still legible.
+  // Show the FULL word the crane is placing (founder: "show all the letters it
+  // is trying to put"). The bricks shrink to share a fixed vertical budget so a
+  // long girder stays inside the bay instead of running off the top. Only a
+  // pathologically long word (> the cap) badges any remainder.
   const { chars: beamChars, hiddenCount } = craneBeamBricks(beamWord);
-  const beamH = beamChars.length * CRANE_BEAM_TILE_PX;
+  const beamTilePx = craneBeamTilePx(beamChars.length);
+  const beamH = beamChars.length * beamTilePx;
+  // Glyph size tracks the brick so dense (small-brick) girders stay legible.
+  const beamFontPx = Math.max(11, Math.round(beamTilePx * 0.5));
 
   // Instability dots — 0, 1, 2, 3 (3 = next miss topples a floor).
   const dots = Array.from({ length: TOPPLE_AFTER_SLOPPY + 1 }, (_, i) => i < consecutiveSloppy);
@@ -316,7 +320,7 @@ const WordTowerCrane = forwardRef<WordTowerCraneHandle, WordTowerCraneProps>(fun
                   The bricks wear the FINAL committed material colour, so the girder does
                   NOT change colour when it lands. The "stop here" skill cue lives on the
                   glow ring + the reticle/shadow below, not on the face. */}
-              <div className="relative mx-auto" style={{ width: `${CRANE_BEAM_TILE_PX}px` }}>
+              <div className="relative mx-auto" style={{ width: `${beamTilePx}px` }}>
                 <div
                   data-testid="crane-block"
                   className={cn(
@@ -328,15 +332,15 @@ const WordTowerCrane = forwardRef<WordTowerCraneHandle, WordTowerCraneProps>(fun
                     // the skill shot stays readable while the colour stays honest.
                     onSweetSpot && 'ring-4 ring-neo-lime ring-offset-2 ring-offset-neo-navy',
                   )}
-                  style={{ width: `${CRANE_BEAM_TILE_PX}px`, height: `${beamH}px` }}
+                  style={{ width: `${beamTilePx}px`, height: `${beamH}px` }}
                   dir={language === 'he' ? 'rtl' : 'ltr'}
                 >
                   {beamChars.map((ch, i) => (
                     <span
                       key={i}
                       data-testid="crane-letter"
-                      className="flex flex-1 items-center justify-center rounded-neo border-neo-thick border-black font-neo-display text-base font-black uppercase shadow-hard"
-                      style={{ backgroundColor: blockColorHex, color: blockTextHex }}
+                      className="flex flex-1 items-center justify-center rounded-neo border-neo-thick border-black font-neo-display font-black uppercase shadow-hard"
+                      style={{ backgroundColor: blockColorHex, color: blockTextHex, fontSize: `${beamFontPx}px` }}
                     >
                       {ch}
                     </span>

--- a/fe-next/components/wordTower/WordTowerHud.tsx
+++ b/fe-next/components/wordTower/WordTowerHud.tsx
@@ -159,7 +159,7 @@ export function WordTowerHud(props: WordTowerHudProps) {
             : <ChevronUp className="h-3 w-3 text-neo-white/40" />}
         </button>
         {deckOpen && (
-        <div className="space-y-1">
+        <div className="space-y-0.5">
         {/* Rejection feedback — the wheel's centre hub shows the live word, so the
             old framed builder slot is gone; the error line stays. */}
         {lastError && errorKey > 0 && (
@@ -223,12 +223,12 @@ export function WordTowerHud(props: WordTowerHudProps) {
             moved INTO the wheel's centre hub (build a word → tap the centre to
             lift it → tap again to drop), so the redundant bottom build button is
             gone and the deck is shorter. Disabled while a word is in flight. */}
-        <div className="mx-auto flex max-w-md items-center justify-center gap-3">
+        <div className="mx-auto flex max-w-md items-center justify-center gap-2.5">
           <button
             type="button"
             onClick={onScramble}
             disabled={scramblesLeft <= 0 || isPlacing}
-            className="flex items-center gap-1 rounded-neo border-neo-thick border-black bg-neo-purple px-3 py-2 font-neo-display font-bold text-neo-white shadow-hard disabled:opacity-40 active:translate-y-0.5 active:shadow-hard-pressed"
+            className="flex items-center gap-1 rounded-neo border-neo-thick border-black bg-neo-purple px-3 py-1.5 font-neo-display font-bold text-neo-white shadow-hard disabled:opacity-40 active:translate-y-0.5 active:shadow-hard-pressed"
             aria-label={t('wordTower.hud.scramble')}
           >
             <Shuffle className="h-5 w-5" />
@@ -238,7 +238,7 @@ export function WordTowerHud(props: WordTowerHudProps) {
             type="button"
             onClick={onBackspace}
             disabled={selected.length === 0 || isPlacing}
-            className="rounded-neo border-neo-thick border-black bg-neo-navy-light px-3 py-2.5 text-neo-white shadow-hard disabled:opacity-40 active:translate-y-0.5 active:shadow-hard-pressed"
+            className="rounded-neo border-neo-thick border-black bg-neo-navy-light px-3 py-1.5 text-neo-white shadow-hard disabled:opacity-40 active:translate-y-0.5 active:shadow-hard-pressed"
             aria-label={t('wordTower.hud.backspace')}
           >
             <Delete className="h-5 w-5" />

--- a/fe-next/components/wordTower/WordTowerMutatorBanner.tsx
+++ b/fe-next/components/wordTower/WordTowerMutatorBanner.tsx
@@ -10,8 +10,9 @@ interface Props {
   reducedMotion?: boolean;
 }
 
-/** How long the intro card holds before fading (ms). */
-const INTRO_MS = 4200;
+/** How long the intro card holds before fading (ms). The persistent chip keeps
+ *  the twist visible afterwards, so the big card can clear quickly. */
+const INTRO_MS = 3000;
 
 /**
  * WordTowerMutatorBanner — pops the day's shared twist once on entry, then

--- a/fe-next/components/wordTower/WordTowerPlay.tsx
+++ b/fe-next/components/wordTower/WordTowerPlay.tsx
@@ -64,8 +64,15 @@ import { WordTowerNextRivalChip } from './WordTowerNextRivalChip';
 
 /** How long a transient celebration toast holds before it auto-dismisses. Kept
  *  short + uniform so banners clear quickly and never pile up / "stick" on
- *  screen (founder: the toasts were staying up too long). */
-const TOAST_MS = 1300;
+ *  screen (founder 2026-06-19: "the notifications stay stuck and don't
+ *  disappear"). Trimmed again so even back-to-back drops never leave a banner
+ *  lingering over the play area. */
+const TOAST_MS = 950;
+
+/** The big centre DROP VERDICT is the most screen-dominant banner, so it clears
+ *  fastest — long enough to read the result + metres, gone before the next drop
+ *  so it never blocks the tower. */
+const VERDICT_MS = 750;
 
 /** Verdict-pop colour by band — mirrors the swinging-beam tint families. */
 const VERDICT_TONE_CLASS: Record<VerdictTone, string> = {
@@ -370,7 +377,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
   // Dismiss via the shared hook (keyed on the verdict's own resultKey) rather than
   // an inline timer, so the lifespan is owned in ONE place and can never be reset
   // by an unrelated re-render — the same robustness the other banners already use.
-  useAutoDismiss(verdict?.key, () => setVerdict(null), TOAST_MS);
+  useAutoDismiss(verdict?.key, () => setVerdict(null), VERDICT_MS);
 
   // Combo-milestone fanfare — a one-shot "×5 ON FIRE!" beat the moment the combo
   // crosses 3/5/10/20. Keyed off resultKey so it fires on the placing tick only.
@@ -618,6 +625,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
         resultKey={tower.state.resultKey}
         errorKey={tower.state.errorKey}
         lastResult={tower.state.lastResult}
+        dropQuality={lastOutcomeRef.current?.quality}
         reducedMotion={reducedMotion}
         bottomInsetPx={deckHeight}
         palette={skin.palette}

--- a/fe-next/components/wordTower/WordTowerScene.tsx
+++ b/fe-next/components/wordTower/WordTowerScene.tsx
@@ -30,6 +30,7 @@ import { WordTowerSighting } from './WordTowerSighting';
 import { WordTowerMascot } from './WordTowerMascot';
 import { WordTowerMinimap } from './WordTowerMinimap';
 import type { RivalMarker } from '@/lib/wordTower/rivals';
+import type { PlacementQuality } from '@/lib/wordTower/cranePlacement';
 
 interface SceneProps {
   floors: WordTowerFloor[];
@@ -43,6 +44,10 @@ interface SceneProps {
   /** Bumps each rejected word — shakes the pending stack. */
   errorKey: number;
   lastResult: ApplyResult | null;
+  /** Quality of the latest crane drop (perfect/good/sloppy/miss) — drives the
+   *  colour-coded landing FX so the player SEES whether they did good/ok/bad,
+   *  not just reads a label. Paired with `resultKey` (the fire trigger). */
+  dropQuality?: PlacementQuality;
   reducedMotion?: boolean;
   /** Height (px) of the bottom control deck — the tower grounds just above it. */
   bottomInsetPx?: number;
@@ -141,7 +146,7 @@ function snapContainerY(c: Container, toY: number, dur: number, cancelled: () =>
  * recolours in place, removed pending tiles pop out, survivors slide. Fires the
  * per-word celebration FX, and offsets the whole stack by the user's pan.
  */
-function TowerCanvasLayer({ floors, biomeId, pendingWord, resultKey, lastResult, reducedMotion, bottomInsetPx = 220, anchorLen = 1, leanDeg = 0, clutchSaveKey = 0, toppleKey = 0, toppleFloors = 1, instability = 0, palette = ZONE_MATERIAL, panState }: SceneProps & { panState: MutableRefObject<PanState> }) {
+function TowerCanvasLayer({ floors, biomeId, pendingWord, resultKey, lastResult, dropQuality, reducedMotion, bottomInsetPx = 220, anchorLen = 1, leanDeg = 0, clutchSaveKey = 0, toppleKey = 0, toppleFloors = 1, instability = 0, palette = ZONE_MATERIAL, panState }: SceneProps & { panState: MutableRefObject<PanState> }) {
   const engine = useGameEngine();
   const containerRef = useRef<Container | null>(null);
   const registry = useRef<Map<string, TileSprite>>(new Map());
@@ -451,19 +456,45 @@ function TowerCanvasLayer({ floors, biomeId, pendingWord, resultKey, lastResult,
     }
   }, [biomeId, engine, reducedMotion]);
 
-  // Celebration FX on each accepted word.
+  // Celebration FX on each accepted word — COLOUR-CODED BY DROP QUALITY so the
+  // player instantly SEES whether they landed good/ok/bad (founder 2026-06-19:
+  // "add more FX on the drop, make it noticeable when it was good, ok or bad").
+  // A full-screen tint flash carries the verdict's colour (green/cyan/yellow/red)
+  // while particles + shake scale the punch; the word-length tier (high-rise →
+  // skyscraper) adds an EXTRA flourish on top for a long build.
+  const dropQualityRef = useRef(dropQuality);
+  dropQualityRef.current = dropQuality;
   useEffect(() => {
     if (resultKey === 0 || !lastResult || reducedMotion) return;
     const { width: W, height: H } = engine;
     const x = W / 2;
-    const y = H * 0.2;
-    if (lastResult.tier === 'skyscraper') {
-      engine.particles.burst(GOLD_STARS, x, y, 48);
-      engine.shake.shake({ intensity: 10, duration: 0.4, decay: 'exponential' });
-    } else if (lastResult.tier === 'highRise' || lastResult.tier === 'tall') {
-      engine.particles.burst(CONFETTI_BURST, x, y, 40);
+    const y = H * 0.22;
+    const q = dropQualityRef.current ?? 'good';
+    if (q === 'perfect') {
+      // Triumph — a bright lime wash, a gold star shower, and a satisfying kick.
+      engine.flash.flash({ color: 0xbfff00, duration: 0.32, intensity: 0.34 });
+      engine.particles.burst(GOLD_STARS, x, y, 40);
+      engine.shake.shake({ intensity: 8, duration: 0.32, decay: 'exponential' });
+    } else if (q === 'good') {
+      // Solid — a cool cyan wash + a healthy confetti pop.
+      engine.flash.flash({ color: 0x22d3ee, duration: 0.26, intensity: 0.22 });
+      engine.particles.burst(CONFETTI_BURST, x, y, 26);
+    } else if (q === 'sloppy') {
+      // Just ok — a brief amber blink + a small puff, no celebration.
+      engine.flash.flash({ color: 0xffe135, duration: 0.22, intensity: 0.18 });
+      engine.particles.burst(COMBO_FLASH, x, y, 12);
     } else {
-      engine.particles.burst(COMBO_FLASH, x, y, 14);
+      // Bad — a red warning wash + a sharp jolt so a fumbled drop clearly stings.
+      engine.flash.flash({ color: 0xff3366, duration: 0.3, intensity: 0.3 });
+      engine.particles.burst(COMBO_FLASH, x, y, 8);
+      engine.shake.shake({ intensity: 5, duration: 0.26, decay: 'exponential' });
+    }
+    // Word-length tier flourish on top of the quality cue (longer build = more).
+    if (lastResult.tier === 'skyscraper') {
+      engine.particles.burst(GOLD_STARS, x, y, 30);
+      engine.shake.shake({ intensity: 9, duration: 0.34, decay: 'exponential' });
+    } else if (lastResult.tier === 'highRise' || lastResult.tier === 'tall') {
+      engine.particles.burst(CONFETTI_BURST, x, y, 20);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resultKey]);

--- a/fe-next/components/wordTower/WordTowerWheel.tsx
+++ b/fe-next/components/wordTower/WordTowerWheel.tsx
@@ -35,8 +35,11 @@ export interface WordTowerWheelProps {
   onDrop: () => void;
 }
 
-/** Ring radius as a percentage of half the stage (letters sit on this circle). */
-const RING_PCT = 38;
+/** Ring radius as a percentage of half the stage (letters sit on this circle).
+ *  Founder ask (2026-06-19): tighten the circle (smaller ring) while the letter
+ *  tiles themselves get BIGGER — a denser, punchier wheel that also frees deck
+ *  height. */
+const RING_PCT = 33;
 
 /** Polar → cartesian on the 0..100 SVG/percent grid (0 = top, clockwise). */
 function letterPos(i: number, n: number): { x: number; y: number } {
@@ -99,7 +102,7 @@ export function WordTowerWheel({
 
   return (
     <div
-      className="relative mx-auto aspect-square w-full max-w-[230px] touch-none select-none"
+      className="relative mx-auto aspect-square w-full max-w-[206px] touch-none select-none"
       onPointerDown={onDown}
       onPointerMove={placing ? undefined : handlePointerMove}
       onPointerUp={placing ? undefined : handlePointerUp}
@@ -181,7 +184,7 @@ export function WordTowerWheel({
             aria-label={t(isGolden ? 'wordTower.a11y.goldenTile' : 'wordTower.a11y.tile', { letter })}
             aria-pressed={isSel}
             className={cn(
-              'absolute z-10 flex h-[15%] w-[15%] items-center justify-center rounded-full border-neo-thick border-black font-neo-display text-lg font-black uppercase shadow-hard transition-all duration-300',
+              'absolute z-10 flex h-[19%] w-[19%] items-center justify-center rounded-full border-neo-thick border-black font-neo-display text-2xl font-black uppercase shadow-hard transition-all duration-300',
               placing ? 'scale-50 opacity-0' : 'opacity-100',
               isSel
                 ? 'bg-neo-cyan text-black ring-2 ring-neo-cyan ring-offset-2 ring-offset-neo-navy'
@@ -243,7 +246,7 @@ export function WordTowerWheel({
             onClick={onDrop}
             aria-label={t('wordTower.crane.steer')}
             className={cn(
-              'pointer-events-auto flex h-[72px] w-[72px] flex-col items-center justify-center rounded-full border-neo-thick border-black bg-gradient-to-b from-neo-lime-light to-neo-lime font-neo-display text-[11px] font-black uppercase leading-tight text-black shadow-hard active:translate-y-0.5',
+              'pointer-events-auto flex h-[66px] w-[66px] flex-col items-center justify-center rounded-full border-neo-thick border-black bg-gradient-to-b from-neo-lime-light to-neo-lime font-neo-display text-[11px] font-black uppercase leading-tight text-black shadow-hard active:translate-y-0.5',
               !reducedMotion && 'animate-neo-pop',
             )}
           >
@@ -256,7 +259,7 @@ export function WordTowerWheel({
             onClick={onSubmit}
             aria-label={t('wordTower.hud.build')}
             className={cn(
-              'pointer-events-auto flex h-[72px] min-w-[72px] max-w-[78%] flex-col items-center justify-center gap-0.5 rounded-full border-neo-thick border-black bg-gradient-to-b from-neo-cyan-light to-neo-cyan px-3 font-neo-display font-black uppercase leading-none text-black shadow-hard active:translate-y-0.5',
+              'pointer-events-auto flex h-[66px] min-w-[66px] max-w-[78%] flex-col items-center justify-center gap-0.5 rounded-full border-neo-thick border-black bg-gradient-to-b from-neo-cyan-light to-neo-cyan px-3 font-neo-display font-black uppercase leading-none text-black shadow-hard active:translate-y-0.5',
               !reducedMotion && 'animate-neo-pop',
             )}
           >

--- a/fe-next/components/wordTower/__tests__/useCraneDrop.test.tsx
+++ b/fe-next/components/wordTower/__tests__/useCraneDrop.test.tsx
@@ -16,7 +16,7 @@ import { useCraneDrop } from '../useCraneDrop';
 import { evaluatePlacement } from '@/lib/wordTower/cranePlacement';
 import { perkModifiers } from '@/lib/wordTower/perks';
 
-const SLOPPY = () => evaluatePlacement(0.4, 0); // a sloppy drop (offset in the sloppy band)
+const SLOPPY = () => evaluatePlacement(0.5, 0); // a sloppy drop (offset in the sloppy band)
 const PERFECT = () => evaluatePlacement(0, 0);
 
 describe('useCraneDrop', () => {
@@ -41,7 +41,7 @@ describe('useCraneDrop', () => {
   it('a non-perfect drop breaks the perfect streak', () => {
     const { result } = renderHook(() => useCraneDrop(vi.fn(), vi.fn()));
     act(() => result.current.onDrop(evaluatePlacement(0, 0)));
-    act(() => result.current.onDrop(evaluatePlacement(0.4, 0))); // sloppy
+    act(() => result.current.onDrop(evaluatePlacement(0.5, 0))); // sloppy
     expect(result.current.perfectStreak).toBe(0);
     expect(result.current.consecutiveSloppy).toBe(1);
   });

--- a/fe-next/lib/wordTower/__tests__/craneBeamDisplay.test.ts
+++ b/fe-next/lib/wordTower/__tests__/craneBeamDisplay.test.ts
@@ -1,18 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import { craneBeamBricks, CRANE_BEAM_MAX_BRICKS } from '../craneBeamDisplay';
+import {
+  craneBeamBricks,
+  craneBeamTilePx,
+  CRANE_BEAM_MAX_BRICKS,
+  CRANE_BEAM_TILE_MIN_PX,
+  CRANE_BEAM_TILE_MAX_PX,
+} from '../craneBeamDisplay';
 
-describe('craneBeamBricks — cap the carried girder to a few bricks', () => {
+describe('craneBeamBricks — show the whole word, badge only the rare overflow', () => {
   it('shows every letter when the word fits the cap (no overflow)', () => {
     const { chars, hiddenCount } = craneBeamBricks('CAT');
     expect(chars).toEqual(['C', 'A', 'T']);
     expect(hiddenCount).toBe(0);
   });
 
-  it('caps a long word to the max bricks and reports the hidden remainder', () => {
-    const { chars, hiddenCount } = craneBeamBricks('CONIFER'); // 7 letters
+  it('shows a normal long word IN FULL (no stub) — founder: show all letters', () => {
+    const { chars, hiddenCount } = craneBeamBricks('CONIFER'); // 7 letters ≤ cap
+    expect(chars).toEqual(['C', 'O', 'N', 'I', 'F', 'E', 'R']);
+    expect(hiddenCount).toBe(0);
+  });
+
+  it('caps only a pathologically long word and badges the remainder', () => {
+    const word = 'A'.repeat(CRANE_BEAM_MAX_BRICKS + 4);
+    const { chars, hiddenCount } = craneBeamBricks(word);
     expect(chars.length).toBe(CRANE_BEAM_MAX_BRICKS);
-    expect(chars).toEqual(['C', 'O', 'N']); // first N letters, base→top
-    expect(hiddenCount).toBe(7 - CRANE_BEAM_MAX_BRICKS);
+    expect(hiddenCount).toBe(4);
   });
 
   it('never returns more bricks than the cap, for any length', () => {
@@ -40,8 +52,28 @@ describe('craneBeamBricks — cap the carried girder to a few bricks', () => {
   });
 
   it('hiddenCount + visible always equals the full length', () => {
-    const word = 'SKYSCRAPER';
+    const word = 'A'.repeat(14);
     const { chars, hiddenCount } = craneBeamBricks(word);
     expect(chars.length + hiddenCount).toBe(word.length);
+  });
+});
+
+describe('craneBeamTilePx — bricks shrink so the full word fits the bay', () => {
+  it('keeps the comfy max size for short words', () => {
+    expect(craneBeamTilePx(1)).toBe(CRANE_BEAM_TILE_MAX_PX);
+    expect(craneBeamTilePx(3)).toBe(CRANE_BEAM_TILE_MAX_PX);
+  });
+
+  it('shrinks monotonically as the word grows longer', () => {
+    expect(craneBeamTilePx(8)).toBeLessThan(craneBeamTilePx(5));
+    expect(craneBeamTilePx(5)).toBeLessThan(craneBeamTilePx(3));
+  });
+
+  it('never returns an illegibly small or oversized brick', () => {
+    for (let n = 0; n <= 20; n++) {
+      const px = craneBeamTilePx(n);
+      expect(px).toBeGreaterThanOrEqual(CRANE_BEAM_TILE_MIN_PX);
+      expect(px).toBeLessThanOrEqual(CRANE_BEAM_TILE_MAX_PX);
+    }
   });
 });

--- a/fe-next/lib/wordTower/__tests__/cranePlacement.test.ts
+++ b/fe-next/lib/wordTower/__tests__/cranePlacement.test.ts
@@ -48,10 +48,10 @@ describe('evaluatePlacement — cosy reward amplifier (never a fail-gate)', () =
   });
 
   it('a loose drop is SLOPPY: trims and reduces height, but tower stands', () => {
-    const r = evaluatePlacement(0.4, 0);
+    const r = evaluatePlacement(0.5, 0);
     expect(r.quality).toBe('sloppy');
     expect(r.heightMultiplier).toBeLessThan(1);
-    expect(r.overlap).toBeCloseTo(0.6);
+    expect(r.overlap).toBeCloseTo(0.5);
     expect(r.topples).toBe(false);
   });
 

--- a/fe-next/lib/wordTower/__tests__/towerLayout.test.ts
+++ b/fe-next/lib/wordTower/__tests__/towerLayout.test.ts
@@ -82,7 +82,7 @@ describe('towerRowLayout (grounded camera)', () => {
   });
 
   it('short tower is grounded: base sits near the bottom (above the deck), no shift', () => {
-    const l = towerRowLayout({ pinCount: 3, H, bottomInsetPx: inset });
+    const l = towerRowLayout({ pinCount: 2, H, bottomInsetPx: inset });
     expect(l.shift).toBe(0);
     // base (pos 0) centred at baseCenter, which is above the control deck
     expect(l.centerY(0)).toBe(l.baseCenter);
@@ -90,14 +90,14 @@ describe('towerRowLayout (grounded camera)', () => {
   });
 
   it('grounded tower never pushes its newest tile above the build line', () => {
-    // Within the visible cap (default 3 rows) the tower stays grounded.
-    const l = towerRowLayout({ pinCount: 3, H, bottomInsetPx: inset });
+    // Within the visible cap (default 2 rows) the tower stays grounded.
+    const l = towerRowLayout({ pinCount: 2, H, bottomInsetPx: inset });
     expect(l.shift).toBe(0);
     // top committed tile stays at or below topCenter (i.e. under the crane line)
-    expect(l.centerY(2)).toBeGreaterThanOrEqual(l.topCenter);
+    expect(l.centerY(1)).toBeGreaterThanOrEqual(l.topCenter);
   });
 
-  // ── "max 3 blocks on screen" — the camera shows only the newest few rows so
+  // ── "top 2 blocks on screen" — the camera shows only the newest few rows so
   //    most of the screen stays clean sky; the rest scrolls below the deck. ──
   it('keeps the tower grounded up to maxVisibleRows, then pans on the next row', () => {
     const mvr = 3;
@@ -108,9 +108,9 @@ describe('towerRowLayout (grounded camera)', () => {
     expect(towerRowLayout({ pinCount: mvr + 1, H, bottomInsetPx: inset, maxVisibleRows: mvr }).shift).toBeGreaterThan(0);
   });
 
-  it('defaults to a 3-row visible cap', () => {
-    expect(towerRowLayout({ pinCount: 3, H, bottomInsetPx: inset }).shift).toBe(0);
-    expect(towerRowLayout({ pinCount: 4, H, bottomInsetPx: inset }).shift).toBeGreaterThan(0);
+  it('defaults to a 2-row visible cap (only the top 2 blocks show when regular)', () => {
+    expect(towerRowLayout({ pinCount: 2, H, bottomInsetPx: inset }).shift).toBe(0);
+    expect(towerRowLayout({ pinCount: 3, H, bottomInsetPx: inset }).shift).toBeGreaterThan(0);
   });
 
   it('build line sits exactly (maxVisibleRows-1) rows above the grounded base', () => {

--- a/fe-next/lib/wordTower/craneBeamDisplay.ts
+++ b/fe-next/lib/wordTower/craneBeamDisplay.ts
@@ -1,17 +1,39 @@
 /**
- * Word Tower — carried-girder brick cap (pure).
+ * Word Tower — carried-girder brick cap + sizing (pure).
  *
  * The crane carries the just-built word as a VERTICAL column of one-brick-per-
- * letter tiles. A long word (e.g. CONIFER → 7 bricks) builds a girder so tall it
- * runs off the top of the bay and crowds the HUD. The full word already lives in
- * the builder slot below, so the carried payload only needs to READ as "a stack
- * of letter blocks" — it does not need every glyph. We therefore cap the girder
- * to a few bricks and surface any remainder as a small "+N" badge on the top
- * brick, keeping the crane compact and the screen uncluttered.
+ * letter tiles. Founder ask (2026-06-19): "when the crane puts the letters, show
+ * ALL the letters it is trying to put." So the girder now renders the WHOLE word
+ * (every glyph) instead of a 3-brick stub. To stop a long word from running off
+ * the top of the bay, {@link craneBeamTilePx} shrinks each brick to fit a fixed
+ * vertical budget — the column gets denser, not taller. A pathologically long
+ * word (> the cap) still badges the remainder so the crane never overflows.
  */
 
-/** Max letter-bricks rendered on the carried girder (founder: "show up to 3"). */
-export const CRANE_BEAM_MAX_BRICKS = 3;
+/** Max letter-bricks rendered on the carried girder. High enough to show every
+ *  letter of essentially any real word in full (founder: "show all the letters");
+ *  the rare longer word badges the overflow so the bay never overflows. */
+export const CRANE_BEAM_MAX_BRICKS = 10;
+
+/** Vertical pixel budget the carried girder must fit within (the bay below the
+ *  hook). Bricks shrink to share it once the word is long. */
+export const CRANE_BEAM_BUDGET_PX = 150;
+/** Brick size clamps (px) — never so small it's illegible, never bigger than the
+ *  comfortable default that short words use. */
+export const CRANE_BEAM_TILE_MIN_PX = 16;
+export const CRANE_BEAM_TILE_MAX_PX = 38;
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+/**
+ * Per-brick pixel size for a girder carrying `count` letters: the full word is
+ * shown, so the bricks shrink to share {@link CRANE_BEAM_BUDGET_PX} once the
+ * column is tall, clamped to a legible range. A short word keeps the comfy max.
+ */
+export function craneBeamTilePx(count: number): number {
+  if (count <= 0) return CRANE_BEAM_TILE_MAX_PX;
+  return Math.round(clamp(CRANE_BEAM_BUDGET_PX / count, CRANE_BEAM_TILE_MIN_PX, CRANE_BEAM_TILE_MAX_PX));
+}
 
 export interface CraneBeamBricks {
   /** Bricks to render, base→top (word[0] first). Length ≤ the cap. */

--- a/fe-next/lib/wordTower/cranePlacement.ts
+++ b/fe-next/lib/wordTower/cranePlacement.ts
@@ -21,10 +21,16 @@ export interface PlacementOutcome {
   topples: boolean;
 }
 
-/** Normalised drop-error band edges (0 = dead centre). */
-export const PERFECT_MAX = 0.08;
-export const GOOD_MAX = 0.25;
-export const SLOPPY_MAX = 0.6;
+/** Normalised drop-error band edges (0 = dead centre).
+ *
+ * Founder ask (2026-06-19): "make the player stay more in the GREEN area so he
+ * really feels he succeeded." The perfect + good ("green") windows are widened
+ * so a reasonably-timed release reliably lands a celebrated drop — the crane is
+ * a reward amplifier, not a precision fail-gate. Only a clearly mistimed release
+ * falls to sloppy/miss. */
+export const PERFECT_MAX = 0.14;
+export const GOOD_MAX = 0.4;
+export const SLOPPY_MAX = 0.62;
 /** Cosy "catch": a missed drop still lands at least this much of the block. */
 export const MIN_CAUGHT_OVERLAP = 0.2;
 /** Bad drops in a row before a miss is allowed to topple a floor. */

--- a/fe-next/lib/wordTower/towerLayout.ts
+++ b/fe-next/lib/wordTower/towerLayout.ts
@@ -62,10 +62,12 @@ export function courseTileLayout(word: string, courseW: number, opts: CourseOpts
 }
 
 /** Default number of committed rows kept on screen before the camera follows
- *  the climb. Founder ask: "show max 3 blocks so most of the screen is clean."
- *  Once the tower passes this, the base scrolls off below the deck and only the
- *  newest `maxVisibleRows` rows stay in the compact bottom construction zone. */
-export const DEFAULT_MAX_VISIBLE_ROWS = 3;
+ *  the climb. Founder ask (2026-06-19): "the tower should show only the top 2
+ *  letter blocks when regular — scrolling reveals all the rest." Once the tower
+ *  passes this, the base scrolls off below the deck and only the newest
+ *  `maxVisibleRows` rows stay in the compact bottom construction zone; the user
+ *  pans down to review everything below. */
+export const DEFAULT_MAX_VISIBLE_ROWS = 2;
 
 /** Inputs for the grounded tower-camera row layout. */
 export interface TowerRowLayoutInput {


### PR DESCRIPTION
- Notifications: trim toast holds (1300→950ms) and give the screen-dominant
  centre verdict its own faster life (750ms) + shorter mutator intro so banners
  never linger/stack over the play area on back-to-back drops.
- Wheel: tighter ring (38→33%) with bigger glyphs (text-2xl, 19% tiles) and a
  smaller footprint (230→206px) — denser, punchier, frees deck height.
- Bottom deck: tightened gaps/padding so the control deck is shorter.
- Crane: render the FULL word being placed (cap 3→10) with dynamically-sized
  bricks (craneBeamTilePx) so a long girder still fits the bay.
- Tower: show only the top 2 settled blocks when regular (DEFAULT_MAX_VISIBLE_ROWS
  3→2); scroll reveals the rest.
- Drops: widen the green bands (perfect 0.08→0.14, good 0.25→0.40) so success
  feels earned + reliable, and add colour-coded landing FX (green/cyan/yellow/red
  flash + scaled particles/shake) so good/ok/bad is unmistakable.

Tests updated for the new band edges, beam cap + sizing, and visible-row cap.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T4pxHb2f24hC4onGyKVVSd