### PR TITLE
feat(word-tower): polish play UI — feel, layout, and stuck-toast fixes

### DIFF
--- a/fe-next/components/wordTower/WordTowerHud.tsx
+++ b/fe-next/components/wordTower/WordTowerHud.tsx
@@ -38,6 +38,8 @@ export interface WordTowerHudProps {
    *  imperative `drop()`. */
   onCraneDrop?: () => void;
   onSelectTile: (i: number) => void;
+  /** Tap an already-selected wheel tile to unselect it. */
+  onDeselectTile?: (i: number) => void;
   onBackspace: () => void;
   onClear: () => void;
   onSubmit: () => void;
@@ -64,7 +66,7 @@ export function WordTowerHud(props: WordTowerHudProps) {
     accentHex = '#7c8a99', reducedMotion = false,
     possibleWords, clueWord, onReroll, goldenLetter, lastError, errorKey, lastResult, resultKey,
     pendingWord, onCraneDrop,
-    onSelectTile, onBackspace, onClear, onSubmit, onScramble, onDeckHeight, t, dir,
+    onSelectTile, onDeselectTile, onBackspace, onClear, onSubmit, onScramble, onDeckHeight, t, dir,
   } = props;
   void onClear;
 
@@ -139,7 +141,7 @@ export function WordTowerHud(props: WordTowerHudProps) {
           // above the edge when collapsed so re-opening the drawer never grazes
           // the system back-gesture zone and exits the game.
           deckOpen
-            ? 'pb-[calc(env(safe-area-inset-bottom)+1.15rem)]'
+            ? 'pb-[calc(env(safe-area-inset-bottom)+1.65rem)]'
             : 'pb-[calc(env(safe-area-inset-bottom)+1.6rem)]',
         )}
       >
@@ -234,6 +236,7 @@ export function WordTowerHud(props: WordTowerHudProps) {
             dir={dir}
             t={t}
             onSelectTile={onSelectTile}
+            onDeselectTile={onDeselectTile}
             onSubmit={onSubmit}
             onDrop={() => onCraneDrop?.()}
           />

--- a/fe-next/components/wordTower/WordTowerPlay.tsx
+++ b/fe-next/components/wordTower/WordTowerPlay.tsx
@@ -452,6 +452,17 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
   useEffect(() => {
     if (tower.state.pendingWord) setVerdict(null);
   }, [tower.state.pendingWord]);
+  // Belt-and-suspenders against the "messages stay stuck" report: the instant the
+  // player begins spelling the NEXT word (first tile selected), drop every
+  // lingering post-drop celebration so none can bleed across builds even if a
+  // timer was starved. (useAutoDismiss/useExitReveal now also self-heal via rAF.)
+  useEffect(() => {
+    if (tower.word.length === 1) {
+      setVerdict(null);
+      setComboFx(null);
+      setSurpriseFx(null);
+    }
+  }, [tower.word.length]);
 
   // Combo-milestone fanfare — a one-shot "×5 ON FIRE!" beat the moment the combo
   // crosses 3/5/10/20. Keyed off resultKey so it fires on the placing tick only.
@@ -858,8 +869,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
         </div>
       )}
 
-      {/* Tower-skin picker — equip the materials you've unlocked by climbing. */}
-      <WordTowerSkinPicker skin={skin} bestHeightM={personalBest} t={t} dir={dir} reducedMotion={reducedMotion} />
+      {/* (Tower-skin picker now lives in the top-bar actions row beside Share.) */}
 
       {/* NEW SKIN UNLOCKED — the variable-reward beat when a climb crosses a
           skin's height milestone (the new look is auto-equipped). */}
@@ -888,7 +898,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
           while the NEW ZONE banner is paying off the arrival. */}
       {tease && !zoneText && (
         <div
-          className="pointer-events-none absolute left-1/2 top-[6%] z-20 -translate-x-1/2 flex items-center gap-1 rounded-neo border-neo border-black bg-neo-navy/75 px-2 py-1 font-neo-body text-[11px] font-bold text-neo-cyan backdrop-blur-sm"
+          className="pointer-events-none absolute left-1/2 top-[13%] z-20 -translate-x-1/2 flex items-center gap-1 rounded-neo border-neo border-black bg-neo-navy/75 px-2 py-1 font-neo-body text-[11px] font-bold text-neo-cyan backdrop-blur-sm"
           aria-live="polite"
         >
           <ChevronsUp className="h-3 w-3" />
@@ -899,7 +909,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
       {/* NEW ZONE banner — the headline of entering a new biome */}
       {zoneR.value && (
         <div
-          className={`pointer-events-none absolute left-1/2 top-[9%] z-30 -translate-x-1/2 ${fxClass(zoneR.exiting, 'animate-neo-pop')} rounded-neo border-neo-thick border-black bg-neo-cyan px-4 py-2 text-center shadow-hard`}
+          className={`pointer-events-none absolute left-1/2 top-[13%] z-30 -translate-x-1/2 ${fxClass(zoneR.exiting, 'animate-neo-pop')} rounded-neo border-neo-thick border-black bg-neo-cyan px-4 py-2 text-center shadow-hard`}
           aria-live="polite"
         >
           <div className="font-neo-body text-[10px] font-bold uppercase tracking-[0.2em] text-black/60">{t('wordTower.zone.entered')}</div>
@@ -1149,6 +1159,9 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
           >
             <Share2 className="h-4 w-4" />
           </button>
+          {/* Tower-skin picker sits right beside Share (founder ask: "skin
+              selection can be near the share") instead of floating mid-screen. */}
+          <WordTowerSkinPicker inline skin={skin} bestHeightM={personalBest} t={t} dir={dir} reducedMotion={reducedMotion} />
           <button
             type="button"
             onClick={onOpenLeaderboard}
@@ -1180,6 +1193,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
           lastResult={tower.state.lastResult}
           resultKey={tower.state.resultKey}
           onSelectTile={selectTileHaptic}
+          onDeselectTile={tower.deselectTile}
           onBackspace={tower.backspace}
           onClear={tower.clear}
           onSubmit={tower.hold}

--- a/fe-next/components/wordTower/WordTowerScene.tsx
+++ b/fe-next/components/wordTower/WordTowerScene.tsx
@@ -108,6 +108,12 @@ interface PanState {
 /** Fraction of the user's pan applied to the background (parallax — bg slower). */
 const BG_PAN_DEPTH = 0.4;
 
+/** Max pending-preview ghost bricks drawn at the crown while spelling. Founder
+ *  ask (2026-06-20): "the tower should always display max 2 top letter blocks —
+ *  here you can see around 5." Capping the live preview keeps the tower's crown
+ *  clean; the full word still reads in the wheel hub + on the carried girder. */
+const MAX_PENDING_PREVIEW = 2;
+
 /** How far the user must scroll down (px) before the back-to-top button shows. */
 const BACK_TO_TOP_REVEAL_PX = 90;
 
@@ -211,7 +217,12 @@ function TowerCanvasLayer({ floors, biomeId, pendingWord, resultKey, lastResult,
     const pendingColor = wordColor(floors.length);
     const topSurface = blockSurface(biomeId);
     // Skip the anchor (pendingWord[0]) when it's already the committed top.
-    const pchars = C === 0 ? Array.from(pendingWord) : Array.from(pendingWord).slice(anchorLen);
+    // Cap the live ghost preview to the first MAX_PENDING_PREVIEW bricks so a long
+    // word doesn't grow a tall column of blocks above the crown (the full word is
+    // shown in the wheel hub + carried on the crane girder). Stable positions →
+    // the diff registry keeps each preview brick's char fixed as the word grows.
+    const pchars = (C === 0 ? Array.from(pendingWord) : Array.from(pendingWord).slice(anchorLen))
+      .slice(0, MAX_PENDING_PREVIEW);
 
     const live: LiveCell[] = committed.map((cell, i) => {
       const zone = biomeForHeight(alts[i] ?? 0);

--- a/fe-next/components/wordTower/WordTowerSkinPicker.tsx
+++ b/fe-next/components/wordTower/WordTowerSkinPicker.tsx
@@ -13,6 +13,10 @@ interface Props {
   t: (key: string, params?: Record<string, string | number>) => string;
   dir: 'ltr' | 'rtl';
   reducedMotion?: boolean;
+  /** Render the trigger as a normal flex item (no absolute positioning) so it can
+   *  sit inside the top-bar actions row next to Share/Leaderboard (founder ask:
+   *  "skin selection can be near the share"). */
+  inline?: boolean;
 }
 
 const hex = (n: number) => `#${n.toString(16).padStart(6, '0')}`;
@@ -22,17 +26,22 @@ const hex = (n: number) => `#${n.toString(16).padStart(6, '0')}`;
  * skins equip on tap; locked ones show the height still to climb (the carrot).
  * Self-contained open state so the parent mounts it with one line.
  */
-export function WordTowerSkinPicker({ skin, bestHeightM, t, dir, reducedMotion }: Props) {
+export function WordTowerSkinPicker({ skin, bestHeightM, t, dir, reducedMotion, inline = false }: Props) {
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      {/* Trigger — a small palette button tucked under the top bar. */}
+      {/* Trigger — a small palette button. Inline = a flush flex item that lives
+          in the top-bar actions row beside Share/Leaderboard; otherwise the old
+          floating button tucked under the top bar. */}
       <button
         type="button"
         onClick={() => setOpen(true)}
         aria-label={t('wordTower.skin.open')}
-        className="pointer-events-auto absolute end-2 top-[14%] z-[9] flex h-9 w-9 items-center justify-center rounded-neo border-neo-thick border-black bg-neo-navy/85 text-neo-cyan shadow-hard backdrop-blur-sm active:translate-y-0.5 active:shadow-hard-pressed"
+        className={cn(
+          'pointer-events-auto relative flex h-9 w-9 items-center justify-center rounded-neo border-neo-thick border-black bg-neo-navy/85 text-neo-cyan shadow-hard backdrop-blur-sm active:translate-y-0.5 active:shadow-hard-pressed',
+          !inline && 'absolute end-2 top-[14%] z-[9]',
+        )}
       >
         <Palette className="h-5 w-5" />
         {/* Live swatch dot of the equipped skin. */}

--- a/fe-next/components/wordTower/WordTowerStatHud.tsx
+++ b/fe-next/components/wordTower/WordTowerStatHud.tsx
@@ -32,6 +32,10 @@ const TIER_CLASS: Record<ArchitectTier, string> = {
 
 export function WordTowerStatHud({ heightM, biomeId, floorsCount, personalBestM, combo, tier, t }: Props) {
   const mult = comboMult(combo);
+  // Compact two-line card (founder ask 2026-06-20: the stat card was a tall
+  // 4-row stack that overlapped the next-zone chip + mode toggle). Line 1: the
+  // big altitude + combo + best. Line 2: biome · floors with the tier badge
+  // inline. Shorter footprint → no collision with the top-centre banners.
   return (
     <div className="pointer-events-none flex flex-col items-center rounded-neo border-neo border-black bg-neo-navy/85 px-3 py-1 text-center shadow-hard-sm backdrop-blur-sm">
       <div className="flex items-baseline gap-2">
@@ -43,20 +47,20 @@ export function WordTowerStatHud({ heightM, biomeId, floorsCount, personalBestM,
             <Flame className="h-3 w-3" aria-hidden />×{mult.toFixed(1)}
           </span>
         )}
+        {personalBestM > 0 && (
+          <span className="font-neo-body text-[10px] font-bold leading-none text-neo-yellow tabular-nums">
+            {t('wordTower.hud.best', { m: Math.round(personalBestM) })}
+          </span>
+        )}
       </div>
-      <span className="font-neo-body text-[10px] uppercase leading-tight tracking-wider text-neo-cyan">
-        {t(`wordTower.biome.${biomeId}`)} · {t('wordTower.hud.floors', { n: floorsCount })}
+      <span className="mt-0.5 flex items-center gap-1.5 font-neo-body text-[10px] uppercase leading-none tracking-wider text-neo-cyan">
+        <span>{t(`wordTower.biome.${biomeId}`)} · {t('wordTower.hud.floors', { n: floorsCount })}</span>
+        {tier && (
+          <span className={`rounded-sm border border-black px-1 py-px font-neo-display text-[9px] font-black uppercase leading-none tracking-wide ${TIER_CLASS[tier]}`}>
+            {t(`wordTower.tier.${tier.toLowerCase()}`)}
+          </span>
+        )}
       </span>
-      {tier && (
-        <span className={`mt-0.5 rounded-sm border border-black px-1.5 py-px font-neo-display text-[9px] font-black uppercase leading-none tracking-wide ${TIER_CLASS[tier]}`}>
-          {t(`wordTower.tier.${tier.toLowerCase()}`)}
-        </span>
-      )}
-      {personalBestM > 0 && (
-        <span className="font-neo-body text-[10px] font-bold leading-tight text-neo-yellow">
-          {t('wordTower.hud.best', { m: Math.round(personalBestM) })}
-        </span>
-      )}
     </div>
   );
 }

--- a/fe-next/components/wordTower/WordTowerWheel.tsx
+++ b/fe-next/components/wordTower/WordTowerWheel.tsx
@@ -29,6 +29,8 @@ export interface WordTowerWheelProps {
   dir: 'ltr' | 'rtl';
   t: (key: string, params?: Record<string, string | number>) => string;
   onSelectTile: (i: number) => void;
+  /** Tap an already-selected tile to unselect it (rewinds the path to before it). */
+  onDeselectTile?: (i: number) => void;
   /** Build (validate + hand to the crane). Also fired on a drag-release. */
   onSubmit: () => void;
   /** Drop the held word (drives the crane). Fired by the dial's centre button. */
@@ -59,7 +61,7 @@ function letterPos(i: number, n: number): { x: number; y: number } {
  */
 export function WordTowerWheel({
   tray, selected, word, placing, canBuild, intensity, accentHex, goldenLetter,
-  reducedMotion = false, dir, t, onSelectTile, onSubmit, onDrop,
+  reducedMotion = false, dir, t, onSelectTile, onDeselectTile, onSubmit, onDrop,
 }: WordTowerWheelProps) {
   const n = tray.length;
   const draggingRef = useRef(false);
@@ -89,7 +91,10 @@ export function WordTowerWheel({
   const tapLetter = (i: number) => {
     // The drag hook already added letters this gesture — swallow the trailing click.
     if (addedDuringDragRef.current) { addedDuringDragRef.current = false; return; }
-    if (placing || selected.includes(i)) return;
+    if (placing) return;
+    // Tap an already-selected tile to UNSELECT it (founder ask) — rewinds the
+    // path to just before that letter. Otherwise add it to the spell path.
+    if (selected.includes(i)) { onDeselectTile?.(i); return; }
     onSelectTile(i);
   };
 
@@ -102,7 +107,7 @@ export function WordTowerWheel({
 
   return (
     <div
-      className="relative mx-auto aspect-square w-full max-w-[206px] touch-none select-none"
+      className="relative mx-auto aspect-square w-full max-w-[178px] touch-none select-none"
       onPointerDown={onDown}
       onPointerMove={placing ? undefined : handlePointerMove}
       onPointerUp={placing ? undefined : handlePointerUp}

--- a/fe-next/components/wordTower/useAutoDismiss.ts
+++ b/fe-next/components/wordTower/useAutoDismiss.ts
@@ -28,7 +28,32 @@ export function useAutoDismiss(token: unknown, clear: () => void, ms: number): v
   clearRef.current = clear;
   useEffect(() => {
     if (token == null) return;
-    const id = setTimeout(() => clearRef.current(), ms);
-    return () => clearTimeout(id);
+    let done = false;
+    let raf = 0;
+    const now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    const start = now();
+    const fire = () => {
+      if (done) return;
+      done = true;
+      if (raf) cancelAnimationFrame(raf);
+      clearTimeout(timer);
+      clearRef.current();
+    };
+    // Primary path: a plain setTimeout.
+    const timer = setTimeout(fire, ms);
+    // Watchdog: on a busy mobile webview the Pixi render loop can STARVE
+    // setTimeout, leaving a celebration toast "stuck" on screen (founder report
+    // 2026-06-20: "messages stay stuck — the plus-height + encouragement"). rAF
+    // is pumped every animation frame while the page is visible, so this fires
+    // the dismiss on time even when the timer lags. Whichever wins is idempotent.
+    if (typeof requestAnimationFrame !== 'undefined') {
+      const tick = () => {
+        if (done) return;
+        if (now() - start >= ms) { fire(); return; }
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    }
+    return () => { done = true; clearTimeout(timer); if (raf) cancelAnimationFrame(raf); };
   }, [token, ms]);
 }

--- a/fe-next/components/wordTower/useExitReveal.ts
+++ b/fe-next/components/wordTower/useExitReveal.ts
@@ -26,6 +26,7 @@ export function useExitReveal<T>(source: T | null | undefined, exitMs = 420): { 
 
   useEffect(() => {
     if (timer.current) { clearTimeout(timer.current); timer.current = null; }
+    let raf = 0;
 
     if (source != null) {
       // Live (or refreshed) content — show it now, cancel any pending exit.
@@ -35,14 +36,35 @@ export function useExitReveal<T>(source: T | null | undefined, exitMs = 420): { 
       // Source cleared while something is showing → run the exit, keep the last
       // value on screen until the animation finishes, then unmount it.
       setExiting(true);
-      timer.current = setTimeout(() => {
+      const finish = () => {
+        if (raf) cancelAnimationFrame(raf);
         setValue(null);
         setExiting(false);
         timer.current = null;
-      }, exitMs);
+      };
+      timer.current = setTimeout(finish, exitMs);
+      // rAF watchdog (same rationale as useAutoDismiss): guarantees the exit
+      // completes + unmounts even if the main thread starves setTimeout, so a
+      // toast can never linger half-faded on a busy frame.
+      if (exitMs > 0 && typeof requestAnimationFrame !== 'undefined') {
+        const start = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+        const tick = () => {
+          const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+          if (now - start >= exitMs) {
+            if (timer.current) { clearTimeout(timer.current); }
+            finish();
+            return;
+          }
+          raf = requestAnimationFrame(tick);
+        };
+        raf = requestAnimationFrame(tick);
+      }
     }
 
-    return () => { if (timer.current) { clearTimeout(timer.current); timer.current = null; } };
+    return () => {
+      if (timer.current) { clearTimeout(timer.current); timer.current = null; }
+      if (raf) cancelAnimationFrame(raf);
+    };
   }, [source, exitMs]);
 
   return { value, exiting };

--- a/fe-next/lib/wordTower/__tests__/cranePlacement.test.ts
+++ b/fe-next/lib/wordTower/__tests__/cranePlacement.test.ts
@@ -27,6 +27,16 @@ describe('alignmentBand — live drop-quality preview (matches the scorer)', () 
       expect(alignmentBand(e)).toBe(evaluatePlacement(e, 0).quality);
     }
   });
+
+  // Founder ask 2026-06-20: "stay more around the green placement." The green
+  // window (perfect + good) is wide so a relaxed, roughly-centred tap reliably
+  // lands a celebrated drop — guard it from quietly narrowing again.
+  it('keeps a forgiving green (perfect/good) window', () => {
+    expect(PERFECT_MAX).toBeGreaterThanOrEqual(0.16);
+    expect(GOOD_MAX).toBeGreaterThanOrEqual(0.45);
+    expect(alignmentBand(0.16)).toBe('perfect');
+    expect(alignmentBand(0.44)).toBe('good');
+  });
 });
 
 describe('evaluatePlacement — cosy reward amplifier (never a fail-gate)', () => {

--- a/fe-next/lib/wordTower/__tests__/craneSweep.test.ts
+++ b/fe-next/lib/wordTower/__tests__/craneSweep.test.ts
@@ -80,6 +80,16 @@ describe('sweepPeriodMs — height-ramped difficulty', () => {
     expect(sweepPeriodMs(-3)).toBe(SWEEP_PERIOD_START_MS);
   });
 
+  // Founder ask 2026-06-20: "placing is moving too fast — slower, stay around
+  // green." Lock the relaxed pace so a future tweak can't silently speed it back
+  // up: the ground sweep is a leisurely ≥3s and even the tallest tower never
+  // sweeps faster than a comfortable ≥2s.
+  it('keeps the sweep comfortably slow at every height', () => {
+    expect(SWEEP_PERIOD_START_MS).toBeGreaterThanOrEqual(3000);
+    expect(SWEEP_PERIOD_FLOOR_MS).toBeGreaterThanOrEqual(2000);
+    expect(sweepPeriodMs(9999)).toBeGreaterThanOrEqual(2000);
+  });
+
   it('is monotonically non-increasing in height', () => {
     let prev = sweepPeriodMs(0);
     for (let f = 1; f <= 40; f++) {

--- a/fe-next/lib/wordTower/__tests__/useWordTower.test.ts
+++ b/fe-next/lib/wordTower/__tests__/useWordTower.test.ts
@@ -163,6 +163,37 @@ describe('useWordTower', () => {
     expect(result.current.state.selected).toEqual([0]);
   });
 
+  describe('deselectTile — tap a chosen tile to unselect it', () => {
+    it('tapping the last-selected tile removes just it (backspace-equivalent)', () => {
+      const { result } = setup();
+      pick(result, [0, 1, 2]);
+      act(() => result.current.deselectTile(2));
+      expect(result.current.state.selected).toEqual([0, 1]);
+    });
+
+    it('tapping a tile in the middle rewinds the path to before it', () => {
+      const { result } = setup();
+      pick(result, [0, 1, 2, 3]);
+      act(() => result.current.deselectTile(1));
+      // 1 and everything chosen after it (2, 3) are dropped — clean prefix remains.
+      expect(result.current.state.selected).toEqual([0]);
+    });
+
+    it('tapping the first-selected tile clears the whole word', () => {
+      const { result } = setup();
+      pick(result, [0, 1, 2]);
+      act(() => result.current.deselectTile(0));
+      expect(result.current.state.selected).toEqual([]);
+    });
+
+    it('tapping an unselected tile is a no-op', () => {
+      const { result } = setup();
+      pick(result, [0, 1]);
+      act(() => result.current.deselectTile(4));
+      expect(result.current.state.selected).toEqual([0, 1]);
+    });
+  });
+
   it('scramble spends a scramble, resets combo, clears selection', () => {
     const { result } = setup();
     act(() => result.current.selectTile(0));

--- a/fe-next/lib/wordTower/cranePlacement.ts
+++ b/fe-next/lib/wordTower/cranePlacement.ts
@@ -28,8 +28,8 @@ export interface PlacementOutcome {
  * so a reasonably-timed release reliably lands a celebrated drop — the crane is
  * a reward amplifier, not a precision fail-gate. Only a clearly mistimed release
  * falls to sloppy/miss. */
-export const PERFECT_MAX = 0.14;
-export const GOOD_MAX = 0.4;
+export const PERFECT_MAX = 0.18;
+export const GOOD_MAX = 0.45;
 export const SLOPPY_MAX = 0.62;
 /** Cosy "catch": a missed drop still lands at least this much of the block. */
 export const MIN_CAUGHT_OVERLAP = 0.2;

--- a/fe-next/lib/wordTower/craneSweep.ts
+++ b/fe-next/lib/wordTower/craneSweep.ts
@@ -14,12 +14,18 @@
  * instead of sitting at a flat 1800 ms forever.
  */
 
-/** Sweep period (ms) at the ground floor — generous, learnable. */
-export const SWEEP_PERIOD_START_MS = 2600;
-/** Floor on the period (ms) — the fastest the sweep ever gets, however tall. */
-export const SWEEP_PERIOD_FLOOR_MS = 1400;
-/** How many ms shorter (faster) the sweep gets per floor climbed. */
-export const SWEEP_PERIOD_STEP_MS = 60;
+/** Sweep period (ms) at the ground floor — generous, learnable.
+ *  Founder ask (2026-06-20): "the placing of the word is moving too fast — it
+ *  should be slower and stay more around the green placement." Slowed across the
+ *  board so the trolley dwells longer over the centre and a relaxed tap reliably
+ *  lands in the green window. */
+export const SWEEP_PERIOD_START_MS = 3400;
+/** Floor on the period (ms) — the fastest the sweep ever gets, however tall.
+ *  Raised so even a tall tower never sweeps faster than a comfortably-timed tap. */
+export const SWEEP_PERIOD_FLOOR_MS = 2200;
+/** How many ms shorter (faster) the sweep gets per floor climbed. Gentled so the
+ *  difficulty ramp is slower — the climb stays fair far higher up. */
+export const SWEEP_PERIOD_STEP_MS = 40;
 
 const clamp = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n));
 

--- a/fe-next/lib/wordTower/useWordTower.ts
+++ b/fe-next/lib/wordTower/useWordTower.ts
@@ -45,6 +45,7 @@ export interface WordTowerUIState {
 
 type Action =
   | { type: 'selectTile'; index: number }
+  | { type: 'deselectTile'; index: number }
   | { type: 'backspace' }
   | { type: 'clear' }
   | { type: 'submit'; isInDictionary: (canonWord: string) => boolean }
@@ -67,6 +68,15 @@ function reducer(state: WordTowerUIState, action: Action): WordTowerUIState {
       if (action.index < 0 || action.index >= state.game.tray.length) return state;
       if (state.selected.includes(action.index)) return state; // each tile once
       return { ...state, selected: [...state.selected, action.index] };
+    }
+    case 'deselectTile': {
+      // Tap an already-chosen tile to UNSELECT it (founder ask 2026-06-20). We
+      // rewind the path to just BEFORE that tile — dropping it and everything
+      // chosen after — so the remaining selection stays a clean, contiguous
+      // prefix (no holes in the spell path / connecting polyline).
+      const at = state.selected.indexOf(action.index);
+      if (at === -1) return state;
+      return { ...state, selected: state.selected.slice(0, at) };
     }
     case 'backspace':
       if (state.selected.length === 0) return state;
@@ -171,6 +181,7 @@ export function useWordTower(opts: UseWordTowerOpts) {
   const handlers = useMemo(
     () => ({
       selectTile: (index: number) => dispatch({ type: 'selectTile', index }),
+      deselectTile: (index: number) => dispatch({ type: 'deselectTile', index }),
       backspace: () => dispatch({ type: 'backspace' }),
       clear: () => dispatch({ type: 'clear' }),
       submit: () => dispatch({ type: 'submit', isInDictionary: dictRef.current }),


### PR DESCRIPTION
Founder feedback (2026-06-20) on the Word Tower play screen:

- Slower, greener placement: sweep period raised (3400ms ground / 2200ms
  floor, gentler ramp) and the perfect/good band widened (0.18/0.45) so a
  relaxed tap reliably lands in the green window.
- Tap-to-unselect: tapping an already-chosen wheel tile rewinds the spell
  path to before it (new deselectTile reducer action wired through the wheel).
- Cleaner tower crown: the live ghost preview is capped to 2 bricks so a long
  word no longer grows a ~5-block column above the crown.
- Stuck-toast fix: useAutoDismiss + useExitReveal now self-heal via an rAF
  watchdog so a starved setTimeout on a busy Pixi frame can't leave the
  verdict / +height / encouragement banners frozen on screen; also clear any
  lingering post-drop FX the instant the next word starts.
- Layout: skin picker moved into the top-bar actions row beside Share; the
  altitude/metadata card compacted to two lines and the next-zone + new-zone
  banners dropped below it so the status and metadata no longer overlap.
- Bottom deck: tighter wheel + comfortable bottom safe-area padding so the
  controls sit a touch higher off the edge while the deck reclaims screen.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FS8qJJNTLmCuUmbDF4jiiJ