### PR TITLE
fix(adventure): gate Word Hunt exit behind a confirmation to stop black-screen crash

### DIFF
--- a/fe-next/components/adventure/AdventureHuntGame.tsx
+++ b/fe-next/components/adventure/AdventureHuntGame.tsx
@@ -13,6 +13,7 @@ import { showAchievementToast } from '@/components/achievements/AchievementToast
 import { ADVENTURE_ACHIEVEMENTS } from '@/utils/adventureAchievementUtils';
 import { useAdventureWordValidation } from '@/hooks/useAdventureWordValidation';
 import { WordHuntGameLayout } from '@/components/wordhunt/WordHuntGameLayout';
+import { ConfirmationDialog } from '@/components/ui/ConfirmationDialog';
 import { pickHuntTarget, HUNT_WRONG_GUESS_DAMAGE, HUNT_MAX_ATTEMPTS, getHuntLifePoints } from '@/lib/adventure/huntMode';
 import { getLetterFeedback } from '@/utils/wordHuntFeedback';
 import { cn } from '@/lib/utils';
@@ -154,6 +155,22 @@ const AdventureHuntGame: React.FC<Props> = ({ levelConfig, initialGrid, onLevelC
   const targetWord = state.targetWord;
   const targetLength = targetWord?.length ?? 0;
 
+  // Quit confirmation. Tapping exit mid-match used to call onExit directly,
+  // which fires window.history.back() and tears the live scene down with no
+  // gate — an accidental tap blanked the Capacitor WebView ("black screen on
+  // exit"). Gate it behind a confirmation like classic AdventureGame and every
+  // other Word Hunt surface (MP, daily Survival). Skip the prompt once the game
+  // is over (nothing left to lose) so the post-game exit stays one tap.
+  const [showExitConfirm, setShowExitConfirm] = React.useState(false);
+  const handleRequestExit = useCallback(() => {
+    if (state.isGameOver) { onExit(); return; }
+    setShowExitConfirm(true);
+  }, [state.isGameOver, onExit]);
+  const handleConfirmExit = useCallback(() => {
+    setShowExitConfirm(false);
+    onExit();
+  }, [onExit]);
+
   const completedRef = React.useRef(false);
   React.useEffect(() => {
     if (!state.targetFound || completedRef.current) return;
@@ -207,7 +224,7 @@ const AdventureHuntGame: React.FC<Props> = ({ levelConfig, initialGrid, onLevelC
     <div className="relative h-full w-full bg-neo-navy flex flex-col">
       {/* Exit button */}
       <button
-        onClick={onExit}
+        onClick={handleRequestExit}
         aria-label={t('common.exit')}
         className={cn(
           'absolute top-2 start-2 z-20 p-2 rounded-neo',
@@ -247,7 +264,7 @@ const AdventureHuntGame: React.FC<Props> = ({ levelConfig, initialGrid, onLevelC
           <WordHuntGameLayout
             // Header
             score={state.foundWords.length * 10}
-            onQuit={onExit}
+            onQuit={handleRequestExit}
 
             // Clue boxes
             targetLength={targetLength}
@@ -286,6 +303,19 @@ const AdventureHuntGame: React.FC<Props> = ({ levelConfig, initialGrid, onLevelC
           />
         </div>
       )}
+
+      {/* Quit confirmation — prevents accidental mid-match teardown / black screen */}
+      <ConfirmationDialog
+        open={showExitConfirm}
+        onOpenChange={setShowExitConfirm}
+        title={t('adventure.game.confirmExit')}
+        description={t('adventure.game.confirmExitDesc')}
+        confirmText={t('common.quit')}
+        cancelText={t('common.cancel')}
+        onConfirm={handleConfirmExit}
+        variant="danger"
+        analyticsId="adventure_hunt_quit_confirm"
+      />
     </div>
   );
 };

--- a/fe-next/components/adventure/__tests__/AdventureHuntGame.test.tsx
+++ b/fe-next/components/adventure/__tests__/AdventureHuntGame.test.tsx
@@ -16,6 +16,12 @@ vi.mock('@/contexts/LanguageContext', () => ({
     language: 'en',
     dir: 'ltr',
   }),
+  // ConfirmationDialog (real, un-mocked) calls useLanguage() — provide it too.
+  useLanguage: () => ({
+    t: (key: string) => key,
+    language: 'en',
+    dir: 'ltr',
+  }),
 }));
 
 vi.mock('@/contexts/ProgressionContext', () => ({
@@ -202,7 +208,11 @@ describe('AdventureHuntGame', () => {
     expect(screen.getByRole('button', { name: 'common.exit' })).toBeInTheDocument();
   });
 
-  it('calls onExit when exit button clicked', () => {
+  it('does NOT exit immediately — opens a quit confirmation dialog first', () => {
+    // Regression: tapping exit mid-match used to tear the scene down with no
+    // confirmation (window.history.back → blank Capacitor WebView / "black
+    // screen on exit"). Exit must now be gated behind a confirmation, matching
+    // classic AdventureGame and every other Word Hunt surface.
     render(
       <AdventureHuntGame
         levelConfig={makeHuntLevel()} initialGrid={baseGrid}
@@ -211,7 +221,34 @@ describe('AdventureHuntGame', () => {
       />
     );
     fireEvent.click(screen.getByRole('button', { name: 'common.exit' }));
+    expect(onExit).not.toHaveBeenCalled();
+    expect(screen.getByText('adventure.game.confirmExit')).toBeInTheDocument();
+  });
+
+  it('calls onExit only after the quit confirmation is confirmed', () => {
+    render(
+      <AdventureHuntGame
+        levelConfig={makeHuntLevel()} initialGrid={baseGrid}
+        onLevelComplete={onLevelComplete}
+        onExit={onExit}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'common.exit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'common.quit' }));
     expect(onExit).toHaveBeenCalledOnce();
+  });
+
+  it('does not exit when the quit confirmation is cancelled', () => {
+    render(
+      <AdventureHuntGame
+        levelConfig={makeHuntLevel()} initialGrid={baseGrid}
+        onLevelComplete={onLevelComplete}
+        onExit={onExit}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'common.exit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'common.cancel' }));
+    expect(onExit).not.toHaveBeenCalled();
   });
 
   it('shows level badge W2·L3', () => {


### PR DESCRIPTION
Adventure Word Hunt (and the X button + header quit) called onExit directly,
which fires window.history.back() and tears the live scene down with no gate.
An accidental mid-match tap instantly destroyed the game and blanked the
Capacitor WebView (the "black screen on exit" report) — unlike classic
AdventureGame (handleExitWithConfirm) and every other Word Hunt surface
(multiplayer, daily Survival), which all confirm before exiting.

Route the exit through a ConfirmationDialog ("Exit Level?"), matching the
sibling surfaces. Confirm calls onExit; cancel keeps the match alive. The
prompt is skipped once the game is over (nothing left to lose), so post-game
exit stays a single tap.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KcbBEcAKcQuF7uvi6UVCye