### PR TITLE
feat(daily): make daily-challenge leaderboards span all languages

### DIFF
--- a/fe-next/backend/routes/dailyChallenge.ts
+++ b/fe-next/backend/routes/dailyChallenge.ts
@@ -15,6 +15,7 @@ import { COIN_COSTS } from '../../utils/coinManager';
 import type { Language } from '../../types';
 import wordHuntRouter from './dailyChallenge/wordHuntRoutes';
 import wordWheelRouter from './dailyChallenge/wordWheelRoutes';
+import { rerankSequential, sortClassicPuzzleRowsGlobally } from './dailyChallenge/leaderboardSort';
 import { updateQuestProgress } from '../modules/weeklyQuestManager';
 import { shouldCreditDailyChallengeQuest } from '../../lib/daily/questCredit';
 
@@ -160,13 +161,17 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
         throw new Error('Database connection unavailable');
       }
 
+      // Cross-language (global) leaderboard: no `.eq('language', …)` filter — players
+      // from every language compete together. The view's rank_position is per-language,
+      // so we order by the scoring columns directly and renumber globally below.
       const { data, error } = await supabase
         .from('daily_puzzle_leaderboard')
         .select('*')
         .eq('puzzle_date', date)
-        .eq('language', language)
         .not('player_id', 'is', null)
-        .order('rank_position', { ascending: true })
+        .order('score', { ascending: false, nullsFirst: false })
+        .order('word_count', { ascending: false, nullsFirst: false })
+        .order('time_seconds', { ascending: true, nullsFirst: false })
         .limit(limit);
 
       if (error) {
@@ -177,7 +182,6 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
         .from('daily_puzzle_attempts')
         .select('*', { count: 'exact', head: true })
         .eq('puzzle_date', date)
-        .eq('language', language)
         .not('player_id', 'is', null);
 
       if (countError) {
@@ -187,8 +191,7 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       const { count: totalCount, error: totalCountError } = await supabase
         .from('daily_puzzle_attempts')
         .select('*', { count: 'exact', head: true })
-        .eq('puzzle_date', date)
-        .eq('language', language);
+        .eq('puzzle_date', date);
 
       if (totalCountError) {
         logger.warn('API', `Daily leaderboard total count error: ${totalCountError.message}`);
@@ -198,7 +201,6 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
         .from('daily_puzzle_attempts')
         .select('*', { count: 'exact', head: true })
         .eq('puzzle_date', date)
-        .eq('language', language)
         .is('player_id', null)
         .not('guest_fingerprint', 'is', null);
 
@@ -206,15 +208,11 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
         logger.warn('API', `Daily leaderboard guest count error: ${guestCountError.message}`);
       }
 
-      // Re-number rank_position sequentially among authenticated players only.
-      // The view's rank_position is partitioned by (puzzle_date, language) but
-      // includes guest rows, so post-filter rows would otherwise keep gaps
-      // (e.g. first auth player showing as rank #3 because ranks #1/#2 were guests).
-      // This guarantees each language's leaderboard starts at rank 1.
-      const rerankedData = (data || []).map((row, index) => ({
-        ...row,
-        rank_position: index + 1,
-      }));
+      // Sort the merged cross-language rows by the global scoring order, then
+      // renumber rank_position sequentially 1..N. The view's rank_position is
+      // partitioned per (puzzle_date, language) and includes guests, so it can't
+      // be trusted once the language filter is dropped.
+      const rerankedData = rerankSequential(sortClassicPuzzleRowsGlobally(data || []));
 
       const dataLength = rerankedData.length;
       const queryCount = count ?? 0;

--- a/fe-next/backend/routes/dailyChallenge/__tests__/leaderboardSort.test.ts
+++ b/fe-next/backend/routes/dailyChallenge/__tests__/leaderboardSort.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for cross-language (global) daily-challenge leaderboard ordering.
+ *
+ * Background: each language plays a DIFFERENT daily puzzle, and the SQL views
+ * rank players with ROW_NUMBER() PARTITIONed by language — so every language
+ * gets its own rank #1. Historically the API also filtered `.eq('language', x)`,
+ * so a player only ever saw competitors from their own language.
+ *
+ * New requirement: the daily-challenge leaderboard must include players from
+ * ALL languages in a single global ranking. Because the view's rank_position is
+ * per-language, the route can no longer trust it once the language filter is
+ * dropped — it must re-sort the merged rows by the same scoring criteria and
+ * renumber rank_position 1..N globally.
+ *
+ * These tests pin down that pure ordering + reranking logic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  rerankSequential,
+  sortWordHuntRowsGlobally,
+  sortWordWheelRowsGlobally,
+  sortClassicPuzzleRowsGlobally,
+} from '../leaderboardSort';
+
+describe('rerankSequential', () => {
+  it('renumbers rank_position 1..N regardless of incoming per-language ranks', () => {
+    const rows = [
+      { player_id: 'a', language: 'he', rank_position: 1 },
+      { player_id: 'x', language: 'en', rank_position: 1 },
+      { player_id: 'b', language: 'he', rank_position: 2 },
+    ];
+
+    expect(rerankSequential(rows).map((r) => r.rank_position)).toEqual([1, 2, 3]);
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(rerankSequential([])).toEqual([]);
+  });
+
+  it('preserves all other row fields', () => {
+    const reranked = rerankSequential([{ player_id: 'a', score: 100, rank_position: 9 }]);
+    expect(reranked[0]).toMatchObject({ player_id: 'a', score: 100, rank_position: 1 });
+  });
+});
+
+describe('sortWordHuntRowsGlobally', () => {
+  it('interleaves players from different languages by efficiency score', () => {
+    const rows = [
+      { player_id: 'he-top', language: 'he', solved: true, efficiency_score: 800, attempts_used: 2, completed_at: '2026-06-21T10:00:00Z' },
+      { player_id: 'en-top', language: 'en', solved: true, efficiency_score: 950, attempts_used: 1, completed_at: '2026-06-21T09:00:00Z' },
+      { player_id: 'he-2', language: 'he', solved: true, efficiency_score: 900, attempts_used: 3, completed_at: '2026-06-21T11:00:00Z' },
+    ];
+
+    const sorted = sortWordHuntRowsGlobally(rows);
+
+    // Global order by efficiency desc: en-top(950), he-2(900), he-top(800)
+    expect(sorted.map((r) => r.player_id)).toEqual(['en-top', 'he-2', 'he-top']);
+  });
+
+  it('ranks solved players above unsolved ones', () => {
+    const rows = [
+      { player_id: 'unsolved-high', language: 'en', solved: false, efficiency_score: 999, attempts_used: 10, completed_at: '2026-06-21T08:00:00Z' },
+      { player_id: 'solved-low', language: 'he', solved: true, efficiency_score: 100, attempts_used: 9, completed_at: '2026-06-21T09:00:00Z' },
+    ];
+
+    expect(sortWordHuntRowsGlobally(rows).map((r) => r.player_id)).toEqual(['solved-low', 'unsolved-high']);
+  });
+
+  it('breaks ties on fewer attempts, then earlier completion', () => {
+    const rows = [
+      { player_id: 'later', language: 'en', solved: true, efficiency_score: 500, attempts_used: 2, completed_at: '2026-06-21T12:00:00Z' },
+      { player_id: 'fewer-attempts', language: 'he', solved: true, efficiency_score: 500, attempts_used: 1, completed_at: '2026-06-21T13:00:00Z' },
+      { player_id: 'earlier', language: 'sv', solved: true, efficiency_score: 500, attempts_used: 2, completed_at: '2026-06-21T11:00:00Z' },
+    ];
+
+    expect(sortWordHuntRowsGlobally(rows).map((r) => r.player_id)).toEqual(['fewer-attempts', 'earlier', 'later']);
+  });
+
+  it('does not mutate the input array', () => {
+    const rows = [
+      { player_id: 'a', language: 'en', solved: true, efficiency_score: 1, attempts_used: 1, completed_at: 'z' },
+      { player_id: 'b', language: 'he', solved: true, efficiency_score: 2, attempts_used: 1, completed_at: 'z' },
+    ];
+    const snapshot = rows.map((r) => r.player_id);
+    sortWordHuntRowsGlobally(rows);
+    expect(rows.map((r) => r.player_id)).toEqual(snapshot);
+  });
+});
+
+describe('sortWordWheelRowsGlobally', () => {
+  it('orders all languages by score desc, then word_count desc, then earlier completion', () => {
+    const rows = [
+      { player_id: 'he', language: 'he', score: 120, word_count: 8, completed_at: '2026-06-21T10:00:00Z' },
+      { player_id: 'en', language: 'en', score: 200, word_count: 12, completed_at: '2026-06-21T09:00:00Z' },
+      { player_id: 'es-a', language: 'es', score: 120, word_count: 10, completed_at: '2026-06-21T11:00:00Z' },
+    ];
+
+    expect(sortWordWheelRowsGlobally(rows).map((r) => r.player_id)).toEqual(['en', 'es-a', 'he']);
+  });
+});
+
+describe('sortClassicPuzzleRowsGlobally', () => {
+  it('orders all languages by score desc, word_count desc, then faster time (nulls last)', () => {
+    const rows = [
+      { player_id: 'he', language: 'he', score: 300, word_count: 20, time_seconds: 90 },
+      { player_id: 'en', language: 'en', score: 300, word_count: 20, time_seconds: 60 },
+      { player_id: 'no-time', language: 'sv', score: 300, word_count: 20, time_seconds: null },
+    ];
+
+    expect(sortClassicPuzzleRowsGlobally(rows).map((r) => r.player_id)).toEqual(['en', 'he', 'no-time']);
+  });
+});

--- a/fe-next/backend/routes/dailyChallenge/leaderboardSort.ts
+++ b/fe-next/backend/routes/dailyChallenge/leaderboardSort.ts
@@ -1,0 +1,119 @@
+/**
+ * Pure ordering + reranking helpers for the daily-challenge leaderboards.
+ *
+ * The daily-challenge leaderboard spans ALL languages: every language plays a
+ * different puzzle, but players are merged into a single global ranking by the
+ * same scoring criteria used inside the per-language SQL views.
+ *
+ * The SQL views' `rank_position` is partitioned per language, so once the route
+ * drops the `.eq('language', …)` filter it can no longer rely on that column —
+ * it must re-sort the merged rows here and renumber them 1..N globally.
+ *
+ * These helpers are intentionally pure (no DB, no I/O) so the ordering contract
+ * is unit-testable and shared across every daily-challenge leaderboard route.
+ */
+
+/** Renumber `rank_position` sequentially starting at 1, preserving order + fields. */
+export function rerankSequential<T>(rows: T[]): (T & { rank_position: number })[] {
+  return rows.map((row, index) => ({ ...row, rank_position: index + 1 }));
+}
+
+/** Descending numeric compare with NULL/undefined sorted last. */
+function compareNumberDescNullsLast(a: number | null | undefined, b: number | null | undefined): number {
+  const an = a ?? null;
+  const bn = b ?? null;
+  if (an === null && bn === null) return 0;
+  if (an === null) return 1;
+  if (bn === null) return -1;
+  return bn - an;
+}
+
+/** Ascending numeric compare with NULL/undefined sorted last (e.g. fewer attempts / faster time first). */
+function compareNumberAscNullsLast(a: number | null | undefined, b: number | null | undefined): number {
+  const an = a ?? null;
+  const bn = b ?? null;
+  if (an === null && bn === null) return 0;
+  if (an === null) return 1;
+  if (bn === null) return -1;
+  return an - bn;
+}
+
+/** Ascending string compare (earlier timestamp first); NULL/undefined sorted last. */
+function compareStringAscNullsLast(a: string | null | undefined, b: string | null | undefined): number {
+  const an = a ?? null;
+  const bn = b ?? null;
+  if (an === null && bn === null) return 0;
+  if (an === null) return 1;
+  if (bn === null) return -1;
+  return an.localeCompare(bn);
+}
+
+export interface WordHuntRow {
+  solved?: boolean | null;
+  efficiency_score?: number | null;
+  attempts_used?: number | null;
+  completed_at?: string | null;
+}
+
+/**
+ * Global Word Hunt ordering — mirrors the `daily_word_hunt_leaderboard` view:
+ * solved DESC, efficiency_score DESC NULLS LAST, attempts_used ASC, completed_at ASC.
+ */
+export function sortWordHuntRowsGlobally<T extends WordHuntRow>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => {
+    const solvedDelta = (b.solved ? 1 : 0) - (a.solved ? 1 : 0);
+    if (solvedDelta !== 0) return solvedDelta;
+
+    const effDelta = compareNumberDescNullsLast(a.efficiency_score, b.efficiency_score);
+    if (effDelta !== 0) return effDelta;
+
+    const attemptsDelta = compareNumberAscNullsLast(a.attempts_used, b.attempts_used);
+    if (attemptsDelta !== 0) return attemptsDelta;
+
+    return compareStringAscNullsLast(a.completed_at, b.completed_at);
+  });
+}
+
+export interface WordWheelRow {
+  score?: number | null;
+  word_count?: number | null;
+  completed_at?: string | null;
+}
+
+/**
+ * Global Word Wheel ordering — mirrors the `daily_word_wheel_leaderboard` view:
+ * score DESC, word_count DESC, completed_at ASC.
+ */
+export function sortWordWheelRowsGlobally<T extends WordWheelRow>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => {
+    const scoreDelta = compareNumberDescNullsLast(a.score, b.score);
+    if (scoreDelta !== 0) return scoreDelta;
+
+    const wordsDelta = compareNumberDescNullsLast(a.word_count, b.word_count);
+    if (wordsDelta !== 0) return wordsDelta;
+
+    return compareStringAscNullsLast(a.completed_at, b.completed_at);
+  });
+}
+
+export interface ClassicPuzzleRow {
+  score?: number | null;
+  word_count?: number | null;
+  time_seconds?: number | null;
+}
+
+/**
+ * Global classic daily-puzzle ordering — mirrors the `daily_puzzle_leaderboard`
+ * view: score DESC, word_count DESC, time_seconds ASC NULLS LAST.
+ */
+export function sortClassicPuzzleRowsGlobally<T extends ClassicPuzzleRow>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => {
+    const scoreDelta = compareNumberDescNullsLast(a.score, b.score);
+    if (scoreDelta !== 0) return scoreDelta;
+
+    const wordsDelta = compareNumberDescNullsLast(a.word_count, b.word_count);
+    if (wordsDelta !== 0) return wordsDelta;
+
+    return compareNumberAscNullsLast(a.time_seconds, b.time_seconds);
+  });
+}

--- a/fe-next/backend/routes/dailyChallenge/wordHuntRoutes.ts
+++ b/fe-next/backend/routes/dailyChallenge/wordHuntRoutes.ts
@@ -28,6 +28,7 @@ import {
   computeWordHuntRetryScore,
 } from './utils';
 import { completeMissionForMode } from '../../modules/dailyMissionsManager';
+import { rerankSequential, sortWordHuntRowsGlobally } from './leaderboardSort';
 import { updateDailyProfileStats } from './profileStats';
 import { updateLeaderboardEntry } from '../../modules/supabase/leaderboard';
 import { leaderboardPointsForGame } from '../../modules/leaderboardScoring';
@@ -496,14 +497,18 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       return;
     }
 
+    // Cross-language (global) leaderboard: no `.eq('language', …)` filter — players
+    // from every language compete together. The view's rank_position is per-language,
+    // so we order by the scoring columns directly and renumber globally below.
     const { data, error } = await supabase
       .from('daily_word_hunt_leaderboard')
       .select('*')
       .eq('puzzle_date', date)
-      .eq('language', language)
       .eq('solved', true)
       .not('player_id', 'is', null)
-      .order('rank_position', { ascending: true })
+      .order('efficiency_score', { ascending: false, nullsFirst: false })
+      .order('attempts_used', { ascending: true, nullsFirst: false })
+      .order('completed_at', { ascending: true, nullsFirst: false })
       .limit(limit);
 
     if (error) {
@@ -531,7 +536,6 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       .from('daily_word_hunt_attempts')
       .select('*', { count: 'exact', head: true })
       .eq('puzzle_date', date)
-      .eq('language', language)
       .eq('solved', true)
       .not('player_id', 'is', null);
 
@@ -542,8 +546,7 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
     const { count: totalPlayersCount, error: totalPlayersError } = await supabase
       .from('daily_word_hunt_attempts')
       .select('*', { count: 'exact', head: true })
-      .eq('puzzle_date', date)
-      .eq('language', language);
+      .eq('puzzle_date', date);
 
     if (totalPlayersError) {
       logger.debug('API', `Word Hunt total players count error: ${totalPlayersError.message || totalPlayersError.code || 'Unknown'}`);
@@ -553,7 +556,6 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       .from('daily_word_hunt_attempts')
       .select('*', { count: 'exact', head: true })
       .eq('puzzle_date', date)
-      .eq('language', language)
       .eq('solved', true);
 
     if (totalSolvedError) {
@@ -564,7 +566,6 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       .from('daily_word_hunt_attempts')
       .select('*', { count: 'exact', head: true })
       .eq('puzzle_date', date)
-      .eq('language', language)
       .eq('solved', true)
       .is('player_id', null)
       .not('guest_fingerprint', 'is', null);
@@ -573,13 +574,10 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       logger.warn('API', `Word Hunt guest solved count error: ${guestSolvedError.message || guestSolvedError.code || 'Unknown'}`, { code: guestSolvedError.code, details: guestSolvedError.details });
     }
 
-    // Re-number rank_position sequentially among authenticated players only.
-    // The view's rank_position includes guests, so post-filter rows would otherwise
-    // keep gaps (e.g. only auth player showing as rank #2 because rank #1 was a guest).
-    const rerankedData = (data || []).map((row, index) => ({
-      ...row,
-      rank_position: index + 1,
-    }));
+    // Sort the merged cross-language rows by the global scoring order, then
+    // renumber rank_position sequentially 1..N. The view's rank_position is
+    // partitioned per language (and includes guests), so it can't be trusted here.
+    const rerankedData = rerankSequential(sortWordHuntRowsGlobally(data || []));
 
     const dataLength = rerankedData.length;
     const queryCount = count ?? 0;
@@ -880,10 +878,11 @@ router.get('/alltime-leaderboard/:language', async (req: Request<{ language: str
       return;
     }
 
+    // Cross-language (global) all-time leaderboard: no `.eq('language', …)` filter.
+    // The view aggregates each player across every language and ranks globally.
     const { data, error } = await supabase
       .from('word_hunt_alltime_leaderboard')
       .select('*')
-      .eq('language', language)
       .order('rank_position', { ascending: true })
       .limit(limit);
 
@@ -910,8 +909,7 @@ router.get('/alltime-leaderboard/:language', async (req: Request<{ language: str
 
     const { count, error: countError } = await supabase
       .from('word_hunt_alltime_leaderboard')
-      .select('*', { count: 'exact', head: true })
-      .eq('language', language);
+      .select('*', { count: 'exact', head: true });
 
     if (countError) {
       logger.warn('API', `Word Hunt all-time leaderboard count error: ${countError.message}`);

--- a/fe-next/backend/routes/dailyChallenge/wordWheelRoutes.ts
+++ b/fe-next/backend/routes/dailyChallenge/wordWheelRoutes.ts
@@ -16,6 +16,7 @@ import {
   isValidLanguage,
 } from './utils';
 import { updateDailyProfileStats } from './profileStats';
+import { rerankSequential, sortWordWheelRowsGlobally } from './leaderboardSort';
 import { updateLeaderboardEntry } from '../../modules/supabase/leaderboard';
 import { leaderboardPointsForGame } from '../../modules/leaderboardScoring';
 import { updateQuestProgress } from '../../modules/weeklyQuestManager';
@@ -324,13 +325,17 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       return;
     }
 
+    // Cross-language (global) leaderboard: no `.eq('language', …)` filter — players
+    // from every language compete together. The view's rank_position is per-language,
+    // so we order by the scoring columns directly and renumber globally below.
     const { data, error } = await supabase
       .from('daily_word_wheel_leaderboard')
       .select('*')
       .eq('puzzle_date', date)
-      .eq('language', language)
       .not('player_id', 'is', null)
-      .order('rank_position', { ascending: true })
+      .order('score', { ascending: false, nullsFirst: false })
+      .order('word_count', { ascending: false, nullsFirst: false })
+      .order('completed_at', { ascending: true, nullsFirst: false })
       .limit(limit);
 
     if (error) {
@@ -339,23 +344,19 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       return;
     }
 
-    // Re-rank after filtering out guests
-    const rerankedData = (data || []).map((row, index) => ({
-      ...row,
-      rank_position: index + 1,
-    }));
+    // Sort the merged cross-language rows by the global scoring order, then
+    // renumber rank_position sequentially 1..N (the view's rank is per-language).
+    const rerankedData = rerankSequential(sortWordWheelRowsGlobally(data || []));
 
     const { count: totalCount } = await supabase
       .from('daily_word_wheel_attempts')
       .select('*', { count: 'exact', head: true })
-      .eq('puzzle_date', date)
-      .eq('language', language);
+      .eq('puzzle_date', date);
 
     const { count: guestCount } = await supabase
       .from('daily_word_wheel_attempts')
       .select('*', { count: 'exact', head: true })
       .eq('puzzle_date', date)
-      .eq('language', language)
       .is('player_id', null)
       .not('guest_fingerprint', 'is', null);
 
@@ -364,7 +365,6 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       .from('daily_word_wheel_attempts')
       .select('*', { count: 'exact', head: true })
       .eq('puzzle_date', date)
-      .eq('language', language)
       .gt('word_count', 0);
 
     res.set('Cache-Control', 'public, max-age=20, s-maxage=20, stale-while-revalidate=60');
@@ -409,10 +409,11 @@ router.get('/alltime-leaderboard/:language', async (req: Request<{ language: str
       return;
     }
 
+    // Cross-language (global) all-time leaderboard: no `.eq('language', …)` filter.
+    // The view aggregates each player across every language and ranks globally.
     const { data, error } = await supabase
       .from('word_wheel_alltime_leaderboard')
       .select('*')
-      .eq('language', language)
       .order('rank_position', { ascending: true })
       .limit(limit);
 
@@ -424,8 +425,7 @@ router.get('/alltime-leaderboard/:language', async (req: Request<{ language: str
 
     const { count } = await supabase
       .from('word_wheel_alltime_leaderboard')
-      .select('*', { count: 'exact', head: true })
-      .eq('language', language);
+      .select('*', { count: 'exact', head: true });
 
     res.set('Cache-Control', 'public, max-age=60, s-maxage=60, stale-while-revalidate=180');
     res.json({

--- a/fe-next/supabase/migrations/20260621000000_alltime_leaderboards_all_languages.sql
+++ b/fe-next/supabase/migrations/20260621000000_alltime_leaderboards_all_languages.sql
@@ -1,0 +1,97 @@
+-- =============================================
+-- Daily-challenge all-time leaderboards: span ALL languages
+-- =============================================
+-- The daily-challenge leaderboard must rank players from every language in a
+-- single global ranking (not just the viewer's own language). The "today"
+-- leaderboards are globalised in the API routes (drop the language filter and
+-- re-sort), but the all-time views previously:
+--   * GROUPed BY (player_id, …, language)  → one row per player PER language
+--   * PARTITIONed rank_position BY language → a separate rank #1 per language
+--
+-- This migration recreates both all-time views to aggregate each player across
+-- ALL languages (one row per player) and rank them globally. Column shape and
+-- order are preserved so `select('*')` consumers are unaffected; the `language`
+-- column now reports the player's most recent language (MAX) for display only.
+-- =============================================
+
+-- 1. All-time Word Hunt leaderboard (global, cross-language)
+DROP VIEW IF EXISTS word_hunt_alltime_leaderboard;
+
+CREATE VIEW word_hunt_alltime_leaderboard
+WITH (security_invoker = on, security_barrier = on) AS
+SELECT
+    dwa.player_id::text AS player_identifier,
+    dwa.player_id,
+    MAX(dwa.guest_fingerprint) AS guest_fingerprint,
+    MAX(dwa.language) AS language,
+    COALESCE(p.display_name, MAX(dwa.display_name), 'Guest Player') AS display_name,
+    COALESCE(p.avatar_emoji, MAX(dwa.avatar_emoji), '🎯') AS avatar_emoji,
+    COALESCE(p.avatar_color, MAX(dwa.avatar_color), '#FFE135') AS avatar_color,
+    p.avatar_image,
+    p.profile_picture_url,
+    p.avatar_config AS custom_avatar,
+    COALESCE(p.country_code, MAX(dwa.country_code)) AS country_code,
+    SUM(CASE WHEN dwa.solved THEN COALESCE(dwa.efficiency_score, 0) ELSE 0 END)::integer AS total_efficiency_score,
+    COUNT(*)::integer AS total_games,
+    COUNT(*) FILTER (WHERE dwa.solved)::integer AS games_won,
+    ROUND(AVG(dwa.attempts_used) FILTER (WHERE dwa.solved), 1) AS avg_attempts,
+    MAX(dwa.efficiency_score) FILTER (WHERE dwa.solved) AS best_efficiency,
+    MAX(dwa.completed_at) AS last_played_at,
+    ROW_NUMBER() OVER (
+        ORDER BY
+            SUM(CASE WHEN dwa.solved THEN COALESCE(dwa.efficiency_score, 0) ELSE 0 END) DESC,
+            COUNT(*) FILTER (WHERE dwa.solved) DESC,
+            MAX(dwa.completed_at) DESC
+    ) AS rank_position
+FROM daily_word_hunt_attempts dwa
+LEFT JOIN profiles p ON dwa.player_id = p.id
+WHERE dwa.player_id IS NOT NULL
+GROUP BY dwa.player_id,
+         p.display_name, p.avatar_emoji, p.avatar_color,
+         p.avatar_image, p.profile_picture_url, p.avatar_config, p.country_code;
+
+GRANT SELECT ON word_hunt_alltime_leaderboard TO anon, authenticated;
+
+COMMENT ON VIEW word_hunt_alltime_leaderboard IS
+  'All-time Word Hunt leaderboard — aggregates each player across ALL languages and ranks globally.';
+
+-- 2. All-time Word Wheel leaderboard (global, cross-language) — mirrors hunt shape
+DROP VIEW IF EXISTS word_wheel_alltime_leaderboard;
+
+CREATE VIEW word_wheel_alltime_leaderboard
+WITH (security_invoker = on, security_barrier = on) AS
+SELECT
+    dwa.player_id::text AS player_identifier,
+    dwa.player_id,
+    MAX(dwa.guest_fingerprint) AS guest_fingerprint,
+    MAX(dwa.language) AS language,
+    COALESCE(p.display_name, MAX(dwa.display_name), 'Guest Player') AS display_name,
+    COALESCE(p.avatar_emoji, MAX(dwa.avatar_emoji), '🎯') AS avatar_emoji,
+    COALESCE(p.avatar_color, MAX(dwa.avatar_color), '#6366f1') AS avatar_color,
+    p.avatar_image,
+    p.profile_picture_url,
+    p.avatar_config AS custom_avatar,
+    COALESCE(p.country_code, MAX(dwa.country_code)) AS country_code,
+    SUM(COALESCE(dwa.score, 0))::integer AS total_efficiency_score,
+    COUNT(*)::integer AS total_games,
+    COUNT(*) FILTER (WHERE dwa.score > 0)::integer AS games_won,
+    NULL::numeric AS avg_attempts,
+    MAX(dwa.score)::integer AS best_efficiency,
+    MAX(dwa.completed_at) AS last_played_at,
+    ROW_NUMBER() OVER (
+        ORDER BY
+            SUM(COALESCE(dwa.score, 0)) DESC,
+            COUNT(*) DESC,
+            MAX(dwa.completed_at) DESC
+    ) AS rank_position
+FROM daily_word_wheel_attempts dwa
+LEFT JOIN profiles p ON dwa.player_id = p.id
+WHERE dwa.player_id IS NOT NULL
+GROUP BY dwa.player_id,
+         p.display_name, p.avatar_emoji, p.avatar_color,
+         p.avatar_image, p.profile_picture_url, p.avatar_config, p.country_code;
+
+GRANT SELECT ON word_wheel_alltime_leaderboard TO anon, authenticated;
+
+COMMENT ON VIEW word_wheel_alltime_leaderboard IS
+  'All-time Word Wheel leaderboard — aggregates each player across ALL languages and ranks globally.';


### PR DESCRIPTION
The daily-challenge leaderboard now ranks players across every language in
a single global ranking instead of isolating each player to competitors in
their own language. Each language plays a different puzzle, so scores are
merged by the same scoring criteria the per-language SQL views already use.

Today leaderboards (route-only, no migration):
- Word Hunt, Word Wheel, and classic puzzle leaderboard routes drop the
  `.eq('language', …)` filter on the list + count queries.
- Because the views' rank_position is partitioned per language, the routes
  now order by the scoring columns and renumber rank_position 1..N globally
  via a shared, unit-tested pure helper (leaderboardSort.ts).

All-time leaderboards (migration):
- Recreate word_hunt_alltime_leaderboard and word_wheel_alltime_leaderboard
  to aggregate each player across ALL languages (one row per player) and
  rank globally, instead of one row + rank per (player, language).
- The all-time routes drop the language filter accordingly.

Frontend needs no change: both leaderboard components already derive the
current user's rank from the returned list and re-rank the merged
hunt+wheel rows client-side.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018V9SXxaCSSiKRytMP97Vep