### PR TITLE
fix(word-wheel): restore visible ambient pixi backdrop (was solid black)

### DIFF
--- a/fe-next/components/daily/WordWheelEffectsCanvas.tsx
+++ b/fe-next/components/daily/WordWheelEffectsCanvas.tsx
@@ -169,14 +169,25 @@ function EffectsWorker({ effects, onEffectsConsumed }: EffectsWorkerProps) {
   const ambientRef = useRef(false);
   const urgencyEmitterRef = useRef<ReturnType<typeof particles.create> | null>(null);
 
-  // Ambient floating particles
+  // Ambient floating particles — the calm backdrop behind the wheel.
+  // The shared AMBIENT_BOKEH preset peaks at alpha 0.15 with ~1px specks in a
+  // cool blue palette; over bg-neo-navy (#1a1a2e) that's imperceptible, so the
+  // play area read as flat solid black. Override the visibility-driving fields
+  // here (word-wheel only — the shared preset is untouched) so the layer reads
+  // as a gentle, additive lime/cyan/violet glow that gives the board depth.
   useEffect(() => {
     if (ambientRef.current) return;
     ambientRef.current = true;
     const emitter = particles.create({
       ...AMBIENT_BOKEH,
-      maxParticles: 30,
-      frequency: 0.15,
+      maxParticles: 38,
+      frequency: 0.13,
+      lifetime: { min: 4, max: 8 },
+      speed: { min: 4, max: 12 },
+      scale: { start: 0.6, end: 1.8 },
+      alpha: { start: 0, end: 0.24 },
+      colors: ['bfff00', '00ffff', '8b5cf6'],
+      blendMode: 'add',
       spawnConfig: { width, height },
     });
     emitter.emit(width / 2, height / 2);

--- a/fe-next/components/daily/__tests__/WordWheelEffectsCanvas.ambient.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelEffectsCanvas.ambient.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ParticleConfig } from '@/lib/gameEngine/types';
+
+// ─── Mock GameCanvas ────────────────────────────────────────────────
+// Bypass real PixiJS init — render children directly, expose a spy engine so
+// we can inspect the ambient emitter config the EffectsWorker requests.
+const mockEngine = {
+  particles: {
+    burst: vi.fn(),
+    create: vi.fn(() => ({ emit: vi.fn(), destroy: vi.fn() })),
+  },
+  shake: { light: vi.fn(), medium: vi.fn(), heavy: vi.fn(), shake: vi.fn() },
+  flash: { flash: vi.fn(), danger: vi.fn(), gold: vi.fn(), white: vi.fn(), combo: vi.fn() },
+  timeDilation: { freeze: vi.fn(), slowDown: vi.fn() },
+  width: 400,
+  height: 600,
+};
+
+vi.mock('@/lib/gameEngine/GameCanvas', () => ({
+  GameCanvas: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="mock-game-canvas">{children}</div>
+  ),
+  useGameEngine: () => mockEngine,
+}));
+
+import WordWheelEffectsCanvas from '../WordWheelEffectsCanvas';
+
+const baseProps = { width: 400, height: 600, onEffectsConsumed: vi.fn() };
+
+beforeEach(() => {
+  mockEngine.particles.create.mockClear();
+  mockEngine.particles.burst.mockClear();
+  baseProps.onEffectsConsumed.mockClear();
+});
+
+describe('WordWheelEffectsCanvas — ambient backdrop', () => {
+  it('creates exactly one persistent ambient emitter on mount', () => {
+    render(<WordWheelEffectsCanvas {...baseProps} effects={[]} />);
+    expect(mockEngine.particles.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('the ambient field is tuned to be VISIBLE over the dark navy backdrop', () => {
+    // Regression guard: the ambient layer previously inherited AMBIENT_BOKEH's
+    // near-invisible tuning (peak alpha 0.15, ~1px particles), so the word-wheel
+    // play area read as flat solid black. The ambient must be perceptible.
+    render(<WordWheelEffectsCanvas {...baseProps} effects={[]} />);
+    const config = mockEngine.particles.create.mock.calls[0][0] as ParticleConfig;
+
+    // Peak opacity high enough to register against bg-neo-navy (#1a1a2e).
+    expect(config.alpha.end).toBeGreaterThanOrEqual(0.2);
+    // Soft orbs large enough to be seen (not sub-pixel specks).
+    expect(config.scale.end).toBeGreaterThanOrEqual(1);
+    // A full field of particles, spawned across the whole canvas.
+    expect(config.maxParticles).toBeGreaterThanOrEqual(30);
+    expect(config.spawnConfig?.width).toBe(baseProps.width);
+    expect(config.spawnConfig?.height).toBe(baseProps.height);
+  });
+
+  it('renders without crashing with empty effects', () => {
+    const { container } = render(<WordWheelEffectsCanvas {...baseProps} effects={[]} />);
+    expect(container.querySelector('[data-testid="mock-game-canvas"]')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
The word-wheel play area read as a flat solid black background. The only
ambient layer behind the wheel is the bokeh field in WordWheelEffectsCanvas,
which inherited the shared AMBIENT_BOKEH preset's near-invisible tuning
(peak alpha 0.15, ~1px specks, cool-blue palette). Over bg-neo-navy
(#1a1a2e) that field was imperceptible, so the canvas — though correctly
transparent — exposed only flat navy that reads as black.

Override the visibility-driving fields for the word-wheel ambient emitter
only (the shared AMBIENT_BOKEH preset, also used by Blast legacy, is
untouched): larger soft orbs (scale end 0.6 -> 1.8), perceptible peak alpha
(0.15 -> 0.24), additive blend, and the wheel's lime/cyan/violet palette so
the layer reads as a gentle ambient glow that gives the board depth again.

TDD: WordWheelEffectsCanvas.ambient.test.tsx locks the regression — asserts
the ambient emitter is created once with a VISIBLE config (alpha.end >= 0.2,
scale.end >= 1, full-canvas spawn). Fails on the old tuning, passes now.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N9rMudqBXqZxVeGMivsaHz