### PR TITLE
fix(home-hub): yellow daily card, real progress strip, profile link, localized title

### DIFF
--- a/fe-next/components/landing/home/HomeDailyHero.tsx
+++ b/fe-next/components/landing/home/HomeDailyHero.tsx
@@ -9,7 +9,9 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { trackLandingCtaClick } from '@/utils/growthTracking';
 import { useDailyChallengeStats, type PreloadedDailyStats } from '@/hooks/useDailyChallengeStats';
 import { CUBE_BLUR_DATA_URL } from '@/lib/landing/modeMeta';
-import { streakStripCells } from '@/lib/landing/homeHubFormat';
+import { dailyProgressCells } from '@/lib/landing/homeHubFormat';
+import { getLastSevenDaysCompletion } from '@/utils/dailyChallenge/storage';
+import type { Language } from '@/types';
 
 const DAILY_ART = '/modes/cubes/daily.png';
 
@@ -39,7 +41,12 @@ export function HomeDailyHero({ preloadedStats }: HomeDailyHeroProps) {
   const hasPlayed = mounted ? stats.hasPlayed : false;
   const streak = mounted ? stats.streak : 0;
   const puzzleNumber = mounted ? stats.puzzleNumber : 0;
-  const cells = streakStripCells(streak, 5);
+  // Progress strip = the player's REAL last-5-days completion (each cell filled
+  // when that day's daily was actually played), not an echo of the streak count.
+  // Reads localStorage, so gate behind mount to keep SSR/first-render in sync.
+  const cells = mounted
+    ? dailyProgressCells(getLastSevenDaysCompletion(language as Language), 5)
+    : dailyProgressCells([], 5);
 
   return (
     <Link
@@ -52,11 +59,17 @@ export function HomeDailyHero({ preloadedStats }: HomeDailyHeroProps) {
         'transition-[transform,box-shadow] duration-150 active:translate-x-px active:translate-y-px active:shadow-hard-pressed',
       )}
     >
-      {/* cyan radial wash on the end */}
+      {/* warm amber base tint over the navy — the daily card's signature colour */}
       <span
         aria-hidden="true"
         className="absolute inset-0"
-        style={{ background: 'radial-gradient(120% 120% at 100% 50%, rgba(0,255,255,0.16), transparent 60%)' }}
+        style={{ background: 'linear-gradient(135deg, rgba(255,225,53,0.20) 0%, rgba(255,107,53,0.10) 55%, transparent 100%)' }}
+      />
+      {/* golden radial glow on the end (behind the mascot) */}
+      <span
+        aria-hidden="true"
+        className="absolute inset-0"
+        style={{ background: 'radial-gradient(120% 120% at 100% 50%, rgba(255,225,53,0.28), transparent 60%)' }}
       />
       {/* floating daily mascot */}
       <div className="pointer-events-none absolute -bottom-2.5 -end-3.5 h-[150px] w-[150px] motion-safe:animate-bob">
@@ -73,7 +86,7 @@ export function HomeDailyHero({ preloadedStats }: HomeDailyHeroProps) {
       </div>
 
       <div className="relative max-w-[250px] p-3.5">
-        <span className="inline-flex items-center gap-1.5 rounded-neo-pill border-2 border-black bg-neo-cyan px-2.5 py-[3px] font-neo-display text-[11px] font-bold uppercase tracking-wide text-neo-navy shadow-hard-sm">
+        <span className="inline-flex items-center gap-1.5 rounded-neo-pill border-2 border-black bg-neo-yellow px-2.5 py-[3px] font-neo-display text-[11px] font-bold uppercase tracking-wide text-neo-navy shadow-hard-sm">
           <span className="relative flex h-[7px] w-[7px]">
             <span className="absolute inline-flex h-full w-full rounded-full bg-neo-navy opacity-60 motion-safe:animate-ping" />
             <span className="relative inline-flex h-[7px] w-[7px] rounded-full bg-neo-navy" />
@@ -94,12 +107,12 @@ export function HomeDailyHero({ preloadedStats }: HomeDailyHeroProps) {
               key={i}
               className={cn(
                 'h-[13px] w-[13px] rounded-[3px] border-[1.5px] border-black',
-                filled ? 'bg-neo-lime' : 'bg-neo-navy-light',
+                filled ? 'bg-neo-yellow' : 'bg-neo-navy/60',
               )}
             />
           ))}
           {streak > 0 && (
-            <span className="ms-1.5 inline-flex items-center gap-1 font-neo-display text-[11px] font-semibold text-neo-lime">
+            <span className="ms-1.5 inline-flex items-center gap-1 font-neo-display text-[11px] font-semibold text-neo-yellow">
               <Flame className="h-3 w-3 text-neo-orange" strokeWidth={2.4} aria-hidden="true" />
               {t('landing.home.dayStreak', { n: streak })}
             </span>

--- a/fe-next/components/landing/home/HomeHub.tsx
+++ b/fe-next/components/landing/home/HomeHub.tsx
@@ -65,7 +65,7 @@ export function HomeHub({
 
   return (
     <div className={cn('flex w-full flex-col gap-[18px] px-1.5 pt-1', className)}>
-      <HomeTopBar profile={profile} streak={dailyChallengeStats.currentStreak} t={t} />
+      <HomeTopBar profile={profile} streak={dailyChallengeStats.currentStreak} language={language} t={t} />
 
       <LandingChallengeCards
         layout="hub"

--- a/fe-next/components/landing/home/HomeTopBar.tsx
+++ b/fe-next/components/landing/home/HomeTopBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { Flame } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import Avatar from '@/components/Avatar';
@@ -12,7 +13,13 @@ interface HomeTopBarProps {
   profile: ProfileData | null;
   /** daily-challenge streak (days) */
   streak: number;
-  t: (key: string, params?: Record<string, string | number>) => string;
+  /** active locale — powers the avatar's link to the profile page */
+  language: string;
+  t: (
+    key: string,
+    fallbackOrParams?: string | Record<string, string | number>,
+    params?: Record<string, string | number>,
+  ) => string;
 }
 
 /**
@@ -24,7 +31,7 @@ interface HomeTopBarProps {
  * via the shared `xpManager` curve, coins from `profile.total_coins`. Missing
  * fields degrade gracefully (level 1, no title, 0 coins) — never "undefined".
  */
-export function HomeTopBar({ profile, streak, t }: HomeTopBarProps) {
+export function HomeTopBar({ profile, streak, language, t }: HomeTopBarProps) {
   // Profile + streak are client-resolved (auth/daily hooks). On the server and
   // the first client render they may differ — and `coins.toLocaleString()` is
   // locale-dependent (Node vs browser) — so gate ALL dynamic values behind a
@@ -40,15 +47,23 @@ export function HomeTopBar({ profile, streak, t }: HomeTopBarProps) {
   const progress = getXpProgress(totalXp);
   // Prefer the persisted level but fall back to the XP-derived one if absent.
   const level = p?.current_level ?? progress.currentLevel;
-  const title = getTitleForLevel(level);
+  // `getTitleForLevel` returns a raw constant key (e.g. "LEXICON_KING"). Localize
+  // it via the `landing.home.titles.*` table; fall back to a humanized key so a
+  // missing translation degrades to "Lexicon King" rather than the raw token.
+  const titleKey = getTitleForLevel(level);
+  const title = titleKey ? t(`landing.home.titles.${titleKey}`, humanizeTitleKey(titleKey)) : null;
   const ringPct = clampPercent(progress.progressPercent);
   const coins = p?.total_coins ?? 0;
   const name = p?.display_name || p?.username || t('common.player');
 
   return (
     <div className="flex items-center justify-between gap-2.5 px-0.5">
-      {/* avatar + greeting */}
-      <div className="flex min-w-0 items-center gap-2.5">
+      {/* avatar + greeting — tapping the avatar/name opens the profile */}
+      <Link
+        href={`/${language}/profile`}
+        aria-label={t('nav.profile', 'Profile')}
+        className="flex min-w-0 items-center gap-2.5 rounded-full transition-transform active:scale-95"
+      >
         <div
           className="relative h-[50px] w-[50px] shrink-0 rounded-full p-[3px]"
           style={{
@@ -78,7 +93,7 @@ export function HomeTopBar({ profile, streak, t }: HomeTopBarProps) {
               : t('landing.home.levelOnly', { level })}
           </div>
         </div>
-      </div>
+      </Link>
 
       {/* streak + coins */}
       <div className="flex shrink-0 items-center gap-2">
@@ -95,6 +110,19 @@ export function HomeTopBar({ profile, streak, t }: HomeTopBarProps) {
       </div>
     </div>
   );
+}
+
+/**
+ * Humanize a raw level-title constant as a safety net when its translation is
+ * missing: "LEXICON_KING" → "Lexicon King". Never user-facing in the happy path
+ * (the `landing.home.titles.*` table covers every key), but beats leaking a token.
+ */
+function humanizeTitleKey(key: string): string {
+  return key
+    .toLowerCase()
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
 }
 
 /** Two overlapping lime discs — a tiny stacked-coins glyph, on-brand vs a generic icon. */

--- a/fe-next/components/landing/home/__tests__/HomeTopBar.test.tsx
+++ b/fe-next/components/landing/home/__tests__/HomeTopBar.test.tsx
@@ -10,15 +10,25 @@ vi.mock('@/components/Avatar', () => ({
   default: () => <div data-testid="avatar-stub" />,
 }));
 
-// Simple interpolating t — substitutes {param} tokens so we can assert real output.
-const t = (key: string, params?: Record<string, string | number>) => {
+// Simple interpolating t — substitutes {param} tokens so we can assert real
+// output, and honours a string fallback as the 2nd arg (matches the real `t`).
+const t = (
+  key: string,
+  fallbackOrParams?: string | Record<string, string | number>,
+  paramsArg?: Record<string, string | number>,
+) => {
   const dict: Record<string, string> = {
     'common.player': 'Player',
+    'nav.profile': 'Profile',
     'landing.home.greeting': 'Hey, {name}',
     'landing.home.levelTitle': 'Level {level} · {title}',
     'landing.home.levelOnly': 'Level {level}',
+    'landing.home.titles.LEXICON_KING': 'Lexicon King',
   };
-  let s = dict[key] ?? key;
+  const fallback = typeof fallbackOrParams === 'string' ? fallbackOrParams : undefined;
+  const params =
+    typeof fallbackOrParams === 'object' && fallbackOrParams !== null ? fallbackOrParams : paramsArg;
+  let s = dict[key] ?? fallback ?? key;
   if (params) for (const [k, v] of Object.entries(params)) s = s.replace(`{${k}}`, String(v));
   return s;
 };
@@ -34,7 +44,7 @@ describe('HomeTopBar', () => {
       total_coins: 2840,
     } as unknown as ProfileData;
 
-    render(<HomeTopBar profile={profile} streak={12} t={t} />);
+    render(<HomeTopBar profile={profile} streak={12} language="en" t={t} />);
 
     expect(screen.getByText('Hey, Maya')).toBeInTheDocument();
     expect(screen.getByText('2,840')).toBeInTheDocument(); // localized coins
@@ -43,8 +53,41 @@ describe('HomeTopBar', () => {
     expect(screen.getByText('7')).toBeInTheDocument();
   });
 
+  it('localizes the level title rather than leaking the raw constant key', () => {
+    const profile = {
+      id: 'u1',
+      username: 'fish',
+      display_name: 'Fish',
+      current_level: 76,
+      total_xp: 0,
+      total_coins: 0,
+    } as unknown as ProfileData;
+
+    render(<HomeTopBar profile={profile} streak={0} language="he" t={t} />);
+
+    // Level 76 maps to LEXICON_KING — must render the translated label, never the key.
+    expect(screen.getByText('Level 76 · Lexicon King')).toBeInTheDocument();
+    expect(screen.queryByText(/LEXICON_KING/)).toBeNull();
+  });
+
+  it('links the avatar/greeting to the locale-aware profile page', () => {
+    const profile = {
+      id: 'u1',
+      username: 'fish',
+      display_name: 'Fish',
+      current_level: 7,
+      total_xp: 0,
+      total_coins: 0,
+    } as unknown as ProfileData;
+
+    render(<HomeTopBar profile={profile} streak={0} language="he" t={t} />);
+
+    const link = screen.getByRole('link', { name: 'Profile' });
+    expect(link).toHaveAttribute('href', '/he/profile');
+  });
+
   it('degrades gracefully with a null profile — never "undefined" / no crash', () => {
-    render(<HomeTopBar profile={null} streak={0} t={t} />);
+    render(<HomeTopBar profile={null} streak={0} language="en" t={t} />);
     // falls back to the translated player noun, level 1, zero coins
     expect(screen.getByText('Hey, Player')).toBeInTheDocument();
     // streak "0" + coins "0" both render

--- a/fe-next/lib/landing/__tests__/homeHubFormat.test.ts
+++ b/fe-next/lib/landing/__tests__/homeHubFormat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatLiveShort, streakStripCells, clampPercent } from '../homeHubFormat';
+import { formatLiveShort, streakStripCells, clampPercent, dailyProgressCells } from '../homeHubFormat';
 
 describe('formatLiveShort', () => {
   it('leaves sub-1000 counts as plain integers', () => {
@@ -37,6 +37,44 @@ describe('streakStripCells', () => {
 
   it('defaults to 5 cells', () => {
     expect(streakStripCells(2)).toHaveLength(5);
+  });
+});
+
+describe('dailyProgressCells', () => {
+  const day = (done: boolean) => ({ wordHunt: done, wordWheel: false });
+
+  it('maps the last `total` days to completed/empty cells (oldest→newest)', () => {
+    const days = [day(true), day(false), day(true), day(true), day(false)];
+    expect(dailyProgressCells(days, 5)).toEqual([true, false, true, true, false]);
+  });
+
+  it('treats either word-hunt OR word-wheel completion as done', () => {
+    const days = [
+      { wordHunt: false, wordWheel: true },
+      { wordHunt: true, wordWheel: false },
+      { wordHunt: false, wordWheel: false },
+    ];
+    expect(dailyProgressCells(days, 3)).toEqual([true, true, false]);
+  });
+
+  it('keeps only the most recent `total` days when given more', () => {
+    const days = Array.from({ length: 7 }, (_, i) => day(i >= 5)); // last 2 done
+    expect(dailyProgressCells(days, 5)).toEqual([false, false, false, true, true]);
+  });
+
+  it('left-pads with empty cells when fewer days than `total` are available', () => {
+    expect(dailyProgressCells([day(true), day(true)], 5)).toEqual([
+      false,
+      false,
+      false,
+      true,
+      true,
+    ]);
+  });
+
+  it('defaults to 5 cells and is defensive against empty / missing input', () => {
+    expect(dailyProgressCells([])).toEqual([false, false, false, false, false]);
+    expect(dailyProgressCells(undefined as never)).toHaveLength(5);
   });
 });
 

--- a/fe-next/lib/landing/homeHubFormat.ts
+++ b/fe-next/lib/landing/homeHubFormat.ts
@@ -27,6 +27,25 @@ export function streakStripCells(streak: number, total = 5): boolean[] {
   return Array.from({ length: total }, (_, i) => i < filled);
 }
 
+/**
+ * The daily-challenge progress strip: real recent completion, not a streak echo.
+ * Takes the per-day completion history (each day "done" when either the Word Hunt
+ * OR Word Wheel daily was played) and returns the most recent `total` days as a
+ * boolean[] (oldest→newest). Fewer days than `total` left-pad with empty cells so
+ * the strip width is stable. Unlike `streakStripCells` (which just fills the first
+ * N), this reflects WHICH days were actually completed.
+ */
+export function dailyProgressCells(
+  days: ReadonlyArray<{ wordHunt: boolean; wordWheel: boolean }>,
+  total = 5,
+): boolean[] {
+  const recent = Array.isArray(days) ? days.slice(-total) : [];
+  const cells = recent.map((d) => Boolean(d?.wordHunt || d?.wordWheel));
+  // left-pad so the strip is always `total` wide (oldest cells empty)
+  while (cells.length < total) cells.unshift(false);
+  return cells;
+}
+
 /** Clamp a percentage into 0..100 (NaN/Infinity → 0). Drives the level ring + XP bar. */
 export function clampPercent(pct: number): number {
   if (!Number.isFinite(pct)) return 0;

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -5327,6 +5327,18 @@ const en = {
       "greeting": "Hey, {name}",
       "levelTitle": "Level {level} · {title}",
       "levelOnly": "Level {level}",
+      "titles": {
+        "WORD_SEEKER": "Word Seeker",
+        "LETTER_SCOUT": "Letter Scout",
+        "VOCAB_WARRIOR": "Vocab Warrior",
+        "WORD_KNIGHT": "Word Knight",
+        "LEXICAL_MASTER": "Lexical Master",
+        "DICTIONARY_LORD": "Dictionary Lord",
+        "WORD_LEGEND": "Word Legend",
+        "LEXICON_KING": "Lexicon King",
+        "GRANDMASTER": "Grandmaster",
+        "ETERNAL_CHAMPION": "Eternal Champion"
+      },
       "online": "online",
       "gameModes": "Game Modes",
       "todaysPuzzle": "Today's Puzzle",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -5334,6 +5334,18 @@ const es = {
       "greeting": "Hola, {name}",
       "levelTitle": "Nivel {level} · {title}",
       "levelOnly": "Nivel {level}",
+      "titles": {
+        "WORD_SEEKER": "Buscapalabras",
+        "LETTER_SCOUT": "Explorador de letras",
+        "VOCAB_WARRIOR": "Guerrero del léxico",
+        "WORD_KNIGHT": "Caballero de las palabras",
+        "LEXICAL_MASTER": "Maestro léxico",
+        "DICTIONARY_LORD": "Señor del diccionario",
+        "WORD_LEGEND": "Leyenda de las palabras",
+        "LEXICON_KING": "Rey del léxico",
+        "GRANDMASTER": "Gran maestro",
+        "ETERNAL_CHAMPION": "Campeón eterno"
+      },
       "online": "en línea",
       "gameModes": "Modos de juego",
       "todaysPuzzle": "Reto de hoy",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -5430,6 +5430,18 @@ const he = {
       "greeting": "היי, {name}",
       "levelTitle": "רמה {level} · {title}",
       "levelOnly": "רמה {level}",
+      "titles": {
+        "WORD_SEEKER": "מחפש מילים",
+        "LETTER_SCOUT": "סייר אותיות",
+        "VOCAB_WARRIOR": "לוחם מילים",
+        "WORD_KNIGHT": "אביר המילים",
+        "LEXICAL_MASTER": "אמן הלשון",
+        "DICTIONARY_LORD": "אדון המילון",
+        "WORD_LEGEND": "אגדת המילים",
+        "LEXICON_KING": "מלך המילון",
+        "GRANDMASTER": "רב אמן",
+        "ETERNAL_CHAMPION": "אלוף נצחי"
+      },
       "online": "מחוברים",
       "gameModes": "מצבי משחק",
       "todaysPuzzle": "החידה היומית",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -5301,6 +5301,18 @@ const ja = {
       "greeting": "こんにちは、{name}さん",
       "levelTitle": "レベル{level}・{title}",
       "levelOnly": "レベル{level}",
+      "titles": {
+        "WORD_SEEKER": "ワードシーカー",
+        "LETTER_SCOUT": "レタースカウト",
+        "VOCAB_WARRIOR": "ボキャブウォリアー",
+        "WORD_KNIGHT": "ワードナイト",
+        "LEXICAL_MASTER": "語彙マスター",
+        "DICTIONARY_LORD": "辞書の王",
+        "WORD_LEGEND": "ワードレジェンド",
+        "LEXICON_KING": "辞書王",
+        "GRANDMASTER": "グランドマスター",
+        "ETERNAL_CHAMPION": "永遠の王者"
+      },
       "online": "オンライン",
       "gameModes": "ゲームモード",
       "todaysPuzzle": "今日のパズル",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -5459,6 +5459,18 @@ const sv = {
       "greeting": "Hej, {name}",
       "levelTitle": "Nivå {level} · {title}",
       "levelOnly": "Nivå {level}",
+      "titles": {
+        "WORD_SEEKER": "Ordsökare",
+        "LETTER_SCOUT": "Bokstavsspejare",
+        "VOCAB_WARRIOR": "Ordkrigare",
+        "WORD_KNIGHT": "Ordriddare",
+        "LEXICAL_MASTER": "Lexikal mästare",
+        "DICTIONARY_LORD": "Ordboksherre",
+        "WORD_LEGEND": "Ordlegend",
+        "LEXICON_KING": "Lexikonkung",
+        "GRANDMASTER": "Stormästare",
+        "ETERNAL_CHAMPION": "Evig mästare"
+      },
       "online": "online",
       "gameModes": "Spellägen",
       "todaysPuzzle": "Dagens pussel",


### PR DESCRIPTION
Addresses five Home Hub top-section issues:
- Daily Challenge card now carries a warm amber/yellow tint (base gradient +
  golden radial glow) and yellow accents (pill, progress cells, streak label)
  instead of the cyan/navy look.
- Progress strip is wired to the player's REAL last-5-days completion
  (dailyProgressCells over getLastSevenDaysCompletion) instead of just echoing
  the streak count, so it reflects which days were actually played.
- Streak number and the progress strip are now distinct signals rather than
  the same value rendered twice.
- Tapping the avatar/greeting now navigates to the locale-aware profile page.
- Level title is localized via landing.home.titles.* (all 5 locales) with a
  humanized fallback, so it no longer leaks the raw "LEXICON_KING" constant.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GL6Czrg2RS4yXXKWvrzMdu