### PR TITLE
feat: show Ron a fake +1,000,000 bonus chip on daily results (display-only)

### DIFF
--- a/fe-next/components/daily/WordHuntResultsContent.tsx
+++ b/fe-next/components/daily/WordHuntResultsContent.tsx
@@ -281,6 +281,7 @@ export const WordHuntResultsContent: React.FC<WordHuntResultsContentProps> = ({
       countdown={countdown}
       lifeRemaining={result.lifeRemaining || 0}
       wordsDiscovered={result.wordsDiscovered?.length || 0}
+      currentUserId={profile?.id}
       t={t}
     />
 

--- a/fe-next/components/daily/results/ResultDisplay.tsx
+++ b/fe-next/components/daily/results/ResultDisplay.tsx
@@ -9,9 +9,10 @@
 
 import React, { useState, useMemo } from 'react';
 import { m } from 'framer-motion';
-import { Flame, Clock, Eye, EyeOff, Skull, Zap, Target, BookOpen, Sparkles } from 'lucide-react';
+import { Flame, Clock, Eye, EyeOff, Skull, Zap, Target, BookOpen, Sparkles, PartyPopper } from 'lucide-react';
 import { applyHebrewFinalLetters } from '@/shared/utils/wordNormalization';
 import { getScoreBreakdown } from '@/utils/aiHintGenerator';
+import { isRonPrankUser, RON_PRANK_BONUS_POINTS } from '@/utils/dailyChallenge/ronPrank';
 import { fireConfetti } from '@/utils/confettiUtils';
 import { ScoreGaugeRing } from './ScoreGaugeRing';
 import { getScoreTier } from './scoreFeedbackTiers';
@@ -29,6 +30,8 @@ export interface ResultDisplayProps {
   wordsDiscovered?: number;
   rank?: number;
   totalPlayers?: number;
+  /** Current player's id — drives the display-only Ron bonus easter egg. */
+  currentUserId?: string | null;
   t: (key: string) => string;
 }
 
@@ -76,9 +79,14 @@ export const ResultDisplay: React.FC<ResultDisplayProps> = ({
   countdown,
   lifeRemaining = 0,
   wordsDiscovered = 0,
+  currentUserId,
   t,
 }) => {
   const [wordHidden, setWordHidden] = useState(false);
+
+  // Display-only easter egg: Ron sees a fake "jackpot" bonus chip. Real score,
+  // streak, and leaderboard are untouched — see utils/dailyChallenge/ronPrank.
+  const showRonBonus = solved && isRonPrankUser(currentUserId);
 
   const scoreBreakdown = useMemo(() =>
     getScoreBreakdown(lifeRemaining, attemptsUsed, wordsDiscovered, solved),
@@ -291,6 +299,20 @@ export const ResultDisplay: React.FC<ResultDisplayProps> = ({
                     {chip.icon} +{chip.value}
                   </m.span>
                 ))}
+                {/* Display-only Ron easter egg — fake jackpot bonus chip. */}
+                {showRonBonus && (
+                  <m.span
+                    data-testid="ron-bonus-chip"
+                    custom={3}
+                    variants={chipVariants}
+                    initial="hidden"
+                    animate="visible"
+                    className="inline-flex items-center gap-1 px-3 py-1.5 rounded-neo border-2 text-xs font-black bg-neo-yellow/15 border-neo-yellow/40 text-neo-yellow shadow-hard-sm"
+                  >
+                    <PartyPopper className="w-3.5 h-3.5 inline-block" />
+                    +{RON_PRANK_BONUS_POINTS.toLocaleString('en-US')}
+                  </m.span>
+                )}
               </div>
 
               {/* Tap to celebrate hint (mobile) */}

--- a/fe-next/components/daily/results/__tests__/ResultDisplay.test.tsx
+++ b/fe-next/components/daily/results/__tests__/ResultDisplay.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ResultDisplay } from '../ResultDisplay';
 import { getScoreBreakdown } from '@/utils/aiHintGenerator';
+import { RON_PRANK_USER_ID } from '@/utils/dailyChallenge/ronPrank';
 
 // Mock framer-motion to render immediately
 vi.mock('framer-motion', () => ({
@@ -196,6 +197,38 @@ describe('ResultDisplay Component', () => {
     it('still shows attempts used as a secondary detail under the badge', () => {
       render(<ResultDisplay {...solvedProps} attemptsUsed={3} />);
       expect(screen.getByText('3/10')).toBeInTheDocument();
+    });
+  });
+
+  describe('Ron bonus prank (display-only)', () => {
+    it('shows a fake +1,000,000 bonus chip when the player is Ron and solved', () => {
+      render(<ResultDisplay {...solvedProps} currentUserId={RON_PRANK_USER_ID} />);
+      const chip = screen.getByTestId('ron-bonus-chip');
+      expect(chip).toBeInTheDocument();
+      expect(chip).toHaveTextContent(/\+1,000,000/);
+    });
+
+    it('does NOT show the bonus chip for any other player', () => {
+      render(<ResultDisplay {...solvedProps} currentUserId="not-ron-id" />);
+      expect(screen.queryByTestId('ron-bonus-chip')).not.toBeInTheDocument();
+    });
+
+    it('does NOT show the bonus chip when currentUserId is absent (guests)', () => {
+      render(<ResultDisplay {...solvedProps} />);
+      expect(screen.queryByTestId('ron-bonus-chip')).not.toBeInTheDocument();
+    });
+
+    it('does NOT show the bonus chip in fail state, even for Ron', () => {
+      render(<ResultDisplay {...solvedProps} solved={false} currentUserId={RON_PRANK_USER_ID} />);
+      expect(screen.queryByTestId('ron-bonus-chip')).not.toBeInTheDocument();
+    });
+
+    it('leaves the real score chips unchanged (prank does not alter the real total)', () => {
+      render(<ResultDisplay {...solvedProps} currentUserId={RON_PRANK_USER_ID} />);
+      // Real breakdown for solvedProps: speed=240, accuracy=320, exploration=80
+      expect(screen.getByText(/\+240/)).toBeInTheDocument();
+      expect(screen.getByText(/\+320/)).toBeInTheDocument();
+      expect(screen.getByText(/\+80/)).toBeInTheDocument();
     });
   });
 

--- a/fe-next/utils/dailyChallenge/__tests__/ronPrank.test.ts
+++ b/fe-next/utils/dailyChallenge/__tests__/ronPrank.test.ts
@@ -1,0 +1,39 @@
+/**
+ * ronPrank tests
+ *
+ * Harmless, display-only prank: one specific player (Ron) sees a fake
+ * "+1,000,000" bonus chip on the daily challenge results. These tests pin down
+ * WHO is targeted and that nobody else is — the prank must never leak to other
+ * players, and it must never touch real scoring.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  RON_PRANK_USER_ID,
+  RON_PRANK_BONUS_POINTS,
+  isRonPrankUser,
+} from '../ronPrank';
+
+describe('ronPrank', () => {
+  describe('isRonPrankUser', () => {
+    it('returns true for Ron’s exact user id', () => {
+      // Given Ron's user id, When we check it, Then it is the prank target.
+      expect(isRonPrankUser(RON_PRANK_USER_ID)).toBe(true);
+    });
+
+    it('returns false for any other user id', () => {
+      expect(isRonPrankUser('some-other-user-id')).toBe(false);
+    });
+
+    it('returns false for null/undefined/empty (guests, unknown)', () => {
+      expect(isRonPrankUser(null)).toBe(false);
+      expect(isRonPrankUser(undefined)).toBe(false);
+      expect(isRonPrankUser('')).toBe(false);
+    });
+  });
+
+  describe('bonus points constant', () => {
+    it('is a large, obviously-a-joke number', () => {
+      expect(RON_PRANK_BONUS_POINTS).toBe(1_000_000);
+    });
+  });
+});

--- a/fe-next/utils/dailyChallenge/ronPrank.ts
+++ b/fe-next/utils/dailyChallenge/ronPrank.ts
@@ -1,0 +1,23 @@
+/**
+ * Ron prank — a harmless, DISPLAY-ONLY easter egg.
+ *
+ * When one specific player (Ron) finishes a daily challenge, the results screen
+ * shows a fake "+1,000,000" bonus chip next to his real score chips. It is
+ * purely cosmetic: no real points are awarded, and the stored score, streak,
+ * and leaderboard standings are completely untouched — Ron's points still
+ * accumulate exactly as normal. Nobody else ever sees it.
+ */
+
+/** Ron's Supabase user id — the only account that sees the joke bonus. */
+export const RON_PRANK_USER_ID = 'hdtmpkicuxvtmvrmtybx';
+
+/** The obviously-a-joke bonus amount shown to Ron (display only). */
+export const RON_PRANK_BONUS_POINTS = 1_000_000;
+
+/**
+ * True only for Ron. Guests, unknown users, and everyone else get false, so the
+ * prank never leaks beyond the intended account.
+ */
+export function isRonPrankUser(userId: string | null | undefined): boolean {
+  return !!userId && userId === RON_PRANK_USER_ID;
+}


### PR DESCRIPTION
A harmless easter egg: when the player whose user id is Ron's finishes a
daily challenge, the results screen renders an extra "+1,000,000" jackpot
chip next to his real score chips. It is purely cosmetic — real points,
streak, and leaderboard standings are untouched, and no other player ever
sees it.

- utils/dailyChallenge/ronPrank.ts: target id + isRonPrankUser() guard
- ResultDisplay: optional currentUserId prop renders the chip only for Ron
  in the solved state
- WordHuntResultsContent: passes through profile.id

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M2Jb65cRsETMLbKuzq8yR6