### PR TITLE
fix(word-wheel): restore depth gradient bg (was flat black)

### DIFF
--- a/fe-next/components/daily/WordWheelChallenge.tsx
+++ b/fe-next/components/daily/WordWheelChallenge.tsx
@@ -416,14 +416,44 @@ const WordWheelChallenge: React.FC = () => {
 
   if (phase === 'loading') {
     return (
-      <div className="flex-1 flex items-center justify-center bg-neo-navy">
+      <div
+        className="flex-1 flex items-center justify-center bg-neo-navy"
+        style={{
+          background:
+            'radial-gradient(circle at center, var(--neo-navy-radial) 0%, var(--neo-navy) 70%)',
+        }}
+      >
         <PageLoader size="lg" text={t('wordWheel.loading')} />
       </div>
     );
   }
 
   return (
-    <div ref={containerRef} className="relative flex-1 flex flex-col bg-neo-navy min-h-0 overflow-hidden">
+    <div
+      ref={containerRef}
+      data-testid="word-wheel-stage"
+      className="relative flex-1 flex flex-col bg-neo-navy min-h-0 overflow-hidden"
+      // Depth background (matches ResultsPage): a radial gradient from
+      // --neo-navy-radial (center) to --neo-navy (edges). The pixi bokeh layer
+      // only paints during play and fades in slowly, so without this the stage
+      // exposed flat near-black navy on the ready/loading screens and the first
+      // moments of play. CSS is always-on and phase-independent, so the board
+      // reads with depth instead of solid black.
+      style={{
+        background:
+          'radial-gradient(circle at center, var(--neo-navy-radial) 0%, var(--neo-navy) 70%)',
+      }}
+    >
+      {/* Subtle dot pattern — adds texture/depth over the gradient */}
+      <div
+        className="absolute inset-0 pointer-events-none opacity-[0.04]"
+        style={{
+          backgroundImage: 'radial-gradient(circle, var(--neo-black) 1px, transparent 1px)',
+          backgroundSize: '10px 10px',
+        }}
+        aria-hidden
+      />
+
       {/* PixiJS Effects Layer */}
       {phase === 'playing' && (
         <WordWheelEffectsCanvas

--- a/fe-next/components/daily/__tests__/WordWheelChallenge.background.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelChallenge.background.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Background depth regression.
+ *
+ * Bug: the Word Wheel play area read as a flat solid black background. The
+ * container was a plain `bg-neo-navy` (#1a1a2e) and the only ambient depth
+ * came from the pixi bokeh layer — which only renders during `phase==='playing'`
+ * and fades in slowly, so the ready/loading screens (and the first moments of
+ * play) exposed flat near-black navy.
+ *
+ * Fix: give the container the project's established "depth" background — a
+ * radial gradient from `--neo-navy-radial` (center) to `--neo-navy` (edges),
+ * matching ResultsPage. This is CSS, always-on, and phase-independent, so the
+ * board never reads as flat black.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => {
+    const Stub = () => null;
+    Stub.displayName = 'DynamicStub';
+    return Stub;
+  },
+}));
+
+vi.mock('framer-motion', () => ({
+  m: new Proxy(
+    {},
+    {
+      get: () => ({ children, ...props }: React.ComponentProps<'div'>) => (
+        <div {...props}>{children}</div>
+      ),
+    }
+  ),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (k: string) => k, language: 'en' }),
+}));
+vi.mock('@/contexts/SoundEffectsContext', () => ({
+  useSoundEffects: () => ({ setGameActive: vi.fn() }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    profile: { id: 'player-123', display_name: 'P', avatar_emoji: '🎯', avatar_color: '#fff' },
+    isAuthenticated: true,
+  }),
+}));
+vi.mock('@/contexts/NavigationContext', () => ({
+  useHideNavigation: () => vi.fn(),
+}));
+
+vi.mock('@/utils/dailyChallenge', () => ({
+  getDailyChallengeDate: () => '2026-04-25',
+  getPuzzleNumber: () => 117,
+  hasPlayedWordWheelToday: () => false,
+  getTodaysWordWheelResult: () => null,
+  saveWordWheelResult: vi.fn(),
+  hasPlayedWordHuntToday: () => false,
+  getDailyStreak: () => ({ currentStreak: 0 }),
+  updateDailyStreak: vi.fn(() => ({ currentStreak: 1, longestStreak: 1, lastPlayedDate: null, totalDailiesCompleted: 1 })),
+}));
+vi.mock('@/utils/dailyChallenge/wordWheelGeneration', () => ({
+  generateWordWheelPuzzle: () => ({
+    centerLetter: 'A',
+    outerLetters: ['B', 'C', 'D', 'E', 'F', 'G'],
+    validWords: [],
+  }),
+}));
+vi.mock('@/utils/guestManager', () => ({
+  getGuestFingerprint: () => null,
+}));
+vi.mock('@/hooks/useRewardedAd', () => ({
+  useRewardedAd: () => ({
+    canShowAd: false,
+    isDailyLimitReached: false,
+    showAd: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock('../WordWheelGame', () => ({
+  __esModule: true,
+  default: () => <div data-testid="word-wheel-game" />,
+}));
+vi.mock('../WordWheelResults', () => ({
+  __esModule: true,
+  default: () => <div data-testid="word-wheel-results" />,
+}));
+vi.mock('../TabbedDailyLeaderboard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="tabbed-daily-leaderboard" />,
+}));
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify({ hasPlayed: false }), { status: 200 }))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+import WordWheelChallenge from '../WordWheelChallenge';
+
+describe('WordWheelChallenge background', () => {
+  it('gives the stage a radial depth gradient instead of flat near-black navy', async () => {
+    render(<WordWheelChallenge />);
+
+    const stage = await waitFor(() => screen.getByTestId('word-wheel-stage'));
+
+    // The container must carry the project depth gradient (radial, navy-radial
+    // center -> navy edge), not a flat fill — otherwise it reads as black.
+    expect(stage.style.background).toContain('radial-gradient');
+    expect(stage.style.background).toContain('--neo-navy-radial');
+  });
+});


### PR DESCRIPTION
The Word Wheel stage read as solid black. The container was a flat
bg-neo-navy (#1a1a2e) and the only depth came from the pixi bokeh layer,
which only paints during phase==='playing' and fades in slowly — so the
ready/loading screens and the first moments of play exposed flat near-black
navy.

Apply the project's established depth background (matching ResultsPage): a
radial gradient from --neo-navy-radial (center) to --neo-navy (edges) plus a
subtle dot pattern. CSS is always-on and phase-independent, so the board
reads with depth instead of black, on every phase.

TDD: WordWheelChallenge.background.test.tsx locks the regression — asserts
the stage carries the radial depth gradient. Fails on the old flat fill,
passes now.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XcQxU19r8kRueX7PFjw2Wn