### PR TITLE
feat(multiplayer): polish MP start, blast/wheel bots, and daily→MP cross-promo

### DIFF
--- a/fe-next/backend/services/gameLifecycle/__tests__/botBlast.test.ts
+++ b/fe-next/backend/services/gameLifecycle/__tests__/botBlast.test.ts
@@ -76,6 +76,7 @@ const mocks = vi.hoisted(() => ({
     return setTimeout(() => {}, 0);
   }),
   shouldBotScore: vi.fn(() => true),
+  emitBotLeaderboard: vi.fn(),
   markBotScoringStart: vi.fn(),
   clearBotResyncThrottle: vi.fn(),
   startBotsForWordHunt: vi.fn(),
@@ -141,6 +142,7 @@ vi.mock('../../../modules/botLifecycle', () => ({
 
 vi.mock('./botGame', () => ({
   shouldBotScore: mocks.shouldBotScore,
+  emitBotLeaderboard: mocks.emitBotLeaderboard,
 }));
 
 vi.mock('../botWordHunt', () => ({
@@ -351,6 +353,34 @@ describe('startBotsForBlast', () => {
     const playerFound = mocks.volatileBroadcastToRoom.mock.calls.find(c => c[2] === 'playerFoundWord');
     expect(playerFound).toBeTruthy();
     expect(playerFound![3]).toMatchObject({ isFirstFinder: true });
+  });
+
+  it('broadcasts the bot\'s live score via the shared throttled leaderboard path (not an unthrottled direct emit)', async () => {
+    mocks.findAllWords.mockReturnValue(['hello']);
+    // emitBotLeaderboard routes through the throttled broadcaster — invoke its
+    // callback so we can assert the leaderboard payload actually reaches clients.
+    mocks.getLeaderboardThrottled.mockImplementation((_gc: string, cb: (lb: unknown) => void) =>
+      cb([{ username: 'BotTest', score: 12, isBot: true }]));
+    const bot = makeBot();
+    const blastState = makeBlastState();
+    mocks.getGame.mockReturnValue({
+      gameMode: 'blast', blastModeState: blastState,
+      letterGrid: [['A', 'B', 'C'], ['D', 'E', 'F'], ['G', 'H', 'I']],
+      letterPositions: new Map(), playerCombos: {}, playerScores: {}, playerWords: {},
+    });
+
+    startBotsForBlast(mockIo, gameCode, [bot], blastState, 'en', 120);
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    // Score updated AND broadcast through the SHARED throttled path used by every
+    // other mode — so blast bot scores no longer freeze at 0 on the client.
+    expect(mocks.updatePlayerScore).toHaveBeenCalledWith(gameCode, bot.username, expect.any(Number), true);
+    expect(mocks.getLeaderboardThrottled).toHaveBeenCalled();
+    const lbEmit = mocks.volatileBroadcastToRoom.mock.calls.find((c: unknown[]) => c[2] === 'updateLeaderboard');
+    expect(lbEmit).toBeTruthy();
+    expect(lbEmit![3].leaderboard).toEqual(
+      expect.arrayContaining([expect.objectContaining({ username: 'BotTest', score: 12 })]),
+    );
   });
 
   it('cascades the played word on the bot\'s OWN board (per-player; refill=false is enforced inside cascadeBlastWord)', async () => {

--- a/fe-next/backend/services/gameLifecycle/__tests__/botScoreTuning.test.ts
+++ b/fe-next/backend/services/gameLifecycle/__tests__/botScoreTuning.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Bot Score Tuning Tests
+ *
+ * shouldBotScore accepts an optional per-mode tuning object so short, fast modes
+ * (Wheel Rush) can run gentler bots than the default classic calibration without
+ * forking the shared scoring gate. Verifies targetMult, floorMult, ceilingMult
+ * and graceMs overrides while leaving the default behaviour untouched.
+ */
+
+import { vi, type MockInstance } from 'vitest';
+import {
+  shouldBotScore,
+  markBotScoringStart,
+  clearBotScoringStart,
+  clearBotVariance,
+} from '../botGame';
+
+vi.mock('../../../modules/gameStateManager', () => ({
+  getLeaderboard: vi.fn(),
+  getLeaderboardThrottled: vi.fn(),
+  addPlayerWord: vi.fn(),
+  updatePlayerScore: vi.fn(),
+  trackBotWord: vi.fn(),
+  getGame: vi.fn(),
+  recordFirstFinder: vi.fn(),
+}));
+vi.mock('../../../modules/botManager', () => ({
+  getGameBots: vi.fn(() => []),
+  startBot: vi.fn(),
+  isBot: vi.fn(),
+}));
+vi.mock('../../../utils/socketHelpers', () => ({
+  broadcastToRoom: vi.fn(),
+  volatileBroadcastToRoom: vi.fn(),
+  getGameRoom: vi.fn((code: string) => `room:${code}`),
+}));
+vi.mock('../../../utils/logger', () => ({ default: {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+} }));
+vi.mock('../botWordHunt', () => ({ startBotsForWordHunt: vi.fn() }));
+vi.mock('../../../modules/blastModeManager', () => ({
+  calculateBlastTileBonus: vi.fn(), getTilesOnPath: vi.fn(), recordBlastMove: vi.fn(),
+}));
+vi.mock('../../../modules/wordHuntManager', () => ({ restoreLife: vi.fn(), getLifeBonus: vi.fn() }));
+
+import { getLeaderboard } from '../../../modules/gameStateManager';
+
+describe('shouldBotScore — per-mode tuning', () => {
+  let mathRandomSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5); // variance = 1.0
+  });
+
+  afterEach(() => {
+    mathRandomSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('targetMult lowers the relative score ceiling (gentler bots)', () => {
+    // Human at 600, hard base target = 600 * 1.15 = 690 (well above the 250 floor).
+    getLeaderboard.mockReturnValue([{ username: 'Alice', score: 600, isBot: false }]);
+    clearBotVariance('GAME_T');
+
+    // Without tuning: 680 accepted.
+    expect(shouldBotScore('GAME_T', 'Bot', 675, 5, 'hard')).toBe(true);
+
+    clearBotVariance('GAME_T2');
+    // With targetMult 0.7: target = 690 * 0.7 = 483 → 490 rejected, 470 accepted.
+    expect(shouldBotScore('GAME_T2', 'Bot', 485, 5, 'hard', { targetMult: 0.7 })).toBe(false);
+    expect(shouldBotScore('GAME_T2', 'Bot', 465, 5, 'hard', { targetMult: 0.7 })).toBe(true);
+  });
+
+  it('floorMult lowers the minimum guaranteed bot score', () => {
+    // Human at 100, hard target = 115 but floor (250) dominates by default.
+    getLeaderboard.mockReturnValue([{ username: 'Alice', score: 100, isBot: false }]);
+    clearBotVariance('GAME_F');
+
+    // Default: floor 250 → bot at 240 still accepted.
+    expect(shouldBotScore('GAME_F', 'Bot', 240, 5, 'hard')).toBe(true);
+
+    clearBotVariance('GAME_F2');
+    // floorMult 0.4 → floor 100; target 115 dominates → 120 rejected.
+    expect(shouldBotScore('GAME_F2', 'Bot', 118, 5, 'hard', { floorMult: 0.4 })).toBe(false);
+  });
+
+  it('graceMs shortens the free-scoring window before any human scores', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    getLeaderboard.mockReturnValue([
+      { username: 'Alice', score: 0, isBot: false },
+      { username: 'Bot', score: 0, isBot: true },
+    ]);
+    clearBotScoringStart('GAME_G');
+    markBotScoringStart('GAME_G');
+
+    vi.advanceTimersByTime(12_000); // 12s
+
+    // Default grace (25s): still inside → free scoring.
+    expect(shouldBotScore('GAME_G', 'Bot', 999, 999, 'hard')).toBe(true);
+    // With graceMs 8000: window elapsed → post-grace ceiling applies (hard 900).
+    expect(shouldBotScore('GAME_G', 'Bot', 999, 999, 'hard', { graceMs: 8_000 })).toBe(false);
+
+    clearBotScoringStart('GAME_G');
+  });
+
+  it('omitting tuning preserves default calibration', () => {
+    getLeaderboard.mockReturnValue([{ username: 'Alice', score: 300, isBot: false }]);
+    clearBotVariance('GAME_D');
+    // hard target 345 → 340 accepted, 350 rejected (unchanged behaviour).
+    expect(shouldBotScore('GAME_D', 'Bot', 340, 5, 'hard')).toBe(true);
+    clearBotVariance('GAME_D2');
+    expect(shouldBotScore('GAME_D2', 'Bot', 345, 10, 'hard')).toBe(false);
+  });
+});

--- a/fe-next/backend/services/gameLifecycle/botBlast.ts
+++ b/fe-next/backend/services/gameLifecycle/botBlast.ts
@@ -15,7 +15,7 @@
 import type { Server } from 'socket.io';
 import type { Language, BlastModeState } from '@/shared/types/game';
 import type { Bot } from '../../modules/botBehavior';
-import { getGame, updatePlayerScore, addPlayerWord, recordFirstFinder, trackBotWord, getLeaderboard } from '../../modules/gameStateManager';
+import { getGame, updatePlayerScore, addPlayerWord, recordFirstFinder, trackBotWord } from '../../modules/gameStateManager';
 import {
   calculateBlastTileBonus,
   getTilesOnPath,
@@ -34,7 +34,7 @@ import { broadcastToRoom, volatileBroadcastToRoom, getGameRoom } from '../../uti
 import { findAllWords, getCachedTrie } from '../../modules/boggleSolver';
 import { setBotTimeout } from '../../modules/botLifecycle';
 import { ensureLanguageLoaded } from '../../dictionary';
-import { shouldBotScore } from './botGame';
+import { shouldBotScore, emitBotLeaderboard } from './botGame';
 import { BOT_CONFIG } from '../../modules/botConfig';
 import { makePositionsMap } from '../../modules/wordValidator';
 import logger from '../../utils/logger';
@@ -210,8 +210,12 @@ export function submitBlastWord(
       isFirstFinder,
     });
 
-    const leaderboard = getLeaderboard(gameCode);
-    volatileBroadcastToRoom(io, getGameRoom(gameCode), 'updateLeaderboard', { leaderboard });
+    // Live leaderboard broadcast — route through the SHARED throttled path used
+    // by every other mode (classic/word-hunt/wheel-rush). Blast previously emitted
+    // an unthrottled per-word `updateLeaderboard`, diverging from the proven path;
+    // emitBotLeaderboard caps total leaderboard broadcasts (humans + bots) while
+    // preserving leading + trailing edges so bot scores update live, never stale.
+    emitBotLeaderboard(io, gameCode);
 
     logger.info('BOT_BLAST', `Bot "${bot.username}" submitted "${word}" (+${totalScore}) in ${gameCode}`);
     // Board refresh handled by regenerateBlastBoardIfExhausted above (shared path).

--- a/fe-next/backend/services/gameLifecycle/botGame.ts
+++ b/fe-next/backend/services/gameLifecycle/botGame.ts
@@ -149,17 +149,41 @@ export function getBestHumanScore(gameCode: string): number {
 }
 
 /**
+ * Per-mode tuning for the bot scoring gate. Lets short, fast modes (Wheel Rush)
+ * run gentler bots than the default classic calibration WITHOUT forking the
+ * shared gate. All multipliers default to 1 (no change) and graceMs defaults to
+ * the module-wide grace window.
+ */
+export interface BotScoreTuning {
+  /** Multiplier on the relative score target (<1 = bots aim lower vs best human). */
+  targetMult?: number;
+  /** Multiplier on the per-difficulty minimum-score floor (<1 = lower guaranteed bot score). */
+  floorMult?: number;
+  /** Multiplier on the post-grace fallback ceiling. */
+  ceilingMult?: number;
+  /** Override the free-scoring grace window (ms) before any human has scored. */
+  graceMs?: number;
+}
+
+/** Minimum floor: bots always get at least this many points before capping kicks in. */
+const MIN_BOT_SCORE: Record<string, number> = { easy: 80, medium: 150, hard: 250 };
+
+/**
  * Check whether a bot should be allowed to score.
  * Bots target a percentage of the best human's score (difficulty-dependent).
  * This creates competitive pressure without making bots unbeatable.
  * A ±10% random variance is applied to the target to feel natural.
+ *
+ * `tuning` lets a caller (e.g. the Wheel Rush driver) soften the bots for a
+ * short mode where the classic calibration is disproportionately strong.
  */
 export function shouldBotScore(
   gameCode: string,
   botUsername: string,
   currentBotScore: number,
   pendingScore: number,
-  botDifficulty: string = 'medium'
+  botDifficulty: string = 'medium',
+  tuning?: BotScoreTuning
 ): boolean {
   const bestHuman = getBestHumanScore(gameCode);
   const projectedScore = currentBotScore + pendingScore;
@@ -168,25 +192,25 @@ export function shouldBotScore(
     // No human scored yet. Use a time-based grace window instead of a hard
     // point ceiling, because Blast tile bonuses routinely exceed small ceilings
     // on the first word and would otherwise freeze the bot permanently.
+    const graceMs = tuning?.graceMs ?? BOT_FREE_SCORING_GRACE_MS;
     const startedAt = gameScoringStart.get(gameCode);
-    if (!startedAt || Date.now() - startedAt <= BOT_FREE_SCORING_GRACE_MS) {
+    if (!startedAt || Date.now() - startedAt <= graceMs) {
       return true;
     }
     // Grace window elapsed with no human activity — fall back to a much
     // looser ceiling so bots still contribute rather than going silent.
-    const ceiling = BOT_POST_GRACE_CEILING[botDifficulty] ?? BOT_POST_GRACE_CEILING.medium;
-    return projectedScore <= ceiling;
+    const baseCeiling = BOT_POST_GRACE_CEILING[botDifficulty] ?? BOT_POST_GRACE_CEILING.medium;
+    return projectedScore <= baseCeiling * (tuning?.ceilingMult ?? 1);
   }
 
   const baseTarget = BOT_SCORE_TARGET[botDifficulty] ?? BOT_SCORE_TARGET.medium;
   // Per-(game,bot) variance (±10%), memoized so the target line doesn't
   // flicker as Math.random drifts across consecutive submissions.
   const variance = getOrSeedVariance(gameCode, botUsername);
-  const scoreTarget = bestHuman * baseTarget * variance;
+  const scoreTarget = bestHuman * baseTarget * variance * (tuning?.targetMult ?? 1);
 
-  // Minimum floor: bots always get at least this many points before capping kicks in
-  const MIN_BOT_SCORE: Record<string, number> = { easy: 80, medium: 150, hard: 250 };
-  const floor = MIN_BOT_SCORE[botDifficulty] ?? MIN_BOT_SCORE.medium;
+  const baseFloor = MIN_BOT_SCORE[botDifficulty] ?? MIN_BOT_SCORE.medium;
+  const floor = baseFloor * (tuning?.floorMult ?? 1);
 
   return projectedScore <= Math.max(scoreTarget, floor);
 }

--- a/fe-next/backend/services/gameLifecycle/botWheelRush.ts
+++ b/fe-next/backend/services/gameLifecycle/botWheelRush.ts
@@ -27,10 +27,25 @@ import { broadcastToRoom, volatileBroadcastToRoom, getGameRoom } from '../../uti
 import timerManager from '../../utils/timerManager';
 import { setBotTimeout } from '../../modules/botLifecycle';
 import { ensureLanguageLoaded } from '../../dictionary';
-import { shouldBotScore } from './botGame';
+import { shouldBotScore, type BotScoreTuning } from './botGame';
 import { BOT_CONFIG } from '../../modules/botConfig';
 import { WHEEL_RUSH_MIN_WORD_LEN } from '@/shared/constants/wheelRushConstants';
 import logger from '../../utils/logger';
+
+/**
+ * Wheel Rush is a SHORT (60s) mode, so the classic bot calibration — a 25s
+ * free-scoring grace window, hard bots aiming for 115% of the best human, and a
+ * 250-point floor — made bots dominate the leaderboard. These knobs soften them:
+ * the grace window roughly matches the 10s fog, hard bots cap below the human,
+ * and the floor drops so a modest human round can't be lapped by a guaranteed
+ * bot floor. See shouldBotScore / BotScoreTuning.
+ */
+const WHEEL_RUSH_BOT_TUNING: BotScoreTuning = {
+  targetMult: 0.7,   // hard ≈ 0.80×, medium ≈ 0.67×, easy ≈ 0.53× of best human
+  floorMult: 0.4,    // floors → easy 32 / medium 60 / hard 100
+  ceilingMult: 0.6,  // gentler fallback if nobody has scored yet
+  graceMs: 9_000,    // ≈ fog duration, not the classic 25s
+};
 
 /**
  * DFS trie walk over the wheel letter bag. Each outer letter usable at most
@@ -130,7 +145,7 @@ function submitOneWord(
 
   if (outcome.kind === 'locked') {
     const total = outcome.score;
-    if (!shouldBotScore(gameCode, bot.username, bot.score, total, bot.difficulty)) return;
+    if (!shouldBotScore(gameCode, bot.username, bot.score, total, bot.difficulty, WHEEL_RUSH_BOT_TUNING)) return;
     bot.score += total;
     updatePlayerScore(gameCode, bot.username, total, true);
     addPlayerWord(gameCode, bot.username, word, {
@@ -150,7 +165,7 @@ function submitOneWord(
 
   if (outcome.kind === 'stolen') {
     const total = outcome.score + outcome.stealBonus;
-    if (!shouldBotScore(gameCode, bot.username, bot.score, total, bot.difficulty)) return;
+    if (!shouldBotScore(gameCode, bot.username, bot.score, total, bot.difficulty, WHEEL_RUSH_BOT_TUNING)) return;
     bot.score += total;
     updatePlayerScore(gameCode, bot.username, total, true);
     addPlayerWord(gameCode, bot.username, word, {
@@ -234,8 +249,10 @@ export async function startBotsForWheelRush(
 
   for (const bot of bots) {
     bot.isActive = true;
-    // Shuffled slice so bots diverge — also acts as a soft per-bot cap.
-    const perBotCap = bot.difficulty === 'hard' ? 30 : bot.difficulty === 'medium' ? 20 : 12;
+    // Shuffled slice so bots diverge — also acts as a soft per-bot cap. Trimmed
+    // for the short 60s round so bots can't out-volume a focused human (see
+    // WHEEL_RUSH_BOT_TUNING for the matching score-ceiling softening).
+    const perBotCap = bot.difficulty === 'hard' ? 18 : bot.difficulty === 'medium' ? 12 : 8;
     const words = shuffle(allCandidates).slice(0, perBotCap);
     scheduleBot(io, gameCode, bot, state, words, language, gameEndTime);
     logger.info('BOT_WHEEL', `Bot "${bot.username}" queued ${words.length} wheel words for ${gameCode}`);

--- a/fe-next/components/GoRipplesAnimation.tsx
+++ b/fe-next/components/GoRipplesAnimation.tsx
@@ -2,14 +2,41 @@ import React, { useEffect, useState, useRef } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
 import { useSoundEffects } from '../contexts/SoundEffectsContext';
 import { prefersStaticFullscreenOverlay } from '../lib/native/webViewLayerFlash';
+import Avatar from './Avatar';
+import type { CustomAvatarConfig } from '@/shared/types/customAvatar';
 
 const RING_SIZE_STYLE = { width: 120, height: 120 } as const;
 const GO_TEXT_SHADOW_STYLE = { textShadow: '2px 2px 0px rgba(255,255,255,0.3)' } as const;
+
+/** Max avatars shown in the pre-game hype row — keep it a glanceable few. */
+const MAX_COUNTDOWN_AVATARS = 5;
+
+export interface CountdownPlayer {
+  username: string;
+  avatar?: { customAvatar?: CustomAvatarConfig | null } | null;
+  isBot?: boolean;
+  disconnected?: boolean;
+}
 
 interface GoRipplesAnimationProps {
   onComplete?: () => void;
   /** Translation function for hints */
   t?: (key: string) => string;
+  /**
+   * Roster shown as a row of bouncing avatars above the countdown to build
+   * pre-game excitement ("who am I about to play?"). Humans are prioritized over
+   * bots and the row is capped at MAX_COUNTDOWN_AVATARS. Optional — omit to hide.
+   */
+  players?: ReadonlyArray<CountdownPlayer>;
+}
+
+/** Pick a glanceable few players for the hype row: connected humans first, then the rest. */
+function selectCountdownAvatars(players?: ReadonlyArray<CountdownPlayer>): CountdownPlayer[] {
+  if (!players || players.length === 0) return [];
+  const connected = players.filter(p => !p.disconnected);
+  const humans = connected.filter(p => !p.isBot);
+  const bots = connected.filter(p => p.isBot);
+  return [...humans, ...bots].slice(0, MAX_COUNTDOWN_AVATARS);
 }
 
 // Module-level latch: blocks a duplicate mount within DUP_GUARD_MS of the last
@@ -29,7 +56,7 @@ export function __resetGoRipplesDupGuard(): void {
  * Minimal & calm pre-game countdown with smooth animations
  * Clean 3-2-1-GO with soft cyan glow - easy on the eyes
  */
-const GoRipplesAnimation: React.FC<GoRipplesAnimationProps> = ({ onComplete, t }) => {
+const GoRipplesAnimation: React.FC<GoRipplesAnimationProps> = ({ onComplete, t, players }) => {
   // Lazy-init reads `Date.now()` only at first mount — keeps the render pure
   // for the React Compiler while still latching the dup-guard verdict.
   const [isDuplicate] = useState(() => Date.now() - lastCompletedAt < DUP_GUARD_MS);
@@ -95,8 +122,39 @@ const GoRipplesAnimation: React.FC<GoRipplesAnimationProps> = ({ onComplete, t }
   // bounded elements whose entrance tweens start at `opacity: 0`, so they never
   // expose an uninitialised white compositor backing — only a full-screen
   // animated root does (see the native branch).
+  const countdownAvatars = selectCountdownAvatars(players);
+
   const countdownContent = (
     <>
+      {/* Pre-game hype: a few player avatars bouncing with excitement above the
+          countdown so players see who they're about to face before "GO!". */}
+      {countdownAvatars.length > 0 && (
+        <div
+          data-testid="countdown-avatars"
+          className="absolute top-[24%] flex items-center justify-center -space-x-2"
+        >
+          {countdownAvatars.map((p, i) => (
+            <m.div
+              key={p.username}
+              initial={{ scale: 0, y: 0 }}
+              animate={{ scale: 1, y: [0, -8, 0] }}
+              transition={{
+                scale: { delay: 0.1 + i * 0.08, type: 'spring', stiffness: 400, damping: 16 },
+                y: { delay: 0.1 + i * 0.08, duration: 0.7, repeat: Infinity, repeatType: 'loop', ease: 'easeInOut' },
+              }}
+              className="rounded-full border-3 border-neo-black bg-neo-navy shadow-hard-sm"
+            >
+              <Avatar
+                pixelSize={40}
+                customAvatar={p.avatar?.customAvatar ?? null}
+                userId={p.username}
+                className="rounded-full"
+              />
+            </m.div>
+          ))}
+        </div>
+      )}
+
       {/* Single subtle expanding ring for GO */}
       <AnimatePresence>
         {isGo && (

--- a/fe-next/components/__tests__/GoRipplesAnimation.test.tsx
+++ b/fe-next/components/__tests__/GoRipplesAnimation.test.tsx
@@ -52,6 +52,14 @@ vi.mock('../../contexts/SoundEffectsContext', () => ({
   }),
 }));
 
+// Avatar is heavy (pixi/renderer) — stub it to a marker for the avatar-row tests.
+vi.mock('../Avatar', () => ({
+  __esModule: true,
+  default: ({ userId }: { userId?: string }) => (
+    <div data-testid="countdown-avatar" data-user={userId} />
+  ),
+}));
+
 describe('GoRipplesAnimation', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -271,6 +279,42 @@ describe('GoRipplesAnimation', () => {
       expect(screen.getByText('GO!')).toBeInTheDocument();
       act(() => { vi.advanceTimersByTime(1000); }); // complete
       expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  describe('player avatars during countdown', () => {
+    it('renders avatars for the supplied players to build pre-game excitement', () => {
+      render(
+        <GoRipplesAnimation
+          players={[
+            { username: 'Ann' },
+            { username: 'Bob' },
+          ]}
+        />
+      );
+      expect(screen.getAllByTestId('countdown-avatar')).toHaveLength(2);
+    });
+
+    it('caps the avatar row at 5 and prioritizes humans over bots', () => {
+      render(
+        <GoRipplesAnimation
+          players={[
+            { username: 'Bot1', isBot: true },
+            { username: 'H1' }, { username: 'H2' }, { username: 'H3' },
+            { username: 'H4' }, { username: 'H5' }, { username: 'H6' },
+          ]}
+        />
+      );
+      const avatars = screen.getAllByTestId('countdown-avatar');
+      expect(avatars).toHaveLength(5);
+      // The bot should be dropped in favor of human players when capping.
+      const users = avatars.map(a => a.getAttribute('data-user'));
+      expect(users).not.toContain('Bot1');
+    });
+
+    it('renders no avatar row when no players are supplied', () => {
+      render(<GoRipplesAnimation />);
+      expect(screen.queryByTestId('countdown-avatar')).not.toBeInTheDocument();
     });
   });
 

--- a/fe-next/components/daily/MpModeCrossPromo.tsx
+++ b/fe-next/components/daily/MpModeCrossPromo.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { m } from 'framer-motion';
+import Link from 'next/link';
+import { Users, ArrowRight, RefreshCw, Search } from 'lucide-react';
+import { trackGrowthEvent } from '@/utils/growthTracking';
+import type { Language } from '@/types';
+
+interface MpModeCrossPromoProps {
+  /** Player locale — drives the /{language}/multiplayer route prefix. */
+  language: Language;
+  /** Origin screen for analytics, e.g. 'word_wheel_results' | 'word_hunt_results'. */
+  source: string;
+  t: (key: string, fallback?: string) => string;
+}
+
+/**
+ * Multiplayer cross-promotion shown on Daily Challenge results.
+ *
+ * Nudges players who just finished a daily into the LIVE versions of the same
+ * mechanics — Wheel Rush (Word Wheel MP) and Word Hunt MP — to convert solo
+ * daily players into multiplayer sessions. Click-through is measured against an
+ * on-mount impression so PostHog can compute CTR per target.
+ *
+ * Deliberately rendered AFTER the daily↔daily cross-promo so it never competes
+ * with finishing today's daily pair.
+ */
+const MP_MODES = [
+  {
+    target: 'wheel_rush_mp',
+    mode: 'wheel-rush',
+    icon: RefreshCw,
+    accent: 'bg-neo-purple',
+    titleKey: 'mpCrossPromo.wheelRushTitle',
+    titleFallback: 'Word Wheel · Live',
+    descKey: 'mpCrossPromo.wheelRushDesc',
+    descFallback: 'Race rivals on the wheel in real time',
+  },
+  {
+    target: 'word_hunt_mp',
+    mode: 'word-hunt',
+    icon: Search,
+    accent: 'bg-neo-lime',
+    titleKey: 'mpCrossPromo.wordHuntTitle',
+    titleFallback: 'Word Hunt · Live',
+    descKey: 'mpCrossPromo.wordHuntDesc',
+    descFallback: 'Hunt the hidden words against others',
+  },
+] as const;
+
+const MpModeCrossPromo: React.FC<MpModeCrossPromoProps> = ({ language, source, t }) => {
+  // Impression once per mount (StrictMode double-invoke guard).
+  const impressedRef = useRef(false);
+  useEffect(() => {
+    if (impressedRef.current) return;
+    impressedRef.current = true;
+    for (const m of MP_MODES) {
+      trackGrowthEvent('cross_promo_impression', { target: m.target, source, language });
+    }
+  }, [source, language]);
+
+  return (
+    <div className="w-full z-10 flex flex-col gap-2">
+      <div className="flex items-center gap-1.5 px-1">
+        <Users className="w-4 h-4 text-neo-cyan" />
+        <span className="text-neo-white text-xs font-neo-display font-black uppercase tracking-wider">
+          {t('mpCrossPromo.heading', 'Play live with others')}
+        </span>
+      </div>
+
+      {MP_MODES.map((mode) => {
+        const Icon = mode.icon;
+        return (
+          <m.div
+            key={mode.target}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 26 }}
+          >
+            <Link
+              href={`/${language}/multiplayer?mode=${mode.mode}`}
+              onClick={() => trackGrowthEvent('cross_promo_click', {
+                target: mode.target,
+                source,
+                placement: 'mp_cross_promo',
+                language,
+              })}
+              className={`flex items-center justify-between gap-3 w-full p-4 rounded-neo border-3 border-neo-black ${mode.accent} shadow-hard-lg hover:scale-[1.02] active:translate-x-px active:translate-y-px active:shadow-hard-pressed transition-all`}
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex items-center justify-center w-11 h-11 rounded-neo border-2 border-neo-black bg-neo-navy shrink-0">
+                  <Icon className="w-6 h-6 text-neo-white" />
+                </div>
+                <div>
+                  <span className="block font-neo-display font-black text-neo-black text-base leading-tight">
+                    {t(mode.titleKey, mode.titleFallback)}
+                  </span>
+                  <p className="text-neo-black/70 text-xs mt-0.5">
+                    {t(mode.descKey, mode.descFallback)}
+                  </p>
+                </div>
+              </div>
+              <ArrowRight className="w-6 h-6 text-neo-black shrink-0" />
+            </Link>
+          </m.div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MpModeCrossPromo;

--- a/fe-next/components/daily/WordHuntResultsContent.tsx
+++ b/fe-next/components/daily/WordHuntResultsContent.tsx
@@ -17,6 +17,7 @@ import DailyChallengeInlineSignup from '@/components/auth/DailyChallengeInlineSi
 import TabbedDailyLeaderboard from './TabbedDailyLeaderboard';
 import DailyInsightStack from './DailyInsightStack';
 import CatchUpSuggestion from './CatchUpSuggestion';
+import MpModeCrossPromo from './MpModeCrossPromo';
 import WatchAdButton from './WatchAdButton';
 import WatchAdForRevealButton from '@/components/ads/WatchAdForRevealButton';
 import { applyHebrewFinalLetters } from '@/shared/utils/wordNormalization';
@@ -349,6 +350,12 @@ export const WordHuntResultsContent: React.FC<WordHuntResultsContentProps> = ({
         sees a clear, useful next step instead of a stale cross-promo. */}
     {backToDailyCtaNode}
     {!wordWheelPlayed && crossPromoOrder === 'wheel-first' && wheelCtaNode}
+
+    {/* Multiplayer cross-promo — surfaced once today's daily pair is complete, so
+        it never competes with the daily↔daily "finish today's challenge" CTA. */}
+    {wordWheelPlayed && (
+      <MpModeCrossPromo language={language} source="word_hunt_results" t={t} />
+    )}
 
     {/* Catch up dailies missed in the last 3 days — nudge after finishing one. */}
     <CatchUpSuggestion excludeDate={puzzleDate} />

--- a/fe-next/components/daily/WordWheelResults.tsx
+++ b/fe-next/components/daily/WordWheelResults.tsx
@@ -19,6 +19,7 @@ import TabbedDailyLeaderboard from './TabbedDailyLeaderboard';
 import WordWheelSignupCta from './WordWheelSignupCta';
 import WordWheelReplayCta from './WordWheelReplayCta';
 import CatchUpSuggestion from './CatchUpSuggestion';
+import MpModeCrossPromo from './MpModeCrossPromo';
 import { wasSignupModalDismissedRecently } from '@/utils/dailyChallenge';
 import type { Language } from '@/types';
 import type { WordWheelGameResult } from './WordWheelGame';
@@ -499,6 +500,19 @@ const WordWheelResults: React.FC<WordWheelResultsProps> = ({
             </div>
             <ArrowRight className="w-6 h-6 text-neo-black shrink-0" />
           </Link>
+        </m.div>
+      )}
+
+      {/* Multiplayer cross-promo — only once today's daily pair is complete, so it
+          never competes with the "finish today's challenge" daily↔daily CTA. */}
+      {!isPractice && hasPlayedWordHunt && (
+        <m.div
+          className="w-full z-10"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.58, type: 'spring', stiffness: 300, damping: 26 }}
+        >
+          <MpModeCrossPromo language={language} source="word_wheel_results" t={t} />
         </m.div>
       )}
 

--- a/fe-next/components/daily/__tests__/MpModeCrossPromo.test.tsx
+++ b/fe-next/components/daily/__tests__/MpModeCrossPromo.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * MpModeCrossPromo tests
+ *
+ * Cross-promotion from the Daily Challenge results to the live multiplayer
+ * versions of Word Wheel (Wheel Rush) and Word Hunt. Verifies routing targets
+ * and PostHog instrumentation (impression on mount + click per card).
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import MpModeCrossPromo from '../MpModeCrossPromo';
+
+const trackGrowthEvent = vi.fn();
+vi.mock('@/utils/growthTracking', () => ({
+  trackGrowthEvent: (...args: unknown[]) => trackGrowthEvent(...args),
+}));
+
+// next/link → plain anchor for assertion.
+vi.mock('next/link', () => ({
+  default: ({ href, children, onClick }: { href: string; children: React.ReactNode; onClick?: () => void }) => (
+    <a href={href} onClick={onClick}>{children}</a>
+  ),
+}));
+
+// framer-motion → passthrough.
+vi.mock('framer-motion', () => ({
+  m: new Proxy({}, { get: () => (p: Record<string, unknown>) => <div>{p.children as React.ReactNode}</div> }),
+}));
+
+const t = (_k: string, fb?: string) => fb ?? _k;
+
+describe('MpModeCrossPromo', () => {
+  beforeEach(() => trackGrowthEvent.mockClear());
+
+  it('links Wheel Rush + Word Hunt to the multiplayer routes with the mode param', () => {
+    render(<MpModeCrossPromo language="en" source="word_wheel_results" t={t} />);
+    const hrefs = screen.getAllByRole('link').map(a => a.getAttribute('href'));
+    expect(hrefs).toContain('/en/multiplayer?mode=wheel-rush');
+    expect(hrefs).toContain('/en/multiplayer?mode=word-hunt');
+  });
+
+  it('honors the player locale in the route', () => {
+    render(<MpModeCrossPromo language="he" source="word_hunt_results" t={t} />);
+    const hrefs = screen.getAllByRole('link').map(a => a.getAttribute('href'));
+    expect(hrefs).toContain('/he/multiplayer?mode=wheel-rush');
+  });
+
+  it('fires a cross_promo_impression for each mode on mount', () => {
+    render(<MpModeCrossPromo language="en" source="word_wheel_results" t={t} />);
+    const impressions = trackGrowthEvent.mock.calls.filter(c => c[0] === 'cross_promo_impression');
+    const targets = impressions.map(c => (c[1] as { target: string }).target);
+    expect(targets).toEqual(expect.arrayContaining(['wheel_rush_mp', 'word_hunt_mp']));
+    impressions.forEach(c => expect((c[1] as { source: string }).source).toBe('word_wheel_results'));
+  });
+
+  it('fires cross_promo_click with the target + source when a card is tapped', () => {
+    render(<MpModeCrossPromo language="en" source="word_wheel_results" t={t} />);
+    const wheelLink = screen.getAllByRole('link')
+      .find(a => a.getAttribute('href') === '/en/multiplayer?mode=wheel-rush')!;
+    fireEvent.click(wheelLink);
+    const clicks = trackGrowthEvent.mock.calls.filter(c => c[0] === 'cross_promo_click');
+    expect(clicks).toHaveLength(1);
+    expect(clicks[0][1]).toMatchObject({
+      target: 'wheel_rush_mp',
+      source: 'word_wheel_results',
+      language: 'en',
+    });
+  });
+});

--- a/fe-next/host/HostView.tsx
+++ b/fe-next/host/HostView.tsx
@@ -600,6 +600,7 @@ const HostView: React.FC<HostViewProps> = memo(({
             if (socket) sendCountdownComplete(socket, id, 'HOST');
           }}
           t={t}
+          players={players.playersReady as unknown as React.ComponentProps<typeof GoRipplesAnimation>['players']}
         />
       )}
 

--- a/fe-next/player/PlayerView.tsx
+++ b/fe-next/player/PlayerView.tsx
@@ -421,13 +421,15 @@ const PlayerView: React.FC<PlayerViewProps> = memo(({
     }
   }, [showModeReveal, showStartAnimation, letterGrid, remainingTime, gameActive, waitingForResults, timerResume]);
 
-  // Auto-dismiss mode reveal after 2 seconds, then trigger countdown.
+  // Auto-dismiss mode reveal, then trigger countdown. Kept short (1.1s) so the
+  // splash → 3-2-1 handoff reads as one quick flourish rather than two separate
+  // full-screen "screens" — the laggy mid-start screen-switching players reported.
   // MP enters round same for first-time + returning players (no cozy fork).
   useEffect(() => {
     if (!showModeReveal) return;
     const timer = setTimeout(() => {
       dispatchReveal({ type: 'endReveal' });
-    }, 2000);
+    }, 1100);
     return () => clearTimeout(timer);
   }, [showModeReveal]);
 
@@ -746,6 +748,7 @@ const PlayerView: React.FC<PlayerViewProps> = memo(({
             if (socket) sendCountdownComplete(socket, id, 'PLAYER');
           }}
           t={t}
+          players={playersReady}
         />
       )}
       {/* First-time achievement celebrations for new players */}

--- a/fe-next/utils/growthTracking.ts
+++ b/fe-next/utils/growthTracking.ts
@@ -145,8 +145,12 @@ export type GrowthEvent =
   | 'education_upsell_impression'
   | 'school_lead_submitted'
   | 'school_lead_form_viewed'
-  // Cross-promo CTA tracking (e.g. Word Hunt → Word Wheel)
+  // Cross-promo CTA tracking (e.g. Word Hunt → Word Wheel, Daily → Multiplayer)
   | 'cross_promo_click'
+  // Cross-promo CTA exposure — fires once when a cross-promo card is rendered, so
+  // PostHog can compute click-through rate (clicks / impressions). Props mirror
+  // cross_promo_click: { target, source, placement?, language? }.
+  | 'cross_promo_impression'
   // Results-page CTA tracking — experiment conversion funnel (exp-results-replay-cta-v1)
   // Properties: { cta: 'quick_replay' | 'back_to_lobby' | 'next_step', mode?: string }
   | 'results_cta_clicked'


### PR DESCRIPTION
Several multiplayer-mode polish items:

- Blast: bot live scores no longer freeze at 0. Bot leaderboard updates now
  route through the SHARED throttled emitBotLeaderboard path used by every
  other mode (classic/word-hunt/wheel-rush) instead of an unthrottled direct
  getLeaderboard broadcast that diverged from the proven path.

- Wheel Rush: bots were too strong for the short 60s round. Added per-mode
  tuning (BotScoreTuning) to the shared shouldBotScore gate and applied a
  gentler wheel-rush profile (lower relative target, lower floor, ~9s grace
  vs 25s) plus trimmed per-bot word caps (hard 30→18, medium 20→12, easy
  12→8) so a focused human can win.

- Countdown: GoRipplesAnimation now shows a few bouncing player avatars
  (humans prioritized, capped at 5) to build pre-game excitement; wired from
  PlayerView and HostView.

- Start smoothness: tightened the mode-reveal splash (2s→1.1s) so the
  splash → 3-2-1 handoff reads as one quick flourish, not two screens.

- Cross-promotion: new MpModeCrossPromo surfaces Word Wheel MP (wheel-rush)
  and Word Hunt MP from the daily results once the daily pair is complete,
  with PostHog cross_promo_impression (CTR denominator) + cross_promo_click
  tracking. Added cross_promo_impression to the GrowthEvent union.

Tests: shouldBotScore tuning, blast bot throttled-broadcast, MpModeCrossPromo
routing+telemetry, countdown avatar row. Typecheck + lint clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SWZtuaooZsG4TuFaSnz8Ei