### PR TITLE
feat(results): make MP mode switch clear on desktop results page

### DIFF
--- a/fe-next/components/results/StickyReadyBar.tsx
+++ b/fe-next/components/results/StickyReadyBar.tsx
@@ -38,6 +38,12 @@ interface StickyReadyBarProps {
   onNewSeries?: () => void;
   /** Classroom mode — teacher controls game flow, no auto-countdown */
   isClassroom?: boolean;
+  /**
+   * Desktop results page variant — renders the host mode switcher with a
+   * heading and larger, higher-contrast pills so the active mode (and any
+   * change to it) is unmistakable on the wide desktop bar.
+   */
+  desktopProminent?: boolean;
 }
 
 const ALL_MODES: GameModeOption[] = ['word-hunt', 'classic', 'wheel-rush', 'blast', 'random'];
@@ -79,6 +85,7 @@ export default function StickyReadyBar({
   seriesWinnerUsername,
   onNewSeries,
   isClassroom = false,
+  desktopProminent = false,
 }: StickyReadyBarProps) {
   const { t } = useLanguage();
   const { isOnCrazyGamesPlatform } = useCrazyGames();
@@ -375,10 +382,18 @@ export default function StickyReadyBar({
 
   return (
     <div className="flex flex-col gap-2 flex-1 min-w-0 pb-[env(safe-area-inset-bottom)]">
-        {/* Host mode selector — always-visible horizontal pills */}
+        {/* Host mode selector — always-visible horizontal pills.
+            On desktop (desktopProminent) the bar is wide, so the pills grow,
+            gain a labelled heading, and the active mode gets a high-contrast
+            ring + lift so switching modes reads clearly. */}
         {isHost && selectedGameMode !== undefined && onSelectGameMode && (
           <div className="flex flex-col gap-1 min-w-0">
-            <div className="flex items-center gap-1 px-0.5 min-w-0">
+            {desktopProminent && (
+              <div className="text-center text-[10px] font-black uppercase tracking-widest text-neo-white/60">
+                {t('results.nextRoundMode')}
+              </div>
+            )}
+            <div className={cn('flex items-center px-0.5 min-w-0', desktopProminent ? 'gap-2' : 'gap-1')}>
               {ALL_MODES.map((mode) => {
                 const isActive = selectedGameMode === mode;
                 return (
@@ -396,21 +411,36 @@ export default function StickyReadyBar({
                     }}
                     title={getModeDescription(mode, t)}
                     aria-label={`${getModeLabel(mode, t)} — ${getModeDescription(mode, t)}`}
+                    aria-pressed={isActive}
                     className={cn(
-                      'flex-1 min-w-0 flex items-center justify-center gap-1.5 py-1.5 px-1 text-[9px] font-black uppercase rounded-lg border-2 transition-all',
+                      'flex-1 min-w-0 flex items-center justify-center font-black uppercase rounded-lg border-2 transition-all',
+                      desktopProminent
+                        ? 'gap-2 py-2.5 px-2 text-[11px]'
+                        : 'gap-1.5 py-1.5 px-1 text-[9px]',
                       isActive
-                        ? cn(MODE_ACTIVE_COLORS[mode], 'border-current/30 shadow-xs')
-                        : 'text-neo-white border-transparent hover:text-neo-white hover:bg-neo-white/5'
+                        ? cn(
+                            MODE_ACTIVE_COLORS[mode],
+                            desktopProminent
+                              ? 'border-current shadow-hard-sm scale-105 ring-2 ring-current/40 z-10'
+                              : 'border-current/30 shadow-xs'
+                          )
+                        : cn(
+                            'text-neo-white border-transparent hover:text-neo-white hover:bg-neo-white/5',
+                            desktopProminent && 'opacity-70 hover:opacity-100'
+                          )
                     )}
                   >
-                    <span className="shrink-0 [&>svg]:w-3 [&>svg]:h-3">{MODE_ICONS[mode]}</span>
-                    <span className="hidden xs:inline truncate">{getModeLabel(mode, t)}</span>
+                    <span className={cn('shrink-0', desktopProminent ? '[&>svg]:w-4 [&>svg]:h-4' : '[&>svg]:w-3 [&>svg]:h-3')}>{MODE_ICONS[mode]}</span>
+                    <span className={cn('truncate', desktopProminent ? 'inline' : 'hidden xs:inline')}>{getModeLabel(mode, t)}</span>
                   </button>
                 );
               })}
             </div>
             <div
-              className="min-h-[14px] text-center text-[10px] leading-tight text-neo-white px-2 transition-opacity duration-150"
+              className={cn(
+                'text-center leading-tight text-neo-white px-2 transition-opacity duration-150',
+                desktopProminent ? 'min-h-[16px] text-[11px]' : 'min-h-[14px] text-[10px]'
+              )}
               aria-live="polite"
             >
               {(() => {

--- a/fe-next/components/results/__tests__/StickyReadyBar.modeSelectorDesktop.test.tsx
+++ b/fe-next/components/results/__tests__/StickyReadyBar.modeSelectorDesktop.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * StickyReadyBar Desktop Mode Selector Tests
+ *
+ * Verifies that on the desktop results page the host's game-mode switcher
+ * makes the *active* mode clearly distinguishable from the others, and that
+ * the prominent (desktop) variant adds an explanatory heading.
+ */
+
+import React from 'react';
+import { vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+    dir: 'ltr' as const,
+  }),
+}));
+
+vi.mock('framer-motion', () => ({
+  m: {
+    div: ({ children, className, style, ...props }: any) => (
+      <div className={className} style={style} {...props}>{children}</div>
+    ),
+    button: React.forwardRef(function MotionButton({ children, style, ...props }: any, ref: any) {
+      return <button ref={ref} style={style} {...props}>{children}</button>;
+    }),
+    span: ({ children, className, ...props }: any) => (
+      <span className={className} {...props}>{children}</span>
+    ),
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/Avatar', () => ({
+  __esModule: true,
+  default: ({ userId }: { userId?: string }) => <div data-testid={`avatar-${userId}`} />,
+}));
+
+vi.mock('@/components/GameModeSelector', () => ({
+  MODE_ICONS: {
+    random: <span>🔀</span>,
+    classic: <span>📄</span>,
+    blast: <span>💣</span>,
+    'word-hunt': <span>🎯</span>,
+    'wheel-rush': <span>🎡</span>,
+  },
+  MODE_ACTIVE_COLORS: {
+    random: 'text-neo-purple',
+    classic: 'text-neo-cyan',
+    blast: 'text-neo-orange',
+    'word-hunt': 'text-neo-pink',
+    'wheel-rush': 'text-neo-lime',
+  },
+  getModeLabel: (mode: string) => `label-${mode}`,
+  getModeDescription: (mode: string) => `desc-${mode}`,
+}));
+
+import StickyReadyBar from '../StickyReadyBar';
+
+const baseProps = {
+  isHost: true,
+  isCurrentPlayerReady: false,
+  currentPlayerRank: 1,
+  readyCount: 0,
+  totalPlayers: 2,
+  onStartGame: vi.fn(),
+  onMarkReady: vi.fn(),
+  selectedGameMode: 'classic' as const,
+  onSelectGameMode: vi.fn(),
+};
+
+describe('StickyReadyBar desktop mode selector', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    try { sessionStorage.removeItem('mp-auto-advance-cancelled'); } catch {}
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('marks the selected mode with aria-pressed=true and others false', () => {
+    render(<StickyReadyBar {...baseProps} selectedGameMode="wheel-rush" />);
+
+    const active = screen.getByRole('button', { name: /label-wheel-rush/i });
+    expect(active).toHaveAttribute('aria-pressed', 'true');
+
+    const inactive = screen.getByRole('button', { name: /label-classic/i });
+    expect(inactive).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders the "next round mode" heading in the prominent desktop variant', () => {
+    render(<StickyReadyBar {...baseProps} desktopProminent />);
+    expect(screen.getByText('results.nextRoundMode')).toBeInTheDocument();
+  });
+
+  it('does not render the heading in the default (mobile) variant', () => {
+    render(<StickyReadyBar {...baseProps} />);
+    expect(screen.queryByText('results.nextRoundMode')).not.toBeInTheDocument();
+  });
+
+  it('applies a stronger active treatment (ring) to the selected pill in the prominent variant', () => {
+    render(<StickyReadyBar {...baseProps} desktopProminent selectedGameMode="blast" />);
+    const active = screen.getByRole('button', { name: /label-blast/i });
+    expect(active.className).toMatch(/ring-/);
+  });
+});

--- a/fe-next/components/views/ResultsPage.tsx
+++ b/fe-next/components/views/ResultsPage.tsx
@@ -1287,6 +1287,7 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, gameCode, onRetu
               isSeriesComplete={isSeriesComplete}
               seriesWinnerUsername={seriesWinnerUsername}
               onNewSeries={handleNewSeries}
+              desktopProminent
             />
           </div>
         </div>,

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -2875,6 +2875,7 @@ const en = {
     },
     "of": "of",
     "readyForNextRound": "Ready?",
+    "nextRoundMode": "Next round mode",
     "hostStartDescription": "Start anytime!",
     "readyExplanation": "Ready up to show you're in!",
     "defendTitle": "DEFEND TITLE",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -2667,6 +2667,7 @@ const es = {
     },
     "of": "de",
     "readyForNextRound": "¿Listos para la siguiente ronda?",
+    "nextRoundMode": "Modo de la próxima ronda",
     "readyExplanation": "Marca listo para la siguiente ronda",
     "defendTitle": "¡Defiende tu título!",
     "aheadOf": "por delante de {player}",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -3016,6 +3016,7 @@ const he = {
     },
     "of": "מתוך",
     "readyForNextRound": "מוכנים לסיבוב הבא?",
+    "nextRoundMode": "מצב הסיבוב הבא",
     "hostStartDescription": "התחילו משחק חדש כשכולם מוכנים!",
     "yourPlace": "{place} מתוך {total}",
     "yourPlaceSimple": "מקום {place}",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -2809,6 +2809,7 @@ const ja = {
     },
     "of": "/",
     "readyForNextRound": "次のラウンドの準備はいい？",
+    "nextRoundMode": "次のラウンドのモード",
     "hostStartDescription": "全員の準備ができたら新しいゲームを始めよう！",
     "readyExplanation": "タップしてホストに「もう一回やりたい！」を伝えよう",
     "defendTitle": "王座を守れ！",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -2966,6 +2966,7 @@ const sv = {
     },
     "of": "av",
     "readyForNextRound": "Redo för nästa runda?",
+    "nextRoundMode": "Nästa rundas läge",
     "hostStartDescription": "Starta ett nytt spel när alla är redo!",
     "readyExplanation": "Tryck för att visa att du vill köra igen",
     "defendTitle": "Försvara din titel!",


### PR DESCRIPTION
The host mode switcher in the desktop multiplayer results bar rendered
with mobile-sized pills (9px text, tiny icons) whose active state was only
a faint tint, so changing the next-round mode was easy to miss.

Add a `desktopProminent` variant to StickyReadyBar that the desktop portal
opts into: a labelled "Next round mode" heading, larger pills with visible
labels, dimmed inactive pills, and a high-contrast active treatment
(full-color border + ring + lift). Also expose `aria-pressed` on every
pill for assistive tech. Mobile rendering is unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WB1T5sDAmcnQDtjGZEJiRj