### PR TITLE
fix(practice): keep practice board square (no tall cells)

### DIFF
--- a/fe-next/app/globals.css
+++ b/fe-next/app/globals.css
@@ -773,15 +773,19 @@ html.lexi-native [data-selectable] {
     box-shadow: -6px 6px 0px rgb(var(--neo-black));
   }
 
-  /* Practice sandbox: live game's desktop sizing (`100vw - 500px`) assumes
-     side-chrome that practice doesn't have, causing the frame to overflow
-     the tight `max-w-xs` parent and clip outer columns. Constrain to parent. */
+  /* Practice sandbox: the board wrapper (`[data-testid='practice-board']`) is a
+     `w-full h-full` flex child whose width and height are usually UNEQUAL (full
+     width, tall remaining height). Forcing the frame to `width:100% height:100%`
+     overrode its `aspect-ratio:1/1` and stretched the 4×4 grid into tall
+     rectangles. The wrapper is now a size container (`container-type:size`), so
+     size the frame to the largest square that fits — `min(100cqw, 100cqh)` —
+     keeping 1:1 cells regardless of the wrapper's aspect ratio. */
   [data-testid='practice-board'] & {
-    --board-size: 100%;
-    width: 100%;
-    height: 100%;
-    max-width: 100%;
-    max-height: 100%;
+    --board-size: min(100cqw, 100cqh);
+    width: var(--board-size);
+    height: var(--board-size);
+    max-width: 100cqw;
+    max-height: 100cqh;
     padding: 8px;
   }
 }

--- a/fe-next/components/practice/PracticeClassicSandbox.tsx
+++ b/fe-next/components/practice/PracticeClassicSandbox.tsx
@@ -199,7 +199,7 @@ export default function PracticeClassicSandbox() {
         {/* Fill the flex space; `.game-board-frame` clamps the square to the
             available height (max-height: min(board-size, 100%)). A width-driven
             `aspect-square` here overflowed downward on short viewports. */}
-        <div data-testid="practice-board" className="w-full h-full">
+        <div data-testid="practice-board" className="w-full h-full [container-type:size]">
           <GridComponent
             grid={board}
             interactive

--- a/fe-next/components/practice/PracticeWordHuntSandbox.tsx
+++ b/fe-next/components/practice/PracticeWordHuntSandbox.tsx
@@ -422,7 +422,7 @@ export default function PracticeWordHuntSandbox() {
             available height — mirrors the live game's <SurvivalGridSection>.
             A width-driven `aspect-square` here overflowed downward and painted
             tiles over the discoveries list when vertical room was tight. */}
-        <div data-testid="practice-board" className="w-full h-full">
+        <div data-testid="practice-board" className="w-full h-full [container-type:size]">
           <GridComponent
             grid={board}
             interactive

--- a/fe-next/components/practice/__tests__/PracticeClassicSandbox.boardSizing.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeClassicSandbox.boardSizing.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * PracticeClassicSandbox — board sizing / square-aspect regression.
+ *
+ * Bug (2026-06-22): the `[data-testid='practice-board'] &` override in
+ * globals.css forced the `.game-board-frame` to `width:100%; height:100%`.
+ * Because the board wrapper is a `w-full h-full` flex child whose width and
+ * height are usually UNEQUAL (full width, tall remaining height), this
+ * overrode the frame's `aspect-ratio:1/1` and stretched the 4×4 grid into
+ * tall rectangles (cells taller than wide).
+ *
+ * Fix: the wrapper establishes a size container (`container-type:size`) so the
+ * frame can size itself to the largest square that fits (`min(100cqw,100cqh)`)
+ * and keep 1:1 cells regardless of the wrapper's aspect ratio.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/practice/usePracticeValidator', () => ({
+  usePracticeValidator: () => ({ check: vi.fn().mockResolvedValue({ isValid: true }) }),
+}));
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ language: 'en', t: (k: string) => k }),
+}));
+vi.mock('pixi.js', () => ({
+  Application: class {
+    canvas = document.createElement('canvas');
+    screen = { width: 320, height: 240 };
+    stage = { addChild: vi.fn(), removeChild: vi.fn(), removeChildren: vi.fn() };
+    ticker = { add: vi.fn(), remove: vi.fn() };
+    init = vi.fn().mockResolvedValue(undefined);
+    destroy = vi.fn();
+  },
+  Graphics: class {
+    x = 0;
+    y = 0;
+    alpha = 1;
+    scale = { set: vi.fn() };
+    circle = vi.fn().mockReturnThis();
+    fill = vi.fn().mockReturnThis();
+    clear = vi.fn().mockReturnThis();
+    destroy = vi.fn();
+  },
+}));
+vi.mock('@/components/GridComponent', () => ({
+  default: () => <div data-testid="grid-component-stub" />,
+}));
+
+import PracticeClassicSandbox from '../PracticeClassicSandbox';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('PracticeClassicSandbox — board keeps a square aspect (no tall cells)', () => {
+  it('fills the flex space and establishes a size container for square sizing', () => {
+    const { getByTestId } = render(<PracticeClassicSandbox />);
+    const board = getByTestId('practice-board');
+
+    // Fills the flex container so the frame can clamp to it.
+    expect(board.className).toContain('w-full');
+    expect(board.className).toContain('h-full');
+
+    // Establishes a size container so the frame can resolve `100cqh` and pick
+    // the largest fitting square instead of stretching to the wrapper's height.
+    expect(board.className).toContain('[container-type:size]');
+
+    // Must NOT use a width-driven aspect-square — the square is enforced by the
+    // inner .game-board-frame CSS, not by the wrapper.
+    expect(board.className).not.toContain('aspect-square');
+  });
+});

--- a/fe-next/components/practice/__tests__/PracticeWordHuntSandbox.boardSizing.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeWordHuntSandbox.boardSizing.test.tsx
@@ -61,6 +61,11 @@ describe('PracticeWordHuntSandbox — board fits its flex space (no clipping)', 
     expect(board.className).toContain('h-full');
     expect(board.className).toContain('w-full');
 
+    // Establishes a size container so the frame can resolve `100cqh` and size
+    // itself to the largest fitting square instead of stretching to the
+    // wrapper's (taller) height, which made cells tall rectangles.
+    expect(board.className).toContain('[container-type:size]');
+
     // Must NOT use a width-driven aspect-square — that overflowed downward and
     // painted over the discoveries list. The square is enforced by the inner
     // .game-board-frame CSS, not by the wrapper.


### PR DESCRIPTION
## Problem

In practice mode the grid layout looked off — the letter tiles were stretched into **tall rectangles** instead of squares (visible in the reported screenshot: the 4×4 board rows were spaced much further apart vertically than the columns were horizontally).

## Root cause

The practice-only override in `app/globals.css` forced the board frame to fill its wrapper:

```css
[data-testid='practice-board'] & {
  width: 100%;
  height: 100%;   /* ← overrides aspect-ratio:1/1 */
}
```

The board wrapper (`[data-testid='practice-board']`) is a `w-full h-full` flex child whose width and height are usually **unequal** (full width, but tall remaining vertical space). Setting both `width:100%` and `height:100%` made the explicit dimensions win over the frame's `aspect-ratio:1/1`, stretching the grid — and therefore every cell — into a non-square rectangle.

## Fix

- Make the board wrapper a **size container** (`[container-type:size]`) in both the Classic and Word Hunt sandboxes.
- Size the frame to the **largest square that fits** its wrapper: `min(100cqw, 100cqh)`. This keeps 1:1 cells regardless of the wrapper's aspect ratio, in both portrait and landscape regions.

Affects `PracticeClassicSandbox` and `PracticeWordHuntSandbox` (the two sandboxes that use the real `<GridComponent>` frame).

## Tests

- New regression test `PracticeClassicSandbox.boardSizing.test.tsx`.
- Extended `PracticeWordHuntSandbox.boardSizing.test.tsx` to assert the size-container requirement.
- Full practice suite green (392 tests). Followed RED→GREEN TDD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016YNRZykkpJyRzE9TsLErmk)_