### PR TITLE
fix(popups): stop Hebrew auth/signup modals rendering as an empty backdrop

### DIFF
--- a/fe-next/components/auth/AuthModal.tsx
+++ b/fe-next/components/auth/AuthModal.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import { m, AnimatePresence } from 'framer-motion';
 import { X, Mail, Eye, EyeOff, Wand2, Shield, AlertCircle } from 'lucide-react';
 import { Loader } from '@/components/ui/Loader';
+import { Reveal } from '@/components/ui/Reveal';
 import Link from 'next/link';
 import { Button } from '../ui/button';
 import { useLanguage } from '../../contexts/LanguageContext';
@@ -362,25 +363,23 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, showGuestStats =
   if (!isOpen) return null;
   if (typeof document === 'undefined') return null;
 
+  // Backdrop + panel use CSS entrance animations (tailwindcss-animate), NOT
+  // framer-motion. JS-driven entrance animations can leave the panel pinned at
+  // its invisible `initial` state when the main thread is starved (e.g. parsing
+  // the large Hebrew translation bundle), which rendered the modal as just the
+  // dark backdrop. CSS animations run off the main thread and always settle to
+  // the visible resting state, so the panel can never get stuck invisible.
   return createPortal(
-    <AnimatePresence>
-      <m.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60 backdrop-blur-xs"
+      <div
+        className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60 backdrop-blur-xs animate-in fade-in-0 duration-200"
         onClick={onClose}
       >
-        <m.div
+        <div
           ref={modalRef}
           role="dialog"
           aria-modal="true"
           aria-labelledby="auth-modal-title"
-          initial={{ scale: 0.9, opacity: 0, y: 20 }}
-          animate={{ scale: 1, opacity: 1, y: 0 }}
-          exit={{ scale: 0.9, opacity: 0, y: 20 }}
-          transition={{ type: 'spring', damping: 22, stiffness: 280 }}
-          className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-neo border-3 border-neo-black bg-neo-navy p-6 shadow-hard-lg"
+          className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-neo border-3 border-neo-black bg-neo-navy p-6 shadow-hard-lg animate-in fade-in-0 zoom-in-95 duration-200"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
@@ -467,13 +466,8 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, showGuestStats =
                 </div>
               ) : (
                 <div className="space-y-2.5">
-                  {providers.map((provider, idx) => (
-                    <m.div
-                      key={provider.id}
-                      initial={{ opacity: 0, x: -10 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      transition={{ delay: idx * 0.05 }}
-                    >
+                  {providers.map((provider) => (
+                    <Reveal key={provider.id}>
                       {provider.id === 'google' && useGsiGoogleButton ? (
                         <GoogleSignInButton />
                       ) : (
@@ -496,7 +490,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, showGuestStats =
                         )}
                       </Button>
                       )}
-                    </m.div>
+                    </Reveal>
                   ))}
                 </div>
               )}
@@ -831,9 +825,8 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, showGuestStats =
               </Link>
             </p>
           </div>
-        </m.div>
-      </m.div>
-    </AnimatePresence>,
+        </div>
+      </div>,
     document.body
   );
 };

--- a/fe-next/components/auth/FirstWinSignupModal.tsx
+++ b/fe-next/components/auth/FirstWinSignupModal.tsx
@@ -2,9 +2,9 @@
 
 import React, { useEffect } from 'react';
 import { m } from 'framer-motion';
-import { SPRING_PRESETS } from '@/lib/animation/presets';
 import { Trophy, TrendingUp, Medal, Users } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '../ui/dialog';
+import { Reveal } from '../ui/Reveal';
 import { fireConfetti } from '@/utils/confettiUtils';
 import { useTheme } from '@/utils/ThemeContext';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -117,13 +117,10 @@ const FirstWinSignupModal: React.FC<FirstWinSignupModalProps> = ({
           <div className="absolute top-0 left-1/2 -translate-x-1/2 w-64 h-32 bg-linear-to-b from-yellow-500/20 to-transparent rounded-full blur-3xl pointer-events-none" />
 
 
-          {/* Trophy animation */}
-          <m.div
-            initial={{ scale: 0, rotate: -180 }}
-            animate={{ scale: 1, rotate: 0 }}
-            transition={{ type: 'spring', damping: 10, stiffness: 100, delay: 0.2 }}
-            className="flex justify-center mb-4"
-          >
+          {/* Trophy animation. Reveal (CSS) guarantees the trophy is visible even
+              if the JS animation loop is starved; the inner pulse/sparkles below
+              stay on framer-motion since they are continuous, decorative loops. */}
+          <Reveal noSlide className="flex justify-center mb-4">
             <div className="relative">
               <m.div
                 animate={{
@@ -154,15 +151,10 @@ const FirstWinSignupModal: React.FC<FirstWinSignupModalProps> = ({
                 transition={{ duration: 1.5, repeat: Infinity, delay: 1 }}
               />
             </div>
-          </m.div>
+          </Reveal>
 
           {/* Header */}
-          <m.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.3, ...SPRING_PRESETS.balanced }}
-            className="text-center mb-6"
-          >
+          <Reveal className="text-center mb-6">
             <h2 className="text-2xl font-bold mb-2 text-neo-lime">
               {isMultiGamesVariant
                 ? t('auth.multiGames.title')
@@ -171,13 +163,10 @@ const FirstWinSignupModal: React.FC<FirstWinSignupModalProps> = ({
             <p className={cn('text-sm', isDarkMode ? 'text-gray-300' : 'text-gray-600')}>
               {t(subtitleKey)}
             </p>
-          </m.div>
+          </Reveal>
 
           {/* Benefits list */}
-          <m.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.4, ...SPRING_PRESETS.balanced }}
+          <Reveal
             className={cn('mb-6 p-4 rounded-xl', isDarkMode ? 'bg-neo-navy-elevated/50' : 'bg-gray-50')}
           >
             <p
@@ -189,12 +178,9 @@ const FirstWinSignupModal: React.FC<FirstWinSignupModalProps> = ({
               {t('auth.firstWin.benefitsTitle')}
             </p>
             <ul className="space-y-2">
-              {benefits.map((benefit, index) => (
-                <m.li
+              {benefits.map((benefit) => (
+                <li
                   key={benefit.translationKey}
-                  initial={{ opacity: 0, x: -20 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ delay: 0.5 + index * 0.1, type: 'spring', stiffness: 380, damping: 26 }}
                   className={cn(
                     'flex items-center gap-3 text-sm',
                     isDarkMode ? 'text-gray-200' : 'text-gray-700'
@@ -205,17 +191,14 @@ const FirstWinSignupModal: React.FC<FirstWinSignupModalProps> = ({
                     size={16}
                   />
                   <span>{t(benefit.translationKey)}</span>
-                </m.li>
+                </li>
               ))}
             </ul>
-          </m.div>
+          </Reveal>
 
           {/* Current stats teaser */}
           {guestStats && guestStats.gamesPlayed > 0 && (
-            <m.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ delay: 0.6, ...SPRING_PRESETS.balanced }}
+            <Reveal
               className={cn(
                 'mb-6 p-3 rounded-lg text-center text-sm',
                 isDarkMode
@@ -229,28 +212,19 @@ const FirstWinSignupModal: React.FC<FirstWinSignupModalProps> = ({
                   score: guestStats.totalScore,
                 })}
               </span>
-            </m.div>
+            </Reveal>
           )}
 
           {/* OAuth Sign In Buttons */}
-          <m.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.7, ...SPRING_PRESETS.balanced }}
-          >
+          <Reveal>
             <OAuthButtonGroup onSignIn={signIn} loadingProvider={loadingProvider} />
-          </m.div>
+          </Reveal>
 
           {/* Error Message */}
           {error && <AuthErrorMessage message={error} className="mt-4" />}
 
           {/* Continue as Guest */}
-          <m.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.8, type: 'spring', stiffness: 280, damping: 26 }}
-            className="mt-6 text-center"
-          >
+          <Reveal className="mt-6 text-center">
             <button
               onClick={onClose}
               className={cn(
@@ -260,7 +234,7 @@ const FirstWinSignupModal: React.FC<FirstWinSignupModalProps> = ({
             >
               {t('auth.firstWin.maybeLater')}
             </button>
-          </m.div>
+          </Reveal>
 
           {/* Terms */}
           <AuthTermsFooter className="mt-4" />

--- a/fe-next/components/auth/WordHuntLoginModal.tsx
+++ b/fe-next/components/auth/WordHuntLoginModal.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { m } from 'framer-motion';
 import { Mail, Wand2, AlertCircle } from 'lucide-react';
 import { Loader } from '@/components/ui/Loader';
 import { Button } from '../ui/button';
@@ -12,6 +11,7 @@ import {
   DialogTitle,
   DialogBody,
 } from '@/components/ui/dialog';
+import { Reveal } from '@/components/ui/Reveal';
 
 import { useLanguage } from '../../contexts/LanguageContext';
 import { signInWithMagicLink, sendOtpCode, verifyOtpCode } from '../../lib/supabase';
@@ -152,12 +152,7 @@ const WordHuntLoginModal: React.FC<WordHuntLoginModalProps> = ({ isOpen, onClose
 
         <DialogBody className="p-6 pt-0">
           {/* Content */}
-          <m.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2 }}
-            className="text-center mb-6"
-          >
+          <Reveal className="text-center mb-6">
             <div className="text-5xl mb-4">🎯</div>
             <h2 className="text-2xl font-bold text-white mb-2">
               {t('auth.wordHunt.loginTitle')}
@@ -165,26 +160,21 @@ const WordHuntLoginModal: React.FC<WordHuntLoginModalProps> = ({ isOpen, onClose
             <p className="text-sm text-gray-300">
               {t('auth.wordHunt.loginSubtitle')}
             </p>
-          </m.div>
+          </Reveal>
 
           {/* Success Message */}
           {success ? (
-            <m.div
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
+            <Reveal
+              noSlide
+              role="status"
               className="mb-4 p-4 rounded-lg bg-emerald-900/30 border border-emerald-500/50 text-center"
             >
               <p className="text-sm font-bold text-emerald-300">{success}</p>
-            </m.div>
+            </Reveal>
           ) : (
             <>
               {/* Sign In Buttons */}
-              <m.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.3 }}
-                className="space-y-3 mb-4"
-              >
+              <Reveal className="space-y-3 mb-4">
                 {!isNative() && process.env.NEXT_PUBLIC_GOOGLE_WEB_CLIENT_ID ? (
                   <GoogleSignInButton />
                 ) : (
@@ -216,7 +206,7 @@ const WordHuntLoginModal: React.FC<WordHuntLoginModalProps> = ({ isOpen, onClose
                   )}
                   <span>{t('auth.signInWith', { provider: 'Discord' })}</span>
                 </Button>
-              </m.div>
+              </Reveal>
 
               {/* Email Form (OTP on native, magic link on web) */}
               {!showEmailForm ? (
@@ -228,11 +218,9 @@ const WordHuntLoginModal: React.FC<WordHuntLoginModalProps> = ({ isOpen, onClose
                   <span>{t('auth.inlineSignup.orContinueWith')}</span>
                 </button>
               ) : (
-                <m.form
-                  initial={{ height: 0, opacity: 0 }}
-                  animate={{ height: 'auto', opacity: 1 }}
+                <form
                   onSubmit={handleEmailSubmit}
-                  className="mb-4 space-y-3"
+                  className="mb-4 space-y-3 animate-in fade-in-0 duration-300"
                 >
                   <div className="flex items-center gap-2 text-xs text-gray-500">
                     <div className="flex-1 h-px bg-gray-600" />
@@ -296,36 +284,31 @@ const WordHuntLoginModal: React.FC<WordHuntLoginModalProps> = ({ isOpen, onClose
                       </>
                     )}
                   </Button>
-                </m.form>
+                </form>
               )}
             </>
           )}
 
           {/* Error Message */}
           {error && (
-            <m.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
+            <Reveal
+              noSlide
+              role="alert"
               className="mb-4 p-3 rounded-lg bg-red-900/30 border border-red-500/50 text-red-300 text-sm"
             >
               <AlertCircle className="w-4 h-4 shrink-0 inline-block me-1" />{error}
-            </m.div>
+            </Reveal>
           )}
 
           {/* Skip Option */}
-          <m.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.4 }}
-            className="text-center"
-          >
+          <Reveal noSlide className="text-center">
             <button
               onClick={onClose}
               className="text-sm text-gray-400 hover:text-gray-200 transition-colors"
             >
               {t('auth.wordHunt.skipCta')}
             </button>
-          </m.div>
+          </Reveal>
         </DialogBody>
       </DialogContent>
     </Dialog>

--- a/fe-next/components/auth/shared/AuthModalCloseButton.tsx
+++ b/fe-next/components/auth/shared/AuthModalCloseButton.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { m } from 'framer-motion';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Reveal } from '@/components/ui/Reveal';
 import { useTheme } from '@/utils/ThemeContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
@@ -21,12 +21,7 @@ export function AuthModalCloseButton({ onClose, className }: AuthModalCloseButto
   const isDarkMode = theme === 'dark';
 
   return (
-    <m.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ delay: 0.2 }}
-      className={cn('absolute top-4 inset-e-4', className)}
-    >
+    <Reveal noSlide className={cn('absolute top-4 inset-e-4', className)}>
       <Button
         variant="ghost"
         size="icon"
@@ -39,7 +34,7 @@ export function AuthModalCloseButton({ onClose, className }: AuthModalCloseButto
       >
         <X className="w-5 h-5" />
       </Button>
-    </m.div>
+    </Reveal>
   );
 }
 

--- a/fe-next/components/auth/shared/BenefitsList.tsx
+++ b/fe-next/components/auth/shared/BenefitsList.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { m } from 'framer-motion';
 import { useTheme } from '@/utils/ThemeContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
@@ -10,26 +9,30 @@ interface BenefitsListProps {
   benefits: AuthBenefit[];
   titleKey?: string;
   className?: string;
-  animationDelay?: number;
 }
 
 /**
- * Animated list of benefits for auth signup modals
+ * List of benefits for auth signup modals.
+ *
+ * Uses a CSS entrance (`animate-in`) rather than per-item framer-motion reveals:
+ * JS-driven reveals can leave the items pinned at their invisible `initial` state
+ * when the main thread is starved (e.g. parsing the large Hebrew bundle), which
+ * showed up as popups rendering only the dark backdrop. CSS animations settle to
+ * the visible resting state regardless, so content can never get stuck hidden.
  */
 export function BenefitsList({
   benefits,
   titleKey,
   className,
-  animationDelay = 0.1,
 }: BenefitsListProps) {
   const { theme } = useTheme();
   const { t } = useLanguage();
   const isDarkMode = theme === 'dark';
 
   return (
-    <m.div
+    <div
       className={cn(
-        'p-4 rounded-xl',
+        'p-4 rounded-xl animate-in fade-in-0 duration-300',
         isDarkMode ? 'bg-neo-navy-elevated/50' : 'bg-gray-50',
         className
       )}
@@ -43,12 +46,9 @@ export function BenefitsList({
         </p>
       )}
       <ul className="space-y-2">
-        {benefits.map((benefit, index) => (
-          <m.li
+        {benefits.map((benefit) => (
+          <li
             key={benefit.translationKey}
-            initial={{ opacity: 0, x: -20 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ delay: animationDelay * (index + 1) }}
             className="flex items-center gap-2 text-sm"
           >
             <benefit.icon className={cn(
@@ -58,10 +58,10 @@ export function BenefitsList({
             <span className={isDarkMode ? 'text-gray-300' : 'text-gray-600'}>
               {t(benefit.translationKey)}
             </span>
-          </m.li>
+          </li>
         ))}
       </ul>
-    </m.div>
+    </div>
   );
 }
 

--- a/fe-next/components/auth/shared/OAuthButtonGroup.tsx
+++ b/fe-next/components/auth/shared/OAuthButtonGroup.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { m } from 'framer-motion';
+import { Reveal } from '@/components/ui/Reveal';
 import { useTheme } from '@/utils/ThemeContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { Button } from '@/components/ui/button';
@@ -82,13 +82,8 @@ export function OAuthButtonGroup({
 
   return (
     <div className={cn('space-y-3', className)}>
-      {providers.map((provider, i) => (
-        <m.div
-          key={provider.id}
-          initial={{ opacity: 0, y: 8 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.1 * i, type: 'spring', stiffness: 400, damping: 24 }}
-        >
+      {providers.map((provider) => (
+        <Reveal key={provider.id}>
           {provider.id === 'google' && useGsiGoogleButton ? (
             <GoogleSignInButton />
           ) : (
@@ -110,7 +105,7 @@ export function OAuthButtonGroup({
             </span>
           </Button>
           )}
-        </m.div>
+        </Reveal>
       ))}
     </div>
   );

--- a/fe-next/components/ui/Reveal.tsx
+++ b/fe-next/components/ui/Reveal.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+/**
+ * Reveal — a CSS-based entrance animation (fade + subtle rise).
+ *
+ * Drop-in replacement for the fragile framer-motion pattern used inside many
+ * popups/modals:
+ *
+ *   <m.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} ... />
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * framer-motion entrance animations are JS-driven: the element is rendered at its
+ * invisible `initial` state and only animated to `animate` by a main-thread
+ * animation loop (rAF). If that loop is starved or interrupted — e.g. while the
+ * browser parses the large Hebrew translation bundle, or during a re-render storm
+ * — the loop never advances and the content stays pinned at `opacity: 0`. The
+ * Radix dialog panel itself still renders (it animates via CSS), so the user sees
+ * a dark panel with no visible content: "an empty black screen / only the
+ * backdrop". This was reproduced deterministically: with real framer-motion an
+ * `m.div initial={{ opacity: 0 }}` stays at `opacity: 0` whenever the loop does
+ * not run.
+ *
+ * CSS animations (tailwindcss-animate `animate-in fade-in-0 ...`) run off the
+ * main thread and, crucially, settle to the element's natural resting state
+ * (opacity: 1) even if the keyframes are interrupted or never play. Content can
+ * therefore never get stuck invisible. This mirrors how the Radix dialog/overlay
+ * primitives already animate, which is exactly why those never exhibited the bug.
+ *
+ * Note: no per-item stagger `delay` is supported on purpose. A delay would
+ * require `animation-fill-mode: backwards` to avoid a flash, which reintroduces a
+ * "hidden until the animation runs" state. Reliability beats a staggered cascade
+ * for modal content.
+ */
+type RevealElement = 'div' | 'li' | 'span' | 'form' | 'section';
+
+export interface RevealProps extends React.HTMLAttributes<HTMLElement> {
+  /** Element to render. Defaults to 'div'. */
+  as?: RevealElement;
+  /** Disable the slide so it only fades (use when a transform would shift layout). */
+  noSlide?: boolean;
+}
+
+export const Reveal = React.forwardRef<HTMLElement, RevealProps>(
+  ({ as = 'div', noSlide = false, className, children, ...props }, ref) => {
+    return React.createElement(
+      as,
+      {
+        ref,
+        className: cn(
+          'animate-in fade-in-0 duration-300',
+          !noSlide && 'slide-in-from-bottom-1',
+          className
+        ),
+        ...props,
+      },
+      children
+    );
+  }
+);
+
+Reveal.displayName = 'Reveal';
+
+export default Reveal;

--- a/fe-next/components/ui/__tests__/Reveal.test.tsx
+++ b/fe-next/components/ui/__tests__/Reveal.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for the Reveal primitive.
+ *
+ * Reveal is a CSS-based entrance animation used in place of framer-motion
+ * `m.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}` inside modals/popups.
+ *
+ * The regression it guards against: popups (especially in Hebrew, where the large
+ * translation bundle can starve the main thread) rendered only the dark backdrop
+ * because their content was wrapped in JS-driven framer-motion reveals that never
+ * advanced past their invisible `initial` state. CSS animations run off the main
+ * thread and always settle to the natural (visible) resting state, so content can
+ * never get stuck invisible.
+ *
+ * Given-When-Then style.
+ */
+
+import { vi } from 'vitest';
+// Use the REAL framer-motion in this file so the contrast test below faithfully
+// reproduces the production bug (the global mock ignores `initial`).
+vi.unmock('framer-motion');
+
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { LazyMotion, domMax, m } from 'framer-motion';
+import { Reveal } from '../Reveal';
+
+describe('Reveal', () => {
+  it('renders its children (content is present)', () => {
+    // Given a Reveal wrapping content
+    render(<Reveal>Hello world</Reveal>);
+    // Then the content is in the document
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('uses a CSS entrance animation so content always settles visible', () => {
+    // Given a Reveal
+    render(<Reveal data-testid="r">content</Reveal>);
+    const el = screen.getByTestId('r');
+    // Then it relies on tailwindcss-animate (CSS, off-main-thread), not JS opacity
+    expect(el).toHaveClass('animate-in');
+    expect(el).toHaveClass('fade-in-0');
+  });
+
+  it('never hides content with an inline opacity:0 (the bug being fixed)', () => {
+    // Given a Reveal
+    render(<Reveal data-testid="r">content</Reveal>);
+    const el = screen.getByTestId('r');
+    // Then there is no inline style pinning it invisible
+    expect(el.style.opacity).not.toBe('0');
+  });
+
+  it('forwards a custom className alongside the entrance classes', () => {
+    render(<Reveal data-testid="r" className="space-y-3 mb-4">content</Reveal>);
+    const el = screen.getByTestId('r');
+    expect(el).toHaveClass('space-y-3');
+    expect(el).toHaveClass('mb-4');
+    expect(el).toHaveClass('animate-in');
+  });
+
+  it('can render as a different element via the `as` prop', () => {
+    render(
+      <ul>
+        <Reveal as="li" data-testid="item">list item</Reveal>
+      </ul>
+    );
+    const el = screen.getByTestId('item');
+    expect(el.tagName).toBe('LI');
+    expect(el).toHaveClass('animate-in');
+  });
+
+  it('forwards arbitrary props (e.g. role, onClick) to the element', () => {
+    const onClick = vi.fn();
+    render(<Reveal data-testid="r" role="status" onClick={onClick}>content</Reveal>);
+    const el = screen.getByTestId('r');
+    expect(el).toHaveAttribute('role', 'status');
+    el.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Regression: the empty-popup bug.
+ *
+ * When framer-motion's JS animation loop does not advance (which happens when the
+ * main thread is starved — e.g. parsing the large Hebrew translation bundle — and
+ * is simulated here by jsdom never driving the animation clock), an
+ * `m.div initial={{ opacity: 0 }}` stays pinned at opacity:0. Popups built that
+ * way render only the dark backdrop. Reveal (CSS) never has this failure mode.
+ */
+describe('Reveal — regression vs framer-motion JS reveal', () => {
+  it('framer-motion m.div stays stuck at opacity:0 when the loop never runs', async () => {
+    const r = render(
+      <LazyMotion features={domMax}>
+        <m.div
+          data-testid="fm"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.8 }}
+        >
+          content
+        </m.div>
+      </LazyMotion>
+    );
+    await act(async () => { await new Promise((res) => setTimeout(res, 60)); });
+    // Documents the bug: JS-driven content stays invisible while the loop is not
+    // advancing (here, the delayed start never fires because jsdom does not drive
+    // the animation clock — the same outcome as a starved main thread).
+    expect(r.getByTestId('fm').style.opacity).toBe('0');
+  });
+
+  it('Reveal does NOT pin content invisible under the same conditions', async () => {
+    const r = render(<Reveal data-testid="rv">content</Reveal>);
+    await act(async () => { await new Promise((res) => setTimeout(res, 60)); });
+    // The fix: CSS reveal leaves no inline opacity:0; content is visible.
+    expect(r.getByTestId('rv').style.opacity).not.toBe('0');
+  });
+});


### PR DESCRIPTION
Root cause: framer-motion entrance animations are JS-driven. The element is
rendered at its invisible `initial` state (opacity:0 / scale:0) and only reaches
the visible `animate` state once the main-thread animation loop (rAF) advances.
When that loop is starved or interrupted — e.g. while the browser parses the
large Hebrew translation bundle, or during a re-render — it never advances and
content stays pinned invisible. The Radix dialog panel still renders (it animates
via CSS), so users saw a dark panel with no content: "an empty black screen /
only the backdrop". This reproduces deterministically: with real framer-motion an
`m.div initial={{ opacity: 0 }}` stays at opacity:0 whenever the loop does not run
(see components/ui/__tests__/Reveal.test.tsx regression). The app's global
framer-motion test mock ignores `initial`, which is why the suite never caught it.

Fix: introduce a CSS-based entrance primitive `Reveal` (tailwindcss-animate
`animate-in fade-in-0`). CSS animations run off the main thread and always settle
to the natural, visible resting state even if interrupted, so content can never
get stuck invisible — exactly why the Radix primitives never exhibited this. The
highest-traffic popups Hebrew users hit (login / first-win signup) are migrated
off JS-gated reveals:

- AuthModal: backdrop + panel shells now use CSS entrance (plus fix a structural
  AnimatePresence early-return); OAuth buttons use Reveal.
- FirstWinSignupModal, WordHuntLoginModal: content reveals use Reveal/CSS.
- Shared auth components (OAuthButtonGroup, BenefitsList, AuthModalCloseButton)
  use Reveal/CSS.

Reveal is reusable for migrating the remaining JS-reveal popups.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FR98767MBzxLofsz1HGY7B