### PR TITLE
fix(i18n): add mpCrossPromo translations for all languages

### DIFF
--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -1,5 +1,12 @@
 // EN translations
 const en = {
+  "mpCrossPromo": {
+    "heading": "Play live with others",
+    "wheelRushTitle": "Word Wheel · Live",
+    "wheelRushDesc": "Race rivals on the wheel in real time",
+    "wordHuntTitle": "Word Hunt · Live",
+    "wordHuntDesc": "Hunt the hidden words against others"
+  },
   "playerStyle": {
     "styles": {
       "default": "Classic",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -1,5 +1,12 @@
 // Es translations
 const es = {
+  "mpCrossPromo": {
+    "heading": "Juega en vivo con otros",
+    "wheelRushTitle": "Rueda de Palabras · En vivo",
+    "wheelRushDesc": "Compite contra rivales en la rueda en tiempo real",
+    "wordHuntTitle": "Caza de Palabras · En vivo",
+    "wordHuntDesc": "Caza las palabras ocultas contra otros jugadores"
+  },
   "playerStyle": {
     "styles": {
       "default": "Clásico",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -1,5 +1,12 @@
 // HE translations
 const he = {
+  "mpCrossPromo": {
+    "heading": "שחקו בשידור חי עם אחרים",
+    "wheelRushTitle": "מרוץ הגלגל · לייב",
+    "wheelRushDesc": "התחרו ביריבים על הגלגל בזמן אמת",
+    "wordHuntTitle": "ציד מילים · לייב",
+    "wordHuntDesc": "צודו את המילים הנסתרות מול שחקנים אחרים"
+  },
   "playerStyle": {
     "styles": {
       "default": "קלאסי",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -1,5 +1,12 @@
 // Ja translations
 const ja = {
+  "mpCrossPromo": {
+    "heading": "みんなとライブで対戦",
+    "wheelRushTitle": "ワードホイール · ライブ",
+    "wheelRushDesc": "ホイールでライバルとリアルタイム対戦",
+    "wordHuntTitle": "ワードハント · ライブ",
+    "wordHuntDesc": "隠れた単語を他のプレイヤーと取り合おう"
+  },
   "playerStyle": {
     "styles": {
       "default": "クラシック",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -1,5 +1,12 @@
 // Sv translations
 const sv = {
+  "mpCrossPromo": {
+    "heading": "Spela live med andra",
+    "wheelRushTitle": "Ordhjul · Live",
+    "wheelRushDesc": "Tävla mot rivaler på hjulet i realtid",
+    "wordHuntTitle": "Ordjakt · Live",
+    "wordHuntDesc": "Jaga de dolda orden mot andra spelare"
+  },
   "playerStyle": {
     "styles": {
       "default": "Klassisk",


### PR DESCRIPTION
The MP cross-promo block on Daily Challenge results ("Play live with
others" — Word Wheel · Live / Word Hunt · Live) had no translation keys,
so non-English locales fell back to English. Add native mpCrossPromo
strings for en, he, es, ja, sv.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RhgCNUx7sUyBadnKLWjs5s