### PR TITLE
fix(word-wheel): give the daily stage a visible depth gradient (was black)

### DIFF
--- a/fe-next/components/daily/WordWheelChallenge.tsx
+++ b/fe-next/components/daily/WordWheelChallenge.tsx
@@ -431,7 +431,7 @@ const WordWheelChallenge: React.FC = () => {
         className="flex-1 flex items-center justify-center bg-neo-navy"
         style={{
           background:
-            'radial-gradient(circle at center, var(--neo-navy-radial) 0%, var(--neo-navy) 70%)',
+            'radial-gradient(circle at center, var(--neo-navy-elevated) 0%, var(--neo-navy) 70%)',
         }}
       >
         <PageLoader size="lg" text={t('wordWheel.loading')} />
@@ -444,15 +444,18 @@ const WordWheelChallenge: React.FC = () => {
       ref={containerRef}
       data-testid="word-wheel-stage"
       className="relative flex-1 flex flex-col bg-neo-navy min-h-0 overflow-hidden"
-      // Depth background (matches ResultsPage): a radial gradient from
-      // --neo-navy-radial (center) to --neo-navy (edges). The pixi bokeh layer
-      // only paints during play and fades in slowly, so without this the stage
-      // exposed flat near-black navy on the ready/loading screens and the first
-      // moments of play. CSS is always-on and phase-independent, so the board
-      // reads with depth instead of solid black.
+      // Depth background: a radial gradient from --neo-navy-elevated (#2a2a4e,
+      // center) out to --neo-navy (#1a1a2e, edges). The pixi bokeh layer only
+      // paints during play and fades in slowly, so without an always-on CSS
+      // backdrop the stage exposed flat near-black navy on the ready/loading
+      // screens and the first moments of play. An earlier pass used
+      // --neo-navy-radial (#1e1e3f) as the center, but it sits only ~5
+      // luminance above the navy edge — imperceptible, so the stage still read
+      // as solid black. The elevated center (~17 luminance above the edge)
+      // gives genuine, phase-independent depth.
       style={{
         background:
-          'radial-gradient(circle at center, var(--neo-navy-radial) 0%, var(--neo-navy) 70%)',
+          'radial-gradient(circle at center, var(--neo-navy-elevated) 0%, var(--neo-navy) 70%)',
       }}
     >
       {/* Subtle dot pattern — adds texture/depth over the gradient */}

--- a/fe-next/components/daily/__tests__/WordWheelChallenge.background.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelChallenge.background.test.tsx
@@ -7,10 +7,15 @@
  * and fades in slowly, so the ready/loading screens (and the first moments of
  * play) exposed flat near-black navy.
  *
- * Fix: give the container the project's established "depth" background — a
- * radial gradient from `--neo-navy-radial` (center) to `--neo-navy` (edges),
- * matching ResultsPage. This is CSS, always-on, and phase-independent, so the
- * board never reads as flat black.
+ * An earlier fix added a radial gradient but ran it from `--neo-navy-radial`
+ * (#1e1e3f) to `--neo-navy` (#1a1a2e) — only ~5 relative-luminance apart, i.e.
+ * imperceptible, so the stage STILL read as flat black and the regression kept
+ * coming back.
+ *
+ * Fix: run the radial gradient from a perceptibly-elevated center
+ * (`--neo-navy-elevated`, #2a2a4e, ~17 luminance above the navy edge) out to
+ * `--neo-navy`. This is CSS, always-on, and phase-independent, so the board
+ * reads with real depth instead of flat black regardless of the pixi layer.
  */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -108,14 +113,16 @@ afterEach(() => {
 import WordWheelChallenge from '../WordWheelChallenge';
 
 describe('WordWheelChallenge background', () => {
-  it('gives the stage a radial depth gradient instead of flat near-black navy', async () => {
+  it('gives the stage a radial depth gradient with a perceptibly-elevated center', async () => {
     render(<WordWheelChallenge />);
 
     const stage = await waitFor(() => screen.getByTestId('word-wheel-stage'));
 
-    // The container must carry the project depth gradient (radial, navy-radial
-    // center -> navy edge), not a flat fill — otherwise it reads as black.
+    // The container must carry a radial depth gradient whose center is the
+    // elevated navy (#2a2a4e) — NOT navy-radial (#1e1e3f), which sits only ~5
+    // luminance above the navy edge and so reads as flat black.
     expect(stage.style.background).toContain('radial-gradient');
-    expect(stage.style.background).toContain('--neo-navy-radial');
+    expect(stage.style.background).toContain('--neo-navy-elevated');
+    expect(stage.style.background).not.toContain('--neo-navy-radial');
   });
 });


### PR DESCRIPTION
The Word Wheel daily kept reading as a flat solid black background. The
stage already carried a radial "depth" gradient, but it ran from
--neo-navy-radial (#1e1e3f) to --neo-navy (#1a1a2e) — only ~5 relative
luminance apart, so the gradient was imperceptible and the stage still
read as black. The only other depth (the pixi ambient bokeh) renders
solely during phase==='playing' and fades in slowly, so the
loading/ready screens and the first moments of play exposed flat
near-black navy. This is why earlier "restore depth gradient" passes
didn't stop the black-screen reports.

Run the radial gradient from a perceptibly-elevated center
(--neo-navy-elevated, #2a2a4e, ~17 luminance above the navy edge) out to
--neo-navy. CSS is always-on and phase-independent, so the board now
reads with genuine depth instead of solid black across loading, ready,
and play — regardless of the pixi layer.

Updated the background regression test to lock the elevated center
(asserts --neo-navy-elevated and rejects the near-black --neo-navy-radial).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AkzKKfjLDbEKw3NiGqMzfH