### PR TITLE
fix(practice): make popups always visible + boards scroll on mobile

### DIFF
--- a/fe-next/components/practice/PracticeClassicSandbox.tsx
+++ b/fe-next/components/practice/PracticeClassicSandbox.tsx
@@ -221,7 +221,7 @@ export default function PracticeClassicSandbox() {
   }, [advanceBeat, resetIdle]);
 
   return (
-    <div className="relative flex flex-col items-center w-full max-w-md mx-auto px-4 pt-3 pb-2 gap-2 h-full min-h-0 overflow-hidden md:overflow-y-auto">
+    <div className="relative flex flex-col items-center w-full max-w-md mx-auto px-4 pt-3 pb-2 gap-2 h-full min-h-0 overflow-x-clip overflow-y-auto">
       <PracticePixiFx ref={fxRef} />
 
       {/* HUD strip — back-to-hub left, goal pill right. */}

--- a/fe-next/components/practice/PracticeCompletePopup.tsx
+++ b/fe-next/components/practice/PracticeCompletePopup.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect } from 'react';
 import { X } from 'lucide-react';
-import { AdaptiveMotion, AdaptiveAnimatePresence } from '@/components/motion/AdaptiveMotion';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useSoundEffects } from '@/contexts/SoundEffectsContext';
 import { haptics } from '@/utils/haptics';
@@ -88,91 +87,70 @@ export default function PracticeCompletePopup({ open, mode, onDismiss }: Props) 
     onDismiss();
   }, [onDismiss, playButtonClickSound]);
 
+  if (!open) return null;
+
+  // CSS-only entrance (no Framer): the content's resting state is the normal
+  // cascade (opacity:1), so it can never get stuck invisible behind the dark
+  // backdrop — the bug that painted popups as a bare black overlay on RTL.
   return (
-    <AdaptiveAnimatePresence>
-      {open && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          role="dialog"
-          aria-modal="true"
-          aria-label={t('practice.complete.title')}
-          data-testid="practice-complete-popup"
-        >
-          {/* Backdrop — soft blur. Tap-through is intentional: chain CTA is
-              the primary out, dismiss button is the secondary. */}
-          <AdaptiveMotion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.18 }}
-            className="absolute inset-0 bg-neo-navy/85 backdrop-blur-sm pointer-events-none"
-            aria-hidden
-          />
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('practice.complete.title')}
+      data-testid="practice-complete-popup"
+    >
+      {/* Backdrop — soft blur. Tap-through is intentional: chain CTA is
+          the primary out, dismiss button is the secondary. */}
+      <div
+        className="absolute inset-0 bg-neo-navy/85 backdrop-blur-sm pointer-events-none animate-fadeIn"
+        aria-hidden
+      />
 
-          {/* Confetti burst — celebration moment, layered behind the panel
-              so the panel content stays on top. */}
-          <div
-            className="pointer-events-none absolute inset-0 flex items-center justify-center"
-            aria-hidden
+      {/* Confetti burst — celebration moment, layered behind the panel
+          so the panel content stays on top. */}
+      <div
+        className="pointer-events-none absolute inset-0 flex items-center justify-center"
+        aria-hidden
+      >
+        <InlineConfetti size="lg" />
+      </div>
+
+      <div
+        data-testid={`practice-complete-popup-panel-${mode}`}
+        className={`relative w-full max-w-sm rounded-neo border-3 ${ACCENT_BORDER[mode]} bg-neo-navy-light shadow-hard-lg animate-pop-in`}
+      >
+        {/* Mode-color accent bar — same chrome as MistakeCoach */}
+        <div className={`h-1.5 ${ACCENT_BAR[mode]}`} aria-hidden />
+
+        {onDismiss && (
+          <button
+            type="button"
+            data-testid="practice-complete-popup-dismiss"
+            onClick={handleDismiss}
+            aria-label={t('practice.keepPracticing')}
+            className="absolute top-2 end-2 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-neo-white hover:text-neo-white hover:bg-neo-cream/10 transition-colors"
           >
-            <InlineConfetti size="lg" />
+            <X className="w-4 h-4" aria-hidden />
+          </button>
+        )}
+
+        <div className="p-5 flex flex-col gap-4">
+          <PracticeCompleteBanner mode={mode} />
+          <div className="relative">
+            {/* Subtle pulsing glow ring behind the primary CTA — celebration
+                emphasis. CSS pulse so it never depends on Framer. */}
+            <div
+              aria-hidden
+              className={`pointer-events-none absolute -inset-1 rounded-neo blur-md ${CTA_BG[mode]} opacity-30 animate-pulse`}
+            />
+            <PracticeChainCta
+              currentMode={mode}
+              className={`relative inline-flex items-center justify-center w-full ${CTA_BG[mode]} ${CTA_TEXT[mode]} border-3 border-neo-black rounded-neo py-3 px-4 font-neo-display font-black text-base shadow-hard active:translate-y-px active:shadow-hard-pressed`}
+            />
           </div>
-
-          <AdaptiveMotion.div
-            data-testid={`practice-complete-popup-panel-${mode}`}
-            initial={{ opacity: 0, y: 24, scale: 0.85 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 12, scale: 0.95 }}
-            transition={{ type: 'spring', stiffness: 320, damping: 20 }}
-            className={`relative w-full max-w-sm rounded-neo border-3 ${ACCENT_BORDER[mode]} bg-neo-navy-light shadow-hard-lg`}
-          >
-            {/* Mode-color accent bar — same chrome as MistakeCoach */}
-            <div className={`h-1.5 ${ACCENT_BAR[mode]}`} aria-hidden />
-
-            {onDismiss && (
-              <button
-                type="button"
-                data-testid="practice-complete-popup-dismiss"
-                onClick={handleDismiss}
-                aria-label={t('practice.keepPracticing')}
-                className="absolute top-2 end-2 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-neo-white hover:text-neo-white hover:bg-neo-cream/10 transition-colors"
-              >
-                <X className="w-4 h-4" aria-hidden />
-              </button>
-            )}
-
-            <div className="p-5 flex flex-col gap-4">
-              <AdaptiveMotion.div
-                initial={{ opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.08, duration: 0.22, ease: 'easeOut' }}
-              >
-                <PracticeCompleteBanner mode={mode} />
-              </AdaptiveMotion.div>
-              <AdaptiveMotion.div
-                initial={{ opacity: 0, y: 8, scale: 0.96 }}
-                animate={{ opacity: 1, y: 0, scale: 1 }}
-                transition={{ delay: 0.18, type: 'spring', stiffness: 360, damping: 22 }}
-                className="relative"
-              >
-                {/* Subtle pulsing glow ring behind the primary CTA — celebration
-                    emphasis without breaking neo-brutalist hard-shadow rules
-                    (animation lives on a separate layer). */}
-                <AdaptiveMotion.div
-                  aria-hidden
-                  className={`pointer-events-none absolute -inset-1 rounded-neo blur-md ${CTA_BG[mode]} opacity-30`}
-                  animate={{ opacity: [0.18, 0.35, 0.18] }}
-                  transition={{ duration: 2.4, repeat: Infinity, ease: 'easeInOut' }}
-                />
-                <PracticeChainCta
-                  currentMode={mode}
-                  className={`relative inline-flex items-center justify-center w-full ${CTA_BG[mode]} ${CTA_TEXT[mode]} border-3 border-neo-black rounded-neo py-3 px-4 font-neo-display font-black text-base shadow-hard active:translate-y-px active:shadow-hard-pressed`}
-                />
-              </AdaptiveMotion.div>
-            </div>
-          </AdaptiveMotion.div>
         </div>
-      )}
-    </AdaptiveAnimatePresence>
+      </div>
+    </div>
   );
 }

--- a/fe-next/components/practice/PracticeInstructions.tsx
+++ b/fe-next/components/practice/PracticeInstructions.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { X, HelpCircle } from 'lucide-react';
-import { AdaptiveMotion } from '@/components/motion/AdaptiveMotion';
 import { useLanguage } from '@/contexts/LanguageContext';
 import type { PracticeMode } from '@/lib/practice/practiceTutorialSteps';
 
@@ -132,13 +131,12 @@ export default function PracticeInstructions({ mode, autoOpen = true }: Props) {
         className="absolute inset-0 bg-neo-navy/85 backdrop-blur-sm cursor-default"
       />
 
-      <AdaptiveMotion.div
+      {/* CSS-only entrance (no Framer): the panel's resting state is visible,
+          so it can never stay stuck invisible behind the backdrop — the bug
+          that showed popups as a bare black overlay on RTL/Hebrew. */}
+      <div
         data-testid="practice-instructions"
-        initial={{ opacity: 0, y: 12, scale: 0.95 }}
-        animate={{ opacity: 1, y: 0, scale: 1 }}
-        exit={{ opacity: 0, y: 12 }}
-        transition={{ duration: 0.22, ease: 'easeOut' }}
-        className={`relative w-full max-w-sm rounded-neo border-3 border-neo-black ${ACCENT_BORDER[mode]} bg-neo-navy-light shadow-hard-lg max-h-[calc(100dvh-2rem)] overflow-hidden flex flex-col`}
+        className={`relative w-full max-w-sm rounded-neo border-3 border-neo-black ${ACCENT_BORDER[mode]} bg-neo-navy-light shadow-hard-lg max-h-[calc(100dvh-2rem)] overflow-hidden flex flex-col animate-pop-in`}
       >
         {/* Mode-color bar at the top — same chunky brand language as the live HUD. */}
         <div className={`h-1.5 ${ACCENT_BG[mode]}`} aria-hidden />
@@ -196,7 +194,7 @@ export default function PracticeInstructions({ mode, autoOpen = true }: Props) {
             {t('practice.instructions.cta')}
           </button>
         </div>
-      </AdaptiveMotion.div>
+      </div>
     </div>
   );
 }

--- a/fe-next/components/practice/PracticeMistakeCoach.tsx
+++ b/fe-next/components/practice/PracticeMistakeCoach.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { X } from 'lucide-react';
-import { AdaptiveMotion, AdaptiveAnimatePresence } from '@/components/motion/AdaptiveMotion';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useSoundEffects } from '@/contexts/SoundEffectsContext';
 import { haptics } from '@/utils/haptics';
@@ -71,90 +70,83 @@ export default function PracticeMistakeCoach({ kind, mode, onClose }: Props) {
     onClose();
   }, [onClose, playButtonClickSound]);
 
+  if (!kind) return null;
+
+  // CSS-only entrance (no Framer): the panel's resting state is visible, so it
+  // can never stay stuck invisible behind the backdrop — the bug that showed
+  // these popups as a bare black overlay on RTL/Hebrew.
   return (
-    <AdaptiveAnimatePresence>
-      {kind && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          role="dialog"
-          aria-modal="true"
-          aria-label={t('practice.mistakeCoach.ariaLabel')}
-          data-testid="practice-mistake-coach"
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('practice.mistakeCoach.ariaLabel')}
+      data-testid="practice-mistake-coach"
+    >
+      {/* Backdrop — tap-to-dismiss with soft fade. */}
+      <button
+        type="button"
+        data-testid="practice-mistake-coach-backdrop"
+        aria-label={t('practice.mistakeCoach.cta')}
+        onClick={handleDismiss}
+        className="absolute inset-0 bg-neo-navy/90 backdrop-blur-sm cursor-default animate-fadeIn"
+      />
+
+      {/* Modal panel. */}
+      <div
+        data-testid={`practice-mistake-coach-panel-${kind}`}
+        className={`relative w-full max-w-sm rounded-neo border-3 border-neo-black ${ACCENT_BORDER[mode]} bg-neo-navy-light shadow-hard-lg max-h-[calc(100dvh-2rem)] overflow-hidden flex flex-col animate-pop-in`}
+      >
+        {/* Mode-color accent bar at top — matches help modal language. */}
+        <div className={`h-1.5 ${ACCENT_BG[mode]}`} aria-hidden />
+
+        <button
+          type="button"
+          data-testid="practice-mistake-coach-dismiss"
+          onClick={handleDismiss}
+          aria-label={t('practice.mistakeCoach.cta')}
+          className="absolute top-2 end-2 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-neo-white hover:text-neo-white hover:bg-neo-cream/10 transition-colors"
         >
-          {/* Backdrop — tap-to-dismiss with soft fade. */}
-          <AdaptiveMotion.button
-            type="button"
-            data-testid="practice-mistake-coach-backdrop"
-            aria-label={t('practice.mistakeCoach.cta')}
-            onClick={handleDismiss}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.18 }}
-            className="absolute inset-0 bg-neo-navy/90 backdrop-blur-sm cursor-default"
-          />
+          <X className="w-4 h-4" aria-hidden />
+        </button>
 
-          {/* Modal panel — bouncy spring entrance for a friendly hello. */}
-          <AdaptiveMotion.div
-            data-testid={`practice-mistake-coach-panel-${kind}`}
-            initial={{ opacity: 0, y: 24, scale: 0.85 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 12, scale: 0.95 }}
-            transition={{ type: 'spring', stiffness: 320, damping: 22 }}
-            className={`relative w-full max-w-sm rounded-neo border-3 border-neo-black ${ACCENT_BORDER[mode]} bg-neo-navy-light shadow-hard-lg max-h-[calc(100dvh-2rem)] overflow-hidden flex flex-col`}
-          >
-            {/* Mode-color accent bar at top — matches help modal language. */}
-            <div className={`h-1.5 ${ACCENT_BG[mode]}`} aria-hidden />
+        <div className="p-4 sm:p-5 flex flex-col gap-3 min-h-0 overflow-y-auto">
+          {/* Hero illustration — the visual story carries the lesson.
+              Capped height (4:3 + max-vh) so body text + CTA always fit
+              on short phones without forcing modal scroll. */}
+          <div className="relative w-full aspect-[4/3] max-h-[28vh] sm:max-h-[32vh] rounded-neo overflow-hidden border-2 border-neo-black flex-shrink-0">
+            <Image
+              src={IMAGE_FOR_KIND[kind]}
+              alt=""
+              fill
+              sizes="(max-width: 640px) 90vw, 384px"
+              className="object-cover"
+              priority
+            />
+          </div>
 
-            <button
-              type="button"
-              data-testid="practice-mistake-coach-dismiss"
-              onClick={handleDismiss}
-              aria-label={t('practice.mistakeCoach.cta')}
-              className="absolute top-2 end-2 z-10 inline-flex items-center justify-center w-8 h-8 rounded-full text-neo-white hover:text-neo-white hover:bg-neo-cream/10 transition-colors"
+          <div className="flex flex-col gap-2 text-neo-white text-center">
+            <h2
+              className={`text-lg font-neo-display font-black ${ACCENT_TEXT[mode]}`}
             >
-              <X className="w-4 h-4" aria-hidden />
-            </button>
+              {t(`practice.mistakeCoach.${kind}.title`)}
+            </h2>
+            <p className="text-sm font-neo-body text-neo-white leading-snug">
+              {t(`practice.mistakeCoach.${kind}.body`)}
+            </p>
+          </div>
 
-            <div className="p-4 sm:p-5 flex flex-col gap-3 min-h-0 overflow-y-auto">
-              {/* Hero illustration — the visual story carries the lesson.
-                  Capped height (4:3 + max-vh) so body text + CTA always fit
-                  on short phones without forcing modal scroll. */}
-              <div className="relative w-full aspect-[4/3] max-h-[28vh] sm:max-h-[32vh] rounded-neo overflow-hidden border-2 border-neo-black flex-shrink-0">
-                <Image
-                  src={IMAGE_FOR_KIND[kind]}
-                  alt=""
-                  fill
-                  sizes="(max-width: 640px) 90vw, 384px"
-                  className="object-cover"
-                  priority
-                />
-              </div>
-
-              <div className="flex flex-col gap-2 text-neo-white text-center">
-                <h2
-                  className={`text-lg font-neo-display font-black ${ACCENT_TEXT[mode]}`}
-                >
-                  {t(`practice.mistakeCoach.${kind}.title`)}
-                </h2>
-                <p className="text-sm font-neo-body text-neo-white leading-snug">
-                  {t(`practice.mistakeCoach.${kind}.body`)}
-                </p>
-              </div>
-
-              <button
-                type="button"
-                data-testid="practice-mistake-coach-cta"
-                onClick={handleDismiss}
-                className={`w-full inline-flex items-center justify-center rounded-neo border-3 border-neo-black ${ACCENT_BG[mode]} text-neo-black py-3 font-neo-display font-black text-base shadow-hard active:translate-y-px active:shadow-hard-pressed`}
-              >
-                {t('practice.mistakeCoach.cta')}
-              </button>
-            </div>
-          </AdaptiveMotion.div>
+          <button
+            type="button"
+            data-testid="practice-mistake-coach-cta"
+            onClick={handleDismiss}
+            className={`w-full inline-flex items-center justify-center rounded-neo border-3 border-neo-black ${ACCENT_BG[mode]} text-neo-black py-3 font-neo-display font-black text-base shadow-hard active:translate-y-px active:shadow-hard-pressed`}
+          >
+            {t('practice.mistakeCoach.cta')}
+          </button>
         </div>
-      )}
-    </AdaptiveAnimatePresence>
+      </div>
+    </div>
   );
 }
 

--- a/fe-next/components/practice/PracticeTutorialSheet.tsx
+++ b/fe-next/components/practice/PracticeTutorialSheet.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { ArrowLeft, ArrowRight, ChevronLeft, ChevronRight, Move, TrendingUp, Compass, Target, Route, Disc, Hand, Plus, type LucideIcon } from 'lucide-react';
 import { m, type PanInfo } from 'framer-motion';
-import { AdaptiveMotion } from '@/components/motion/AdaptiveMotion';
 import { useSoundEffects } from '@/contexts/SoundEffectsContext';
 import { haptics } from '@/utils/haptics';
 import { tutorialTipKeys, type PracticeMode } from '@/lib/practice/practiceTutorialSteps';
@@ -127,11 +126,12 @@ const PracticeTutorialSheet: React.FC<PracticeTutorialSheetProps> = ({ mode, t, 
       data-testid="practice-tutorial-sheet"
       className="min-h-[100dvh] w-full bg-linear-to-b from-neo-navy to-neo-navy-light flex items-center justify-center px-4 sm:px-6 py-5 sm:py-8"
     >
-      <AdaptiveMotion.div
-        initial={{ opacity: 0, y: 12 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5, ease: 'easeOut' }}
-        className="w-full max-w-md md:max-w-2xl flex flex-col gap-4"
+      {/* CSS-only entrance (no Framer): the sheet's resting state is visible,
+          so a stalled JS animation can never leave the player staring at a bare
+          dark gradient — the "black overlay" bug seen on RTL/Hebrew. */}
+      <div
+        data-testid="practice-tutorial-content"
+        className="w-full max-w-md md:max-w-2xl flex flex-col gap-4 animate-fadeIn"
       >
         {/* Top bar — back arrow + tutorial label + skip */}
         <div className="flex items-center justify-between gap-3">
@@ -271,7 +271,7 @@ const PracticeTutorialSheet: React.FC<PracticeTutorialSheetProps> = ({ mode, t, 
             <ArrowRight className="w-4 h-4 rtl:rotate-180" aria-hidden />
           </button>
         </div>
-      </AdaptiveMotion.div>
+      </div>
     </div>
   );
 };

--- a/fe-next/components/practice/PracticeWheelSandbox.tsx
+++ b/fe-next/components/practice/PracticeWheelSandbox.tsx
@@ -140,7 +140,7 @@ export default function PracticeWheelSandbox() {
   const noopEffect = useCallback(() => {}, []);
 
   return (
-    <div className="relative flex flex-col items-stretch w-full max-w-md mx-auto px-4 pt-3 pb-2 gap-2 h-full min-h-0 overflow-hidden md:overflow-y-auto">
+    <div className="relative flex flex-col items-stretch w-full max-w-md mx-auto px-4 pt-3 pb-2 gap-2 h-full min-h-0 overflow-x-clip overflow-y-auto">
       {/* HUD strip — back-to-hub + the one number that matters (goal progress).
           WordWheelGame carries its own score chip below, so the shell only adds
           the practice goal. */}

--- a/fe-next/components/practice/PracticeWordHuntSandbox.tsx
+++ b/fe-next/components/practice/PracticeWordHuntSandbox.tsx
@@ -337,7 +337,7 @@ export default function PracticeWordHuntSandbox() {
   const liveHref = `/${language}/daily/word-hunt`;
 
   return (
-    <div className="relative flex flex-col items-stretch w-full max-w-md mx-auto px-4 pt-3 pb-2 gap-2 h-full min-h-0 overflow-hidden md:overflow-y-auto">
+    <div className="relative flex flex-col items-stretch w-full max-w-md mx-auto px-4 pt-3 pb-2 gap-2 h-full min-h-0 overflow-x-clip overflow-y-auto">
       <PracticePixiFx ref={fxRef} />
 
       {/* Discovery mechanic onboarding tip */}

--- a/fe-next/components/practice/__tests__/PracticeCompletePopup.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeCompletePopup.test.tsx
@@ -88,4 +88,15 @@ describe('PracticeCompletePopup', () => {
     expect(screen.getByTestId('practice-chain-cta')).toBeInTheDocument();
     expect(screen.queryByTestId('practice-complete-popup-play-real')).toBeNull();
   });
+
+  // Regression: the celebratory panel revealed via a Framer entrance starting at
+  // opacity 0. When that animation didn't run (observed on Hebrew/RTL) only the
+  // dark backdrop showed — "a black overlay screen". The panel must reveal via a
+  // CSS entrance whose resting state is visible, never a stuck inline opacity:0.
+  it('reveals the panel via a CSS entrance, never a stuck inline opacity:0', () => {
+    render(<PracticeCompletePopup open mode="classic" />);
+    const panel = screen.getByTestId('practice-complete-popup-panel-classic');
+    expect(panel.className).toContain('animate-pop-in');
+    expect(panel.style.opacity).not.toBe('0');
+  });
 });

--- a/fe-next/components/practice/__tests__/PracticeInstructions.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeInstructions.test.tsx
@@ -79,4 +79,16 @@ describe('PracticeInstructions overlay', () => {
     // The on-demand "?" pill is still available for reference.
     expect(screen.getByTestId('practice-instructions-toggle')).toBeInTheDocument();
   });
+
+  // Regression: popups used a Framer entrance (initial opacity 0 → animate 1).
+  // When that JS animation didn't run (observed on Hebrew/RTL), the panel stayed
+  // invisible and only the dark backdrop showed — "a black overlay screen". The
+  // panel must reveal via a CSS animation whose RESTING state is visible, never
+  // an inline opacity:0 that can get stuck.
+  it('reveals the panel via a CSS entrance, never a stuck inline opacity:0', () => {
+    render(<PracticeInstructions mode="classic" />);
+    const panel = screen.getByTestId('practice-instructions');
+    expect(panel.className).toContain('animate-pop-in');
+    expect(panel.style.opacity).not.toBe('0');
+  });
 });

--- a/fe-next/components/practice/__tests__/PracticeMistakeCoach.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeMistakeCoach.test.tsx
@@ -123,6 +123,17 @@ describe('<PracticeMistakeCoach>', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  // Regression: panel revealed via a Framer entrance starting at opacity 0.
+  // When the animation didn't run (observed on Hebrew/RTL) only the dark
+  // backdrop showed. Reveal must be a CSS entrance with a visible resting
+  // state, never a stuck inline opacity:0.
+  it('reveals the panel via a CSS entrance, never a stuck inline opacity:0', () => {
+    render(<PracticeMistakeCoach kind="notAWord" mode="classic" onClose={() => {}} />);
+    const panel = screen.getByTestId('practice-mistake-coach-panel-notAWord');
+    expect(panel.className).toContain('animate-pop-in');
+    expect(panel.style.opacity).not.toBe('0');
+  });
+
   it('switches images per kind via deterministic data-testid', () => {
     const { rerender } = render(
       <PracticeMistakeCoach kind="notAWord" mode="classic" onClose={() => {}} />,

--- a/fe-next/components/practice/__tests__/PracticeSandbox.responsive.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeSandbox.responsive.test.tsx
@@ -1,52 +1,38 @@
 /**
  * PracticeSandbox responsive layout contract (className-based).
  *
- * On desktop (md+), the sandbox root MUST allow vertical scroll to prevent
- * clipped content when the welcome card consumes vertical space. This test
- * verifies that the className strings match the expected pattern.
+ * The sandbox root MUST allow vertical scroll (and clip horizontally) at EVERY
+ * breakpoint — not just desktop. The live games (e.g. DailyWordHuntSurvival)
+ * use `overflow-x-clip overflow-y-auto`, so on short phones their content is
+ * never clipped: the board fills the available flex space and the page scrolls
+ * if the surrounding chrome doesn't fit. Practice previously used
+ * `overflow-hidden md:overflow-y-auto`, which hard-clipped on mobile and
+ * squeezed the board on short viewports (the reported "board responsiveness"
+ * bug). This test pins the new contract so we don't regress to mobile clipping.
  *
- * NOTE: jsdom has no layout engine, so visual verification (no clipped content,
- * card visible at 1280×633) must be done via browser screenshot. This test
- * verifies the classNames are correct.
+ * NOTE: jsdom/happy-dom has no layout engine, so visual verification (no clipped
+ * content, board fills the viewport) must be done via browser screenshot. This
+ * test only verifies the className strings.
  */
 import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 
+const ROOTS = [
+  'PracticeClassicSandbox.tsx',
+  'PracticeWordHuntSandbox.tsx',
+  'PracticeWheelSandbox.tsx',
+];
+
 describe('PracticeSandbox — responsive overflow contract (classNames)', () => {
-  it('PracticeClassicSandbox root contains md:overflow-y-auto', () => {
-    const filePath = path.join(
-      __dirname,
-      '../PracticeClassicSandbox.tsx'
-    );
-    const content = fs.readFileSync(filePath, 'utf-8');
-    // Find the root div around line 224
-    const match = content.match(
-      /return\s*\(\s*<div className="relative flex flex-col items-center w-full[^"]*overflow-hidden[^"]*">/
-    );
-    expect(match).toBeTruthy();
-    expect(content).toMatch(/md:overflow-y-auto/);
-  });
-
-  it('PracticeWordHuntSandbox root contains md:overflow-y-auto', () => {
-    const filePath = path.join(
-      __dirname,
-      '../PracticeWordHuntSandbox.tsx'
-    );
-    const content = fs.readFileSync(filePath, 'utf-8');
-    expect(content).toContain('md:overflow-y-auto');
-    expect(content).toContain('items-stretch w-full');
-    expect(content).toContain('overflow-hidden');
-  });
-
-  it('PracticeWheelSandbox root contains md:overflow-y-auto', () => {
-    const filePath = path.join(
-      __dirname,
-      '../PracticeWheelSandbox.tsx'
-    );
-    const content = fs.readFileSync(filePath, 'utf-8');
-    expect(content).toContain('md:overflow-y-auto');
-    expect(content).toContain('items-stretch w-full');
-    expect(content).toContain('overflow-hidden');
-  });
+  for (const file of ROOTS) {
+    it(`${file} root scrolls vertically at every breakpoint (matches live game)`, () => {
+      const content = fs.readFileSync(path.join(__dirname, '..', file), 'utf-8');
+      // Vertical scroll is always available — never hard-clipped on mobile.
+      expect(content).toContain('overflow-y-auto');
+      expect(content).toContain('overflow-x-clip');
+      // Must NOT hard-clip content (the old mobile `overflow-hidden` default).
+      expect(content).not.toContain('overflow-hidden md:overflow-y-auto');
+    });
+  }
 });

--- a/fe-next/components/practice/__tests__/PracticeTutorialSheet.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeTutorialSheet.test.tsx
@@ -106,6 +106,17 @@ describe('PracticeTutorialSheet', () => {
     expect(screen.getByTestId('practice-tutorial-sheet')).toBeInTheDocument();
   });
 
+  // Regression: the sheet content used a Framer entrance starting at opacity 0
+  // over a dark gradient. When that animation didn't run (observed on RTL) the
+  // player saw only the dark gradient — a "black overlay". Reveal must be a CSS
+  // entrance with a visible resting state, never a stuck inline opacity:0.
+  it('reveals content via a CSS entrance, never a stuck inline opacity:0', () => {
+    render(<PracticeTutorialSheet mode="classic" t={t} onContinue={() => {}} />);
+    const content = screen.getByTestId('practice-tutorial-content');
+    expect(content.className).toContain('animate-fadeIn');
+    expect(content.style.opacity).not.toBe('0');
+  });
+
   it('renders a per-slide illustration component (one per slide) instead of a single hero image', () => {
     render(<PracticeTutorialSheet mode="classic" t={t} onContinue={() => {}} />);
     expect(screen.getByTestId('practice-tutorial-art-classic-0')).toBeInTheDocument();

--- a/fe-next/tailwind.config.js
+++ b/fe-next/tailwind.config.js
@@ -423,6 +423,14 @@ module.exports = {
           "60%": { transform: "scale(1.1) rotate(2deg)", opacity: "1" },
           "100%": { transform: "scale(1) rotate(0deg)", opacity: "1" },
         },
+        // Clean modal entrance (scale + fade, no rotate). CSS-only so the
+        // content's RESTING state is the normal cascade (opacity:1) — it can
+        // never get stuck invisible the way a stalled Framer entrance can,
+        // which was painting popups as a bare dark overlay (esp. RTL/Hebrew).
+        "pop-in": {
+          "0%": { transform: "scale(0.95) translateY(8px)", opacity: "0" },
+          "100%": { transform: "scale(1) translateY(0)", opacity: "1" },
+        },
         "neo-slide-in": {
           "0%": { transform: "translateY(-20px) rotate(-3deg)", opacity: "0" },
           "60%": { transform: "translateY(5px) rotate(1deg)" },
@@ -607,6 +615,8 @@ module.exports = {
         "neo-press": "neo-press 0.1s ease-out forwards",
         "neo-wobble": "neo-wobble 0.3s ease-in-out",
         "neo-pop": "neo-pop 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards",
+        "pop-in": "pop-in 0.26s cubic-bezier(0.16, 1, 0.3, 1) forwards",
+        "fadeIn": "fadeIn 0.2s ease-out forwards",
         "neo-slide-in": "neo-slide-in 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards",
         "neo-shake": "neo-shake 0.5s cubic-bezier(0.36, 0.07, 0.19, 0.97)",
         "pressure-border": "pressure-border 5s linear forwards",


### PR DESCRIPTION
Two practice-mode bugs:

1. Popups rendered as a bare black/dark overlay (esp. RTL/Hebrew). Every
   practice popup (complete, instructions, mistake coach, tutorial sheet)
   hid its content inside an AdaptiveMotion/Framer entrance starting at
   opacity:0 and relied on the JS animation to reveal it over a dark
   backdrop. When that entrance didn't run, the panel stayed invisible
   while the backdrop showed — exactly the reported "black overlay, no
   content". Switched these entrances to CSS animations (new `pop-in` +
   existing `fadeIn`) whose RESTING state is the normal cascade
   (opacity:1), so content can never get stuck invisible. Matches the
   codebase's existing "CSS-only, no Framer Motion needed" pattern.

2. Practice boards got squeezed/clipped on short mobile viewports. The
   sandbox roots used `overflow-hidden md:overflow-y-auto`, hard-clipping
   on mobile, while the live games (e.g. DailyWordHuntSurvival) use
   `overflow-x-clip overflow-y-auto` so content is never clipped and the
   board fills the available flex space. Aligned the three sandboxes
   (classic/word-hunt/wheel) with the live-game scroll contract.

The grids themselves already reuse the real GridComponent/WordWheelGame.

Tests: added visibility regression guards (panel reveals via CSS, never a
stuck inline opacity:0) for all four popups; updated the responsive
overflow contract test to the new mobile-scroll behavior.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M9gXFUHo42uGVVjo8BFPco