### PR TITLE
fix(daily): sync homepage fire-icon streak with weekly chest

### DIFF
--- a/fe-next/app/api/daily/weekly-chest/status/route.ts
+++ b/fe-next/app/api/daily/weekly-chest/status/route.ts
@@ -90,6 +90,13 @@ export async function GET(request: NextRequest) {
     const completedCycles = findCompletedCycles(allDates)
     const unclaimed = completedCycles.find(c => !openedCycleStarts.has(c.cycleStart))
 
+    // Live streak: the full consecutive-day run from `today` backward across ALL
+    // modes (+ freezes). This is the single source of truth for the daily "fire"
+    // streak shown on the homepage card and the /daily header — computed the SAME
+    // way the chest progress is, so the two surfaces can never disagree. Computed
+    // unconditionally so the fire icon stays correct even on the backdated path.
+    const liveProgress = computeCycleProgress(allDates, today)
+
     // Backdated path: prior cycle still owed — surface it as the active cycle so
     // the player can still claim what they earned even after a new week began.
     // In-progress path: show current streak from `today` backward.
@@ -101,7 +108,7 @@ export async function GET(request: NextRequest) {
           daysCompleted: 7,
           isClaimable: true,
         }
-      : computeCycleProgress(allDates, today)
+      : liveProgress
 
     // Projected tier — what tier the chest would be if claimed right now, based
     // on the player's performance so far this cycle. Puzzle/Hunt/Wheel all
@@ -132,6 +139,7 @@ export async function GET(request: NextRequest) {
       cycleNumber: progress.cycleNumber,
       completedDates: progress.completedDates,
       daysCompleted: progress.daysCompleted,
+      currentStreak: liveProgress.currentStreak,
       isClaimable,
       pendingChest,
       weekScore,

--- a/fe-next/components/daily/DailyChallengeCube.tsx
+++ b/fe-next/components/daily/DailyChallengeCube.tsx
@@ -41,7 +41,10 @@ const DailyChallengeCube: React.FC<DailyChallengeCubeProps> = ({ preloadedStats 
   const countdown = mounted ? stats.countdown : '';
   const hasPlayed = mounted ? stats.hasPlayed : false;
   const hasSolved = mounted ? stats.hasSolved : null;
-  const streak = mounted ? stats.streak : 0;
+  // Prefer the chest-authoritative streak from `preloadedStats` (all daily modes
+  // + freezes) so this cube's fire chip matches the weekly chest; fall back to the
+  // hook's localStorage value when rendered without preloaded stats.
+  const streak = mounted ? (preloadedStats?.currentStreak ?? stats.streak) : 0;
   const puzzleNumber = mounted ? stats.puzzleNumber : 0;
 
   return (

--- a/fe-next/components/daily/DailyHub.tsx
+++ b/fe-next/components/daily/DailyHub.tsx
@@ -12,8 +12,8 @@ import {
   getSecondsUntilNextDaily,
   hasPlayedWordHuntToday,
   hasPlayedWordWheelToday,
-  getDailyStreak,
 } from '@/utils/dailyChallenge';
+import { useDailyStreak } from '@/hooks/useDailyStreak';
 import { getLastSevenDaysCompletion } from '@/utils/dailyChallenge/storage';
 import LastSevenDaysIndicator from './LastSevenDaysIndicator';
 import { formatTimeHHMMSS } from '@/shared/utils/timeFormatting';
@@ -135,7 +135,9 @@ export default function DailyHub() {
 
   const date = getDailyChallengeDate();
   const puzzleNumber = getPuzzleNumber(date);
-  const streak = getDailyStreak();
+  // Same chest-authoritative streak the WeeklyChestCard below uses, so the header
+  // fire icon and the chest can't show different numbers on the same screen.
+  const { streak: currentStreak } = useDailyStreak();
   const playedWH = hasPlayedWordHuntToday(gameLang);
   const playedWW = hasPlayedWordWheelToday(gameLang);
   const bothDone = playedWH && playedWW;
@@ -173,9 +175,9 @@ export default function DailyHub() {
 
         {/* Streak & Countdown */}
         <div className="flex items-center justify-center gap-4">
-          {streak.currentStreak > 0 && (
+          {currentStreak > 0 && (
             <span className="text-neo-lime font-neo-display font-black text-lg">
-              🔥 {streak.currentStreak}
+              🔥 {currentStreak}
             </span>
           )}
           <span className="flex items-center gap-1.5 text-neo-white text-sm">

--- a/fe-next/components/daily/__tests__/DailyChallengeCube.test.tsx
+++ b/fe-next/components/daily/__tests__/DailyChallengeCube.test.tsx
@@ -77,6 +77,20 @@ describe('DailyChallengeCube', () => {
     expect(screen.getByText(/5 daily\.dayStreak/)).toBeInTheDocument();
   });
 
+  it('prefers the chest-authoritative preloaded streak over the localStorage value', () => {
+    // The hook's `streak` is the legacy localStorage (Word-Hunt-only) value; when
+    // the landing page threads the chest's all-modes streak through preloadedStats,
+    // the cube must show THAT so its fire chip matches the weekly chest.
+    mockStats.mockReturnValue({ ...baseStats, streak: 5 });
+    render(
+      <DailyChallengeCube
+        preloadedStats={{ hasPlayed: false, hasSolved: null, currentStreak: 9, puzzleNumber: 123, loading: false }}
+      />,
+    );
+    expect(screen.getByText(/9 daily\.dayStreak/)).toBeInTheDocument();
+    expect(screen.queryByText(/5 daily\.dayStreak/)).not.toBeInTheDocument();
+  });
+
   it('shows the won badge when the player solved today', () => {
     mockStats.mockReturnValue({ ...baseStats, hasPlayed: true, hasSolved: true });
     render(<DailyChallengeCube />);

--- a/fe-next/components/daily/__tests__/DailyHub.streak.test.tsx
+++ b/fe-next/components/daily/__tests__/DailyHub.streak.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * DailyHub header streak:
+ *   The "🔥 N" header reads the chest-authoritative streak (useDailyStreak →
+ *   all daily modes + freezes, server-computed) — NOT the Word-Hunt-only
+ *   localStorage counter — so it can never disagree with the WeeklyChestCard
+ *   rendered directly beneath it on the same screen.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('framer-motion', () => ({
+  m: new Proxy({}, {
+    get: () => ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div>,
+  }),
+}));
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }: React.PropsWithChildren<{ href: string }>) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (k: string) => k, language: 'en', dir: 'ltr' }),
+}));
+
+vi.mock('@/shared/utils/timeFormatting', () => ({ formatTimeHHMMSS: () => '00:00:00' }));
+
+vi.mock('@/utils/dailyChallenge', () => ({
+  getDailyChallengeDate: () => '2026-05-18',
+  getPuzzleNumber: () => 42,
+  getSecondsUntilNextDaily: () => 3600,
+  hasPlayedWordHuntToday: () => false,
+  hasPlayedWordWheelToday: () => false,
+}));
+
+vi.mock('@/utils/dailyChallenge/storage', () => ({ getLastSevenDaysCompletion: () => [] }));
+vi.mock('../LastSevenDaysIndicator', () => ({ __esModule: true, default: () => <div /> }));
+vi.mock('../WeeklyChestCard', () => ({ __esModule: true, default: () => <div data-testid="weekly-chest" /> }));
+vi.mock('../WeeklyChestModal', () => ({ __esModule: true, default: () => null }));
+
+const mockStreak = vi.fn();
+vi.mock('@/hooks/useDailyStreak', () => ({ useDailyStreak: () => mockStreak() }));
+
+import DailyHub from '../DailyHub';
+
+describe('DailyHub — header fire icon', () => {
+  it('renders the chest-authoritative streak from useDailyStreak', () => {
+    mockStreak.mockReturnValue({ streak: 23, loading: false });
+    render(<DailyHub />);
+    expect(screen.getByText(/🔥\s*23/)).toBeInTheDocument();
+  });
+
+  it('hides the fire icon when there is no streak', () => {
+    mockStreak.mockReturnValue({ streak: 0, loading: false });
+    render(<DailyHub />);
+    expect(screen.queryByText(/🔥/)).toBeNull();
+  });
+});

--- a/fe-next/components/landing/LandingView.tsx
+++ b/fe-next/components/landing/LandingView.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils';
 import { useLiveRoomStats } from '@/hooks/useLiveRoomStats';
 import { usePlayerStats } from '@/hooks/usePlayerStats';
 import { useDailyChallengeStatus } from '@/hooks/useDailyChallengeStatus';
+import { useDailyStreak } from '@/hooks/useDailyStreak';
 import { useTopPlayers } from '@/hooks/useTopPlayers';
 import { useLandingStats } from '@/hooks/useLandingStats';
 import { InlineBannerAd } from '@/components/ads';
@@ -92,6 +93,10 @@ const LandingView: React.FC<LandingViewProps> = ({ initialData, onStartOnboardin
   const liveRoomStats = useLiveRoomStats();
   const { allTimeBest: playerAllTimeBest } = usePlayerStats();
   const dailyChallengeStatus = useDailyChallengeStatus(language as 'en' | 'he' | 'sv' | 'ja' | 'es');
+  // Fire-icon streak comes from the chest's all-modes, server-authoritative walk
+  // (NOT the Word-Hunt-only localStorage counter), so the homepage card + top-bar
+  // pill stay in sync with the weekly chest. Falls back to the local seed instantly.
+  const { streak: dailyStreak } = useDailyStreak();
   const { activeEvents, myEvents, joinEvent: joinEventAction } = useEvents();
   const { players: topPlayers, loading: topPlayersLoading } = useTopPlayers(5, {
     initialData: initialData?.topPlayers,
@@ -154,7 +159,9 @@ const LandingView: React.FC<LandingViewProps> = ({ initialData, onStartOnboardin
   const dailyChallengeStats = {
     hasPlayed: dailyChallengeStatus.hasPlayed,
     hasSolved: dailyChallengeStatus.hasSolved,
-    currentStreak: dailyChallengeStatus.currentStreak,
+    // Chest-authoritative streak (all daily modes + freezes) — keeps the fire icon
+    // identical to the weekly chest instead of the Word-Hunt-only legacy counter.
+    currentStreak: dailyStreak,
     puzzleNumber: dailyChallengeStatus.puzzleNumber,
     loading: dailyChallengeStatus.loading,
   };

--- a/fe-next/components/landing/home/HomeDailyHero.tsx
+++ b/fe-next/components/landing/home/HomeDailyHero.tsx
@@ -40,7 +40,10 @@ export function HomeDailyHero({ preloadedStats }: HomeDailyHeroProps) {
   const countdown = mounted ? stats.countdown : '';
   const hasPlayed = mounted ? stats.hasPlayed : false;
   const hasSolved = mounted ? stats.hasSolved : false;
-  const streak = mounted ? stats.streak : 0;
+  // Prefer the chest-authoritative streak threaded through `preloadedStats`
+  // (all daily modes + freezes) so the fire icon matches the weekly chest; fall
+  // back to the hook's localStorage value when no preloaded streak is supplied.
+  const streak = mounted ? (preloadedStats?.currentStreak ?? stats.streak) : 0;
   const puzzleNumber = mounted ? stats.puzzleNumber : 0;
   // Progress strip = the player's REAL last-5-days completion (each cell filled
   // when that day's daily was actually played), not an echo of the streak count.

--- a/fe-next/hooks/__tests__/useDailyStreak.test.ts
+++ b/fe-next/hooks/__tests__/useDailyStreak.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+// Control the localStorage fallback deterministically.
+vi.mock('@/utils/dailyChallenge', () => ({
+  getDailyStreak: vi.fn(() => ({ currentStreak: 3 })),
+}));
+
+import { getDailyStreak } from '@/utils/dailyChallenge';
+import { useDailyStreak } from '../useDailyStreak';
+
+describe('useDailyStreak — server (all-modes chest) streak is the source of truth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDailyStreak).mockReturnValue({ currentStreak: 3 } as ReturnType<typeof getDailyStreak>);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('seeds from the localStorage streak for an instant first paint', () => {
+    // No fetch resolution yet — the hook should paint the local value immediately.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
+    const { result } = renderHook(() => useDailyStreak());
+    expect(result.current.streak).toBe(3);
+  });
+
+  it('replaces the local seed with the authoritative server streak', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ currentStreak: 12 }),
+      }),
+    );
+    const { result } = renderHook(() => useDailyStreak());
+    await waitFor(() => expect(result.current.streak).toBe(12));
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('keeps the local fallback when the request fails (offline / guest 401)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    const { result } = renderHook(() => useDailyStreak());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.streak).toBe(3);
+  });
+
+  it('never throws when fetch is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+    const { result } = renderHook(() => useDailyStreak());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.streak).toBe(3);
+  });
+});

--- a/fe-next/hooks/useDailyStreak.ts
+++ b/fe-next/hooks/useDailyStreak.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getDailyStreak } from '@/utils/dailyChallenge';
+
+export interface DailyStreakState {
+  /** Consecutive-day daily streak (the "fire" number). */
+  streak: number;
+  /** True until the authoritative server value resolves. */
+  loading: boolean;
+}
+
+/**
+ * useDailyStreak — the single source of truth for the daily "fire" streak.
+ *
+ * Why this exists: the fire icon used to read a Word-Hunt-only counter from
+ * localStorage (`DAILY_STREAK_KEY`), while the weekly chest counts a day as done
+ * if ANY daily mode (Hunt / Wheel / Puzzle) was completed — and it's
+ * streak-freeze aware and server-authoritative. The two drifted constantly
+ * (cross-device play, freezes, or simply playing the Wheel but not the Hunt).
+ *
+ * This hook makes the fire icon agree with the chest by reading the SAME
+ * server-computed all-modes consecutive-day streak (`/api/daily/weekly-chest/status`
+ * → `currentStreak`). It seeds from the local counter for an instant first paint,
+ * then the server value wins. On error (offline, or a guest's 401) it keeps the
+ * local seed, so guests/offline behave exactly as before.
+ */
+export function useDailyStreak(): DailyStreakState {
+  const [streak, setStreak] = useState<number>(() =>
+    typeof window === 'undefined' ? 0 : getDailyStreak().currentStreak,
+  );
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    const sync = async () => {
+      try {
+        const res = await fetch('/api/daily/weekly-chest/status');
+        if (!res.ok) return; // guest 401 / rate-limit / 5xx — keep the local seed
+        const json = await res.json();
+        const value = Number(json?.currentStreak);
+        if (active && Number.isFinite(value)) {
+          setStreak(Math.max(0, Math.trunc(value)));
+        }
+      } catch {
+        // Offline / fetch unavailable — keep the localStorage fallback.
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    sync();
+
+    // Refresh when the player returns to the tab so a just-completed daily (or a
+    // cross-device play) updates the fire icon without a hard reload — the same
+    // freshness contract the rest of the daily surfaces follow.
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') sync();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    window.addEventListener('focus', sync);
+
+    return () => {
+      active = false;
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('focus', sync);
+    };
+  }, []);
+
+  return { streak, loading };
+}
+
+export default useDailyStreak;

--- a/fe-next/hooks/useWeeklyChest.ts
+++ b/fe-next/hooks/useWeeklyChest.ts
@@ -17,6 +17,8 @@ export type ChestTier = 'bronze' | 'silver' | 'gold'
 export interface WeeklyChestState {
   loading: boolean
   daysCompleted: number
+  /** Full consecutive-day streak (can exceed 7) — powers the daily "fire" icon. */
+  currentStreak: number
   completedDates: string[]
   cycleStart: string
   cycleNumber: number
@@ -32,6 +34,7 @@ export interface WeeklyChestState {
 
 const DEFAULTS = {
   daysCompleted: 0,
+  currentStreak: 0,
   completedDates: [] as string[],
   cycleStart: '',
   cycleNumber: 1,
@@ -50,6 +53,10 @@ function normalizeStatus(json: unknown): typeof DEFAULTS {
   const daysCompleted = Number.isFinite(rawDays)
     ? Math.max(0, Math.min(7, Math.trunc(rawDays)))
     : 0
+  // currentStreak is the full consecutive run — NOT clamped to 7 (the fire icon
+  // shows real streaks like "23"), only floored at 0 and integer-coerced.
+  const rawStreak = Number(obj.currentStreak)
+  const currentStreak = Number.isFinite(rawStreak) ? Math.max(0, Math.trunc(rawStreak)) : 0
   const completedDates = Array.isArray(obj.completedDates)
     ? (obj.completedDates.filter(d => typeof d === 'string') as string[])
     : []
@@ -69,6 +76,7 @@ function normalizeStatus(json: unknown): typeof DEFAULTS {
     : 0
   return {
     daysCompleted,
+    currentStreak,
     completedDates,
     cycleStart,
     cycleNumber,

--- a/fe-next/lib/daily/__tests__/weeklyChest.test.ts
+++ b/fe-next/lib/daily/__tests__/weeklyChest.test.ts
@@ -157,6 +157,7 @@ describe('computeCycleProgress', () => {
     expect(r.cycleNumber).toBe(1)
     expect(r.cycleStart).toBe('2026-05-12')
     expect(r.isClaimable).toBe(false)
+    expect(r.currentStreak).toBe(1)
   })
 
   it('returns daysCompleted 7 and isClaimable for 7 consecutive days', () => {
@@ -165,6 +166,7 @@ describe('computeCycleProgress', () => {
     expect(r.daysCompleted).toBe(7)
     expect(r.cycleNumber).toBe(1)
     expect(r.isClaimable).toBe(true)
+    expect(r.currentStreak).toBe(7)
   })
 
   it('starts cycle 2 on day 8', () => {
@@ -178,17 +180,40 @@ describe('computeCycleProgress', () => {
     expect(r.daysCompleted).toBe(1)
   })
 
+  // The fire-icon streak is the FULL consecutive-day run (it can exceed 7), not
+  // the within-cycle day count — so day 8 reads "8-day streak" while the chest
+  // shows day 1 of cycle 2. Both derive from the same walk, so they never disagree.
+  it('reports the full consecutive-day streak across cycle boundaries', () => {
+    const dates = Array.from({ length: 8 }, (_, i) => {
+      const d = new Date('2026-05-05')
+      d.setDate(d.getDate() + i)
+      return d.toISOString().split('T')[0]
+    })
+    const r = computeCycleProgress(dates, '2026-05-12')
+    expect(r.currentStreak).toBe(8)
+  })
+
   it('resets streak on gap', () => {
     const dates = ['2026-05-08','2026-05-09','2026-05-11','2026-05-12']
     const r = computeCycleProgress(dates, today)
     expect(r.daysCompleted).toBe(2)
     expect(r.cycleNumber).toBe(1)
+    expect(r.currentStreak).toBe(2)
+  })
+
+  it('does not count the streak when today is not completed', () => {
+    // Played yesterday + the day before, but not today → the live streak from
+    // `today` is 0 (the run ended yesterday). Matches the chest walk-back.
+    const r = computeCycleProgress(['2026-05-10', '2026-05-11'], today)
+    expect(r.currentStreak).toBe(0)
+    expect(r.daysCompleted).toBe(0)
   })
 
   it('returns empty progress with no dates', () => {
     const r = computeCycleProgress([], today)
     expect(r.daysCompleted).toBe(0)
     expect(r.isClaimable).toBe(false)
+    expect(r.currentStreak).toBe(0)
   })
 })
 

--- a/fe-next/lib/daily/weeklyChest.ts
+++ b/fe-next/lib/daily/weeklyChest.ts
@@ -6,6 +6,13 @@ export interface CycleProgress {
   completedDates: string[]
   daysCompleted: number
   isClaimable: boolean
+  /**
+   * Full consecutive-day run ending today (can exceed 7) — the number the daily
+   * "fire" streak shows. Distinct from `daysCompleted`, which wraps within the
+   * current 7-day chest cycle. Both come from the same backward walk, so the
+   * homepage fire icon and the chest can never contradict each other.
+   */
+  currentStreak: number
 }
 
 export interface DayScore {
@@ -169,7 +176,7 @@ export function computeCycleProgress(
   }
 
   if (streak.length === 0) {
-    return { cycleStart: today, cycleNumber: 1, completedDates: [], daysCompleted: 0, isClaimable: false }
+    return { cycleStart: today, cycleNumber: 1, completedDates: [], daysCompleted: 0, isClaimable: false, currentStreak: 0 }
   }
 
   const streakLen = streak.length
@@ -178,5 +185,5 @@ export function computeCycleProgress(
   const completedDates = streak.slice(streak.length - daysInCurrentCycle)
   const cycleStart = completedDates[0]
 
-  return { cycleStart, cycleNumber, completedDates, daysCompleted: daysInCurrentCycle, isClaimable: daysInCurrentCycle === 7 }
+  return { cycleStart, cycleNumber, completedDates, daysCompleted: daysInCurrentCycle, isClaimable: daysInCurrentCycle === 7, currentStreak: streakLen }
 }


### PR DESCRIPTION
The daily "fire" streak on the homepage card (HomeDailyHero / DailyChallengeCube),
the home top-bar pill, and the /daily header read a Word-Hunt-only counter from
localStorage (DAILY_STREAK_KEY), while the weekly chest counts a day as done if
ANY daily mode was completed — and is streak-freeze aware and server-authoritative.
The two drifted (cross-device play, freezes, or playing the Wheel but not the Hunt).

Make the chest's all-modes, server-computed consecutive-day count the single
source of truth for the fire icon:

- computeCycleProgress: expose currentStreak (full consecutive run, can exceed 7)
- /api/daily/weekly-chest/status: return currentStreak (live, even on backdated path)
- useWeeklyChest: surface currentStreak
- useDailyStreak: new shared hook — seeds from localStorage for instant paint,
  then the server chest streak wins; refreshes on focus/visibility
- LandingView / cards / DailyHub header: consume the chest-authoritative streak

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XNuGLqwSEuKbkwWwBroTkB