### PR TITLE
fix(popups): migrate all remaining popups off JS-gated reveals (empty-backdrop fix)

### DIFF
--- a/fe-next/components/EmojiAvatarPicker.tsx
+++ b/fe-next/components/EmojiAvatarPicker.tsx
@@ -2,8 +2,9 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { m, AnimatePresence } from 'framer-motion';
+import { AnimatePresence } from 'framer-motion';
 import { Check, X, User, Paintbrush } from 'lucide-react';
+import { Reveal } from '@/components/ui/Reveal';
 import Image from 'next/image';
 import { AVATARS, getAvatarPath, type AvatarConfig } from '@/utils/avatarConfig';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -132,20 +133,16 @@ const EmojiAvatarPicker: React.FC<AvatarPickerProps> = ({
   return createPortal(
     <AnimatePresence>
       {isOpen && (
-      <m.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
+      <Reveal
+        noSlide
         className="fixed inset-0 z-1000 flex items-center justify-center bg-black/60 p-4"
         onClick={onClose}
         role="dialog"
         aria-modal="true"
         aria-label={t('profile.chooseAvatar')}
       >
-        <m.div
-          initial={{ scale: 0.9, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1 }}
-          exit={{ scale: 0.9, opacity: 0 }}
+        <Reveal
+          noSlide
           className="w-full max-w-md rounded-neo overflow-hidden bg-neo-navy border-3 border-neo-black shadow-hard-lg"
           onClick={(e) => e.stopPropagation()}
         >
@@ -255,8 +252,8 @@ const EmojiAvatarPicker: React.FC<AvatarPickerProps> = ({
               {t('common.save')}
             </button>
           </div>
-        </m.div>
-      </m.div>
+        </Reveal>
+      </Reveal>
       )}
       {showBuilder && (
         <AvatarBuilderModal

--- a/fe-next/components/MusicControls.tsx
+++ b/fe-next/components/MusicControls.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { Button } from './ui/button';
 import { useHapticsConfig } from '../contexts/HapticsContext';
 import { resolveMasterMuteClick } from '@/lib/audio/masterMuteToggle';
+import { Reveal } from '@/components/ui/Reveal';
 
 /**
  * MusicControls - Neo-Brutalist styled volume controls with separate music and SFX sliders
@@ -140,11 +141,8 @@ const MusicControls: React.FC = memo(() => {
       {hasMounted && createPortal(
         <AnimatePresence>
           {showSlider && (
-            <m.div
-              initial={{ opacity: 0, y: -10, scale: 0.95, rotate: -2 }}
-              animate={{ opacity: 1, y: 0, scale: 1, rotate: 1 }}
-              exit={{ opacity: 0, y: -10, scale: 0.95 }}
-              transition={{ duration: 0.15, ease: [0.68, -0.55, 0.265, 1.55] }}
+            <Reveal
+              noSlide
               className="
                 fixed p-3
                 min-w-[150px]
@@ -269,7 +267,7 @@ const MusicControls: React.FC = memo(() => {
                   </span>
                 )}
               </div>
-            </m.div>
+            </Reveal>
           )}
         </AnimatePresence>,
         document.body

--- a/fe-next/components/OnboardingModal.tsx
+++ b/fe-next/components/OnboardingModal.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { m, AnimatePresence } from 'framer-motion';
 import { ArrowLeft, ArrowRight, Rocket } from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle, DialogDescription, DialogBody, DialogFooter } from './ui/dialog';
 import { Button } from './ui/button';
@@ -241,23 +240,20 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({ isOpen, onClose }) =>
           <OnboardingProgress currentStep={currentStep} totalSteps={TOTAL_STEPS} />
         </div>
 
-        {/* Step content with animation and swipe support */}
+        {/* Step content with animation and swipe support.
+            Keyed CSS entrance (animate-in) instead of framer-motion: the JS
+            animation loop can be starved while the large Hebrew bundle parses,
+            which would leave the step pinned at its invisible `initial` state and
+            show an empty modal. Re-mounting on `key={currentStep}` replays the
+            CSS animation on each step change; CSS runs off the main thread and
+            always settles visible. */}
         <DialogBody className="space-y-3 px-3 sm:px-6" {...swipeHandlers}>
-          <AnimatePresence mode="wait">
-            <m.div
-              key={currentStep}
-              initial={{ opacity: 0, x: dir === 'rtl' ? -20 : 20 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: dir === 'rtl' ? 20 : -20 }}
-              transition={{
-                duration: 0.25,
-                ease: [0.25, 0.1, 0.25, 1]
-              }}
-              style={{ willChange: 'transform, opacity' }}
-            >
-              {renderStep()}
-            </m.div>
-          </AnimatePresence>
+          <div
+            key={currentStep}
+            className="animate-in fade-in-0 slide-in-from-bottom-1 duration-300"
+          >
+            {renderStep()}
+          </div>
 
           {/* Swipe hint indicator - only shown on mobile */}
           <div className="block sm:hidden text-center text-xs text-neo-white mt-2">

--- a/fe-next/components/ProfileCustomizationModal.tsx
+++ b/fe-next/components/ProfileCustomizationModal.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
-import { m, AnimatePresence } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Check, X, Sparkles, ArrowRight } from 'lucide-react';
+import { Reveal } from '@/components/ui/Reveal';
 import { Loader } from '@/components/ui/Loader';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody, DialogFooter } from '@/components/ui/dialog';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -188,27 +189,23 @@ const ProfileCustomizationModal: React.FC<ProfileCustomizationModalProps> = ({
               </m.div>
 
               {/* Validation indicator */}
-              <AnimatePresence>
-                {displayName.length > 0 && (
-                  <m.div
-                    initial={{ opacity: 0, scale: 0.5 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.5 }}
-                    className={cn(
-                      'w-9 h-9 rounded-full border-2 flex items-center justify-center shadow-hard-sm shrink-0',
-                      isNameValid
-                        ? 'bg-neo-lime border-neo-black'
-                        : 'bg-neo-red border-neo-black'
-                    )}
-                  >
-                    {isNameValid ? (
-                      <Check className="text-neo-black w-4 h-4" />
-                    ) : (
-                      <X className="text-neo-white w-4 h-4" />
-                    )}
-                  </m.div>
-                )}
-              </AnimatePresence>
+              {displayName.length > 0 && (
+                <Reveal
+                  noSlide
+                  className={cn(
+                    'w-9 h-9 rounded-full border-2 flex items-center justify-center shadow-hard-sm shrink-0',
+                    isNameValid
+                      ? 'bg-neo-lime border-neo-black'
+                      : 'bg-neo-red border-neo-black'
+                  )}
+                >
+                  {isNameValid ? (
+                    <Check className="text-neo-black w-4 h-4" />
+                  ) : (
+                    <X className="text-neo-white w-4 h-4" />
+                  )}
+                </Reveal>
+              )}
             </div>
 
             {/* Character counter / Error */}

--- a/fe-next/components/achievements/AchievementDock.tsx
+++ b/fe-next/components/achievements/AchievementDock.tsx
@@ -6,6 +6,7 @@ import { m, AnimatePresence } from 'framer-motion';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { cn } from '../../lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
+import { Reveal } from '../ui/Reveal';
 import type { AchievementPayload } from '@/shared/types/socket';
 
 interface LocalizedAchievement {
@@ -199,11 +200,8 @@ const AchievementDock = ({ achievements = EMPTY_ACHIEVEMENTS, className }: Achie
       {isMounted && createPortal(
         <AnimatePresence>
           {isExpanded && panelPosition && (
-            <m.div
-              initial={{ opacity: 0, scale: 0.9, y: -10, rotate: -2 }}
-              animate={{ opacity: 1, scale: 1, y: 0, rotate: 0 }}
-              exit={{ opacity: 0, scale: 0.9, y: -10 }}
-              transition={{ type: 'spring', damping: 20, stiffness: 300 }}
+            <Reveal
+              noSlide
               style={{
                 position: 'fixed',
                 top: panelPosition.top,
@@ -231,16 +229,7 @@ const AchievementDock = ({ achievements = EMPTY_ACHIEVEMENTS, className }: Achie
                   {localizedAchievements.map((achievement, index) => (
                     <Tooltip key={`${achievement.name}-${index}`}>
                       <TooltipTrigger asChild>
-                        <m.div
-                          initial={index === localizedAchievements.length - 1 && hasNewAchievement ? {
-                            x: 20,
-                            opacity: 0,
-                          } : false}
-                          animate={{
-                            x: 0,
-                            opacity: 1,
-                          }}
-                          transition={{ duration: 0.3 }}
+                        <Reveal
                           className={cn(
                             'flex items-center gap-3 p-3 rounded-md',
                             'bg-neo-white border-3 border-neo-black',
@@ -260,7 +249,7 @@ const AchievementDock = ({ achievements = EMPTY_ACHIEVEMENTS, className }: Achie
                               {achievement.description}
                             </p>
                           </div>
-                        </m.div>
+                        </Reveal>
                       </TooltipTrigger>
                       <TooltipContent
                         side="left"
@@ -273,7 +262,7 @@ const AchievementDock = ({ achievements = EMPTY_ACHIEVEMENTS, className }: Achie
                   ))}
                 </TooltipProvider>
               </div>
-            </m.div>
+            </Reveal>
           )}
         </AnimatePresence>,
         document.body

--- a/fe-next/components/achievements/AchievementQueue.tsx
+++ b/fe-next/components/achievements/AchievementQueue.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useMemo, useRef, useEffect, createContext
 import { createPortal } from 'react-dom';
 import { m, AnimatePresence } from 'framer-motion';
 import dynamic from 'next/dynamic';
+import { Reveal } from '@/components/ui/Reveal';
 import { UnifiedAchievementModal } from './UnifiedAchievementModal';
 import type { CinematicPlayerProps } from '../adventure/boss/cinematics/CinematicPlayer';
 
@@ -219,12 +220,9 @@ function AchievementInlineToast({
   // to avoid the element extending beyond viewport bounds, which gets
   // clipped by overflow-x:clip on body (screen-fit class)
   const toast = (
-    <m.div
+    <Reveal
+      noSlide
       data-testid="achievement-inline-toast"
-      initial={{ y: -40, opacity: 0, scale: 0.92 }}
-      animate={{ y: 0, opacity: 1, scale: 1 }}
-      exit={{ y: -20, opacity: 0, scale: 0.96 }}
-      transition={{ type: 'spring', stiffness: 460, damping: 22, mass: 0.6 }}
       className="fixed inset-x-0 z-60 flex justify-center pointer-events-none px-4"
       style={{
         top: 'max(1rem, env(safe-area-inset-top, 1rem))',
@@ -270,11 +268,9 @@ function AchievementInlineToast({
             className="absolute inset-0 rounded-full"
             aria-hidden
           />
-          <m.div
+          <Reveal
+            noSlide
             data-testid="achievement-inline-icon"
-            initial={{ scale: 0, rotate: -180 }}
-            animate={{ scale: 1, rotate: 0 }}
-            transition={{ delay: 0.05, type: 'spring', stiffness: 360, damping: 12 }}
             className="relative w-9 h-9 flex items-center justify-center rounded-full border-2 border-neo-black"
             style={{ backgroundColor: iconBg }}
           >
@@ -285,7 +281,7 @@ function AchievementInlineToast({
             >
               {icon}
             </m.span>
-          </m.div>
+          </Reveal>
           {sparkles.map((s, i) => (
             <m.span
               key={i}
@@ -311,18 +307,15 @@ function AchievementInlineToast({
 
         {/* Text content */}
         <div className="relative flex flex-col flex-1 min-w-0 leading-tight">
-          <m.span
-            initial={{ opacity: 0, y: -3 }}
-            animate={{ opacity: 0.7, y: 0 }}
-            transition={{ delay: 0.12 }}
-            className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-[0.12em] text-neo-white"
+          <Reveal
+            as="span"
+            className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-[0.12em] text-neo-white opacity-70"
           >
             <span>{t('achievements.unlocked')}</span>
             {tier && tierColors && tierStyle.showRarityBadge && (
-              <m.span
-                initial={{ scale: 0, rotate: -8 }}
-                animate={{ scale: 1, rotate: 0 }}
-                transition={{ delay: 0.22, type: 'spring', stiffness: 500, damping: 14 }}
+              <Reveal
+                as="span"
+                noSlide
                 className="px-1.5 py-px rounded-sm font-black tracking-wider"
                 style={{
                   backgroundColor: tierColors.bg,
@@ -332,21 +325,19 @@ function AchievementInlineToast({
                 data-testid="achievement-inline-rarity"
               >
                 {tier}
-              </m.span>
+              </Reveal>
             )}
-          </m.span>
-          <m.span
+          </Reveal>
+          <Reveal
+            as="span"
             data-testid="achievement-inline-name"
-            initial={{ opacity: 0, y: 3 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.18 }}
             className="font-black text-sm truncate text-neo-lime"
           >
             {name}
-          </m.span>
+          </Reveal>
         </div>
       </div>
-    </m.div>
+    </Reveal>
   );
 
   // Use portal to render at body level, escaping overflow constraints

--- a/fe-next/components/auth/WinnerOnboarding.tsx
+++ b/fe-next/components/auth/WinnerOnboarding.tsx
@@ -3,11 +3,11 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { m, AnimatePresence } from 'framer-motion';
-import { SPRING_PRESETS } from '@/lib/animation/presets';
 import { Trophy, Sparkles, Check, AlertCircle } from 'lucide-react';
 import Image from 'next/image';
 import { Button } from '../ui/button';
 import { Loader } from '@/components/ui/Loader';
+import { Reveal } from '@/components/ui/Reveal';
 import { useTheme } from '../../utils/ThemeContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { cn } from '../../lib/utils';
@@ -125,18 +125,12 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
 
   return createPortal(
     <AnimatePresence>
-      <m.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
+      <Reveal
+        noSlide
         className="fixed inset-0 z-110 flex items-center justify-center p-4 bg-black/70 backdrop-blur-xs"
         onClick={(e) => e.stopPropagation()}
       >
-        <m.div
-          initial={{ scale: 0.8, opacity: 0, y: 30 }}
-          animate={{ scale: 1, opacity: 1, y: 0 }}
-          exit={{ scale: 0.8, opacity: 0, y: 30 }}
-          transition={{ type: 'spring', damping: 20, stiffness: 300 }}
+        <Reveal
           className={cn(
             'w-full max-w-2xl rounded-2xl p-8 shadow-2xl overflow-hidden relative border-4',
             isDarkMode
@@ -149,10 +143,8 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
           <div className="absolute top-0 left-1/2 -translate-x-1/2 w-96 h-48 bg-amber-500/10 rounded-full blur-3xl pointer-events-none" />
 
           {/* Trophy animation */}
-          <m.div
-            initial={{ scale: 0, rotate: -180 }}
-            animate={{ scale: 1, rotate: 0 }}
-            transition={{ type: 'spring', damping: 10, stiffness: 100, delay: 0.2 }}
+          <Reveal
+            noSlide
             className="flex justify-center mb-6 relative"
           >
             <m.div
@@ -166,13 +158,10 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
               <Trophy className="w-20 h-20 text-amber-400" />
               <Sparkles className="absolute -top-2 -right-2 w-8 h-8 text-yellow-300" />
             </m.div>
-          </m.div>
+          </Reveal>
 
           {/* Header */}
-          <m.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.3, ...SPRING_PRESETS.balanced }}
+          <Reveal
             className="text-center mb-8"
           >
             <h1 className="text-4xl font-black mb-3 text-neo-lime">
@@ -184,12 +173,10 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
             )}>
               {celebrationMsg.subtitle}
             </p>
-          </m.div>
+          </Reveal>
 
-          <m.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.4, ...SPRING_PRESETS.balanced }}
+          <Reveal
+            noSlide
             className="space-y-6"
           >
             {/* Avatar Selection */}
@@ -203,11 +190,9 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
 
               {/* Preview */}
               <div className="flex justify-center mb-4">
-                <m.div
+                <Reveal
                   key={selectedAvatar.id}
-                  initial={{ scale: 0.8, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  transition={{ type: 'spring', stiffness: 400, damping: 22 }}
+                  noSlide
                   className="relative"
                 >
                   <div className={cn(
@@ -231,7 +216,7 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
                   )}>
                     {selectedAvatar.name}
                   </div>
-                </m.div>
+                </Reveal>
               </div>
 
               {/* Avatar Grid */}
@@ -338,9 +323,9 @@ const WinnerOnboarding: React.FC<WinnerOnboardingProps> = ({
                 </>
               )}
             </Button>
-          </m.div>
-        </m.div>
-      </m.div>
+          </Reveal>
+        </Reveal>
+      </Reveal>
     </AnimatePresence>,
     document.body
   );

--- a/fe-next/components/avatar/AvatarBuilderModal.tsx
+++ b/fe-next/components/avatar/AvatarBuilderModal.tsx
@@ -8,6 +8,7 @@ import { AVATAR_CATEGORY_ICONS } from './AvatarCategoryIcons';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { safeToLocaleString } from '@/utils/bcp47Locale';
 import { AdaptiveMotion, AdaptiveAnimatePresence } from '@/components/motion/AdaptiveMotion';
+import { Reveal } from '@/components/ui/Reveal';
 import AvatarRenderer from './AvatarRenderer';
 import { getAvatarTier, type Tier } from './AvatarTierEffects';
 import AvatarEquipBurst from './AvatarEquipBurst';
@@ -198,14 +199,11 @@ export default function AvatarBuilderModal({
 
   return createPortal(
     <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/60 p-4 pb-[calc(1rem+min(var(--admob-banner-height,0px),120px)+min(var(--web-anchor-ad-height,0px),120px))] overflow-hidden" role="presentation" onClick={onClose} onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}>
-      <AdaptiveMotion.div
-        ref={dialogRef}
+      <Reveal
+        ref={dialogRef as React.Ref<HTMLElement>}
         role="dialog"
         aria-modal="true"
         aria-labelledby="avatar-builder-title"
-        initial={{ opacity: 0, scale: 0.9, y: 20 }}
-        animate={{ opacity: 1, scale: 1, y: 0 }}
-        transition={{ type: 'spring', damping: 25, stiffness: 300 }}
         className="bg-neo-navy border-3 border-black shadow-hard-lg rounded-neo-lg w-full max-w-[95vw] sm:max-w-xl md:max-w-2xl max-h-full flex flex-col min-h-0 [container-type:inline-size]"
         onClick={(e: React.MouseEvent) => e.stopPropagation()}
       >
@@ -290,24 +288,23 @@ export default function AvatarBuilderModal({
           className="flex-1 overflow-y-auto p-3 sm:p-4 min-h-0"
           onMouseDown={(e) => { if (shouldSuppressPointerFocus(e.target)) e.preventDefault(); }}
         >
-          <AdaptiveAnimatePresence mode="wait">
-            <AdaptiveMotion.div
-              key={activeCategory}
-              initial={{ opacity: 0, x: 16 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -16 }}
-              transition={{ duration: 0.12 }}
-            >
-              <CategoryOptions
-                category={activeCategory}
-                config={config}
-                updateConfig={updateConfig}
-                t={t}
-                premium={premium ?? undefined}
-                onCoinSpend={setCoinSpendAmount}
-              />
-            </AdaptiveMotion.div>
-          </AdaptiveAnimatePresence>
+          {/* Keyed CSS entrance (animate-in) instead of framer: a starved JS
+              loop would leave the options grid pinned at its invisible `initial`
+              state. Re-mounting on `key={activeCategory}` replays the CSS slide;
+              CSS runs off the main thread and always settles visible. */}
+          <div
+            key={activeCategory}
+            className="animate-in fade-in-0 slide-in-from-bottom-1 duration-200"
+          >
+            <CategoryOptions
+              category={activeCategory}
+              config={config}
+              updateConfig={updateConfig}
+              t={t}
+              premium={premium ?? undefined}
+              onCoinSpend={setCoinSpendAmount}
+            />
+          </div>
         </div>
 
         {/* Actions — single row, secondary icon-only on narrow */}
@@ -388,7 +385,7 @@ export default function AvatarBuilderModal({
           coinAmount={coinSpendAmount}
           onAnimationComplete={() => setCoinSpendAmount(null)}
         />
-      </AdaptiveMotion.div>
+      </Reveal>
     </div>,
     document.body
   );

--- a/fe-next/components/celebration/NewYearCountdown.tsx
+++ b/fe-next/components/celebration/NewYearCountdown.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
 import { Sparkles, PartyPopper } from 'lucide-react';
 import { Dialog, DialogContent, DialogBody, DialogTitle } from '../ui/dialog';
+import { Reveal } from '../ui/Reveal';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useNewYearDetection, formatTimeRemaining } from '../../hooks/useNewYearDetection';
 import { triggerHaptic } from '../../utils/hapticFeedback';
@@ -150,11 +151,7 @@ function NewYearCountdownInner({ enabled = true }: NewYearCountdownProps) {
             {t('newYear.countdownTitle')}
           </DialogTitle>
           <DialogBody className="text-center py-8">
-            <m.div
-              className="flex flex-col items-center gap-6"
-              initial={{ scale: 0.8, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-            >
+            <Reveal noSlide className="flex flex-col items-center gap-6">
               <Sparkles className="w-16 h-16 text-neo-lime" />
 
               <div>
@@ -166,13 +163,11 @@ function NewYearCountdownInner({ enabled = true }: NewYearCountdownProps) {
                 </p>
               </div>
 
-              {/* Countdown number */}
-              <m.div
+              {/* Countdown number — keyed CSS zoom replays each second; CSS keeps
+                  the big number visible even if the JS loop is starved. */}
+              <div
                 key={newYearState.secondsUntilMidnight}
-                className="relative"
-                initial={{ scale: 0, rotate: -10 }}
-                animate={{ scale: 1, rotate: 0 }}
-                transition={{ type: 'spring', damping: 10 }}
+                className="relative animate-in zoom-in-50 duration-300"
               >
                 <div
                   className="text-9xl font-black text-neo-pink border-8 border-neo-black rounded-neo-xl shadow-hard-2xl bg-neo-lime w-48 h-48 flex items-center justify-center"
@@ -182,12 +177,12 @@ function NewYearCountdownInner({ enabled = true }: NewYearCountdownProps) {
                 >
                   {newYearState.secondsUntilMidnight}
                 </div>
-              </m.div>
+              </div>
 
               <p className="text-lg font-bold text-neo-black uppercase">
                 {t('newYear.almostThere')}
               </p>
-            </m.div>
+            </Reveal>
           </DialogBody>
         </DialogContent>
       </Dialog>
@@ -199,12 +194,7 @@ function NewYearCountdownInner({ enabled = true }: NewYearCountdownProps) {
             {t('newYear.happyNewYear')}
           </DialogTitle>
           <DialogBody className="text-center py-12 relative">
-            <m.div
-              className="flex flex-col items-center gap-8"
-              initial={{ scale: 0.5, opacity: 0, rotate: -10 }}
-              animate={{ scale: 1, opacity: 1, rotate: 0 }}
-              transition={{ type: 'spring', damping: 15 }}
-            >
+            <Reveal noSlide className="flex flex-col items-center gap-8">
               <PartyPopper className="w-20 h-20 text-neo-pink animate-neo-wobble" />
 
               {/* Happy New Year text */}
@@ -232,24 +222,17 @@ function NewYearCountdownInner({ enabled = true }: NewYearCountdownProps) {
                 </m.h1>
 
                 {/* Year badge */}
-                <m.div
+                <Reveal
+                  noSlide
                   className="mt-6 inline-block bg-neo-cyan text-neo-black border-4 border-neo-black rounded-neo-lg shadow-hard-lg px-8 py-3"
-                  initial={{ scale: 0, rotate: -15 }}
-                  animate={{ scale: 1, rotate: 0 }}
-                  transition={{ delay: 0.3, type: 'spring', damping: 12 }}
                 >
                   <span className="text-5xl font-black">{newYearState.celebrationYear}</span>
-                </m.div>
+                </Reveal>
               </div>
 
-              <m.p
-                className="text-xl font-bold text-neo-black uppercase max-w-md"
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.5 }}
-              >
+              <p className="text-xl font-bold text-neo-black uppercase max-w-md animate-in fade-in-0 slide-in-from-bottom-1 duration-300">
                 {t('newYear.celebrationMessage')}
-              </m.p>
+              </p>
 
               {/* Confetti emoji decorations */}
               <div className="flex gap-4 text-4xl">
@@ -273,7 +256,7 @@ function NewYearCountdownInner({ enabled = true }: NewYearCountdownProps) {
                   </m.span>
                 ))}
               </div>
-            </m.div>
+            </Reveal>
           </DialogBody>
         </DialogContent>
       </Dialog>

--- a/fe-next/components/daily/CreateChallengeModal.tsx
+++ b/fe-next/components/daily/CreateChallengeModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { m } from 'framer-motion';
+import { Reveal } from '@/components/ui/Reveal';
 import { Copy, Check, Share2, Crown, Grid3X3, Grid2X2, Sparkles, Zap, X, BarChart3 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
@@ -196,11 +197,8 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
         <div className="max-h-[90vh] overflow-y-auto">
           {/* Header */}
             <div className="relative flex items-center justify-between p-3 sm:p-4 border-b-neo-thick border-neo-black bg-linear-to-br from-neo-lime to-neo-pink sticky top-0 z-10">
-              <m.div
+              <Reveal
                 className="flex items-center gap-3"
-                initial={{ x: -20, opacity: 0 }}
-                animate={{ x: 0, opacity: 1 }}
-                transition={{ type: 'spring', stiffness: 380, damping: 26, delay: 0.2 }}
               >
                 <div className="relative">
                   <Crown className="w-7 h-7 sm:w-8 sm:h-8 text-neo-black drop-shadow-xs" strokeWidth={2.5} />
@@ -215,7 +213,7 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
                 <h2 className="font-bold text-xl sm:text-2xl uppercase tracking-tight text-neo-black drop-shadow-xs">
                   {t('daily.createChallengeTitle')}
                 </h2>
-              </m.div>
+              </Reveal>
               <button
                 onClick={handleClose}
                 aria-label={t('common.close')}
@@ -228,11 +226,9 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
             {/* Content */}
             <div className="p-4 sm:p-6 overflow-y-auto max-h-[calc(90vh-80px)]">
               {step === 'config' && (
-                <m.div
+                <Reveal
+                  noSlide
                   className="space-y-4"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  transition={{ type: 'spring', stiffness: 300, damping: 26, delay: 0.1 }}
                 >
                   {/* Board Size Selection */}
                   <div className="space-y-3">
@@ -261,16 +257,14 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
                           <span className="text-xs sm:text-sm font-bold uppercase tracking-wide">{t('daily.classic')}</span>
                         </div>
                         {boardSize === 5 && (
-                          <m.div
+                          <Reveal
+                            noSlide
                             className="absolute -top-2 -right-2"
-                            initial={{ opacity: 0, scale: 0.95 }}
-                            animate={{ opacity: 1, scale: 1, rotate: 360 }}
-                            transition={{ type: 'spring', bounce: 0.6 }}
                           >
                             <div className="bg-neo-pink border-3 border-neo-black rounded-full p-1 shadow-hard-sm">
                               <Check className="w-4 h-4 text-neo-white" strokeWidth={3} />
                             </div>
-                          </m.div>
+                          </Reveal>
                         )}
                       </m.button>
 
@@ -292,26 +286,21 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
                           <span className="text-xs sm:text-sm font-bold uppercase tracking-wide">{t('daily.pro')}</span>
                         </div>
                         {boardSize === 7 && (
-                          <m.div
+                          <Reveal
+                            noSlide
                             className="absolute -top-2 -right-2"
-                            initial={{ opacity: 0, scale: 0.95 }}
-                            animate={{ opacity: 1, scale: 1, rotate: 360 }}
-                            transition={{ type: 'spring', bounce: 0.6 }}
                           >
                             <div className="bg-neo-pink border-3 border-neo-black rounded-full p-1 shadow-hard-sm">
                               <Check className="w-4 h-4 text-neo-white" strokeWidth={3} />
                             </div>
-                          </m.div>
+                          </Reveal>
                         )}
                       </m.button>
                     </div>
                   </div>
 
                   {/* Word Input */}
-                  <m.div
-                    initial={{ opacity: 0, y: 10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ type: 'spring', stiffness: 300, damping: 26, delay: 0.2 }}
+                  <Reveal
                     className="space-y-2"
                   >
                     <label htmlFor="target-word" className="block text-sm sm:text-base font-black text-neo-black dark:text-neo-white uppercase tracking-tight">
@@ -337,23 +326,17 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
                       dir={language === 'he' ? 'rtl' : 'ltr'}
                     />
                     {wordError && (
-                      <m.p
-                        initial={{ opacity: 0, y: -5 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        className="text-sm font-bold text-red-600 flex items-center gap-2"
+                      <p
+                        className="animate-in fade-in-0 slide-in-from-bottom-1 duration-300 text-sm font-bold text-red-600 flex items-center gap-2"
                       >
                         <span className="inline-block w-1 h-1 rounded-full bg-red-600" />
                         {wordError}
-                      </m.p>
+                      </p>
                     )}
-                  </m.div>
+                  </Reveal>
 
                   {/* Generate Button */}
-                  <m.div
-                    initial={{ opacity: 0, y: 10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ type: 'spring', stiffness: 300, damping: 26, delay: 0.4 }}
-                  >
+                  <Reveal>
                     <Button
                       onClick={handleCreate}
                       className="relative w-full max-w-btn h-14 sm:h-16 text-lg sm:text-xl font-black bg-linear-to-br from-neo-pink to-neo-pink/80 hover:from-neo-pink/90 hover:to-neo-pink/70 text-neo-white border-neo-thick border-neo-black shadow-hard-lg hover:shadow-hard-xl hover:-translate-y-1 active:translate-y-0 active:shadow-hard-sm rounded-xl transition-all uppercase tracking-wide overflow-hidden group"
@@ -368,15 +351,14 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
                         transition={{ repeat: Infinity, duration: 2, ease: 'linear' }}
                       />
                     </Button>
-                  </m.div>
-                </m.div>
+                  </Reveal>
+                </Reveal>
               )}
 
               {step === 'loading' && (
-                <m.div
+                <Reveal
+                  noSlide
                   className="flex flex-col items-center justify-center py-12 sm:py-16 space-y-6"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
                 >
                   {/* Animated Loader */}
                   <div className="relative">
@@ -428,31 +410,24 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
                       ))}
                     </m.div>
                   </div>
-                </m.div>
+                </Reveal>
               )}
 
               {step === 'share' && (
-                <m.div
+                <Reveal
+                  noSlide
                   className="space-y-6 text-center"
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ type: 'spring', bounce: 0.4 }}
                 >
                   {/* Success Mascot with 3D effect */}
                   <div className="relative flex items-center justify-center h-32 sm:h-40">
                     {/* Background circle */}
-                    <m.div
+                    <Reveal
+                      noSlide
                       className="absolute w-24 h-24 sm:w-32 sm:h-32 bg-linear-to-br from-neo-lime to-neo-pink rounded-full border-neo-thick border-neo-black shadow-hard-lg"
-                      initial={{ opacity: 0, scale: 0.95 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      transition={{ type: 'spring', bounce: 0.6, duration: 0.6 }}
                     />
 
                     {/* Mascot popping out of circle (3D effect) */}
-                    <m.div
-                      initial={{ opacity: 0, scale: 0.95, rotate: -180, y: 20 }}
-                      animate={{ opacity: 1, scale: 1, rotate: 0, y: -8 }}
-                      transition={{ type: 'spring', bounce: 0.6, duration: 0.8, delay: 0.1 }}
+                    <Reveal
                       className="relative z-10"
                     >
                       <Mascot
@@ -462,7 +437,7 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
                         className="drop-shadow-2xl"
                         clipBorder="none"
                       />
-                    </m.div>
+                    </Reveal>
 
                     {/* Confetti particles */}
                     {[...Array(8)].map((_, i) => (
@@ -488,23 +463,16 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
                   </div>
 
                   {/* Success Message */}
-                  <m.div
-                    initial={{ y: 20, opacity: 0 }}
-                    animate={{ y: 0, opacity: 1 }}
-                    transition={{ type: 'spring', stiffness: 300, damping: 26, delay: 0.3 }}
-                  >
+                  <Reveal>
                     <h3 className="font-black text-2xl sm:text-3xl mb-2 text-neo-black dark:text-neo-white uppercase tracking-tight">
                       {t('daily.challengeCreated')}
                     </h3>
                     <p className="text-base text-slate-700 dark:text-slate-300 font-medium">{t('daily.challengeCreatedDesc')}</p>
-                  </m.div>
+                  </Reveal>
 
                   {/* Share URL Box */}
-                  <m.div
+                  <Reveal
                     className="flex items-center gap-2 bg-neo-cream border-3 border-neo-black rounded-xl p-3 shadow-hard-sm"
-                    initial={{ y: 20, opacity: 0 }}
-                    animate={{ y: 0, opacity: 1 }}
-                    transition={{ type: 'spring', stiffness: 300, damping: 26, delay: 0.4 }}
                   >
                     <div className="flex-1 overflow-hidden">
                       <p className="text-xs text-slate-600 dark:text-slate-400 font-bold uppercase mb-1">{t('daily.challengeLink')}</p>
@@ -526,13 +494,10 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
                         <Copy className="w-5 h-5 text-neo-black" strokeWidth={2.5} />
                       )}
                     </m.button>
-                  </m.div>
+                  </Reveal>
 
                   {/* Share Button */}
-                  <m.div
-                    initial={{ y: 20, opacity: 0 }}
-                    animate={{ y: 0, opacity: 1 }}
-                    transition={{ type: 'spring', stiffness: 280, damping: 26, delay: 0.5 }}
+                  <Reveal
                     className="space-y-3"
                   >
                     <Button
@@ -558,34 +523,31 @@ export const CreateChallengeModal: React.FC<CreateChallengeModalProps> = ({ isOp
                     >
                       {t('daily.close')}
                     </Button>
-                  </m.div>
+                  </Reveal>
 
                   {/* Footer Hint */}
-                  <m.div
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    transition={{ type: 'spring', stiffness: 280, damping: 26, delay: 0.6 }}
+                  <Reveal
+                    noSlide
                     className="pt-4 border-t-3 border-gray-200"
                   >
                     <p className="text-sm text-slate-600 dark:text-slate-400 font-medium flex items-center justify-center gap-2">
                       <Sparkles className="w-4 h-4 text-neo-pink" />
                       {t('daily.canPlayYourself')}
                     </p>
-                  </m.div>
-                </m.div>
+                  </Reveal>
+                </Reveal>
               )}
 
               {step === 'stats' && puzzleCode && (
-                <m.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
+                <Reveal
+                  noSlide
                   className="space-y-4"
                 >
                   <CustomChallengeStats
                     puzzleCode={puzzleCode}
                     onClose={() => setStep('share')}
                   />
-                </m.div>
+                </Reveal>
               )}
             </div>
         </div>

--- a/fe-next/components/daily/WordHuntWordsModal.tsx
+++ b/fe-next/components/daily/WordHuntWordsModal.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { m, AnimatePresence } from 'framer-motion';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
 import { Hash, Zap } from 'lucide-react';
+import { Reveal } from '@/components/ui/Reveal';
 
 interface WordEntry {
   word: string;
@@ -85,21 +85,18 @@ export const WordHuntWordsModal: React.FC<WordHuntWordsModalProps> = ({
                 : t('wordWheel.noWordsSubmitted', 'No words found')}
             </p>
           ) : (
-            <AnimatePresence mode="popLayout">
-              <div className="flex flex-wrap gap-1.5">
-                {sortedWords.map((word, idx) => (
-                  <m.span
-                    key={`${word}-${idx}`}
-                    initial={{ opacity: 0, scale: 0.8 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    transition={{ delay: idx * 0.015, type: 'spring', stiffness: 500, damping: 25 }}
-                    className="inline-flex items-center px-2.5 py-1 rounded-neo border-2 border-neo-black bg-neo-white text-neo-navy text-xs sm:text-sm font-black uppercase shadow-hard-xs"
-                  >
-                    {word}
-                  </m.span>
-                ))}
-              </div>
-            </AnimatePresence>
+            <div className="flex flex-wrap gap-1.5">
+              {sortedWords.map((word, idx) => (
+                <Reveal
+                  as="span"
+                  noSlide
+                  key={`${word}-${idx}`}
+                  className="inline-flex items-center px-2.5 py-1 rounded-neo border-2 border-neo-black bg-neo-white text-neo-navy text-xs sm:text-sm font-black uppercase shadow-hard-xs"
+                >
+                  {word}
+                </Reveal>
+              ))}
+            </div>
           )}
         </div>
       </DialogContent>

--- a/fe-next/components/daily/WordWheelWordsModal.tsx
+++ b/fe-next/components/daily/WordWheelWordsModal.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { m, AnimatePresence } from 'framer-motion';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
 import { Trophy, Hash, Star } from 'lucide-react';
+import { Reveal } from '@/components/ui/Reveal';
 import { applyHebrewFinalLetters } from '@/shared/utils/wordNormalization';
 import type { Language } from '@/types';
 
@@ -169,22 +169,19 @@ export const WordWheelWordsModal: React.FC<WordWheelWordsModalProps> = ({
                 </p>
               ) : (
                 <>
-                  <AnimatePresence mode="popLayout">
-                    <div className="flex flex-wrap gap-1.5">
-                      {visibleWords.map((word, idx) => (
-                        <m.span
-                          key={`${word}-${idx}`}
-                          data-testid="missed-word-chip"
-                          initial={{ opacity: 0, scale: 0.8 }}
-                          animate={{ opacity: 1, scale: 1 }}
-                          transition={{ delay: idx * 0.015, type: 'spring', stiffness: 500, damping: 25 }}
-                          className="inline-flex items-center px-2.5 py-1 rounded-neo border-2 border-neo-black bg-neo-white text-neo-navy text-xs sm:text-sm font-black uppercase shadow-hard-xs"
-                        >
-                          {language === 'he' ? applyHebrewFinalLetters(word) : word}
-                        </m.span>
-                      ))}
-                    </div>
-                  </AnimatePresence>
+                  <div className="flex flex-wrap gap-1.5">
+                    {visibleWords.map((word, idx) => (
+                      <Reveal
+                        as="span"
+                        noSlide
+                        key={`${word}-${idx}`}
+                        data-testid="missed-word-chip"
+                        className="inline-flex items-center px-2.5 py-1 rounded-neo border-2 border-neo-black bg-neo-white text-neo-navy text-xs sm:text-sm font-black uppercase shadow-hard-xs"
+                      >
+                        {language === 'he' ? applyHebrewFinalLetters(word) : word}
+                      </Reveal>
+                    ))}
+                  </div>
 
                   {showToggle && (
                     <button

--- a/fe-next/components/engagement/CalendarRewardsModal.tsx
+++ b/fe-next/components/engagement/CalendarRewardsModal.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { m } from 'framer-motion';
 import { Calendar, Gift, Zap, Sparkles, Shield, Crown, Flame } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody, DialogDescription } from '@/components/ui/dialog';
@@ -13,6 +12,7 @@ import { toast } from 'react-hot-toast';
 import { Loader } from '@/components/ui/Loader';
 import { PageLoader } from '@/components/ui/PageLoader';
 import { fetchWithAuth, postWithAuth } from '@/utils/authFetch';
+import { Reveal } from '@/components/ui/Reveal';
 
 const AuthModal = dynamic(() => import('@/components/auth/AuthModal'), { ssr: false });
 
@@ -246,11 +246,7 @@ export function CalendarRewardsModal({ isOpen, onClose }: CalendarRewardsModalPr
 
               {/* Claim button for today */}
               {calendarStatus.canClaimToday && (
-                <m.div
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  className="mt-3 sm:mt-4"
-                >
+                <Reveal className="mt-3 sm:mt-4">
                   <Button
                     onClick={handleClaimReward}
                     disabled={isClaiming}
@@ -265,7 +261,7 @@ export function CalendarRewardsModal({ isOpen, onClose }: CalendarRewardsModalPr
                       </>
                     )}
                   </Button>
-                </m.div>
+                </Reveal>
               )}
 
               {/* Already claimed message */}

--- a/fe-next/components/engagement/MysteryRewardPopup.tsx
+++ b/fe-next/components/engagement/MysteryRewardPopup.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { m, AnimatePresence } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Dialog, DialogContent, DialogTitle } from '../ui/dialog';
+import { Reveal } from '@/components/ui/Reveal';
 import { cn } from '@/lib/utils';
 import { Sparkles, Gift, Zap, Star, Crown } from 'lucide-react';
 import { fireConfetti } from '@/utils/confettiUtils';
@@ -182,15 +183,18 @@ const MysteryRewardPopup: React.FC<MysteryRewardPopupProps> = ({
         </DialogTitle>
 
         <div className="p-6 flex flex-col items-center">
-          <AnimatePresence mode="wait">
+          {/* Phase swap uses keyed CSS entrances (animate-in) instead of
+              framer-motion: a starved JS loop (e.g. while the large Hebrew
+              bundle parses) would leave the active phase pinned at its invisible
+              `initial` state, showing an empty popup. Distinct keys remount on
+              phase change so the CSS entrance replays; CSS runs off the main
+              thread and always settles visible. */}
+          <>
             {phase === 'chest' && (
               /* Chest Phase - Show mystery box */
-              <m.div
+              <div
                 key="chest"
-                initial={{ scale: 0.5, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                exit={{ scale: 1.2, opacity: 0 }}
-                className="flex flex-col items-center gap-4"
+                className="flex flex-col items-center gap-4 animate-in fade-in-0 zoom-in-95 duration-300"
               >
                 <m.div
                   animate={{
@@ -216,17 +220,14 @@ const MysteryRewardPopup: React.FC<MysteryRewardPopupProps> = ({
                 >
                   {t('mysteryReward.opening')}
                 </m.div>
-              </m.div>
+              </div>
             )}
 
             {phase === 'opening' && (
               /* Opening Phase - Shaking/glowing animation */
-              <m.div
+              <div
                 key="opening"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                className="flex flex-col items-center gap-4"
+                className="flex flex-col items-center gap-4 animate-in fade-in-0 duration-300"
               >
                 <m.div
                   animate={{
@@ -258,27 +259,17 @@ const MysteryRewardPopup: React.FC<MysteryRewardPopupProps> = ({
                 >
                   {t('mysteryReward.revealing')}
                 </m.div>
-              </m.div>
+              </div>
             )}
 
             {phase === 'reveal' && (
               /* Reveal Phase - Show the reward */
-              <m.div
+              <div
                 key="reveal"
-                initial={{ scale: 0.95, opacity: 0, rotateY: 180 }}
-                animate={{ scale: 1, opacity: 1, rotateY: 0 }}
-                transition={{
-                  type: 'spring',
-                  damping: 15,
-                  stiffness: 150
-                }}
-                className="flex flex-col items-center gap-4 text-center"
+                className="flex flex-col items-center gap-4 text-center animate-in fade-in-0 zoom-in-95 duration-300"
               >
                 {/* Rarity Badge */}
-                <m.div
-                  initial={{ y: -20, opacity: 0 }}
-                  animate={{ y: 0, opacity: 1 }}
-                  transition={{ delay: 0.2 }}
+                <Reveal
                   className={cn(
                     'px-3 py-1 rounded-full text-xs font-black uppercase tracking-wide',
                     rarity === 'legendary' && 'bg-yellow-500 text-yellow-900',
@@ -289,7 +280,7 @@ const MysteryRewardPopup: React.FC<MysteryRewardPopupProps> = ({
                   )}
                 >
                   {rarity}
-                </m.div>
+                </Reveal>
 
                 {/* Reward Icon */}
                 <m.div
@@ -312,21 +303,15 @@ const MysteryRewardPopup: React.FC<MysteryRewardPopupProps> = ({
                 </m.div>
 
                 {/* Reward Display */}
-                <m.div
-                  initial={{ y: 20, opacity: 0 }}
-                  animate={{ y: 0, opacity: 1 }}
-                  transition={{ delay: 0.3 }}
-                >
+                <Reveal>
                   <p className="text-2xl font-black text-white">
                     {reward.display}
                   </p>
-                </m.div>
+                </Reveal>
 
                 {/* Trigger info */}
-                <m.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  transition={{ delay: 0.5 }}
+                <Reveal
+                  noSlide
                   className="text-center space-y-1"
                 >
                   <p className="text-xs text-white">
@@ -341,14 +326,10 @@ const MysteryRewardPopup: React.FC<MysteryRewardPopupProps> = ({
                     {reward.triggerType === 'long_word' && (t('mysteryReward.longWordExplain'))}
                     {reward.triggerType === 'achievement' && (t('mysteryReward.achievementExplain'))}
                   </p>
-                </m.div>
+                </Reveal>
 
                 {/* Excited mascot */}
-                <m.div
-                  initial={{ scale: 0, y: 20 }}
-                  animate={{ scale: 1, y: 0 }}
-                  transition={{ delay: 0.4, type: 'spring', stiffness: 250, damping: 15 }}
-                >
+                <Reveal>
                   <SilentVideo
                     src={rarity === 'legendary' || rarity === 'epic' ? '/mascot/celebration.webp' : '/mascot/flexing.webp'}
                     width={80}
@@ -357,26 +338,24 @@ const MysteryRewardPopup: React.FC<MysteryRewardPopupProps> = ({
                     preload="metadata"
                     aria-hidden="true"
                   />
-                </m.div>
+                </Reveal>
 
                 {/* Tap to dismiss */}
-                <m.button
+                <button
                   onClick={onClose}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  transition={{ delay: 1 }}
                   className={cn(
                     'mt-4 px-6 py-2.5 rounded-neo border-2 border-neo-black shadow-hard-sm',
                     'font-bold uppercase text-sm',
                     'bg-white/20 hover:bg-white/30 transition-colors',
+                    'animate-in fade-in-0 duration-300',
                     styles.text
                   )}
                 >
                   {t('mysteryReward.awesome')}
-                </m.button>
-              </m.div>
+                </button>
+              </div>
             )}
-          </AnimatePresence>
+          </>
         </div>
       </DialogContent>
     </Dialog>

--- a/fe-next/components/engagement/PrestigeModal.tsx
+++ b/fe-next/components/engagement/PrestigeModal.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
-import { m, AnimatePresence } from 'framer-motion';
+import { m } from 'framer-motion';
 import Image from 'next/image';
 import { Dialog, DialogContent, DialogTitle } from '../ui/dialog';
 import { cn } from '@/lib/utils';
 import { Sparkles, Star, Crown, Zap, AlertTriangle, Check } from 'lucide-react';
 import { Loader } from '@/components/ui/Loader';
+import { Reveal } from '@/components/ui/Reveal';
 import { toRoman, PRESTIGE_CONFIG, type PrestigeReward } from '@/backend/modules/xpManager';
 
 interface PrestigeModalProps {
@@ -113,16 +114,18 @@ export const PrestigeModal: React.FC<PrestigeModalProps> = ({
           <Sparkles className={cn('w-6 h-6', colors.text)} />
         </div>
 
+        {/* View swap uses keyed CSS entrances (animate-in) rather than
+            framer-motion: a starved JS loop (e.g. during Hebrew bundle parse)
+            would leave the active view pinned at its invisible `initial` state,
+            showing an empty modal. Distinct keys remount on swap so the CSS
+            entrance replays; CSS runs off the main thread and always settles
+            visible. */}
         <div className="p-5 space-y-5">
-          <AnimatePresence mode="wait">
             {prestigeComplete ? (
               /* Success Animation */
-              <m.div
+              <div
                 key="success"
-                initial={{ opacity: 0, scale: 0.8 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0 }}
-                className="flex flex-col items-center gap-4 py-6"
+                className="flex flex-col items-center gap-4 py-6 animate-in fade-in-0 zoom-in-95 duration-300"
               >
                 <Image
                   src="/mascot/powerup-nobg.webp"
@@ -151,27 +154,21 @@ export const PrestigeModal: React.FC<PrestigeModalProps> = ({
                 </div>
 
                 <div className="flex gap-2 mt-2">
-                  {nextRewards.map((reward, rewardIdx) => (
-                    <m.div
+                  {nextRewards.map((reward) => (
+                    <Reveal
                       key={reward.value}
-                      initial={{ opacity: 0, y: 20 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: 0.5 + rewardIdx * 0.2 }}
                       className="text-3xl"
                     >
                       {reward.icon}
-                    </m.div>
+                    </Reveal>
                   ))}
                 </div>
-              </m.div>
+              </div>
             ) : isConfirming ? (
               /* Confirmation View */
-              <m.div
+              <div
                 key="confirm"
-                initial={{ opacity: 0, x: 20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -20 }}
-                className="space-y-4"
+                className="space-y-4 animate-in fade-in-0 slide-in-from-bottom-1 duration-300"
               >
                 <div className="flex items-start gap-3 p-4 rounded-neo bg-neo-lime/20 border-2 border-neo-lime/50">
                   <AlertTriangle className="w-6 h-6 text-neo-lime shrink-0 mt-0.5" />
@@ -228,15 +225,12 @@ export const PrestigeModal: React.FC<PrestigeModalProps> = ({
                     )}
                   </button>
                 </div>
-              </m.div>
+              </div>
             ) : (
               /* Main View */
-              <m.div
+              <div
                 key="main"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                className="space-y-4"
+                className="space-y-4 animate-in fade-in-0 duration-300"
               >
                 {/* Current Status */}
                 <div className="flex items-center justify-between p-4 rounded-neo bg-neo-cream/5 border-2 border-white/10">
@@ -291,12 +285,9 @@ export const PrestigeModal: React.FC<PrestigeModalProps> = ({
                       </p>
 
                       <div className="grid gap-2">
-                        {nextRewards.map((reward, rewardIdx) => (
-                          <m.div
+                        {nextRewards.map((reward) => (
+                          <Reveal
                             key={reward.value}
-                            initial={{ opacity: 0, x: -10 }}
-                            animate={{ opacity: 1, x: 0 }}
-                            transition={{ delay: rewardIdx * 0.1 }}
                             className={cn(
                               'flex items-center gap-3 p-3 rounded-neo',
                               'bg-neo-cream/5 border-2',
@@ -316,7 +307,7 @@ export const PrestigeModal: React.FC<PrestigeModalProps> = ({
                             {reward.type === 'title' && (
                               <Crown className={cn('w-4 h-4', canPrestige ? 'text-neo-lime' : 'text-neo-white')} />
                             )}
-                          </m.div>
+                          </Reveal>
                         ))}
                       </div>
                     </div>
@@ -351,9 +342,8 @@ export const PrestigeModal: React.FC<PrestigeModalProps> = ({
                     )}
                   </>
                 )}
-              </m.div>
+              </div>
             )}
-          </AnimatePresence>
         </div>
       </DialogContent>
     </Dialog>

--- a/fe-next/components/modals/UnifiedShareModal.tsx
+++ b/fe-next/components/modals/UnifiedShareModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback, useMemo, useEffect, useState } from 'react';
-import { m } from 'framer-motion';
+import { Reveal } from '@/components/ui/Reveal';
 import { QRCodeSVG } from 'qrcode.react';
 import { Copy, MessageCircle, Trophy, Flame, Check, Target, Mail, MessageSquare } from 'lucide-react';
 import { Loader } from '@/components/ui/Loader';
@@ -250,9 +250,7 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
         <div className="p-4 space-y-4">
           {/* Post-game Stats Display - Enhanced Share Card */}
           {isPostGame && gameResult && (
-            <m.div
-              initial={{ y: -10, opacity: 0 }}
-              animate={{ y: 0, opacity: 1 }}
+            <Reveal
               className="flex flex-col items-center gap-3"
             >
               {/* Witty Message */}
@@ -264,17 +262,15 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
 
               {/* Player Archetype Badge */}
               {gameResult.archetype && (
-                <m.div
-                  initial={{ scale: 0.8, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  transition={{ delay: 0.1 }}
+                <Reveal
+                  noSlide
                   className="inline-flex items-center gap-2 px-4 py-2 rounded-neo border-2 border-neo-cyan/50 bg-neo-cyan/20"
                 >
                   <span className="text-xl">{gameResult.archetype.emoji}</span>
                   <span className="text-sm font-bold text-neo-cyan">
                     {gameResult.archetype.name}
                   </span>
-                </m.div>
+                </Reveal>
               )}
 
               {/* Main Stats Row */}
@@ -329,10 +325,8 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                 <div className="flex items-center justify-center gap-3 flex-wrap">
                   {/* Longest Word */}
                   {gameResult.longestWord && (
-                    <m.div
-                      initial={{ scale: 0.9, opacity: 0 }}
-                      animate={{ scale: 1, opacity: 1 }}
-                      transition={{ delay: 0.15 }}
+                    <Reveal
+                      noSlide
                       className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-neo border-2 border-purple-500/50 bg-purple-500/20"
                     >
                       <span className="text-purple-300 text-xs font-bold uppercase">
@@ -341,14 +335,12 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                       <span className="text-white font-black text-sm uppercase">
                         {gameResult.longestWord}
                       </span>
-                    </m.div>
+                    </Reveal>
                   )}
                   {/* Achievements */}
                   {gameResult.achievements && gameResult.achievements.length > 0 && (
-                    <m.div
-                      initial={{ scale: 0.9, opacity: 0 }}
-                      animate={{ scale: 1, opacity: 1 }}
-                      transition={{ delay: 0.2 }}
+                    <Reveal
+                      noSlide
                       className="inline-flex items-center gap-1 px-3 py-1.5 rounded-neo border-2 border-neo-lime/50 bg-neo-lime/20"
                     >
                       <span className="text-lg">
@@ -359,17 +351,15 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                           +{gameResult.achievements.length - 3}
                         </span>
                       )}
-                    </m.div>
+                    </Reveal>
                   )}
                 </div>
               )}
 
               {/* Placement Badge */}
               {gameResult.placement && gameResult.totalPlayers && gameResult.totalPlayers > 1 && (
-                <m.div
-                  initial={{ scale: 0.9, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  transition={{ delay: 0.25 }}
+                <Reveal
+                  noSlide
                   className={cn(
                     'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-neo border-2',
                     gameResult.placement === 1 ? 'border-yellow-500/50 bg-yellow-500/20' :
@@ -390,16 +380,14 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                   <span className="text-gray-400 text-xs">
                     / {gameResult.totalPlayers}
                   </span>
-                </m.div>
+                </Reveal>
               )}
-            </m.div>
+            </Reveal>
           )}
 
           {/* QR Code - Hidden on mobile, visible on desktop */}
-          <m.div
-            initial={{ scale: 0.9, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            transition={{ delay: 0.1 }}
+          <Reveal
+            noSlide
             className="hidden sm:flex flex-col items-center"
           >
             <p className="text-xs font-bold text-white uppercase tracking-wide mb-2">
@@ -417,13 +405,10 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                 includeMargin={false}
               />
             </div>
-          </m.div>
+          </Reveal>
 
           {/* Room Code Display */}
-          <m.div
-            initial={{ y: 10, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ delay: 0.2 }}
+          <Reveal
             className="flex items-center justify-center gap-2"
           >
             <div className="bg-neo-lime text-neo-black border-3 border-neo-black rounded-neo px-4 py-2 shadow-hard-sm">
@@ -442,24 +427,19 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
             >
               {copied ? <Check className="w-4 h-4 text-neo-black" /> : <Copy className="w-4 h-4 text-neo-black" />}
             </button>
-          </m.div>
+          </Reveal>
 
           {/* Simplified Share Options - Only Copy + WhatsApp */}
-          <m.div
-            initial={{ y: 10, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ delay: 0.3 }}
+          <Reveal
             className="space-y-3"
           >
             {/* Primary: Copy Link - Full Width */}
-            <m.button
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              transition={{ delay: 0.35 }}
+            <button
               onClick={handleCopyLink}
               disabled={isLoading}
               aria-label={copied ? t('share.linkCopied') : t('share.copyLink')}
               className={cn(
+                'animate-in fade-in-0 duration-300',
                 'w-full flex items-center justify-center gap-2 p-4 rounded-neo',
                 'border-4 border-neo-black shadow-hard-lg',
                 'hover:shadow-hard-xl hover:-translate-y-1 active:shadow-hard-sm active:translate-y-0',
@@ -478,16 +458,14 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                 <Copy className="w-5 h-5" />
               )}
               <span>{copied ? t('share.linkCopied') : t('share.copyLink')}</span>
-            </m.button>
+            </button>
 
             {/* Secondary: WhatsApp - Full Width */}
-            <m.button
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              transition={{ delay: 0.4 }}
+            <button
               onClick={handleWhatsApp}
               aria-label={t('share.whatsapp')}
               className={cn(
+                'animate-in fade-in-0 duration-300',
                 'w-full flex items-center justify-center gap-2 p-3 rounded-neo',
                 'border-2 border-neo-black shadow-hard-sm',
                 'hover:shadow-hard-md hover:-translate-y-0.5 active:shadow-none active:translate-y-0',
@@ -499,17 +477,15 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
             >
               <MessageCircle className="w-5 h-5" />
               <span>{t('share.whatsapp')}</span>
-            </m.button>
+            </button>
 
             {/* More Platforms Toggle */}
-            <m.button
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ delay: 0.42 }}
+            <button
               onClick={() => setShowMorePlatforms(!showMorePlatforms)}
               aria-expanded={showMorePlatforms}
               aria-controls="more-platforms"
               className={cn(
+                'animate-in fade-in-0 duration-300',
                 'w-full flex items-center justify-center gap-1.5 py-2 rounded-neo',
                 'text-white hover:text-white transition-colors',
                 'font-medium text-xs uppercase tracking-wide',
@@ -525,26 +501,21 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
               >
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
               </svg>
-            </m.button>
+            </button>
 
             {/* Additional Share Platforms */}
             {showMorePlatforms && (
-              <m.div
+              <Reveal
+                noSlide
                 id="more-platforms"
-                initial={{ height: 0, opacity: 0 }}
-                animate={{ height: 'auto', opacity: 1 }}
-                exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: 0.2 }}
                 className="grid grid-cols-2 gap-2"
               >
                 {/* Twitter/X */}
-                <m.button
-                  initial={{ scale: 0.9, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  transition={{ delay: 0.05 }}
+                <button
                   onClick={handleTwitter}
                   aria-label={t('share.twitter')}
                   className={cn(
+                    'animate-in fade-in-0 duration-300',
                     'flex items-center justify-center gap-2 p-3 rounded-neo',
                     'border-2 border-neo-black shadow-hard-sm',
                     'hover:shadow-hard-md hover:-translate-y-0.5 active:shadow-none active:translate-y-0',
@@ -558,16 +529,14 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                     <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
                   </svg>
                   <span>{t('share.twitter')}</span>
-                </m.button>
+                </button>
 
                 {/* Discord */}
-                <m.button
-                  initial={{ scale: 0.9, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  transition={{ delay: 0.1 }}
+                <button
                   onClick={handleDiscord}
                   aria-label={t('share.discord')}
                   className={cn(
+                    'animate-in fade-in-0 duration-300',
                     'flex items-center justify-center gap-2 p-3 rounded-neo',
                     'border-2 border-neo-black shadow-hard-sm',
                     'hover:shadow-hard-md hover:-translate-y-0.5 active:shadow-none active:translate-y-0',
@@ -579,16 +548,14 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                 >
                   <MessageSquare className="w-4 h-4" />
                   <span>{t('share.discord')}</span>
-                </m.button>
+                </button>
 
                 {/* Email */}
-                <m.button
-                  initial={{ scale: 0.9, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  transition={{ delay: 0.15 }}
+                <button
                   onClick={handleEmail}
                   aria-label={t('share.email')}
                   className={cn(
+                    'animate-in fade-in-0 duration-300',
                     'flex items-center justify-center gap-2 p-3 rounded-neo',
                     'border-2 border-neo-black shadow-hard-sm',
                     'hover:shadow-hard-md hover:-translate-y-0.5 active:shadow-none active:translate-y-0',
@@ -600,17 +567,15 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                 >
                   <Mail className="w-4 h-4" />
                   <span>{t('share.email')}</span>
-                </m.button>
+                </button>
 
                 {/* SMS - Mobile Only */}
                 {isMobile && (
-                  <m.button
-                    initial={{ scale: 0.9, opacity: 0 }}
-                    animate={{ scale: 1, opacity: 1 }}
-                    transition={{ delay: 0.2 }}
+                  <button
                     onClick={handleSms}
                     aria-label={t('share.sms')}
                     className={cn(
+                      'animate-in fade-in-0 duration-300',
                       'flex items-center justify-center gap-2 p-3 rounded-neo',
                       'border-2 border-neo-black shadow-hard-sm',
                       'hover:shadow-hard-md hover:-translate-y-0.5 active:shadow-none active:translate-y-0',
@@ -622,21 +587,19 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                   >
                     <MessageCircle className="w-4 h-4" />
                     <span>{t('share.sms')}</span>
-                  </m.button>
+                  </button>
                 )}
-              </m.div>
+              </Reveal>
             )}
 
             {/* Challenge a Friend (Post-game only, when challenge data is available) */}
             {isPostGame && challengeData && (
-              <m.button
-                initial={{ scale: 0.95, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                transition={{ delay: 0.42 }}
+              <button
                 onClick={handleCreateChallenge}
                 disabled={isCreatingChallenge}
                 aria-label={t('challenge.challengeFriend')}
                 className={cn(
+                  'animate-in fade-in-0 duration-300',
                   'w-full flex items-center justify-center gap-2 p-3 rounded-neo',
                   'border-2 border-neo-black shadow-hard-sm',
                   'hover:shadow-hard-md hover:-translate-y-0.5 active:shadow-none active:translate-y-0',
@@ -659,18 +622,16 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                     ? t('share.linkCopied')
                     : t('challenge.challengeFriend')}
                 </span>
-              </m.button>
+              </button>
             )}
 
             {/* Native Share (Mobile Only) */}
             {canNativeShare && (
-              <m.button
-                initial={{ scale: 0.95, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                transition={{ delay: 0.45 }}
+              <button
                 onClick={handleNativeShare}
                 aria-label={t('share.more')}
                 className={cn(
+                  'animate-in fade-in-0 duration-300',
                   'w-full sm:hidden flex items-center justify-center gap-2 p-3 rounded-neo',
                   'border-2 border-white/30 shadow-hard-sm',
                   'hover:shadow-hard-md hover:-translate-y-0.5 transition-all',
@@ -680,9 +641,9 @@ const UnifiedShareModal: React.FC<UnifiedShareModalProps> = ({
                 )}
               >
                 <span>{t('share.more')}</span>
-              </m.button>
+              </button>
             )}
-          </m.div>
+          </Reveal>
         </div>
       </DialogContent>
     </Dialog>

--- a/fe-next/components/multiplayer/CreateRoomModal.tsx
+++ b/fe-next/components/multiplayer/CreateRoomModal.tsx
@@ -19,6 +19,7 @@ import { sanitizeRoomName } from '@/utils/consts';
 import { validateUsername } from '@/utils/validation';
 import { cn } from '@/lib/utils';
 import { AdaptiveMotion, AdaptiveAnimatePresence } from '@/components/motion/AdaptiveMotion';
+import { Reveal } from '@/components/ui/Reveal';
 import { Swords, Loader2, MapPin } from 'lucide-react';
 import type { Language } from '@/shared/types/game';
 
@@ -144,10 +145,7 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({
         </DialogHeader>
 
         {/* ── Battle Arena Banner ── */}
-        <AdaptiveMotion.div
-          initial={{ opacity: 0, y: -16, scale: 0.95 }}
-          animate={{ opacity: 1, y: 0, scale: 1 }}
-          transition={{ ...SPRING, delay: 0.05 }}
+        <Reveal
           className="relative bg-linear-to-r from-neo-orange to-neo-pink px-5 py-4 border-b-4 border-black overflow-hidden"
         >
           {/* Halftone dot pattern overlay */}
@@ -162,15 +160,12 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({
               </h2>
             </div>
           </div>
-        </AdaptiveMotion.div>
+        </Reveal>
 
         <div className="px-5 py-5 space-y-5">
 
           {/* ── Hero Avatar + Name ── */}
-          <AdaptiveMotion.div
-            initial={{ opacity: 0, y: 16 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ ...SPRING, delay: 0.1 }}
+          <Reveal
             className="flex flex-col items-center space-y-3"
           >
             {/* Avatar with glow ring */}
@@ -263,16 +258,13 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({
                 </span>
               </div>
             </div>
-          </AdaptiveMotion.div>
+          </Reveal>
 
           {/* ── Divider ── */}
           <div className="border-t-2 border-neo-white/5" />
 
           {/* ── Room Name (optional) ── */}
-          <AdaptiveMotion.div
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ ...SPRING, delay: 0.18 }}
+          <Reveal
             className="space-y-1.5"
           >
             <label htmlFor="create-room-name" className="text-[10px] font-black uppercase text-neo-white flex items-center gap-1.5 tracking-widest">
@@ -290,13 +282,10 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({
               placeholder={generateRoomName(username || 'Your')}
               className="w-full h-11 px-3 bg-neo-navy-light/50 border-3 border-neo-white/20 rounded-neo text-neo-white text-sm font-bold placeholder:text-neo-white outline-hidden focus:border-neo-cyan/50 focus:bg-neo-navy-light/70 transition-colors"
             />
-          </AdaptiveMotion.div>
+          </Reveal>
 
           {/* ── Language — inline flag pills ── */}
-          <AdaptiveMotion.div
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ ...SPRING, delay: 0.22 }}
+          <Reveal
             className="space-y-2"
           >
             <p className="text-[10px] font-black uppercase text-neo-white tracking-widest">
@@ -322,7 +311,7 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({
                 </AdaptiveMotion.button>
               ))}
             </div>
-          </AdaptiveMotion.div>
+          </Reveal>
         </div>
 
         {/* ── CTA ── */}

--- a/fe-next/components/training/SkillUnlockToast.tsx
+++ b/fe-next/components/training/SkillUnlockToast.tsx
@@ -7,6 +7,7 @@ import { Check, MoveUpRight, RotateCw, Target, Trophy, Sparkles } from 'lucide-r
 import { useTheme } from '@/utils/ThemeContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
+import { Reveal } from '@/components/ui/Reveal';
 import type { TrainingSkillId } from './TrainingProgressBar';
 
 interface SkillConfig {
@@ -113,12 +114,9 @@ const SkillUnlockToast: React.FC<SkillUnlockToastProps> = ({
   return createPortal(
     <AnimatePresence>
       {skillId && (
-        <m.div
+        <Reveal
+          noSlide
           key={`skill-unlock-${skillId}`}
-          initial={{ opacity: 0, y: -50, scale: 0.8 }}
-          animate={{ opacity: 1, y: 0, scale: 1 }}
-          exit={{ opacity: 0, y: -30, scale: 0.9 }}
-          transition={{ type: 'spring', damping: 15, stiffness: 300 }}
           className="fixed top-4 left-1/2 -translate-x-1/2 z-50 pointer-events-none"
         >
           <m.div
@@ -132,17 +130,15 @@ const SkillUnlockToast: React.FC<SkillUnlockToastProps> = ({
             transition={{ duration: 0.3, delay: 0.2 }}
           >
             {/* Icon with color background */}
-            <m.div
+            <Reveal
+              noSlide
               className={cn(
                 'flex items-center justify-center w-8 h-8 rounded-lg',
                 config.bgColor
               )}
-              initial={{ rotate: -180, scale: 0 }}
-              animate={{ rotate: 0, scale: 1 }}
-              transition={{ type: 'spring', damping: 10, delay: 0.1 }}
             >
               <Check className="w-5 h-5 text-white" />
-            </m.div>
+            </Reveal>
 
             {/* Text */}
             <div className="flex flex-col">
@@ -165,7 +161,7 @@ const SkillUnlockToast: React.FC<SkillUnlockToastProps> = ({
               transition={{ duration: duration / 1000, ease: 'linear' }}
             />
           </m.div>
-        </m.div>
+        </Reveal>
       )}
     </AnimatePresence>,
     document.body

--- a/fe-next/components/training/TrainingAnalysisModal.tsx
+++ b/fe-next/components/training/TrainingAnalysisModal.tsx
@@ -2,8 +2,8 @@
 
 import React, { useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { m, AnimatePresence } from 'framer-motion';
-import { SPRING_PRESETS } from '@/lib/animation/presets';
+import { m } from 'framer-motion';
+import { Reveal } from '@/components/ui/Reveal';
 import {
   X,
   Trophy,
@@ -125,19 +125,12 @@ const TrainingAnalysisModal: React.FC<TrainingAnalysisModalProps> = ({
   const progressPercent = Math.round((masteredCount / totalSkills) * 100);
 
   return createPortal(
-    <AnimatePresence>
-      <m.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
+      <Reveal
+        noSlide
         className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60 backdrop-blur-xs"
         onClick={handleClose}
       >
-        <m.div
-          initial={{ scale: 0.8, opacity: 0, y: 20 }}
-          animate={{ scale: 1, opacity: 1, y: 0 }}
-          exit={{ scale: 0.8, opacity: 0, y: 20 }}
-          transition={{ type: 'spring', damping: 20, stiffness: 300 }}
+        <Reveal
           className={cn(
             'w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-2xl p-6 shadow-2xl relative',
             isDarkMode
@@ -166,10 +159,8 @@ const TrainingAnalysisModal: React.FC<TrainingAnalysisModalProps> = ({
           </button>
 
           {/* Header with celebration */}
-          <m.div
-            initial={{ scale: 0 }}
-            animate={{ scale: 1 }}
-            transition={{ type: 'spring', stiffness: 400, damping: 10, delay: 0.1 }}
+          <Reveal
+            noSlide
             className="flex justify-center mb-4"
           >
             {hasPassed ? (
@@ -196,13 +187,10 @@ const TrainingAnalysisModal: React.FC<TrainingAnalysisModalProps> = ({
                 )} size={48} />
               </div>
             )}
-          </m.div>
+          </Reveal>
 
           {/* Title */}
-          <m.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2, ...SPRING_PRESETS.balanced }}
+          <Reveal
             className="text-center mb-6"
           >
             <h2 className={cn(
@@ -227,13 +215,11 @@ const TrainingAnalysisModal: React.FC<TrainingAnalysisModalProps> = ({
                 ? (t('training.analysis.subtitleComplete'))
                 : (t('training.analysis.subtitleProgress'))}
             </p>
-          </m.div>
+          </Reveal>
 
           {/* Progress bar */}
-          <m.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.25, type: 'spring', stiffness: 280, damping: 26 }}
+          <Reveal
+            noSlide
             className="mb-6"
           >
             <div className="flex justify-between mb-1">
@@ -260,26 +246,21 @@ const TrainingAnalysisModal: React.FC<TrainingAnalysisModalProps> = ({
                 )}
               />
             </div>
-          </m.div>
+          </Reveal>
 
           {/* Skills grid */}
-          <m.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.3, ...SPRING_PRESETS.balanced }}
+          <Reveal
+            noSlide
             className="grid grid-cols-2 gap-3 mb-6"
           >
-            {allSkills.map((skill, index) => {
+            {allSkills.map((skill) => {
               const config = SKILL_CONFIGS[skill];
               const isMastered = summary.mastered.includes(skill);
               const Icon = config.icon;
 
               return (
-                <m.div
+                <Reveal
                   key={skill}
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.35 + index * 0.05, type: 'spring', stiffness: 380, damping: 26 }}
                   className={cn(
                     'p-3 rounded-xl border-2 transition-all',
                     isMastered
@@ -319,16 +300,14 @@ const TrainingAnalysisModal: React.FC<TrainingAnalysisModalProps> = ({
                   )}>
                     {t(`training.analysis.skills.${skill}`) || config.label}
                   </p>
-                </m.div>
+                </Reveal>
               );
             })}
-          </m.div>
+          </Reveal>
 
           {/* Stats */}
-          <m.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.4, ...SPRING_PRESETS.balanced }}
+          <Reveal
+            noSlide
             className={cn(
               'p-4 rounded-xl mb-6',
               isDarkMode ? 'bg-neo-navy-elevated/50' : 'bg-gray-50'
@@ -384,14 +363,12 @@ const TrainingAnalysisModal: React.FC<TrainingAnalysisModalProps> = ({
                 </p>
               </div>
             </div>
-          </m.div>
+          </Reveal>
 
           {/* Tips for improvement (if not passed) */}
           {!hasPassed && summary.needsWork.length > 0 && (
-            <m.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ delay: 0.45, type: 'spring', stiffness: 280, damping: 26 }}
+            <Reveal
+              noSlide
               className={cn(
                 'p-4 rounded-xl mb-6 border',
                 isDarkMode
@@ -419,14 +396,11 @@ const TrainingAnalysisModal: React.FC<TrainingAnalysisModalProps> = ({
                   </li>
                 ))}
               </ul>
-            </m.div>
+            </Reveal>
           )}
 
           {/* Action Buttons */}
-          <m.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.5, type: 'spring', stiffness: 280, damping: 26 }}
+          <Reveal
             className="space-y-3"
           >
             {hasPassed ? (
@@ -505,10 +479,9 @@ const TrainingAnalysisModal: React.FC<TrainingAnalysisModalProps> = ({
                 )}
               </>
             )}
-          </m.div>
-        </m.div>
-      </m.div>
-    </AnimatePresence>,
+          </Reveal>
+        </Reveal>
+      </Reveal>,
     document.body
   );
 };

--- a/fe-next/components/voting/WordFeedbackModal.tsx
+++ b/fe-next/components/voting/WordFeedbackModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, memo, useRef } from 'react';
 import { m } from 'framer-motion';
 import { ThumbsUp, ThumbsDown, Book, CheckCircle, HelpCircle } from 'lucide-react';
+import { Reveal } from '@/components/ui/Reveal';
 import Avatar from '../Avatar';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { applyHebrewFinalLetters } from '../../utils/utils';
@@ -221,16 +222,8 @@ const WordFeedbackModal = memo<WordFeedbackModalProps>(({
         className="bg-neo-cream border-4 border-neo-black max-w-md overflow-hidden"
         dir={dir}
       >
-        <m.div
+        <Reveal
           key={currentWord.word}
-          initial={{ opacity: 0, scale: 0.8, y: 50, rotate: -5 }}
-          animate={{ opacity: 1, scale: 1, y: 0, rotate: -1 }}
-          exit={{ opacity: 0, scale: 0.9, y: -30, rotate: 3 }}
-          transition={{
-            type: 'spring',
-            stiffness: 300,
-            damping: 20
-          }}
         >
           <DialogHeader
             variant="pink"
@@ -250,18 +243,14 @@ const WordFeedbackModal = memo<WordFeedbackModalProps>(({
 
           <DialogBody className="space-y-4">
             {/* Encouragement - Dictionary focused */}
-            <m.p
-              initial={{ opacity: 0, y: -10 }}
-              animate={{ opacity: 1, y: 0 }}
-              className="text-center text-neo-pink font-bold text-sm"
+            <p
+              className="text-center text-neo-pink font-bold text-sm animate-in fade-in-0 duration-300 slide-in-from-bottom-1"
             >
               {encouragementSentence}
-            </m.p>
+            </p>
             {/* Submitter Info */}
             {currentWord.submittedBy && (
-              <m.div
-                initial={{ opacity: 0, y: -10 }}
-                animate={{ opacity: 1, y: 0 }}
+              <Reveal
                 className="flex flex-col items-center gap-1"
               >
                 <Avatar
@@ -271,15 +260,12 @@ const WordFeedbackModal = memo<WordFeedbackModalProps>(({
                 <span className="text-xs text-neo-white font-semibold">
                   {currentWord.submittedBy}
                 </span>
-              </m.div>
+              </Reveal>
             )}
 
             {/* Word Card - Cleaner, focused on the word */}
-            <m.div
+            <Reveal
               key={currentWord.word}
-              initial={{ scale: 0.9, y: 20 }}
-              animate={{ scale: 1, y: 0 }}
-              transition={{ delay: 0.1, type: 'spring', stiffness: 300, damping: 20 }}
               className="
                 bg-neo-lime
                 border-3 border-neo-black
@@ -313,14 +299,11 @@ const WordFeedbackModal = memo<WordFeedbackModalProps>(({
                   </p>
                 </div>
               )}
-            </m.div>
+            </Reveal>
 
             {/* Voting Buttons */}
             {!hasVoted ? (
-              <m.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.3 }}
+              <Reveal
                 className="flex gap-3 justify-center"
               >
                 {/* Thumbs Down */}
@@ -385,11 +368,10 @@ const WordFeedbackModal = memo<WordFeedbackModalProps>(({
                   <ThumbsUp className="w-5 h-5" />
                   <span>{t('wordFeedback.realWord')}</span>
                 </button>
-              </m.div>
+              </Reveal>
             ) : (
-              <m.div
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
+              <Reveal
+                noSlide
                 className="text-center py-4"
               >
                 <span className="text-2xl font-black text-neo-pink flex items-center justify-center gap-2">
@@ -399,7 +381,7 @@ const WordFeedbackModal = memo<WordFeedbackModalProps>(({
                     : (t('wordFeedback.thankYou'))
                   }
                 </span>
-              </m.div>
+              </Reveal>
             )}
 
             {/* Timer Bar */}
@@ -430,7 +412,7 @@ const WordFeedbackModal = memo<WordFeedbackModalProps>(({
               </div>
             </div>
           </DialogBody>
-        </m.div>
+        </Reveal>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Why

Follow-up sweep to the auth/signup fix. **Stacked on `claude/hebrew-popup-empty-screen-xjoy2h`** (which introduces the `Reveal` primitive) — this PR's diff is only the remaining popups. Review/merge that branch first.

### Root cause (recap)
framer-motion entrance animations are **JS-driven**: an `m.*` is painted at its invisible `initial` state (`opacity:0` / `scale:0`) and only reaches the visible `animate` state once the **main-thread** animation loop advances. When that loop is **starved** (e.g. while the browser parses the ~700KB Hebrew translation bundle) or interrupted, content stays pinned invisible. The Radix dialog panel still renders (it animates via **CSS**, off the main thread), so users saw a dark panel with no content — "an empty black screen / only the backdrop". This was reproduced deterministically (see `Reveal.test.tsx` in the base PR). The global framer-motion test mock ignores `initial`, which is why the suite never caught it.

## What

Migrated every remaining popup/modal/overlay to the CSS `Reveal` primitive (or plain elements with `animate-in` classes), and converted `AnimatePresence mode="wait"` **phase/step/tab swaps** to **keyed CSS entrances** (re-mounting on `key` replays the CSS animation), so whole-view content can no longer be gated behind a JS-driven invisible parent.

**Modals:** `UnifiedShareModal`, `CreateChallengeModal`, `TrainingAnalysisModal`, `CreateRoomModal`, `ProfileCustomizationModal`, `AvatarBuilderModal` (tab swap), `WinnerOnboarding`, `EmojiAvatarPicker`, `WordWheelWordsModal`, `WordHuntWordsModal`, `CalendarRewardsModal`.

**Phase/step swaps → keyed CSS:** `OnboardingModal`, `PrestigeModal` (success/confirm/main), `MysteryRewardPopup` (chest/opening/reveal).

**Engagement / celebration / achievements / overlays:** `PrestigeModal`, `MysteryRewardPopup`, `NewYearCountdown`, `AchievementQueue`, `AchievementDock`, `SkillUnlockToast`, `MusicControls`, `WordFeedbackModal`.

## Scope notes
- **Left on framer-motion intentionally:** continuous/looping decorative animations, `drag`, and `whileHover`/`whileTap` elements — they don't gate content visibility.
- **Out of scope:** tooltips and page-level (non-backdrop) content — they don't exhibit the "empty backdrop" symptom (e.g. `RoomListView`/`ResultsPage`/`DailyReadyScreen` page animations, `WordChip`/`PlayerArchetypeBadge` tooltips).
- A few `exit` fade-outs are dropped where an entrance was converted (cosmetic; reliability > exit polish for popups).

## Verification
- 20 files changed; **ESLint clean**, **tsc clean** on all changed files.
- **2030 tests pass.** The only failing tests (`CrosswordVersus`, `MultiplayerFlow`, `WordHuntResultsContent`) are **pre-existing** and unrelated — they fail identically with this branch's changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR98767MBzxLofsz1HGY7B)_