### PR TITLE
fix(popups): migrate remaining black-screen modals off JS-gated reveals

### DIFF
--- a/fe-next/components/achievements/UnifiedAchievementModal.tsx
+++ b/fe-next/components/achievements/UnifiedAchievementModal.tsx
@@ -15,9 +15,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useRef } from 'react';
-import { m, AnimatePresence } from 'framer-motion';
 import { cn } from '@/lib/utils';
-import { SPRING_PRESETS } from '@/lib/animation/presets';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useSoundEffects } from '@/contexts/SoundEffectsContext';
 import { fireConfetti } from '@/utils/confettiUtils';
@@ -191,146 +189,119 @@ export function UnifiedAchievementModal(props: UnifiedAchievementModalProps) {
     ? t('achievements.unlocked')
     : t('achievements.upgraded');
 
+  // CSS entrances (animate-in) instead of framer-motion: a starved main thread —
+  // e.g. while the large Hebrew bundle parses — would leave a framer-motion
+  // `initial` opacity:0 pinned, so the user sees only the dark backdrop ("black
+  // screen"). CSS runs off the main thread and always settles visible.
   return (
-    <AnimatePresence>
-      <m.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        onClick={handleBackdropClick}
+    <div
+      onClick={handleBackdropClick}
+      className={cn(
+        'fixed inset-0 z-60',
+        'flex items-center justify-center',
+        'bg-neo-black/80 backdrop-blur-xs',
+        'animate-in fade-in-0 duration-300'
+      )}
+      data-testid="unified-achievement-modal"
+    >
+      <div
         className={cn(
-          'fixed inset-0 z-60',
-          'flex items-center justify-center',
-          'bg-neo-black/80 backdrop-blur-xs'
+          'relative p-8 rounded-neo',
+          'bg-neo-navy border-4',
+          'shadow-hard-lg',
+          'max-w-sm w-full mx-4',
+          'animate-in fade-in-0 zoom-in-95 duration-300'
         )}
-        data-testid="unified-achievement-modal"
+        style={{
+          borderColor: tierColors?.border || '#BFFF00',
+          boxShadow: tierColors
+            ? `0 0 30px ${tierColors.glow}`
+            : '0 0 30px rgba(191, 255, 0, 0.5)',
+        }}
       >
-        <m.div
-          initial={{ scale: 0.5, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1 }}
-          exit={{ scale: 0.5, opacity: 0 }}
-          transition={{ type: 'spring', damping: 15, stiffness: 300 }}
+        {/* Celebration mascot */}
+        <div className="flex justify-center mb-2 animate-in zoom-in-50 duration-300">
+          <SilentVideo
+            src="/mascot/celebration.webp"
+            width={64}
+            height={64}
+            className="drop-shadow-[2px_2px_0px_rgba(0,0,0,1)]"
+            preload="metadata"
+            aria-hidden="true"
+          />
+        </div>
+
+        {/* Achievement Icon */}
+        <div
           className={cn(
-            'relative p-8 rounded-neo',
-            'bg-neo-navy border-4',
-            'shadow-hard-lg',
-            'max-w-sm w-full mx-4'
+            'w-20 h-20 mx-auto mb-6',
+            'flex items-center justify-center',
+            'rounded-full border-4 border-neo-white',
+            'animate-in zoom-in-50 duration-300'
           )}
           style={{
-            borderColor: tierColors?.border || '#BFFF00',
-            boxShadow: tierColors
-              ? `0 0 30px ${tierColors.glow}`
-              : '0 0 30px rgba(191, 255, 0, 0.5)',
+            backgroundColor: tierColors?.bg || '#333',
           }}
         >
-          {/* Celebration mascot */}
-          <m.div
-            className="flex justify-center mb-2"
-            initial={{ scale: 0, rotate: -20 }}
-            animate={{ scale: 1, rotate: 0 }}
-            transition={{ delay: 0.1, type: 'spring', stiffness: 200, damping: 12 }}
-          >
-            <SilentVideo
-              src="/mascot/celebration.webp"
-              width={64}
-              height={64}
-              className="drop-shadow-[2px_2px_0px_rgba(0,0,0,1)]"
-              preload="metadata"
-              aria-hidden="true"
-            />
-          </m.div>
+          <span className="text-4xl">{normalized.icon}</span>
+        </div>
 
-          {/* Achievement Icon */}
-          <m.div
-            initial={{ scale: 0 }}
-            animate={{ scale: 1 }}
-            transition={{ delay: 0.2, type: 'spring', stiffness: 400, damping: 10 }}
-            className={cn(
-              'w-20 h-20 mx-auto mb-6',
-              'flex items-center justify-center',
-              'rounded-full border-4 border-neo-white'
-            )}
-            style={{
-              backgroundColor: tierColors?.bg || '#333',
-            }}
-          >
-            <span className="text-4xl">{normalized.icon}</span>
-          </m.div>
-
-          {/* Title */}
-          <m.h2
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.3, ...SPRING_PRESETS.balanced }}
-            className={cn(
-              'text-xl font-black text-center mb-2',
-              'text-neo-white'
-            )}
-          >
-            {titleText}
-          </m.h2>
-
-          {/* Achievement Name */}
-          <m.h3
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.4, ...SPRING_PRESETS.balanced }}
-            className={cn('text-2xl font-black text-center mb-2')}
-            style={{ color: tierColors?.text || 'var(--neo-lime)' }}
-          >
-            {normalized.name}
-          </m.h3>
-
-          {/* Tier Badge */}
-          {normalized.tier && (
-            <m.div
-              initial={{ opacity: 0, scale: 0 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ delay: 0.5, type: 'spring', stiffness: 400, damping: 22 }}
-              className="flex items-center justify-center gap-2 mb-4"
-            >
-              <span className="text-2xl">{tierIcon}</span>
-              <span
-                className="text-lg font-bold uppercase"
-                style={{ color: tierColors?.text }}
-              >
-                {normalized.tier}
-              </span>
-            </m.div>
+        {/* Title */}
+        <h2
+          className={cn(
+            'text-xl font-black text-center mb-2',
+            'text-neo-white',
+            'animate-in fade-in-0 duration-300'
           )}
+        >
+          {titleText}
+        </h2>
 
-          {/* Achievement Description */}
-          <m.p
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.6, type: 'spring', stiffness: 280, damping: 26 }}
-            className="text-center text-neo-white text-sm"
-          >
-            {normalized.description}
-          </m.p>
+        {/* Achievement Name */}
+        <h3
+          className={cn('text-2xl font-black text-center mb-2', 'animate-in fade-in-0 duration-300')}
+          style={{ color: tierColors?.text || 'var(--neo-lime)' }}
+        >
+          {normalized.name}
+        </h3>
 
-          {/* Continue Button - Neo-Lime (Green) */}
-          <m.button
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.7, type: 'spring', stiffness: 280, damping: 26 }}
-            onClick={props.onClose}
-            className={cn(
-              'mt-6 w-full py-3',
-              'bg-neo-lime text-neo-black',
-              'font-black text-lg',
-              'border-3 border-neo-black rounded-neo',
-              'shadow-hard hover:shadow-hard-lg',
-              'hover:-translate-y-0.5',
-              'active:translate-y-0.5 active:shadow-hard-pressed',
-              'transition-all duration-200'
-            )}
-          >
-            {t('common.continue')}
-          </m.button>
-        </m.div>
-      </m.div>
-    </AnimatePresence>
+        {/* Tier Badge */}
+        {normalized.tier && (
+          <div className="flex items-center justify-center gap-2 mb-4 animate-in fade-in-0 zoom-in-95 duration-300">
+            <span className="text-2xl">{tierIcon}</span>
+            <span
+              className="text-lg font-bold uppercase"
+              style={{ color: tierColors?.text }}
+            >
+              {normalized.tier}
+            </span>
+          </div>
+        )}
+
+        {/* Achievement Description */}
+        <p className="text-center text-neo-white text-sm animate-in fade-in-0 duration-300">
+          {normalized.description}
+        </p>
+
+        {/* Continue Button - Neo-Lime (Green) */}
+        <button
+          onClick={props.onClose}
+          className={cn(
+            'mt-6 w-full py-3',
+            'bg-neo-lime text-neo-black',
+            'font-black text-lg',
+            'border-3 border-neo-black rounded-neo',
+            'shadow-hard hover:shadow-hard-lg',
+            'hover:-translate-y-0.5',
+            'active:translate-y-0.5 active:shadow-hard-pressed',
+            'transition-all duration-200',
+            'animate-in fade-in-0 duration-300'
+          )}
+        >
+          {t('common.continue')}
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/fe-next/components/connections/OutOfLivesModal.tsx
+++ b/fe-next/components/connections/OutOfLivesModal.tsx
@@ -30,28 +30,23 @@ export default function OutOfLivesModal({ open, isAdmin, level, onRevive, onQuit
   return (
     <AnimatePresence>
       {open && (
-        <m.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-neo-navy/85 backdrop-blur-sm px-6"
+        // CSS entrances (animate-in) instead of framer-motion for the backdrop
+        // and card: a starved main thread — e.g. while the large Hebrew bundle
+        // parses — would leave a framer-motion `initial` opacity:0 pinned, so the
+        // user sees only the dark backdrop ("black screen"). CSS runs off the
+        // main thread and always settles visible.
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-neo-navy/85 backdrop-blur-sm px-6 animate-in fade-in-0 duration-300"
           dir={isRTL ? 'rtl' : 'ltr'}
         >
-          <m.div
-            initial={{ scale: 0.85, y: 40, opacity: 0 }}
-            animate={{ scale: 1, y: 0, opacity: 1 }}
-            exit={{ scale: 0.9, opacity: 0 }}
-            transition={{ type: 'spring', stiffness: 320, damping: 24 }}
-            className="relative w-full max-w-sm rounded-neo border-neo-thick border-neo-red bg-neo-navy-light shadow-hard-lg p-6 text-center"
+          <div
+            className="relative w-full max-w-sm rounded-neo border-neo-thick border-neo-red bg-neo-navy-light shadow-hard-lg p-6 text-center animate-in fade-in-0 zoom-in-95 duration-300"
           >
-            <m.div
-              initial={{ scale: 0, rotate: -20 }}
-              animate={{ scale: 1, rotate: 0 }}
-              transition={{ delay: 0.1, type: 'spring', stiffness: 300, damping: 14 }}
-              className="mx-auto mb-4 inline-flex items-center justify-center w-16 h-16 rounded-full bg-neo-red/15 border-neo-thick border-neo-red"
+            <div
+              className="mx-auto mb-4 inline-flex items-center justify-center w-16 h-16 rounded-full bg-neo-red/15 border-neo-thick border-neo-red animate-in zoom-in-50 duration-300"
             >
               <Heart className="w-8 h-8 text-neo-red" aria-hidden="true" />
-            </m.div>
+            </div>
 
             <h2 className="font-neo-display text-2xl text-neo-white font-bold mb-2">
               {t('connections.outOfLives')}
@@ -103,8 +98,8 @@ export default function OutOfLivesModal({ open, isAdmin, level, onRevive, onQuit
                 <p className="text-neo-white text-xs">{t('connections.noAdAvailable')}</p>
               )}
             </div>
-          </m.div>
-        </m.div>
+          </div>
+        </div>
       )}
     </AnimatePresence>
   );

--- a/fe-next/components/consent/ParentalConsentModal.tsx
+++ b/fe-next/components/consent/ParentalConsentModal.tsx
@@ -21,7 +21,6 @@
 'use client';
 
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { m, AnimatePresence } from 'framer-motion';
 import { ShieldCheck, X, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -145,27 +144,22 @@ export function ParentalConsentModal({
     return null;
   }
 
+  // CSS entrances (animate-in) instead of framer-motion: a starved main thread —
+  // e.g. while the large Hebrew bundle parses — would leave a framer-motion
+  // `initial` opacity:0 pinned, so the user sees only the dark backdrop ("black
+  // screen"). CSS runs off the main thread and always settles visible.
   return (
-    <AnimatePresence>
-      {isOpen && (
         <div
           className="fixed inset-0 z-[100] flex items-center justify-center"
           onClick={handleBackdropClick}
         >
           {/* Backdrop */}
-          <m.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="absolute inset-0 bg-neo-black/60 backdrop-blur-xs"
+          <div
+            className="absolute inset-0 bg-neo-black/60 backdrop-blur-xs animate-in fade-in-0 duration-300"
           />
 
           {/* Modal */}
-          <m.div
-            initial={{ opacity: 0, scale: 0.95, y: 20 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: 20 }}
-            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+          <div
             role="dialog"
             aria-modal="true"
             aria-labelledby="consent-modal-title"
@@ -174,7 +168,8 @@ export function ParentalConsentModal({
               'bg-white',
               'border-4 border-neo-black rounded-neo',
               'shadow-hard-xl',
-              'max-h-[90vh] overflow-y-auto'
+              'max-h-[90vh] overflow-y-auto',
+              'animate-in fade-in-0 zoom-in-95 duration-300'
             )}
           >
             {/* Header */}
@@ -393,10 +388,8 @@ export function ParentalConsentModal({
                   : t('consent.submit')}
               </button>
             </form>
-          </m.div>
+          </div>
         </div>
-      )}
-    </AnimatePresence>
   );
 }
 

--- a/fe-next/components/education/AchievementUnlockModal.tsx
+++ b/fe-next/components/education/AchievementUnlockModal.tsx
@@ -13,7 +13,6 @@
 
 import { memo, useEffect, useId, useRef } from 'react';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
-import { m, AnimatePresence } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { fireLevelUpConfetti } from '@/utils/confettiUtils';
@@ -52,7 +51,7 @@ const TOAST_DISMISS_MS = 3000;
 // ==============================================
 
 const AchievementUnlockModal = memo<AchievementUnlockModalProps>(({ unlock, onClose }) => {
-  const { t, dir } = useLanguage();
+  const { t } = useLanguage();
   const titleId = useId();
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -111,11 +110,15 @@ const AchievementUnlockModal = memo<AchievementUnlockModalProps>(({ unlock, onCl
     ? t('education.achievements.newBadge')
     : t('education.achievements.tierUpgrade');
 
+  // CSS entrances (animate-in) instead of framer-motion: a starved main thread —
+  // e.g. while the large Hebrew bundle parses — would leave a framer-motion
+  // `initial` opacity:0 pinned, so the user sees only the dark backdrop ("black
+  // screen"). CSS runs off the main thread and always settles visible.
   return (
-    <AnimatePresence>
+    <>
       {/* Toast Layout (Bronze/Silver) */}
       {isToast && (
-        <m.div
+        <div
           role="dialog"
           aria-modal="false"
           aria-labelledby={titleId}
@@ -125,12 +128,9 @@ const AchievementUnlockModal = memo<AchievementUnlockModalProps>(({ unlock, onCl
             'bg-neo-navy border-3 border-neo-black',
             'rounded-neo shadow-hard',
             'p-4',
-            'cursor-pointer'
+            'cursor-pointer',
+            'animate-in fade-in-0 slide-in-from-top-2 duration-300'
           )}
-          initial={{ opacity: 0, x: dir === 'rtl' ? -50 : 50, scale: 0.9 }}
-          animate={{ opacity: 1, x: 0, scale: 1 }}
-          exit={{ opacity: 0, x: dir === 'rtl' ? -50 : 50, scale: 0.9 }}
-          transition={{ type: 'spring', stiffness: 300, damping: 25 }}
           onClick={onClose}
         >
           {/* Toast Content */}
@@ -167,48 +167,38 @@ const AchievementUnlockModal = memo<AchievementUnlockModalProps>(({ unlock, onCl
               </p>
             </div>
           </div>
-        </m.div>
+        </div>
       )}
 
       {/* Full Modal Layout (Gold/Platinum) */}
       {isFullModal && (
-        <m.div
+        <div
           role="dialog"
           aria-modal="true"
           aria-labelledby={titleId}
           className={cn(
             'fixed inset-0 z-60',
             'flex items-center justify-center',
-            'bg-neo-black/80 backdrop-blur-xs'
+            'bg-neo-black/80 backdrop-blur-xs',
+            'animate-in fade-in-0 duration-300'
           )}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
           onClick={onClose}
         >
           {/* Modal Card */}
-          <m.div
+          <div
             ref={modalRef}
             className={cn(
               'relative w-full max-w-md mx-4',
               'bg-neo-navy border-4 border-neo-black',
               'rounded-neo shadow-hard-lg',
               'p-6 md:p-8',
-              'text-center'
+              'text-center',
+              'animate-in fade-in-0 zoom-in-95 duration-300'
             )}
-            initial={{ scale: 0, rotate: -5 }}
-            animate={{ scale: 1, rotate: 0 }}
-            exit={{ scale: 0, rotate: 5 }}
-            transition={{ type: 'spring', stiffness: 300, damping: 20 }}
             onClick={(e) => e.stopPropagation()}
           >
             {/* Celebration Mascot */}
-            <m.div
-              className="mb-4"
-              initial={{ scale: 0, rotate: -30 }}
-              animate={{ scale: [0, 1.3, 1], rotate: [30, -15, 0] }}
-              transition={{ delay: 0.2, duration: 0.5, ease: 'easeOut' }}
-            >
+            <div className="mb-4 animate-in zoom-in-50 duration-300">
               <SilentVideo
                 src="/mascot/celebration.webp"
                 width={80}
@@ -217,14 +207,15 @@ const AchievementUnlockModal = memo<AchievementUnlockModalProps>(({ unlock, onCl
                 preload="metadata"
                 aria-hidden="true"
               />
-            </m.div>
+            </div>
 
             {/* Title */}
             <h2
               id={titleId}
               className={cn(
                 'text-3xl md:text-4xl font-black',
-                'mb-4'
+                'mb-4',
+                'animate-in fade-in-0 duration-300'
               )}
               style={{
                 color: TIER_COLORS[tier],
@@ -237,45 +228,41 @@ const AchievementUnlockModal = memo<AchievementUnlockModalProps>(({ unlock, onCl
             {/* Badge Display */}
             <div className="mb-6">
               <p className="text-neo-white font-bold text-lg mb-2">{badgeText}</p>
-              <m.div
+              <div
                 className={cn(
                   'inline-flex items-center justify-center',
                   'w-20 h-20 md:w-24 md:h-24',
-                  'border-4 rounded-full'
+                  'border-4 rounded-full',
+                  'animate-in zoom-in-50 duration-300'
                 )}
                 style={{
                   backgroundColor: `${TIER_COLORS[tier]}20`,
                   borderColor: TIER_COLORS[tier],
                 }}
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
-                transition={{ delay: 0.4, type: 'spring', stiffness: 200 }}
               >
                 <span className="text-4xl md:text-5xl">{icon}</span>
-              </m.div>
+              </div>
             </div>
 
             {/* Tier Badge */}
-            <m.div
+            <div
               className={cn(
                 'mb-6 py-2 px-4 rounded-neo',
-                'border-neo'
+                'border-neo',
+                'animate-in fade-in-0 duration-300'
               )}
               style={{
                 backgroundColor: `${TIER_COLORS[tier]}20`,
                 borderColor: TIER_COLORS[tier],
               }}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.6 }}
             >
               <p className="font-bold text-sm uppercase tracking-wide" style={{ color: TIER_COLORS[tier] }}>
                 {tierName}
               </p>
-            </m.div>
+            </div>
 
             {/* Continue Button */}
-            <m.button
+            <button
               onClick={onClose}
               className={cn(
                 'w-full py-3 px-6',
@@ -285,18 +272,16 @@ const AchievementUnlockModal = memo<AchievementUnlockModalProps>(({ unlock, onCl
                 'shadow-hard hover:shadow-hard-lg hover:-translate-y-0.5',
                 'active:translate-y-0.5 active:shadow-hard-pressed',
                 'focus-visible:outline-hidden focus-visible:ring-4 focus-visible:ring-neo-cyan',
-                'transition-all duration-200'
+                'transition-all duration-200',
+                'animate-in fade-in-0 duration-300'
               )}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.8 }}
             >
               {t('education.achievements.continue')}
-            </m.button>
-          </m.div>
-        </m.div>
+            </button>
+          </div>
+        </div>
       )}
-    </AnimatePresence>
+    </>
   );
 });
 

--- a/fe-next/components/engagement/ReferralMilestonePopup.tsx
+++ b/fe-next/components/engagement/ReferralMilestonePopup.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { m, AnimatePresence } from 'framer-motion';
 import { X, Users, Gift, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useTheme } from '@/utils/ThemeContext';
@@ -78,26 +77,22 @@ export function ReferralMilestonePopup({
   const colors = MILESTONE_COLORS[milestone.milestone] || MILESTONE_COLORS.first_game_played;
   const gameCount = MILESTONE_ICONS[milestone.milestone] || '1';
 
+  // CSS entrances (animate-in) instead of framer-motion: a starved main thread —
+  // e.g. while the large Hebrew bundle parses — would leave a framer-motion
+  // `initial` opacity:0 pinned, so the user sees only the dark backdrop ("black
+  // screen"). CSS runs off the main thread and always settles visible.
   return (
-    <AnimatePresence>
-      {isOpen && (
+    isOpen && (
         <>
           {/* Backdrop */}
-          <m.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 bg-black/60 backdrop-blur-xs"
+          <div
+            className="fixed inset-0 z-50 bg-black/60 backdrop-blur-xs animate-in fade-in-0 duration-300"
             onClick={handleClose}
           />
 
           {/* Popup */}
-          <m.div
-            initial={{ opacity: 0, scale: 0.8, y: 20 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.8, y: 20 }}
-            transition={{ type: 'spring', damping: 20, stiffness: 300 }}
-            className={`fixed left-1/2 top-1/2 z-50 w-[90%] max-w-sm -translate-x-1/2 -translate-y-1/2 ${
+          <div
+            className={`fixed left-1/2 top-1/2 z-50 w-[90%] max-w-sm -translate-x-1/2 -translate-y-1/2 animate-in fade-in-0 duration-300 ${
               isDarkMode
                 ? 'bg-neo-black border-neo-cream/30'
                 : 'bg-neo-cream border-neo-black'
@@ -118,92 +113,64 @@ export function ReferralMilestonePopup({
 
             {/* Header with gradient */}
             <div className={`bg-linear-to-br ${colors.bg} p-6 pb-8 text-center text-white`}>
-              <m.div
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
-                transition={{ delay: 0.2, type: 'spring', stiffness: 200 }}
-                className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-white/20 backdrop-blur-xs mb-3"
+              <div
+                className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-white/20 backdrop-blur-xs mb-3 animate-in zoom-in-50 duration-300"
               >
                 <Users className="w-10 h-10" />
-              </m.div>
+              </div>
 
-              <m.h2
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.3 }}
-                className="text-xl font-bold"
-              >
+              <h2 className="text-xl font-bold animate-in fade-in-0 duration-300">
                 {t('referral.milestoneTitle')}
-              </m.h2>
+              </h2>
             </div>
 
             {/* Content */}
             <div className="p-6 text-center">
               {/* Friend name and milestone */}
-              <m.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.4 }}
-                className="mb-4"
-              >
+              <div className="mb-4 animate-in fade-in-0 duration-300">
                 <p className={`text-lg ${isDarkMode ? 'text-neo-white' : 'text-neo-black'}`}>
                   <span className="font-bold">{milestone.referredUsername}</span>
                   {' '}
                   {t(`referral.milestone_${milestone.milestone}`)}
                 </p>
-              </m.div>
+              </div>
 
               {/* Game count badge */}
-              <m.div
-                initial={{ scale: 0, rotate: -180 }}
-                animate={{ scale: 1, rotate: 0 }}
-                transition={{ delay: 0.5, type: 'spring', stiffness: 200 }}
-                className={`inline-flex items-center justify-center w-16 h-16 rounded-full bg-linear-to-br ${colors.bg} text-white text-2xl font-bold shadow-lg mb-4`}
+              <div
+                className={`inline-flex items-center justify-center w-16 h-16 rounded-full bg-linear-to-br ${colors.bg} text-white text-2xl font-bold shadow-lg mb-4 animate-in zoom-in-50 duration-300`}
               >
                 {gameCount}
-              </m.div>
+              </div>
 
               {/* Reward */}
-              <m.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.6 }}
-                className={`flex items-center justify-center gap-2 text-lg font-bold mb-4 ${colors.text}`}
+              <div
+                className={`flex items-center justify-center gap-2 text-lg font-bold mb-4 animate-in fade-in-0 duration-300 ${colors.text}`}
               >
                 <Gift className="w-5 h-5" />
                 <span>+{milestone.rewardXp} XP</span>
                 <Sparkles className="w-5 h-5" />
-              </m.div>
+              </div>
 
               {/* Message */}
-              <m.p
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ delay: 0.7 }}
-                className={`text-sm ${isDarkMode ? 'text-neo-white' : 'text-neo-black/70'}`}
+              <p
+                className={`text-sm animate-in fade-in-0 duration-300 ${isDarkMode ? 'text-neo-white' : 'text-neo-black/70'}`}
               >
                 {t('referral.milestoneMessage')}
-              </m.p>
+              </p>
 
               {/* Close button */}
-              <m.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.8 }}
-                className="mt-6"
-              >
+              <div className="mt-6 animate-in fade-in-0 duration-300">
                 <Button
                   onClick={handleClose}
                   className={`w-full bg-linear-to-r ${colors.bg} text-white font-bold py-3 rounded-xl hover:opacity-90 transition-opacity`}
                 >
                   {t('common.awesome')}
                 </Button>
-              </m.div>
+              </div>
             </div>
-          </m.div>
+          </div>
         </>
-      )}
-    </AnimatePresence>
+      )
   );
 }
 

--- a/fe-next/components/gift/AdminGiftModal.tsx
+++ b/fe-next/components/gift/AdminGiftModal.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { LazyMotion, domAnimation, m, AnimatePresence } from 'framer-motion';
 import { Gift, Sparkles, Coins, Crown, X, Award } from 'lucide-react';
 import Image from 'next/image';
 import { useDevicePerformance } from '@/hooks/useDevicePerformance';
@@ -270,39 +269,31 @@ export function AdminGiftModal({
     }
   };
 
+  // CSS entrances (animate-in) instead of framer-motion for the backdrop and
+  // card: a starved main thread — e.g. while the large Hebrew bundle parses —
+  // would leave a framer-motion `initial` opacity:0 pinned, so the user sees only
+  // the dark backdrop ("black screen"). CSS runs off the main thread and always
+  // settles visible. (The GSAP reveal timeline animates already-visible content.)
   return (
-    <LazyMotion features={domAnimation}>
-      <AnimatePresence>
-      {show && (
-        <m.div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-        >
+      show && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-in fade-in-0 duration-300">
           {/* Backdrop */}
-          <m.div
-            className="absolute inset-0 bg-black/70 backdrop-blur-xs"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
+          <div
+            className="absolute inset-0 bg-black/70 backdrop-blur-xs animate-in fade-in-0 duration-300"
             onClick={phase === 'ready' ? onDismiss : undefined}
           />
 
           {/* Modal Content */}
-          <m.div
+          <div
             ref={containerRef}
             className={cn(
               'relative w-full max-w-md',
               'bg-linear-to-br from-neo-navy via-neo-navy to-purple-900/30',
               'rounded-xl overflow-hidden',
               'shadow-2xl',
+              'animate-in fade-in-0 zoom-in-95 duration-300',
               className
             )}
-            initial={{ scale: 0.5, opacity: 0, rotate: -10 }}
-            animate={{ scale: 1, opacity: 1, rotate: 0 }}
-            exit={{ scale: 0.5, opacity: 0, rotate: 10 }}
-            transition={{ type: 'spring', damping: 15, stiffness: 300 }}
           >
             {/* VIP Gold/Purple Border */}
             <div className="absolute inset-0 rounded-xl border-4 border-gradient-to-r from-amber-400 via-purple-500 to-amber-400 pointer-events-none"
@@ -338,14 +329,9 @@ export function AdminGiftModal({
             {/* Content */}
             <div className="relative p-6 text-center">
               {/* Header Line */}
-              <m.div
-                className="text-amber-400 text-sm font-medium mb-4 tracking-wide uppercase"
-                initial={{ opacity: 0, y: -10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.3 }}
-              >
+              <div className="text-amber-400 text-sm font-medium mb-4 tracking-wide uppercase animate-in fade-in-0 duration-300">
                 {getHeaderLine()}
-              </m.div>
+              </div>
 
               {/* Icon Container with Glow Ring */}
               <div className="gift-icon-container relative mx-auto w-24 h-24 mb-6">
@@ -413,11 +399,8 @@ export function AdminGiftModal({
 
                   {/* Before/After Balance Display (skip for already-claimed gifts) */}
                   {gift.claimed ? null : phase === 'done' ? (
-                    <m.div
-                      className="mt-3 pt-3 border-t border-white/10 flex justify-center gap-6 text-xs"
-                      initial={{ opacity: 0, y: 5 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: 0.2 }}
+                    <div
+                      className="mt-3 pt-3 border-t border-white/10 flex justify-center gap-6 text-xs animate-in fade-in-0 duration-300"
                     >
                       {gift.xp_amount > 0 && (
                         <div className="text-purple-300/80">
@@ -431,7 +414,7 @@ export function AdminGiftModal({
                           <span className="font-bold">{(startCoinsRef.current + gift.coin_amount).toLocaleString()} {t('gift.coins')}</span>
                         </div>
                       )}
-                    </m.div>
+                    </div>
                   ) : (
                     <div className="mt-3 pt-3 border-t border-white/10 flex justify-center gap-6 text-xs text-white">
                       {gift.xp_amount > 0 && (
@@ -453,11 +436,8 @@ export function AdminGiftModal({
 
               {/* Badge Section */}
               {gift.badge && (
-                <m.div
-                  className="gift-badge mb-6 p-4 bg-white/5 rounded-lg border border-white/10"
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: 0.4 }}
+                <div
+                  className="gift-badge mb-6 p-4 bg-white/5 rounded-lg border border-white/10 animate-in fade-in-0 duration-300"
                 >
                   <div className="flex items-center justify-center gap-3">
                     <div className={cn(
@@ -495,7 +475,7 @@ export function AdminGiftModal({
                       </p>
                     </div>
                   </div>
-                </m.div>
+                </div>
               )}
 
               {/* Claim Button */}
@@ -535,10 +515,8 @@ export function AdminGiftModal({
                 </p>
               )}
             </div>
-          </m.div>
-        </m.div>
-      )}
-      </AnimatePresence>
-    </LazyMotion>
+          </div>
+        </div>
+      )
   );
 }

--- a/fe-next/components/landing/ShareReferralModal.tsx
+++ b/fe-next/components/landing/ShareReferralModal.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useEffect, useRef } from 'react';
-import { m, AnimatePresence } from 'framer-motion';
 import { X, Copy, Check, Share2, Gift } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useAuth } from '@/contexts/AuthContext';
@@ -40,30 +39,27 @@ export function ShareReferralModal({ isOpen, onClose }: ShareReferralModalProps)
     }
   }, [isOpen, fetchShareData]);
 
+  // CSS entrances (animate-in) instead of framer-motion: a starved main thread —
+  // e.g. while the large Hebrew bundle parses — would leave a framer-motion
+  // `initial` opacity:0 pinned, so the user sees only the dark backdrop ("black
+  // screen"). CSS runs off the main thread and always settles visible.
   return (
-    <AnimatePresence>
-      {isOpen && (
+    isOpen && (
         <>
-          <m.div
+          <div
             data-testid="share-modal-backdrop"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 bg-neo-black/60 z-[60] backdrop-blur-xs"
+            className="fixed inset-0 bg-neo-black/60 z-[60] backdrop-blur-xs animate-in fade-in-0 duration-300"
             onClick={onClose}
             aria-hidden="true"
           />
 
-          <m.div
+          <div
             ref={dialogRef}
-            initial={{ opacity: 0, y: 60, scale: 0.96 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 20, scale: 0.97 }}
-            transition={{ type: 'spring', stiffness: 400, damping: 30 }}
             role="dialog"
             aria-modal="true"
             aria-labelledby="share-modal-title"
             className={cn(
+              'animate-in fade-in-0 duration-300',
               'fixed bottom-0 left-0 right-0 z-61',
               'sm:bottom-auto sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2',
               'sm:w-full sm:max-w-md',
@@ -208,9 +204,8 @@ export function ShareReferralModal({ isOpen, onClose }: ShareReferralModalProps)
               )}
               <span aria-live="polite">{copied ? (t('common.copied')) : (t('common.copy'))}</span>
             </button>
-          </m.div>
+          </div>
         </>
-      )}
-    </AnimatePresence>
+      )
   );
 }

--- a/fe-next/components/results/WordHuntPromoPopup.tsx
+++ b/fe-next/components/results/WordHuntPromoPopup.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { m, AnimatePresence } from 'framer-motion';
+import { m } from 'framer-motion';
 import { X, Target, Sparkles, Zap, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -59,53 +59,40 @@ const WordHuntPromoPopup: React.FC<WordHuntPromoPopupProps> = ({
     router.push(`/${language}/multiplayer?mode=word-hunt&autoCreate=true`);
   }, [language, router]);
 
+  // CSS entrances (animate-in) for the wrapper/backdrop/card instead of
+  // framer-motion: a starved main thread — e.g. while the large Hebrew bundle
+  // parses — would leave a framer-motion `initial` opacity:0 pinned, so the user
+  // sees only the dark backdrop ("black screen"). CSS runs off the main thread
+  // and always settles visible. Looping decorations + the hover CTA stay on
+  // framer-motion (they never gate content visibility).
   return (
-    <AnimatePresence>
-      {isVisible && (
-        <m.div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.3 }}
-        >
+    isVisible && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-in fade-in-0 duration-300">
           {/* Backdrop */}
-          <m.div
-            className="absolute inset-0 bg-black/70 backdrop-blur-xs"
+          <div
+            className="absolute inset-0 bg-black/70 backdrop-blur-xs animate-in fade-in-0 duration-300"
             onClick={showCloseButton ? handleClose : undefined}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.4 }}
           />
 
           {/* Popup Card */}
-          <m.div
+          <div
             className={cn(
               'relative w-full max-w-sm overflow-hidden rounded-neo border-3 border-neo-black',
               'bg-neo-navy shadow-[8px_8px_0px_rgb(var(--neo-black))]',
+              'animate-in fade-in-0 zoom-in-95 duration-300',
               isRTL && 'shadow-[-8px_8px_0px_rgb(var(--neo-black))]'
             )}
-            initial={{ opacity: 0, scale: 0.8, y: 40 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.9, y: 20 }}
-            transition={{ type: 'spring', stiffness: 400, damping: 28, delay: 0.1 }}
           >
             {/* Close Button — delayed appearance */}
-            <AnimatePresence>
-              {showCloseButton && (
-                <m.button
-                  onClick={handleClose}
-                  className="absolute top-2 inset-e-2 z-30 flex items-center justify-center w-8 h-8 rounded-full bg-neo-black/60 text-neo-white hover:text-neo-white hover:bg-neo-black/80 transition-colors"
-                  initial={{ opacity: 0, scale: 0 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0 }}
-                  transition={{ type: 'spring', stiffness: 500, damping: 25 }}
-                  aria-label={t('common.close') || 'Close'}
-                >
-                  <X className="w-4 h-4" />
-                </m.button>
-              )}
-            </AnimatePresence>
+            {showCloseButton && (
+              <button
+                onClick={handleClose}
+                className="absolute top-2 inset-e-2 z-30 flex items-center justify-center w-8 h-8 rounded-full bg-neo-black/60 text-neo-white hover:text-neo-white hover:bg-neo-black/80 transition-colors animate-in fade-in-0 zoom-in-50 duration-300"
+                aria-label={t('common.close') || 'Close'}
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
 
             {/* Hero Image */}
             <div className="relative w-full aspect-video overflow-hidden">
@@ -182,19 +169,14 @@ const WordHuntPromoPopup: React.FC<WordHuntPromoPopupProps> = ({
               </m.button>
 
               {/* Dismiss text — appears with close button */}
-              <AnimatePresence>
-                {showCloseButton && (
-                  <m.button
-                    onClick={handleClose}
-                    className="mt-3 text-xs text-neo-white hover:text-neo-white transition-colors"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    transition={{ delay: 0.3 }}
-                  >
-                    {t('wordHuntPromo.dismiss')}
-                  </m.button>
-                )}
-              </AnimatePresence>
+              {showCloseButton && (
+                <button
+                  onClick={handleClose}
+                  className="mt-3 text-xs text-neo-white hover:text-neo-white transition-colors animate-in fade-in-0 duration-300"
+                >
+                  {t('wordHuntPromo.dismiss')}
+                </button>
+              )}
             </div>
 
             {/* Halftone texture */}
@@ -205,10 +187,9 @@ const WordHuntPromoPopup: React.FC<WordHuntPromoPopupProps> = ({
                 backgroundSize: '6px 6px',
               }}
             />
-          </m.div>
-        </m.div>
-      )}
-    </AnimatePresence>
+          </div>
+        </div>
+      )
   );
 };
 

--- a/fe-next/components/social/GiftModal.tsx
+++ b/fe-next/components/social/GiftModal.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState } from 'react';
-import { m } from 'framer-motion';
 import { X, Lightbulb, Shield, Coins } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
@@ -49,12 +48,12 @@ const GiftModal: React.FC<GiftModalProps> = ({
 
   return (
     <div data-testid="gift-modal" className="fixed inset-0 z-50 flex items-center justify-center bg-neo-black/60 backdrop-blur-xs">
-      <m.div
-        initial={{ scale: 0.9, opacity: 0 }}
-        animate={{ scale: 1, opacity: 1 }}
-        exit={{ scale: 0.9, opacity: 0 }}
-        className="bg-neo-navy-light border-3 border-neo-black rounded-neo p-5 shadow-hard-xl w-full max-w-md mx-4"
-      >
+      {/* CSS entrance (animate-in) instead of framer-motion: a starved main
+          thread — e.g. while the large Hebrew bundle parses — would leave a
+          framer-motion `initial` opacity:0 pinned, showing only the dark
+          backdrop ("black screen"). CSS runs off the main thread and always
+          settles visible. */}
+      <div className="bg-neo-navy-light border-3 border-neo-black rounded-neo p-5 shadow-hard-xl w-full max-w-md mx-4 animate-in fade-in-0 zoom-in-95 duration-300">
         {/* Header */}
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-xl font-black text-white uppercase">
@@ -150,7 +149,7 @@ const GiftModal: React.FC<GiftModalProps> = ({
         >
           {t('socialGift.send', 'Send Gift')}
         </button>
-      </m.div>
+      </div>
     </div>
   );
 };

--- a/fe-next/components/social/__tests__/GiftModal.blackScreen.test.tsx
+++ b/fe-next/components/social/__tests__/GiftModal.blackScreen.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Regression: the Hebrew "black screen" popup bug.
+ *
+ * GiftModal renders a dark, opaque backdrop (a plain `fixed inset-0 bg-neo-black/60`
+ * div) with its actual card content inside. If the card is wrapped in a
+ * framer-motion `m.div initial={{ scale: 0.9, opacity: 0 }}`, that content only
+ * becomes visible once the main-thread JS animation loop (rAF) advances. When the
+ * loop is starved — which happens in Hebrew because parsing the large translation
+ * bundle blocks the main thread — the content stays pinned at opacity:0 while the
+ * dark backdrop still paints, so the user sees only a black screen.
+ *
+ * This file uses the REAL framer-motion (the global test mock strips `initial`,
+ * which is exactly why the suite never caught the bug) to faithfully reproduce the
+ * starved-loop condition: jsdom never drives the animation clock, so an
+ * `initial: opacity:0` stays at 0 — the same outcome as a blocked main thread.
+ *
+ * The fix: the card uses a CSS entrance (`animate-in`) instead, which runs off the
+ * main thread and always settles to the natural, visible resting state.
+ *
+ * Given-When-Then style.
+ */
+
+import { vi } from 'vitest';
+// Use the REAL framer-motion so this test reproduces the production bug.
+vi.unmock('framer-motion');
+
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { LazyMotion, domMax } from 'framer-motion';
+import GiftModal from '../GiftModal';
+import { LanguageProvider } from '@/contexts/LanguageContext';
+
+function renderModal() {
+  return render(
+    <LazyMotion features={domMax}>
+      <LanguageProvider>
+        <GiftModal
+          isOpen
+          onClose={vi.fn()}
+          onSend={vi.fn()}
+          recipientName="Bob"
+          senderBalance={100}
+          giftsRemaining={2}
+        />
+      </LanguageProvider>
+    </LazyMotion>
+  );
+}
+
+describe('GiftModal — Hebrew black-screen regression', () => {
+  it('does not pin the card content invisible when the animation loop never runs', async () => {
+    // Given the modal is open over its dark backdrop
+    renderModal();
+    // When the main-thread animation loop never advances (jsdom never drives it)
+    await act(async () => {
+      await new Promise((res) => setTimeout(res, 60));
+    });
+    // Then the card wrapping all the visible content is NOT stuck at opacity:0
+    const backdrop = screen.getByTestId('gift-modal');
+    const card = backdrop.firstElementChild as HTMLElement;
+    expect(card).toBeTruthy();
+    expect(card.style.opacity).not.toBe('0');
+  });
+
+  it('keeps the send button reachable (content actually rendered, not just present)', async () => {
+    renderModal();
+    await act(async () => {
+      await new Promise((res) => setTimeout(res, 60));
+    });
+    // The send button lives inside the card; it must not be inside an
+    // opacity:0-pinned ancestor.
+    const sendButton = screen.getByTestId('send-gift-button');
+    expect(sendButton).toBeInTheDocument();
+    const card = screen.getByTestId('gift-modal').firstElementChild as HTMLElement;
+    expect(card.style.opacity).not.toBe('0');
+  });
+});


### PR DESCRIPTION
Follow-up sweep to the auth/signup and first popup-sweep fixes. Same root
cause: a popup that paints an opaque/dark backdrop via CSS but wraps its
content in a framer-motion element with an invisible `initial` (opacity:0 /
scale:0) only becomes visible once the main-thread rAF loop advances. In
Hebrew the large translation bundle parses on the main thread and starves
that loop, so the content stays pinned invisible while the dark backdrop
still paints — the user sees a black screen. CSS entrances
(tailwindcss-animate `animate-in`) run off the main thread and always settle
to the visible resting state, so content can never get stuck invisible.

Migrated the remaining offenders (full-screen dark backdrop + framer-motion
`initial`-hidden content) to CSS `animate-in` entrances:

- OutOfLivesModal (connections revive)
- ReferralMilestonePopup
- UnifiedAchievementModal
- AchievementUnlockModal (education, toast + full modal)
- ShareReferralModal (landing)
- WordHuntPromoPopup
- ParentalConsentModal
- AdminGiftModal (framer gates only; GSAP reveal timeline untouched)
- GiftModal (social)

Looping/decorative `animate`-only elements and `whileHover`/`whileTap`
buttons are intentionally left on framer-motion — they never gate content
visibility. Added a regression test (real framer-motion, not the global mock
that strips `initial`) reproducing the starved-loop black screen on GiftModal
and proving the CSS entrance never pins the card at opacity:0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HnZh1iUvyirCNAsa3iFWdq