### PR TITLE
refactor(daily): calm the Word Wheel results CTA stack into one quiet tier

### DIFF
--- a/fe-next/components/daily/MpModeCrossPromo.tsx
+++ b/fe-next/components/daily/MpModeCrossPromo.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef } from 'react';
 import { m } from 'framer-motion';
 import Link from 'next/link';
-import { Users, ArrowRight, RefreshCw, Search } from 'lucide-react';
+import { Users, RefreshCw, Search } from 'lucide-react';
 import { trackGrowthEvent } from '@/utils/growthTracking';
 import type { Language } from '@/types';
 
@@ -31,21 +31,17 @@ const MP_MODES = [
     target: 'wheel_rush_mp',
     mode: 'wheel-rush',
     icon: RefreshCw,
-    accent: 'bg-neo-purple',
+    iconColor: 'text-neo-purple',
     titleKey: 'mpCrossPromo.wheelRushTitle',
     titleFallback: 'Word Wheel · Live',
-    descKey: 'mpCrossPromo.wheelRushDesc',
-    descFallback: 'Race rivals on the wheel in real time',
   },
   {
     target: 'word_hunt_mp',
     mode: 'word-hunt',
     icon: Search,
-    accent: 'bg-neo-lime',
+    iconColor: 'text-neo-lime',
     titleKey: 'mpCrossPromo.wordHuntTitle',
     titleFallback: 'Word Hunt · Live',
-    descKey: 'mpCrossPromo.wordHuntDesc',
-    descFallback: 'Hunt the hidden words against others',
   },
 ] as const;
 
@@ -69,43 +65,37 @@ const MpModeCrossPromo: React.FC<MpModeCrossPromoProps> = ({ language, source, t
         </span>
       </div>
 
-      {MP_MODES.map((mode) => {
-        const Icon = mode.icon;
-        return (
-          <m.div
-            key={mode.target}
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ type: 'spring', stiffness: 300, damping: 26 }}
-          >
-            <Link
-              href={`/${language}/multiplayer?mode=${mode.mode}`}
-              onClick={() => trackGrowthEvent('cross_promo_click', {
-                target: mode.target,
-                source,
-                placement: 'mp_cross_promo',
-                language,
-              })}
-              className={`flex items-center justify-between gap-3 w-full p-4 rounded-neo border-3 border-neo-black ${mode.accent} shadow-hard-lg hover:scale-[1.02] active:translate-x-px active:translate-y-px active:shadow-hard-pressed transition-all`}
+      <div data-testid="mp-live-grid" className="grid grid-cols-2 gap-2">
+        {MP_MODES.map((mode) => {
+          const Icon = mode.icon;
+          return (
+            <m.div
+              key={mode.target}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ type: 'spring', stiffness: 300, damping: 26 }}
             >
-              <div className="flex items-center gap-3">
-                <div className="flex items-center justify-center w-11 h-11 rounded-neo border-2 border-neo-black bg-neo-navy shrink-0">
-                  <Icon className="w-6 h-6 text-neo-white" />
-                </div>
-                <div>
-                  <span className="block font-neo-display font-black text-neo-black text-base leading-tight">
-                    {t(mode.titleKey, mode.titleFallback)}
-                  </span>
-                  <p className="text-neo-black/70 text-xs mt-0.5">
-                    {t(mode.descKey, mode.descFallback)}
-                  </p>
-                </div>
-              </div>
-              <ArrowRight className="w-6 h-6 text-neo-black shrink-0" />
-            </Link>
-          </m.div>
-        );
-      })}
+              <Link
+                href={`/${language}/multiplayer?mode=${mode.mode}`}
+                onClick={() => trackGrowthEvent('cross_promo_click', {
+                  target: mode.target,
+                  source,
+                  placement: 'mp_cross_promo',
+                  language,
+                })}
+                className="flex h-full flex-col items-center justify-center gap-2 p-3 rounded-neo border-2 border-neo-black bg-neo-navy-light shadow-hard-sm hover:bg-neo-navy active:translate-x-px active:translate-y-px transition-colors text-center"
+              >
+                <span className="flex items-center justify-center w-9 h-9 rounded-neo border-2 border-neo-black bg-neo-navy shrink-0">
+                  <Icon className={`w-5 h-5 ${mode.iconColor}`} />
+                </span>
+                <span className="font-neo-display font-black text-neo-white text-xs leading-tight">
+                  {t(mode.titleKey, mode.titleFallback)}
+                </span>
+              </Link>
+            </m.div>
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/fe-next/components/daily/WordWheelReplayCta.tsx
+++ b/fe-next/components/daily/WordWheelReplayCta.tsx
@@ -46,19 +46,17 @@ const WordWheelReplayCta: React.FC = () => {
         href={href}
         data-testid="wheel-replay-cta"
         onClick={() => trackGrowthEvent('wheel_practice_cta_clicked', { experiment: EXPERIMENT_KEY, variant })}
-        className="flex items-center justify-between gap-3 w-full p-4 rounded-neo border-3 border-neo-black bg-neo-purple shadow-hard-lg hover:scale-[1.02] active:translate-x-px active:translate-y-px active:shadow-hard-pressed transition-all"
+        className="flex items-center gap-3 w-full p-3 rounded-neo border-2 border-neo-black bg-neo-navy-light shadow-hard-sm hover:bg-neo-navy active:translate-x-px active:translate-y-px transition-colors"
       >
-        <span className="flex items-center gap-3">
-          <span className="flex items-center justify-center w-11 h-11 rounded-neo border-2 border-neo-black bg-neo-navy shrink-0">
-            <RotateCcw className="w-6 h-6 text-neo-purple" aria-hidden />
+        <span className="flex items-center justify-center w-9 h-9 rounded-neo border-2 border-neo-black bg-neo-navy shrink-0">
+          <RotateCcw className="w-5 h-5 text-neo-purple" aria-hidden />
+        </span>
+        <span>
+          <span className="block font-neo-display font-black text-neo-white text-sm leading-tight">
+            {t('wordWheel.replay.title')}
           </span>
-          <span>
-            <span className="block font-neo-display font-black text-neo-white text-sm leading-tight">
-              {t('wordWheel.replay.title')}
-            </span>
-            <span className="block text-neo-white/70 text-xs mt-0.5">
-              {t('wordWheel.replay.subtitle')}
-            </span>
+          <span className="block text-neo-white/55 text-xs mt-0.5">
+            {t('wordWheel.replay.subtitle')}
           </span>
         </span>
       </Link>

--- a/fe-next/components/daily/WordWheelResults.tsx
+++ b/fe-next/components/daily/WordWheelResults.tsx
@@ -483,22 +483,22 @@ const WordWheelResults: React.FC<WordWheelResultsProps> = ({
           <Link
             href={`/${language}/daily`}
             data-testid="back-to-daily-link"
-            className="flex items-center justify-between gap-3 w-full p-5 rounded-neo border-3 border-neo-black bg-neo-cyan shadow-hard-lg hover:scale-[1.02] active:translate-x-px active:translate-y-px active:shadow-hard-pressed transition-all"
+            className="flex items-center justify-between gap-3 w-full p-3 rounded-neo border-2 border-neo-black bg-neo-navy-light shadow-hard-sm hover:bg-neo-navy active:translate-x-px active:translate-y-px transition-colors"
           >
             <div className="flex items-center gap-3">
-              <div className="flex items-center justify-center w-12 h-12 rounded-neo border-2 border-neo-black bg-neo-navy shrink-0">
-                <Home className="w-7 h-7 text-neo-cyan" />
+              <div className="flex items-center justify-center w-9 h-9 rounded-neo border-2 border-neo-black bg-neo-navy shrink-0">
+                <Home className="w-5 h-5 text-neo-cyan" />
               </div>
               <div>
-                <span className="block font-neo-display font-black text-neo-black text-base leading-tight">
+                <span className="block font-neo-display font-black text-neo-white text-sm leading-tight">
                   {t('wordWheel.results.backToDaily', 'Back to Daily Hub')}
                 </span>
-                <p className="text-neo-black/70 text-xs mt-0.5">
+                <p className="text-neo-white/55 text-xs mt-0.5">
                   {t('wordWheel.results.backToDailyDesc', "See today's leaderboard")}
                 </p>
               </div>
             </div>
-            <ArrowRight className="w-6 h-6 text-neo-black shrink-0" />
+            <ArrowRight className="w-5 h-5 text-neo-white/40 shrink-0" />
           </Link>
         </m.div>
       )}

--- a/fe-next/components/daily/__tests__/MpModeCrossPromo.test.tsx
+++ b/fe-next/components/daily/__tests__/MpModeCrossPromo.test.tsx
@@ -15,10 +15,11 @@ vi.mock('@/utils/growthTracking', () => ({
   trackGrowthEvent: (...args: unknown[]) => trackGrowthEvent(...args),
 }));
 
-// next/link → plain anchor for assertion.
+// next/link → plain anchor for assertion (className passed through so we can
+// assert the calm secondary styling).
 vi.mock('next/link', () => ({
-  default: ({ href, children, onClick }: { href: string; children: React.ReactNode; onClick?: () => void }) => (
-    <a href={href} onClick={onClick}>{children}</a>
+  default: ({ href, children, onClick, className }: { href: string; children: React.ReactNode; onClick?: () => void; className?: string }) => (
+    <a href={href} onClick={onClick} className={className}>{children}</a>
   ),
 }));
 
@@ -51,6 +52,22 @@ describe('MpModeCrossPromo', () => {
     const targets = impressions.map(c => (c[1] as { target: string }).target);
     expect(targets).toEqual(expect.arrayContaining(['wheel_rush_mp', 'word_hunt_mp']));
     impressions.forEach(c => expect((c[1] as { source: string }).source).toBe('word_wheel_results'));
+  });
+
+  it('groups the two live modes in a compact 2-column grid', () => {
+    render(<MpModeCrossPromo language="en" source="word_wheel_results" t={t} />);
+    const grid = screen.getByTestId('mp-live-grid');
+    expect(grid.className).toMatch(/grid-cols-2/);
+  });
+
+  it('uses calm secondary styling — no saturated full-fill or heavy shadow', () => {
+    render(<MpModeCrossPromo language="en" source="word_wheel_results" t={t} />);
+    for (const link of screen.getAllByRole('link')) {
+      const cls = link.className;
+      expect(cls).toContain('bg-neo-navy-light');
+      expect(cls).not.toMatch(/bg-neo-(purple|lime|cyan)\b/);
+      expect(cls).not.toContain('shadow-hard-lg');
+    }
   });
 
   it('fires cross_promo_click with the target + source when a card is tapped', () => {

--- a/fe-next/components/daily/__tests__/WordWheelReplayCta.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelReplayCta.test.tsx
@@ -59,6 +59,14 @@ describe('WordWheelReplayCta', () => {
     expect(mockTrackExposure).toHaveBeenCalled();
   });
 
+  it('uses calm secondary styling — no saturated full-fill or heavy shadow', () => {
+    render(<WordWheelReplayCta />);
+    const cls = screen.getByTestId('wheel-replay-cta').className;
+    expect(cls).toContain('bg-neo-navy-light');
+    expect(cls).not.toMatch(/bg-neo-purple\b/);
+    expect(cls).not.toContain('shadow-hard-lg');
+  });
+
   it('fires wheel_practice_cta_clicked when tapped', () => {
     render(<WordWheelReplayCta />);
     fireEvent.click(screen.getByTestId('wheel-replay-cta'));

--- a/fe-next/components/daily/__tests__/WordWheelResults.crossPromoTranslation.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelResults.crossPromoTranslation.test.tsx
@@ -128,5 +128,29 @@ describe('WordWheelResults — cross-promo CTA translation + gating', () => {
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute('href', '/en/daily');
     });
+
+    it('renders the back-to-daily CTA with calm secondary styling (no loud full-fill)', async () => {
+      vi.doMock('@/contexts/LanguageContext', () => ({
+        useLanguage: () => ({
+          t: (k: string, fb?: string) => fb || k,
+          language: 'en',
+          dir: 'ltr',
+        }),
+      }));
+      const { default: Component } = await import('../WordWheelResults');
+      render(
+        <Component
+          result={baseResult}
+          puzzleNumber={1}
+          puzzleDate="2026-04-21"
+          language="en"
+          hasPlayedWordHunt={true}
+        />
+      );
+      const cls = screen.getByTestId('back-to-daily-link').className;
+      expect(cls).toContain('bg-neo-navy-light');
+      expect(cls).not.toMatch(/bg-neo-cyan\b/);
+      expect(cls).not.toContain('shadow-hard-lg');
+    });
   });
 });


### PR DESCRIPTION
The "already finished today" Word Wheel results screen stacked four
full-bleed, saturated CTAs (border-3 + shadow-hard-lg + solid
purple/cyan/lime fills) with no visual hierarchy — a wall of equally
loud buttons that gave the eye no entry point.

Demote them to a single secondary language: dark bg-neo-navy-light
surface, border-2 + shadow-hard-sm, subtle hover, with each mode's
color kept only as the icon tint for identity. Group the two live
modes into a compact 2-col grid and drop their redundant descriptions.

The !hasPlayedWordHunt "Step 2 of 2" CTA stays loud — it's a real
task step in a different state, not part of this terminal dead-end.

Affects WordWheelReplayCta, the back-to-hub CTA, and MpModeCrossPromo
(also reused on Word Hunt results, so the calmer look propagates).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V8iatgXTGXeE3VxfqHcfHQ