### PR TITLE
refactor(daily): swap leaderboard emojis for lucide icons

### DIFF
--- a/fe-next/components/daily/DailyLeaderboard.tsx
+++ b/fe-next/components/daily/DailyLeaderboard.tsx
@@ -281,7 +281,9 @@ const DailyLeaderboard: React.FC<DailyLeaderboardProps> = ({
           </div>
         </div>
         <div className="text-center py-6">
-          <div className="text-4xl mb-3">🏆</div>
+          <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-2xl bg-linear-to-br from-indigo-500 to-purple-600 text-white border-2 border-indigo-600 shadow-md">
+            <Trophy aria-hidden className="h-7 w-7 text-amber-300" />
+          </div>
           <p className="text-slate-700 dark:text-slate-300 font-bold text-sm sm:text-base">
             {totalAttempts > 0
               ? (t('daily.signUpToAppear'))

--- a/fe-next/components/daily/DailyLeaderboardRow.tsx
+++ b/fe-next/components/daily/DailyLeaderboardRow.tsx
@@ -2,7 +2,7 @@
 
 import React, { memo } from 'react';
 import { m } from 'framer-motion';
-import { Clock, Sparkles, Crown, Eye } from 'lucide-react';
+import { Clock, Sparkles, Crown, Eye, Target, CircleDot } from 'lucide-react';
 import { getRankDisplay } from '@/utils/rankingStyles';
 import { formatDistanceToNow, getCountryFlag } from '@/shared/utils';
 import Avatar from '@/components/Avatar';
@@ -159,7 +159,8 @@ export const TodayParticipantRow = memo<{
           )}
           {(participant.word_hunt_score ?? 0) > 0 && (participant.word_wheel_score ?? 0) > 0 && (
             <span className="text-[10px] sm:text-xs text-slate-500 dark:text-slate-400 font-medium ms-1 inline-flex items-center gap-1">
-              🎯 {participant.word_hunt_score}
+              <Target aria-hidden className="w-3 h-3" />
+              {participant.word_hunt_score}
               <span aria-hidden>·</span>
               {onViewWheelWords && participant.player_id ? (
                 <button
@@ -169,11 +170,15 @@ export const TodayParticipantRow = memo<{
                   aria-label={t('wordWheel.viewSubmittedWords')}
                   title={t('wordWheel.viewSubmittedWords')}
                 >
-                  🎡 {participant.word_wheel_score}
+                  <CircleDot aria-hidden className="w-3 h-3" />
+                  {participant.word_wheel_score}
                   <Eye aria-hidden className="w-3 h-3 opacity-80" />
                 </button>
               ) : (
-                <span>🎡 {participant.word_wheel_score}</span>
+                <span className="inline-flex items-center gap-1">
+                  <CircleDot aria-hidden className="w-3 h-3" />
+                  {participant.word_wheel_score}
+                </span>
               )}
             </span>
           )}

--- a/fe-next/components/daily/TabbedDailyLeaderboard.tsx
+++ b/fe-next/components/daily/TabbedDailyLeaderboard.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, memo, useMemo, useRef } from 'react';
 import { useSafeInterval } from '@/hooks/useSafeTimeout';
 import { m, AnimatePresence } from 'framer-motion';
-import { Trophy, ChevronDown, ChevronUp, Crown, Calendar, Users } from 'lucide-react';
+import { Trophy, ChevronDown, ChevronUp, Crown, Calendar, Users, Target, CircleDot } from 'lucide-react';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useFriends } from '@/hooks/useFriends';
 import type { Language } from '@/types';
@@ -549,7 +549,9 @@ const TabbedDailyLeaderboard: React.FC<TabbedDailyLeaderboardProps> = ({
     if (isEmpty) {
       return (
         <div className="text-center py-6">
-          <div className="text-4xl mb-3">🏆</div>
+          <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-2xl bg-linear-to-br from-indigo-500 to-purple-600 text-white border-2 border-indigo-600 shadow-md">
+            <Trophy aria-hidden className="h-7 w-7 text-amber-300" />
+          </div>
           <p className="text-slate-700 dark:text-slate-300 font-bold text-sm sm:text-base">
             {activeTab === 'friends'
               ? t('leaderboard.noFriendsPlayed')
@@ -637,7 +639,7 @@ const TabbedDailyLeaderboard: React.FC<TabbedDailyLeaderboardProps> = ({
             <span>{t('wordHunt.leaderboard.title')}</span>
             <span
               className={`
-                text-[10px] sm:text-xs font-black px-2 py-0.5 rounded-full border-2 border-neo-black shadow-xs normal-case tracking-normal
+                inline-flex items-center gap-1 text-[10px] sm:text-xs font-black px-2 py-0.5 rounded-full border-2 border-neo-black shadow-xs normal-case tracking-normal
                 ${scope === 'word-hunt' ? 'bg-neo-cyan text-neo-black' : ''}
                 ${scope === 'word-wheel' ? 'bg-neo-purple text-white' : ''}
                 ${scope === 'combined' ? 'bg-neo-lime text-neo-black' : ''}
@@ -650,9 +652,25 @@ const TabbedDailyLeaderboard: React.FC<TabbedDailyLeaderboardProps> = ({
                     : 'Word Wheel only'
               }
             >
-              {scope === 'combined' && <>🎯 + 🎡 {t('wordHunt.leaderboard.scopeCombined') || 'Combined'}</>}
-              {scope === 'word-hunt' && <>🎯 {t('wordHunt.leaderboard.scopeWordHunt') || 'Word Hunt'}</>}
-              {scope === 'word-wheel' && <>🎡 {t('wordHunt.leaderboard.scopeWordWheel') || 'Word Wheel'}</>}
+              {scope === 'combined' && (
+                <>
+                  <Target aria-hidden className="w-3 h-3" />
+                  <CircleDot aria-hidden className="w-3 h-3" />
+                  {t('wordHunt.leaderboard.scopeCombined') || 'Combined'}
+                </>
+              )}
+              {scope === 'word-hunt' && (
+                <>
+                  <Target aria-hidden className="w-3 h-3" />
+                  {t('wordHunt.leaderboard.scopeWordHunt') || 'Word Hunt'}
+                </>
+              )}
+              {scope === 'word-wheel' && (
+                <>
+                  <CircleDot aria-hidden className="w-3 h-3" />
+                  {t('wordHunt.leaderboard.scopeWordWheel') || 'Word Wheel'}
+                </>
+              )}
             </span>
           </h3>
           {!isLoading && !error && (
@@ -663,9 +681,15 @@ const TabbedDailyLeaderboard: React.FC<TabbedDailyLeaderboardProps> = ({
                   <span className="mx-1.5">•</span>
                   {scope === 'combined' && todayHuntSolved > 0 && todayWheelSolved > 0 ? (
                     <>
-                      <span className="text-emerald-600 dark:text-emerald-400">🎯 {todayHuntSolved} {t('wordHunt.leaderboard.solved')}</span>
+                      <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+                        <Target aria-hidden className="w-3.5 h-3.5" />
+                        {todayHuntSolved} {t('wordHunt.leaderboard.solved')}
+                      </span>
                       <span className="mx-1.5">•</span>
-                      <span className="text-emerald-600 dark:text-emerald-400">🎡 {todayWheelSolved} {t('wordHunt.leaderboard.solved')}</span>
+                      <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+                        <CircleDot aria-hidden className="w-3.5 h-3.5" />
+                        {todayWheelSolved} {t('wordHunt.leaderboard.solved')}
+                      </span>
                     </>
                   ) : (
                     <span className="text-emerald-600 dark:text-emerald-400">{totalSolvedCount} {t('wordHunt.leaderboard.solved')}</span>

--- a/fe-next/components/daily/__tests__/TabbedDailyLeaderboard.solvedCount.test.tsx
+++ b/fe-next/components/daily/__tests__/TabbedDailyLeaderboard.solvedCount.test.tsx
@@ -424,8 +424,9 @@ describe('TabbedDailyLeaderboard - Solved Count Display', () => {
     });
 
     // Per-mode solved counts visible separately, so it's never solved > played
-    expect(screen.getByText(/🎯.*4.*solved/)).toBeInTheDocument();
-    expect(screen.getByText(/🎡.*6.*solved/)).toBeInTheDocument();
+    // (mode is now denoted by a lucide icon rather than an emoji, so match on text only)
+    expect(screen.getByText(/4.*solved/)).toBeInTheDocument();
+    expect(screen.getByText(/6.*solved/)).toBeInTheDocument();
 
     // Confirm the bug is gone: no element renders the summed "10 solved"
     expect(screen.queryByText('10 solved')).not.toBeInTheDocument();


### PR DESCRIPTION
Replace 🎯/🎡/🏆 emojis in the daily leaderboard header badge,
per-mode solved counts, participant score breakdown, and empty
states with lucide icons (Target for Word Hunt, CircleDot for
Word Wheel, Trophy in a gradient tile). Matches the icon
convention already used in the admin Today Games stats bar and
renders consistently across platforms.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bo4uX3kEz7Z8QPCQ7waPKs