### PR TITLE
fix(header): drop redundant AuthButton loading skeleton

### DIFF
--- a/fe-next/components/auth/AuthButton.tsx
+++ b/fe-next/components/auth/AuthButton.tsx
@@ -163,12 +163,15 @@ const AuthButton = ({ inline = false, onClose, onSignInClick, onSignUpClick }: A
 
   if (!isSupabaseEnabled) return null;
 
-  // While Supabase auth or CrazyGames SDK is still resolving, show skeleton.
-  // Without this guard, standard auth buttons flash for ~5s before SDK detects CrazyGames.
+  // While Supabase auth or the CrazyGames SDK is still resolving, render nothing.
+  // Every render-site (HeaderDesktopControls / HeaderMobileMenu) already gates this
+  // button on `!loading && !cgLoading`, so a skeleton here is redundant — and it
+  // visibly flashes a stray gray pulse pill next to the already-styled controls
+  // because `isReady` (hasCheckedUser) lags slightly behind the SDK loading flag.
+  // Holding the slot empty avoids that flash without re-introducing the ~5s
+  // standard-auth flash the parent gates already prevent.
   if (loading || !isReady) {
-    return (
-      <div className={cn('w-24 h-9 rounded-full animate-pulse', isDarkMode ? 'bg-neo-navy-elevated' : 'bg-gray-200')} />
-    );
+    return null;
   }
 
   const handleSignOut = async (): Promise<void> => {

--- a/fe-next/components/auth/__tests__/AuthButton.loadingState.test.tsx
+++ b/fe-next/components/auth/__tests__/AuthButton.loadingState.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * AuthButton loading-state tests
+ *
+ * The header render-sites (HeaderDesktopControls / HeaderMobileMenu) already
+ * gate AuthButton on `!loading && !cgLoading`, so an internal loading skeleton
+ * is redundant — and it visibly flashes a stray gray pulse pill next to the
+ * already-styled controls because `isReady` (hasCheckedUser) lags slightly
+ * behind the SDK loading flag. While auth is still resolving, AuthButton must
+ * render nothing rather than a redundant skeleton placeholder.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+vi.mock('../../../contexts/LanguageContext', () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+    language: 'en',
+    setLanguage: vi.fn(),
+    dir: 'ltr',
+  }),
+}));
+
+vi.mock('../../../contexts/PlayerStyleContext', () => ({
+  usePlayerStyle: () => ({ style: { accentHex: null } }),
+}));
+
+vi.mock('../../../lib/supabase', () => ({ signOut: vi.fn() }));
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+vi.mock('../../Avatar', () => ({ __esModule: true, default: () => <div>Avatar</div> }));
+vi.mock('../../LevelBadge', () => ({ __esModule: true, default: () => <div>Level</div> }));
+vi.mock('../../XpProgressBar', () => ({ getLevelFromXp: () => 10 }));
+vi.mock('../../engagement/CalendarRewardsModal', () => ({ CalendarRewardsModal: () => null }));
+
+const authState = {
+  isAuthenticated: false,
+  profile: null,
+  isSupabaseEnabled: true,
+  loading: true, // auth still resolving
+  isAdmin: false,
+  user: null,
+};
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => authState,
+}));
+
+const crazyGamesState = {
+  isCrazyGames: false,
+  isReady: false, // SDK not finished resolving either
+  user: null,
+  isLoggedIn: false,
+  isLoggingIn: false,
+  login: vi.fn(),
+  isAccountAvailable: false,
+};
+
+vi.mock('@/hooks/useCrazyGamesAuth', () => ({
+  useCrazyGamesAuth: () => crazyGamesState,
+}));
+
+describe('AuthButton — loading state', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing (no redundant skeleton pill) while auth is still resolving', async () => {
+    const { default: AuthButton } = await import('../AuthButton');
+    const { container } = render(<AuthButton />);
+
+    // No animate-pulse skeleton placeholder should be rendered.
+    expect(container.querySelector('.animate-pulse')).toBeNull();
+    // Component should render nothing at all during the loading window.
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
The header auth button is already gated on `!loading && !cgLoading` by every
render-site (HeaderDesktopControls / HeaderMobileMenu), so AuthButton's own
loading skeleton is redundant. Worse, it flashes a stray gray pulse pill next
to the already-styled sound/language controls because `isReady`
(hasCheckedUser) lags slightly behind the SDK loading flag. Render nothing
during the loading window instead — no flash, no re-introduction of the
standard-auth flash the parent gates already prevent.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012D5hzy53YzBPRMx3SwpQmn