### PR TITLE
fix(ads): suppress native banner while a modal is open

### DIFF
--- a/fe-next/components/ads/BannerCoordinatorMount.tsx
+++ b/fe-next/components/ads/BannerCoordinatorMount.tsx
@@ -126,6 +126,11 @@ export default function BannerCoordinatorMount() {
           // first run stays ad-free — see shouldSuppressBanner. Lives on <html>,
           // already covered by the observer below.
           onboarding: document.documentElement.classList.contains('onboarding-active'),
+          // A modal/dialog is open (ref-counted by the shared DialogContent). The
+          // native banner is a SurfaceView composited ABOVE the WebView, so the
+          // dialog's z-90 overlay can't cover it — suppress so it doesn't paint over
+          // the modal's content/CTAs. Lives on <html>, covered by the observer below.
+          modalOpen: document.documentElement.classList.contains('modal-open'),
         }),
       );
     syncSuppress(); // reflect any drawer/game state already active at mount

--- a/fe-next/components/ads/__tests__/bannerSuppressIntegration.test.tsx
+++ b/fe-next/components/ads/__tests__/bannerSuppressIntegration.test.tsx
@@ -66,6 +66,7 @@ describe('Banner suppress/restore — integration', () => {
 
   afterEach(() => {
     document.documentElement.classList.remove('mobile-drawer-open');
+    document.documentElement.classList.remove('modal-open');
   });
 
   it('hides on drawer open and restores (resume + show) on drawer close', async () => {
@@ -97,6 +98,37 @@ describe('Banner suppress/restore — integration', () => {
     await flush();
     await bannerController.whenIdle();
     expect(resumeBannerSpy).toHaveBeenCalled(); // un-hide the GONE AdView
+    expect(showBannerSpy).toHaveBeenCalled();
+  });
+
+  it('hides while a modal is open (html.modal-open) and restores when it closes', async () => {
+    const BannerCoordinatorMount = (await import('../BannerCoordinatorMount')).default;
+    const AnchoredNativeBanner = (await import('../AnchoredNativeBanner')).default;
+    const { bannerController } = await import('@/lib/native/bannerController');
+
+    render(
+      <>
+        <BannerCoordinatorMount />
+        <AnchoredNativeBanner />
+      </>,
+    );
+
+    await waitFor(() => expect(showBannerSpy).toHaveBeenCalled());
+    hideBannerSpy.mockClear();
+    showBannerSpy.mockClear();
+    resumeBannerSpy.mockClear();
+
+    // A dialog opens (the shared DialogContent ref-counts this class) → suppress.
+    document.documentElement.classList.add('modal-open');
+    await flush();
+    await bannerController.whenIdle();
+    expect(hideBannerSpy).toHaveBeenCalled();
+
+    // Dialog closes → banner returns (visibility restored first, then re-show).
+    document.documentElement.classList.remove('modal-open');
+    await flush();
+    await bannerController.whenIdle();
+    expect(resumeBannerSpy).toHaveBeenCalled();
     expect(showBannerSpy).toHaveBeenCalled();
   });
 });

--- a/fe-next/components/ui/__tests__/dialog.modalOpen.test.tsx
+++ b/fe-next/components/ui/__tests__/dialog.modalOpen.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { Dialog, DialogContent, DialogTitle } from '../dialog';
+import { MODAL_OPEN_CLASS } from '@/lib/native/modalOpenSignal';
+
+const hasModalClass = () => document.documentElement.classList.contains(MODAL_OPEN_CLASS);
+
+// This project does NOT auto-cleanup React Testing Library between tests, and the
+// modal-open flag is a module-level ref count, so each test unmounts explicitly and
+// we hard-reset the class to keep tests independent.
+beforeEach(() => {
+  document.documentElement.classList.remove(MODAL_OPEN_CLASS);
+});
+
+describe('DialogContent → html.modal-open (native banner suppression)', () => {
+  it('does NOT flag modal-open while the dialog is closed', () => {
+    const { unmount } = render(
+      <Dialog open={false}>
+        <DialogContent>
+          <DialogTitle>Hi</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(hasModalClass()).toBe(false);
+    unmount();
+  });
+
+  it('flags modal-open while the dialog is open', () => {
+    const { unmount } = render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Hi</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(hasModalClass()).toBe(true);
+    unmount();
+    expect(hasModalClass()).toBe(false); // unmount releases the flag
+  });
+
+  it('clears modal-open when the dialog closes (Content unmounts)', () => {
+    const { rerender, unmount } = render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Hi</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(hasModalClass()).toBe(true);
+
+    rerender(
+      <Dialog open={false}>
+        <DialogContent>
+          <DialogTitle>Hi</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(hasModalClass()).toBe(false);
+    unmount();
+  });
+
+  it('keeps the flag until the last of two stacked dialogs closes', () => {
+    const { unmount: unmountInner } = render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Inner</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    const { unmount: unmountOuter } = render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Outer</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(hasModalClass()).toBe(true);
+
+    unmountInner();
+    expect(hasModalClass()).toBe(true); // one dialog still open
+
+    unmountOuter();
+    expect(hasModalClass()).toBe(false); // last one closed
+  });
+});

--- a/fe-next/components/ui/dialog.tsx
+++ b/fe-next/components/ui/dialog.tsx
@@ -3,6 +3,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 
 import { cn } from "../../lib/utils";
+import { acquireModalOpen, releaseModalOpen } from "../../lib/native/modalOpenSignal";
 
 const Dialog = DialogPrimitive.Root;
 
@@ -58,6 +59,25 @@ interface DialogContentProps extends React.ComponentPropsWithoutRef<typeof Dialo
   closeButtonVariant?: 'default' | 'minimal';
 }
 
+/**
+ * Flags the screen as modal-owned (html.modal-open) for as long as it is mounted.
+ * It is rendered INSIDE DialogPrimitive.Content, which Radix only commits to the
+ * DOM while the dialog is actually open — so this mounts iff open, even though the
+ * parent DialogContent component stays in the React tree across open/close toggles
+ * (the common `<Dialog open={isOpen}><DialogContent>` pattern). The native AdMob
+ * banner is a SurfaceView composited ABOVE the WebView and can't be covered by the
+ * dialog's z-90 overlay, so the banner coordinator reads this flag to hide the
+ * banner while a modal is up. Ref-counted so stacked dialogs don't clear it early
+ * (see modalOpenSignal).
+ */
+const ModalOpenFlag = () => {
+  React.useEffect(() => {
+    acquireModalOpen();
+    return () => releaseModalOpen();
+  }, []);
+  return null;
+};
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
@@ -109,6 +129,9 @@ const DialogContent = React.forwardRef<
       }}
       {...props}
     >
+      {/* Mounts iff the dialog is actually open → flags html.modal-open so the
+          native banner is suppressed while a modal covers the screen. */}
+      <ModalOpenFlag />
       {children}
       {/* Neo-Brutalist Close Button - supports two variants */}
       {!hideCloseButton && (

--- a/fe-next/lib/native/bannerController.test.ts
+++ b/fe-next/lib/native/bannerController.test.ts
@@ -67,6 +67,23 @@ describe('shouldSuppressBanner (pure)', () => {
   it('treats a missing onboarding flag as false (back-compat with existing callers)', () => {
     expect(shouldSuppressBanner({ drawerOpen: false, inGame: false, allowInGame: false })).toBe(false);
   });
+
+  it('suppresses whenever a modal/dialog is open (any screen)', () => {
+    // The native banner is a SurfaceView composited ABOVE the WebView, so an open
+    // Radix dialog (z-90 overlay in the DOM) can't cover it — the banner paints on
+    // top of the modal's content/CTAs (device-confirmed over CreateRoomModal).
+    expect(shouldSuppressBanner({ drawerOpen: false, inGame: false, allowInGame: false, modalOpen: true })).toBe(true);
+  });
+
+  it('modal suppression is not overridden by the in-game opt-in', () => {
+    expect(
+      shouldSuppressBanner({ drawerOpen: false, inGame: true, allowInGame: true, modalOpen: true }),
+    ).toBe(true);
+  });
+
+  it('treats a missing modalOpen flag as false (back-compat with existing callers)', () => {
+    expect(shouldSuppressBanner({ drawerOpen: false, inGame: false, allowInGame: false })).toBe(false);
+  });
 });
 
 describe('BannerController', () => {

--- a/fe-next/lib/native/bannerController.ts
+++ b/fe-next/lib/native/bannerController.ts
@@ -63,14 +63,27 @@ export function selectActiveBannerRequest(
  * "Continue" CTA and tanks the highest-leverage conversion funnel, so we keep the
  * whole first run ad-free. The opt-in does NOT rescue it (no onboarding screen
  * reserves banner room).
+ *
+ * Modal/dialog open (`html.modal-open`, ref-counted by the shared `DialogContent`)
+ * is likewise unconditional: a Radix dialog is a full-screen z-90 overlay in the
+ * DOM, but the native banner is a SurfaceView composited ABOVE the WebView, so it
+ * paints on top of the modal's content and action buttons (device-confirmed over
+ * CreateRoomModal). Modals appear on every route — including in-game ones — so the
+ * in-game opt-in does NOT rescue it: while a modal owns the screen, no banner.
  */
 export function shouldSuppressBanner(input: {
   drawerOpen: boolean;
   inGame: boolean;
   allowInGame: boolean;
   onboarding?: boolean;
+  modalOpen?: boolean;
 }): boolean {
-  return Boolean(input.onboarding) || input.drawerOpen || (input.inGame && !input.allowInGame);
+  return (
+    Boolean(input.onboarding) ||
+    Boolean(input.modalOpen) ||
+    input.drawerOpen ||
+    (input.inGame && !input.allowInGame)
+  );
 }
 
 export interface BannerOps {

--- a/fe-next/lib/native/modalOpenSignal.test.ts
+++ b/fe-next/lib/native/modalOpenSignal.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { acquireModalOpen, releaseModalOpen, MODAL_OPEN_CLASS } from './modalOpenSignal';
+
+const hasClass = () => document.documentElement.classList.contains(MODAL_OPEN_CLASS);
+
+describe('modalOpenSignal (ref-counted html.modal-open)', () => {
+  beforeEach(() => {
+    // Drain any leftover count between tests so each starts clean.
+    while (hasClass()) releaseModalOpen();
+    document.documentElement.classList.remove(MODAL_OPEN_CLASS);
+  });
+
+  it('adds the class on the first acquire', () => {
+    expect(hasClass()).toBe(false);
+    acquireModalOpen();
+    expect(hasClass()).toBe(true);
+  });
+
+  it('removes the class only when the last holder releases (stacked modals)', () => {
+    acquireModalOpen();
+    acquireModalOpen(); // a second modal opened on top of the first
+    expect(hasClass()).toBe(true);
+
+    releaseModalOpen(); // top modal closed — first is still open
+    expect(hasClass()).toBe(true);
+
+    releaseModalOpen(); // last modal closed
+    expect(hasClass()).toBe(false);
+  });
+
+  it('never lets the count go negative (extra release is a no-op)', () => {
+    releaseModalOpen();
+    expect(hasClass()).toBe(false);
+    acquireModalOpen();
+    expect(hasClass()).toBe(true);
+    releaseModalOpen();
+    releaseModalOpen(); // stray release must not flip the class back off-by-one
+    expect(hasClass()).toBe(false);
+  });
+});

--- a/fe-next/lib/native/modalOpenSignal.ts
+++ b/fe-next/lib/native/modalOpenSignal.ts
@@ -1,0 +1,37 @@
+/**
+ * Ref-counted `html.modal-open` flag — the single source of truth for "a modal /
+ * dialog currently owns the screen", read by the native banner coordinator
+ * (BannerCoordinatorMount observes `<html>` classes) to suppress the AdMob
+ * SurfaceView banner while a modal is open.
+ *
+ * WHY a ref-counted class (not a boolean): modals can stack (one dialog opens
+ * another), and several may mount/unmount in quick succession during a transition.
+ * A plain set/clear would let an inner modal's close wrongly clear the flag while
+ * an outer modal is still open. We count holders and only drop the class when the
+ * last one releases. Mirrors the `html.onboarding-active` / `mobile-drawer-open`
+ * class convention so the existing MutationObserver picks it up with no new wiring.
+ *
+ * SSR-safe: every operation no-ops when `document` is undefined.
+ */
+export const MODAL_OPEN_CLASS = 'modal-open';
+
+let openCount = 0;
+
+/** A modal mounted — flag the screen as modal-owned (idempotent per holder). */
+export function acquireModalOpen(): void {
+  if (typeof document === 'undefined') return;
+  openCount += 1;
+  if (openCount === 1) {
+    document.documentElement.classList.add(MODAL_OPEN_CLASS);
+  }
+}
+
+/** A modal unmounted — clear the flag only when no modal remains open. */
+export function releaseModalOpen(): void {
+  if (typeof document === 'undefined') return;
+  if (openCount === 0) return; // stray release (e.g. double-unmount) — never go negative
+  openCount -= 1;
+  if (openCount === 0) {
+    document.documentElement.classList.remove(MODAL_OPEN_CLASS);
+  }
+}


### PR DESCRIPTION
The native AdMob banner is a SurfaceView composited ABOVE the WebView, so
an open Radix dialog (z-90 overlay in the DOM) can't cover it — the banner
painted on top of the modal's content and CTAs (device-confirmed over
CreateRoomModal).

Add a ref-counted `html.modal-open` flag set by the shared DialogContent
for the dialog's open lifetime (mounted inside DialogPrimitive.Content so it
tracks real open state, not the always-in-tree `<Dialog open={isOpen}>`
pattern). The banner coordinator reads it via the existing <html> class
observer and suppresses the banner — same mechanism as drawer/onboarding.
Stacked dialogs are handled by the ref count.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RrChAYRNhqeE7W5p1bQrhM