### PR TITLE
feat(mp-lobby): slim solo-bots prompt, move mute into header, lime invite CTA

### DIFF
--- a/fe-next/components/InGameAudioButton.tsx
+++ b/fe-next/components/InGameAudioButton.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import React, { memo, useCallback } from 'react';
+import React, { memo } from 'react';
 import { Volume2, VolumeX } from 'lucide-react';
 import { useNavigation } from '@/contexts/NavigationContext';
-import { useMusic } from '@/contexts/MusicContext';
-import { useSoundEffects } from '@/contexts/SoundEffectsContext';
 import { useTvFullscreenListener } from '@/hooks/useTvFullscreenListener';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { resolveMasterMuteClick } from '@/lib/audio/masterMuteToggle';
+import { useMasterMute } from '@/hooks/useMasterMute';
 
 /**
  * InGameAudioButton — global, always-available mute control during gameplay.
@@ -27,33 +25,24 @@ import { resolveMasterMuteClick } from '@/lib/audio/masterMuteToggle';
  * swallowed when locked.
  */
 const InGameAudioButton: React.FC = memo(() => {
-  const { isInGame } = useNavigation();
+  const { isInGame, headerAudioControlActive } = useNavigation();
   const isTvFullscreen = useTvFullscreenListener();
-  const { isMuted, toggleMute, audioUnlocked, unlockAudio } = useMusic();
-  const { sfxMuted, toggleSfxMute } = useSoundEffects();
-  const { t, language } = useLanguage();
+  const { language } = useLanguage();
   const isRTL = language === 'he';
-
-  const handleClick = useCallback(() => {
-    const action = resolveMasterMuteClick({ audioUnlocked, isMuted, sfxMuted });
-    if (action.unlock) unlockAudio();
-    if (action.toggleMusic) toggleMute();
-    if (action.toggleSfx) toggleSfxMute();
-  }, [audioUnlocked, unlockAudio, isMuted, sfxMuted, toggleMute, toggleSfxMute]);
+  const { allMuted, toggle, label, title } = useMasterMute();
 
   // Passive broadcast view has no player to mute for — leave it untouched.
-  if (!isInGame || isTvFullscreen) return null;
-
-  const allMuted = isMuted && sfxMuted;
-  const label = allMuted ? t('music.unmute', 'Unmute') : t('music.mute', 'Mute');
+  // Stand down when a visible screen header already hosts a mute control
+  // (e.g. the MP lobby header) so we never show two mute buttons at once.
+  if (!isInGame || isTvFullscreen || headerAudioControlActive) return null;
 
   return (
     <button
       type="button"
-      onClick={handleClick}
+      onClick={toggle}
       aria-label={label}
       aria-pressed={!allMuted}
-      title={allMuted ? t('music.soundOff', 'Sound off') : t('music.soundOn', 'Sound on')}
+      title={title}
       className={[
         'fixed z-[70] top-[max(0.5rem,env(safe-area-inset-top))]',
         isRTL

--- a/fe-next/components/__tests__/InGameAudioButton.test.tsx
+++ b/fe-next/components/__tests__/InGameAudioButton.test.tsx
@@ -19,7 +19,7 @@ import '@testing-library/jest-dom';
  *   - locked audio         → unlock first, move toward audible
  */
 
-const navState = { isInGame: false };
+const navState = { isInGame: false, headerAudioControlActive: false };
 const musicState = {
   isMuted: false,
   audioUnlocked: true,
@@ -47,6 +47,7 @@ import InGameAudioButton from '../InGameAudioButton';
 
 function resetState() {
   navState.isInGame = false;
+  navState.headerAudioControlActive = false;
   musicState.isMuted = false;
   musicState.audioUnlocked = true;
   musicState.toggleMute.mockClear();
@@ -76,6 +77,13 @@ describe('InGameAudioButton', () => {
   it('stays hidden during a passive TV broadcast even while in game', () => {
     navState.isInGame = true;
     tvFullscreen = true;
+    const { container } = render(<InGameAudioButton />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('stands down when a screen header already hosts a mute control', () => {
+    navState.isInGame = true;
+    navState.headerAudioControlActive = true;
     const { container } = render(<InGameAudioButton />);
     expect(container).toBeEmptyDOMElement();
   });

--- a/fe-next/contexts/NavigationContext.tsx
+++ b/fe-next/contexts/NavigationContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState, useMemo, useEffect, type ReactNode } from 'react';
+import { createContext, useContext, useState, useMemo, useEffect, useCallback, type ReactNode } from 'react';
 
 /**
  * Navigation Context
@@ -17,6 +17,13 @@ interface NavigationContextValue {
   activeTab: 'home' | 'brain' | 'profile';
   /** Set the active tab */
   setActiveTab: (tab: 'home' | 'brain' | 'profile') => void;
+  /** True when a visible screen header already hosts its own audio/mute control,
+   *  so the global floating in-game audio FAB should stand down to avoid a
+   *  duplicate control (e.g. the MP lobby header). */
+  headerAudioControlActive: boolean;
+  /** Register an in-header audio control; returns an unregister cleanup.
+   *  Ref-counted so StrictMode double-mounts and multiple screens stay correct. */
+  registerHeaderAudioControl: () => () => void;
 }
 
 const NavigationContext = createContext<NavigationContextValue | null>(null);
@@ -28,6 +35,12 @@ interface NavigationProviderProps {
 export function NavigationProvider({ children }: NavigationProviderProps) {
   const [isInGame, setIsInGame] = useState(false);
   const [activeTab, setActiveTab] = useState<'home' | 'brain' | 'profile'>('home');
+  const [headerAudioControlCount, setHeaderAudioControlCount] = useState(0);
+
+  const registerHeaderAudioControl = useCallback(() => {
+    setHeaderAudioControlCount(c => c + 1);
+    return () => setHeaderAudioControlCount(c => Math.max(0, c - 1));
+  }, []);
 
   // Lock body scroll during gameplay to prevent content from scrolling behind sticky headers
   useEffect(() => {
@@ -45,7 +58,9 @@ export function NavigationProvider({ children }: NavigationProviderProps) {
     setIsInGame,
     activeTab,
     setActiveTab,
-  }), [isInGame, activeTab]);
+    headerAudioControlActive: headerAudioControlCount > 0,
+    registerHeaderAudioControl,
+  }), [isInGame, activeTab, headerAudioControlCount, registerHeaderAudioControl]);
 
   return (
     <NavigationContext.Provider value={value}>
@@ -79,6 +94,22 @@ const NOOP_SET_IN_GAME = (_value: boolean) => {};
 export function useHideNavigation() {
   const context = useContext(NavigationContext);
   return context?.setIsInGame ?? NOOP_SET_IN_GAME;
+}
+
+/**
+ * Declare that the current screen renders its own audio/mute control in a
+ * visible header, so the global in-game audio FAB stands down while `active`.
+ *
+ * Degrades to a no-op outside a NavigationProvider (isolated component tests) —
+ * worst case the global FAB simply stays visible.
+ */
+export function useRegisterHeaderAudioControl(active = true) {
+  const context = useContext(NavigationContext);
+  const register = context?.registerHeaderAudioControl;
+  useEffect(() => {
+    if (!active || !register) return;
+    return register();
+  }, [active, register]);
 }
 
 export default NavigationContext;

--- a/fe-next/contexts/__tests__/NavigationContext.headerAudioControl.test.tsx
+++ b/fe-next/contexts/__tests__/NavigationContext.headerAudioControl.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  NavigationProvider,
+  useNavigation,
+  useRegisterHeaderAudioControl,
+} from '../NavigationContext';
+
+/**
+ * Ref-counted header-audio-control registration: while any screen registers an
+ * in-header mute control, headerAudioControlActive is true so the global FAB
+ * stands down. It must survive multiple concurrent registrants (StrictMode
+ * double-mount, more than one screen) and flip back to false only once the last
+ * one unmounts.
+ */
+
+function Probe() {
+  const { headerAudioControlActive } = useNavigation();
+  return <div data-testid="active">{String(headerAudioControlActive)}</div>;
+}
+
+function Registrant() {
+  useRegisterHeaderAudioControl();
+  return null;
+}
+
+describe('NavigationContext header audio control', () => {
+  it('defaults to inactive', () => {
+    render(
+      <NavigationProvider>
+        <Probe />
+      </NavigationProvider>,
+    );
+    expect(screen.getByTestId('active')).toHaveTextContent('false');
+  });
+
+  it('activates while registered and deactivates only after the last unmounts', () => {
+    function Harness({ a, b }: { a: boolean; b: boolean }) {
+      return (
+        <NavigationProvider>
+          <Probe />
+          {a && <Registrant />}
+          {b && <Registrant />}
+        </NavigationProvider>
+      );
+    }
+    const { rerender } = render(<Harness a={false} b={false} />);
+    expect(screen.getByTestId('active')).toHaveTextContent('false');
+
+    act(() => rerender(<Harness a b />));
+    expect(screen.getByTestId('active')).toHaveTextContent('true');
+
+    // One unregisters — still active because the other holds the count.
+    act(() => rerender(<Harness a b={false} />));
+    expect(screen.getByTestId('active')).toHaveTextContent('true');
+
+    // Last unregisters — back to inactive.
+    act(() => rerender(<Harness a={false} b={false} />));
+    expect(screen.getByTestId('active')).toHaveTextContent('false');
+  });
+});

--- a/fe-next/hooks/__tests__/useMasterMute.test.tsx
+++ b/fe-next/hooks/__tests__/useMasterMute.test.tsx
@@ -1,0 +1,73 @@
+import { vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * useMasterMute — the single source of truth both on-screen audio controls
+ * (the global in-game FAB and the lobby header button) share, so they cannot
+ * drift. Delegates the click decision to resolveMasterMuteClick.
+ */
+
+const musicState = {
+  isMuted: false,
+  audioUnlocked: true,
+  toggleMute: vi.fn(),
+  unlockAudio: vi.fn(),
+};
+const sfxState = {
+  sfxMuted: false,
+  toggleSfxMute: vi.fn(),
+};
+
+vi.mock('@/contexts/MusicContext', () => ({ useMusic: () => musicState }));
+vi.mock('@/contexts/SoundEffectsContext', () => ({ useSoundEffects: () => sfxState }));
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (k: string, f?: string) => f ?? k }),
+}));
+
+import { useMasterMute } from '../useMasterMute';
+
+function reset() {
+  musicState.isMuted = false;
+  musicState.audioUnlocked = true;
+  musicState.toggleMute.mockClear();
+  musicState.unlockAudio.mockClear();
+  sfxState.sfxMuted = false;
+  sfxState.toggleSfxMute.mockClear();
+}
+
+describe('useMasterMute', () => {
+  beforeEach(reset);
+
+  it('reports allMuted only when both channels are silenced', () => {
+    musicState.isMuted = true;
+    sfxState.sfxMuted = true;
+    const { result } = renderHook(() => useMasterMute());
+    expect(result.current.allMuted).toBe(true);
+    expect(result.current.label).toBe('Unmute');
+    expect(result.current.title).toBe('Sound off');
+  });
+
+  it('is not allMuted when only one channel is silenced', () => {
+    musicState.isMuted = true;
+    const { result } = renderHook(() => useMasterMute());
+    expect(result.current.allMuted).toBe(false);
+    expect(result.current.label).toBe('Mute');
+  });
+
+  it('mutes both channels when both are audible', () => {
+    const { result } = renderHook(() => useMasterMute());
+    act(() => result.current.toggle());
+    expect(musicState.toggleMute).toHaveBeenCalledTimes(1);
+    expect(sfxState.toggleSfxMute).toHaveBeenCalledTimes(1);
+  });
+
+  it('unlocks audio without muting when locked', () => {
+    musicState.audioUnlocked = false;
+    const { result } = renderHook(() => useMasterMute());
+    act(() => result.current.toggle());
+    expect(musicState.unlockAudio).toHaveBeenCalledTimes(1);
+    expect(musicState.toggleMute).not.toHaveBeenCalled();
+    expect(sfxState.toggleSfxMute).not.toHaveBeenCalled();
+  });
+});

--- a/fe-next/hooks/useMasterMute.ts
+++ b/fe-next/hooks/useMasterMute.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useMusic } from '@/contexts/MusicContext';
+import { useSoundEffects } from '@/contexts/SoundEffectsContext';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { resolveMasterMuteClick } from '@/lib/audio/masterMuteToggle';
+
+export interface MasterMute {
+  /** True only when BOTH music and SFX are silenced. */
+  allMuted: boolean;
+  /** Master-mute toggle — silence wins when unlocked, unlock-first when locked. */
+  toggle: () => void;
+  /** Localized action label for aria-label ("Mute" / "Unmute"). */
+  label: string;
+  /** Localized tooltip ("Sound on" / "Sound off"). */
+  title: string;
+}
+
+/**
+ * Shared master mute/unmute behaviour for every on-screen audio control.
+ *
+ * Both the global in-game FAB (InGameAudioButton) and the in-header lobby
+ * control read from here so they cannot drift: one call decides the click via
+ * resolveMasterMuteClick (silence-wins when unlocked, never swallow the enable
+ * tap when locked) and exposes the same label/title strings.
+ */
+export function useMasterMute(): MasterMute {
+  const { isMuted, toggleMute, audioUnlocked, unlockAudio } = useMusic();
+  const { sfxMuted, toggleSfxMute } = useSoundEffects();
+  const { t } = useLanguage();
+
+  const toggle = useCallback(() => {
+    const action = resolveMasterMuteClick({ audioUnlocked, isMuted, sfxMuted });
+    if (action.unlock) unlockAudio();
+    if (action.toggleMusic) toggleMute();
+    if (action.toggleSfx) toggleSfxMute();
+  }, [audioUnlocked, unlockAudio, isMuted, sfxMuted, toggleMute, toggleSfxMute]);
+
+  const allMuted = isMuted && sfxMuted;
+
+  return {
+    allMuted,
+    toggle,
+    label: allMuted ? t('music.unmute', 'Unmute') : t('music.mute', 'Mute'),
+    title: allMuted ? t('music.soundOff', 'Sound off') : t('music.soundOn', 'Sound on'),
+  };
+}

--- a/fe-next/host/__tests__/HostPreGameView.classroomMode.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.classroomMode.test.tsx
@@ -70,6 +70,7 @@ vi.mock('../components/pre-game/BattleModeCard', () => ({ BattleModeCard: () => 
 vi.mock('../components/pre-game/StartButton', () => ({ StartButton: () => null }));
 vi.mock('../components/pre-game/MobileBottomNav', () => ({ MobileBottomNav: () => null }));
 vi.mock('../components/pre-game/MobileShareSection', () => ({ MobileShareSection: () => null }));
+vi.mock('../components/pre-game/LobbyAudioButton', () => ({ LobbyAudioButton: () => null }));
 vi.mock('../components/pre-game/PresetInfoDrawer', () => ({ PresetInfoDrawer: () => null }));
 vi.mock('../components/pre-game/desktop', () => ({
   DesktopLobbyLayout: () => null,

--- a/fe-next/host/__tests__/HostPreGameView.lobbyReactions.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.lobbyReactions.test.tsx
@@ -71,6 +71,7 @@ vi.mock('../components/pre-game/BattleModeCard', () => ({ BattleModeCard: () => 
 vi.mock('../components/pre-game/StartButton', () => ({ StartButton: () => null }));
 vi.mock('../components/pre-game/MobileBottomNav', () => ({ MobileBottomNav: () => null }));
 vi.mock('../components/pre-game/MobileShareSection', () => ({ MobileShareSection: () => null }));
+vi.mock('../components/pre-game/LobbyAudioButton', () => ({ LobbyAudioButton: () => null }));
 vi.mock('../components/pre-game/PresetInfoDrawer', () => ({ PresetInfoDrawer: () => null }));
 vi.mock('../components/pre-game/desktop', () => ({
   DesktopLobbyLayout: () => null,

--- a/fe-next/host/__tests__/HostPreGameView.quickPlay.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.quickPlay.test.tsx
@@ -71,6 +71,7 @@ vi.mock('../components/pre-game/BattleModeCard', () => ({ BattleModeCard: () => 
 vi.mock('../components/pre-game/StartButton', () => ({ StartButton: () => null }));
 vi.mock('../components/pre-game/MobileBottomNav', () => ({ MobileBottomNav: () => null }));
 vi.mock('../components/pre-game/MobileShareSection', () => ({ MobileShareSection: () => null }));
+vi.mock('../components/pre-game/LobbyAudioButton', () => ({ LobbyAudioButton: () => null }));
 vi.mock('../components/pre-game/PresetInfoDrawer', () => ({ PresetInfoDrawer: () => null }));
 vi.mock('../components/pre-game/desktop', () => ({
   DesktopLobbyLayout: () => null,

--- a/fe-next/host/__tests__/HostPreGameView.soloHostStart.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.soloHostStart.test.tsx
@@ -80,6 +80,7 @@ vi.mock('../components/pre-game/PlayerRoster', () => ({ PlayerRoster: () => null
 vi.mock('../components/pre-game/BattleModeCard', () => ({ BattleModeCard: () => null }));
 vi.mock('../components/pre-game/MobileBottomNav', () => ({ MobileBottomNav: () => null }));
 vi.mock('../components/pre-game/MobileShareSection', () => ({ MobileShareSection: () => null }));
+vi.mock('../components/pre-game/LobbyAudioButton', () => ({ LobbyAudioButton: () => null }));
 vi.mock('../components/pre-game/PresetInfoDrawer', () => ({ PresetInfoDrawer: () => null }));
 vi.mock('../components/pre-game/desktop', () => ({
   DesktopLobbyLayout: () => null,

--- a/fe-next/host/__tests__/HostPreGameView.tvTutorialMount.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.tvTutorialMount.test.tsx
@@ -128,6 +128,7 @@ vi.mock('../components/pre-game/MobileBottomNav', () => ({
 vi.mock('../components/pre-game/MobileShareSection', () => ({
   MobileShareSection: () => null,
 }));
+vi.mock('../components/pre-game/LobbyAudioButton', () => ({ LobbyAudioButton: () => null }));
 
 vi.mock('../components/pre-game/PresetInfoDrawer', () => ({
   PresetInfoDrawer: () => null,

--- a/fe-next/host/components/HostPreGameView.tsx
+++ b/fe-next/host/components/HostPreGameView.tsx
@@ -21,6 +21,7 @@ import { trackSoloPlayPrompt } from '@/utils/posthogEngagement';
 import { PlayerRoster } from './pre-game/PlayerRoster';
 import { BattleModeCard } from './pre-game/BattleModeCard';
 import { AdvancedSettingsModal } from './pre-game/AdvancedSettingsModal';
+import { LobbyAudioButton } from './pre-game/LobbyAudioButton';
 import { DesktopLobbyLayout, InviteCard } from './pre-game/desktop';
 import { GameInstructions } from './pre-game/GameInstructions';
 import TvTutorialOverlay, { isTvTutorialComplete } from './tv-broadcast/TvTutorialOverlay';
@@ -561,6 +562,7 @@ function HostPreGameView({
             {/* UI-language switcher — only show when UI language differs from room/board language.
                 When they match (same flag on both chips), the chip is redundant clutter (visual audit 2026-05-14). */}
             {language !== roomLanguage && <QuickLanguageSwitcher compact />}
+            <LobbyAudioButton />
             <AdvancedSettingsModal
               timerValue={timerValue}
               setTimerValue={setTimerValue}

--- a/fe-next/host/components/pre-game/LobbyAudioButton.tsx
+++ b/fe-next/host/components/pre-game/LobbyAudioButton.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { memo } from 'react';
+import { Volume2, VolumeX } from 'lucide-react';
+import { useMasterMute } from '@/hooks/useMasterMute';
+import { useRegisterHeaderAudioControl } from '@/contexts/NavigationContext';
+import { cn } from '../../../lib/utils';
+
+/**
+ * LobbyAudioButton — in-header mute control for the MP host lobby.
+ *
+ * The lobby keeps its own visible header (language / invite / settings / exit),
+ * so a floating global mute FAB on top of it is redundant clutter. This button
+ * lives inside that header and, while mounted, registers an in-header audio
+ * control so the global InGameAudioButton stands down (no double control).
+ *
+ * Behaviour is the shared master mute (useMasterMute): one tap silences or
+ * restores both music and SFX, matching every other audio control in the app.
+ */
+export const LobbyAudioButton = memo(function LobbyAudioButton() {
+  useRegisterHeaderAudioControl();
+  const { allMuted, toggle, label, title } = useMasterMute();
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={label}
+      aria-pressed={!allMuted}
+      title={title}
+      data-testid="lobby-audio-button"
+      className={cn(
+        'w-8 h-8 flex items-center justify-center shrink-0 rounded-neo border-2 transition-all',
+        'active:translate-y-0.5 active:shadow-none',
+        allMuted
+          ? 'border-neo-white/20 bg-white/5 text-neo-cream/50 hover:bg-white/10'
+          : 'border-neo-white/20 bg-white/5 text-neo-cream/70 hover:bg-white/10',
+      )}
+    >
+      {allMuted
+        ? <VolumeX className="w-4 h-4" strokeWidth={2.5} aria-hidden="true" />
+        : <Volume2 className="w-4 h-4" strokeWidth={2.5} aria-hidden="true" />}
+    </button>
+  );
+});
+
+export default LobbyAudioButton;

--- a/fe-next/host/components/pre-game/MobileShareSection.tsx
+++ b/fe-next/host/components/pre-game/MobileShareSection.tsx
@@ -82,10 +82,10 @@ export const MobileShareSection = memo<MobileShareSectionProps>(function MobileS
         data-testid="mobile-share-trigger"
         whileTap={{ scale: 0.95 }}
         className={cn(
-          'flex items-center gap-1.5 rounded-full border-2 border-neo-black shadow-hard transition-all font-bold uppercase tracking-wide',
-          compact
-            ? 'h-8 px-3 text-xs bg-white text-neo-black shadow-hard-sm'
-            : 'h-10 px-4 text-sm bg-neo-lime text-neo-black',
+          // Brand-lime CTA in both sizes so "invite" reads as the next action,
+          // not a neutral chip lost among the header's exit/settings controls.
+          'flex items-center gap-1.5 rounded-full border-2 border-neo-black bg-neo-lime text-neo-black font-black uppercase tracking-wide shadow-hard active:translate-y-0.5 active:shadow-hard-sm transition-all',
+          compact ? 'h-8 px-3.5 text-xs' : 'h-10 px-4 text-sm',
           showHint && 'animate-neo-wobble',
         )}
       >

--- a/fe-next/host/components/pre-game/SoloPlayPrompt.tsx
+++ b/fe-next/host/components/pre-game/SoloPlayPrompt.tsx
@@ -17,11 +17,15 @@ interface SoloPlayPromptProps {
 // ==================== Component ====================
 
 /**
- * Solo-host rescue card. Shown immediately (no silent dead-air) when a host is
+ * Solo-host rescue bar. Shown immediately (no silent dead-air) when a host is
  * alone in the lobby, telling them — explicitly — that they can start vs bots
  * right now instead of waiting for humans who may never come. This is the
  * direct countermeasure to the dominant MP pre-game drop (solo host abandons
  * the empty lobby). Neutral on private/public — every solo host gets the offer.
+ *
+ * Compact single-row layout (icon + headline/subtitle + inline CTA) so it
+ * nudges without dominating the lobby — the roster and battle modes stay above
+ * the fold on a phone.
  */
 export const SoloPlayPrompt = memo<SoloPlayPromptProps>(function SoloPlayPrompt({
   onPlayVsBots,
@@ -30,35 +34,37 @@ export const SoloPlayPrompt = memo<SoloPlayPromptProps>(function SoloPlayPrompt(
 }) {
   return (
     <m.div
-      initial={{ opacity: 0, y: -12 }}
+      initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -12 }}
+      exit={{ opacity: 0, y: -10 }}
       className={cn(
-        'flex flex-col items-center gap-3 text-center',
-        'bg-neo-pink/15 border-3 border-neo-pink rounded-neo shadow-hard p-4',
+        'flex items-center gap-3 text-start',
+        'bg-neo-pink/15 border-2 border-neo-pink rounded-neo shadow-hard-sm px-3 py-2',
         className,
       )}
     >
-      <div className="flex items-center gap-2 font-neo-display font-black text-lg text-neo-white">
-        <Bot className="w-6 h-6 text-neo-pink" aria-hidden="true" />
-        <span>{t('hostView.soloPrompt.title')}</span>
+      <Bot className="w-5 h-5 text-neo-pink shrink-0" aria-hidden="true" />
+      <div className="flex-1 min-w-0">
+        <p className="font-neo-display font-black text-sm leading-tight text-neo-white truncate">
+          {t('hostView.soloPrompt.title')}
+        </p>
+        <p className="font-neo-body text-[11px] leading-tight text-neo-cream/80 truncate">
+          {t('hostView.soloPrompt.subtitle')}
+        </p>
       </div>
-      <p className="font-neo-body text-sm text-neo-cream/90 max-w-xs">
-        {t('hostView.soloPrompt.subtitle')}
-      </p>
       <m.button
         type="button"
         onClick={onPlayVsBots}
-        whileTap={{ scale: 0.97 }}
+        whileTap={{ scale: 0.96 }}
         className={cn(
-          'w-full h-12 flex items-center justify-center gap-2',
-          'font-neo-display font-black text-lg uppercase tracking-tight',
-          'bg-neo-lime text-neo-black border-3 border-neo-black rounded-neo shadow-hard-lg',
-          'active:translate-y-0.5 active:shadow-hard-pressed transition-all',
+          'shrink-0 h-9 px-3 flex items-center justify-center gap-1.5',
+          'font-neo-display font-black text-sm uppercase tracking-tight',
+          'bg-neo-lime text-neo-black border-2 border-neo-black rounded-neo shadow-hard-sm',
+          'active:translate-y-0.5 active:shadow-none transition-all',
           'focus-visible:outline-hidden focus-visible:ring-4 focus-visible:ring-neo-cyan',
         )}
       >
-        <Bot className="w-5 h-5" aria-hidden="true" />
+        <Bot className="w-4 h-4" aria-hidden="true" />
         <span>{t('hostView.soloPrompt.cta')}</span>
       </m.button>
     </m.div>

--- a/fe-next/host/components/pre-game/__tests__/LobbyAudioButton.test.tsx
+++ b/fe-next/host/components/pre-game/__tests__/LobbyAudioButton.test.tsx
@@ -1,0 +1,71 @@
+import { vi } from 'vitest';
+import React from 'react';
+import { render, fireEvent, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * LobbyAudioButton — the in-header mute control for the MP host lobby.
+ *
+ * It (1) toggles the shared master mute and (2) registers an in-header audio
+ * control so the global floating FAB stands down while it is mounted.
+ */
+
+const master = {
+  allMuted: false,
+  toggle: vi.fn(),
+  label: 'Mute',
+  title: 'Sound on',
+};
+const registerCleanup = vi.fn();
+const registerHeaderAudioControl = vi.fn(() => registerCleanup);
+
+vi.mock('@/hooks/useMasterMute', () => ({ useMasterMute: () => master }));
+vi.mock('@/contexts/NavigationContext', () => ({
+  useRegisterHeaderAudioControl: (active = true) => {
+    React.useEffect(() => {
+      if (!active) return;
+      return registerHeaderAudioControl();
+    }, [active]);
+  },
+}));
+
+import { LobbyAudioButton } from '../LobbyAudioButton';
+
+function reset() {
+  master.allMuted = false;
+  master.toggle.mockClear();
+  registerCleanup.mockClear();
+  registerHeaderAudioControl.mockClear();
+}
+
+describe('LobbyAudioButton', () => {
+  beforeEach(reset);
+  afterEach(cleanup);
+
+  it('renders a mute control in the header', () => {
+    render(<LobbyAudioButton />);
+    expect(screen.getByTestId('lobby-audio-button')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Mute' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('toggles the shared master mute on click', () => {
+    render(<LobbyAudioButton />);
+    fireEvent.click(screen.getByTestId('lobby-audio-button'));
+    expect(master.toggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the unmute affordance when everything is muted', () => {
+    master.allMuted = true;
+    master.label = 'Unmute';
+    render(<LobbyAudioButton />);
+    expect(screen.getByRole('button', { name: 'Unmute' })).toHaveAttribute('aria-pressed', 'false');
+    master.label = 'Mute';
+  });
+
+  it('registers an in-header audio control while mounted and cleans up on unmount', () => {
+    const { unmount } = render(<LobbyAudioButton />);
+    expect(registerHeaderAudioControl).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(registerCleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/fe-next/host/components/pre-game/__tests__/MobileShareSection.test.tsx
+++ b/fe-next/host/components/pre-game/__tests__/MobileShareSection.test.tsx
@@ -115,6 +115,12 @@ describe('MobileShareSection', () => {
       expect(screen.getByText('Invite')).toBeInTheDocument();
     });
 
+    it('styles the trigger as a brand-lime CTA in compact mode', () => {
+      render(<MobileShareSection gameCode="TEST123" t={mockT} compact />);
+      const trigger = screen.getByTestId('mobile-share-trigger');
+      expect(trigger.className).toContain('bg-neo-lime');
+    });
+
     it('renders copy link and WhatsApp buttons inside dialog', async () => {
       await renderAndOpenDialog('TEST123');
       expect(screen.getByTestId('mobile-copy-link-button')).toBeInTheDocument();


### PR DESCRIPTION
Tightens the host pre-game lobby per design review of the mobile screenshot:

- SoloPlayPrompt: compact single-row bar (icon + headline/subtitle + inline
  CTA) instead of the tall centered card, so the roster and battle modes stay
  above the fold on a phone.
- Audio control: add an in-header LobbyAudioButton driven by a shared
  useMasterMute hook; the global floating InGameAudioButton now stands down
  while a screen registers an in-header control (ref-counted via
  NavigationContext), so we never show two mute buttons at once.
- Invite trigger: brand-lime CTA in both sizes (was a neutral white chip in
  compact) so "invite" reads as the next action.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R9yPyAothR6gqXDGmhxHME