### PR TITLE
fix(playerStyle): suppress style popup on SEO/marketing landing pages

### DIFF
--- a/fe-next/app/components/__tests__/PlayerStyleOnboardingWrapper.route.test.tsx
+++ b/fe-next/app/components/__tests__/PlayerStyleOnboardingWrapper.route.test.tsx
@@ -55,6 +55,14 @@ describe('PlayerStyleOnboardingWrapper route gate', () => {
     expect(screen.queryByTestId('style-popup')).not.toBeInTheDocument();
   });
 
+  it('does NOT render the style popup on an SEO/education landing page', () => {
+    // Reported: the full-screen popup buried the /education hero for search
+    // visitors. Education is an SEO doorway, not an in-app route.
+    pathname = '/en/education/esl-word-games';
+    renderAndSettle();
+    expect(screen.queryByTestId('style-popup')).not.toBeInTheDocument();
+  });
+
   it('renders the style popup on an in-app route (eligible guest)', () => {
     pathname = '/en/practice';
     renderAndSettle();

--- a/fe-next/lib/onboarding/__tests__/allowedRoutes.test.ts
+++ b/fe-next/lib/onboarding/__tests__/allowedRoutes.test.ts
@@ -79,9 +79,68 @@ describe('isLandingRoute', () => {
     '/en/practice',
     '/en/multiplayer',
     '/he/daily',
+    '/en/singleplayer',
+    '/en/blast',
+    '/en/brain',
+    '/en/adventure',
+    '/en/profile',
+    '/en/settings',
+    '/en/quests',
+    '/en/leaderboard',
+    // Blog/editorial content is explicitly NOT a marketing landing — popup allowed.
     '/en/blog/boggle-vs-wordle',
   ])('returns false for the in-app/content route %s (popup allowed there)', (path) => {
     expect(isLandingRoute(path)).toBe(false);
+  });
+
+  describe('marketing / SEO landing doorways (popup suppressed)', () => {
+    it.each([
+      // Education SEO section — the reported case (full-screen popup buried the
+      // /education/esl-word-games hero on a search-visitor doorway).
+      '/en/education',
+      '/en/education/esl-word-games',
+      '/en/education/for-schools',
+      '/en/education/duels',
+      '/he/education',
+      // Info / content doorways
+      '/en/about',
+      '/en/faq',
+      '/en/how-to-play',
+      '/en/rules',
+      '/en/glossary',
+      '/en/guides',
+      '/en/contact',
+      '/en/legal',
+      '/en/accessibility',
+      '/en/editorial-policy',
+      // Word-game SEO doorways
+      '/en/best-online-word-games',
+      '/en/play-boggle-online-free',
+      '/en/word-games-online-free',
+      '/en/brain-training-word-games',
+      '/en/competitive-word-games',
+      '/en/multiplayer-word-game-online',
+      '/en/online-word-games-with-friends',
+      '/en/words-with-friends-alternative',
+      '/en/free-multiplayer-word-game',
+      '/en/scrabble-alternative-online',
+      // Locale-specific landings
+      '/he/hebrew-multiplayer-word-game',
+      '/sv/swedish-multiplayer-word-game',
+      '/es/juego-de-palabras-multijugador',
+      // Competitor comparison landings
+      '/en/lexiclash-vs-scrabble',
+      '/en/lexiclash-vs-wordle',
+      '/en/lexiclash-vs-quizlet',
+      '/he/lexiclash-neged-wordle',
+    ])('returns true for %s', (path) => {
+      expect(isLandingRoute(path)).toBe(true);
+    });
+
+    it('does not match a non-landing route that merely shares a prefix', () => {
+      // '/aboutus' must not be swallowed by the '/about' prefix.
+      expect(isLandingRoute('/en/aboutus')).toBe(false);
+    });
   });
 
   it.each([null, undefined, ''])('returns false for malformed input %s', (value) => {

--- a/fe-next/lib/onboarding/allowedRoutes.ts
+++ b/fe-next/lib/onboarding/allowedRoutes.ts
@@ -14,11 +14,87 @@ export function isOnboardingAllowedRoute(pathname: string | null | undefined): b
   return isLocaleHome(pathname);
 }
 
+const LOCALE_PREFIX = /^\/(?:en|he|sv|ja|es)(?=\/|$)/;
+
 /**
- * The marketing landing route (locale homepage). The one-time "pick your style"
- * popup must NOT auto-open here — it covers the marketing hero and hurts CWV/SEO.
- * Returning users get prompted on their next in-app navigation instead.
+ * SEO / marketing landing-page prefixes (locale-stripped). These are public
+ * "doorway" pages whose job is to convert search visitors — the full-screen
+ * "pick your style" popup buries their hero and hurts CWV/SEO, so it must never
+ * auto-open here. Mirrors the "SEO landings" taxonomy used by GlobalBottomNav.
+ *
+ * NOT included on purpose: /blog and other editorial content (a returning user
+ * reading an article is fine to prompt), and every in-app/game surface
+ * (/multiplayer, /daily, /practice, …) where the popup is meant to appear.
+ */
+const MARKETING_LANDING_PREFIXES: ReadonlyArray<string> = [
+  // Education SEO section (hub + all subpages are search doorways)
+  '/education',
+  // Info / content doorways
+  '/about',
+  '/faq',
+  '/how-to-play',
+  '/rules',
+  '/glossary',
+  '/guides',
+  '/contact',
+  '/legal',
+  '/accessibility',
+  '/editorial-policy',
+  '/download-word-game-android',
+  // Word-game SEO doorways
+  '/best-online-word-games',
+  '/boggle-word-shake-free',
+  '/play-boggle-online-free',
+  '/word-games-online-free',
+  '/brain-training-word-games',
+  '/competitive-word-games',
+  '/multiplayer-word-game-online',
+  '/online-word-games-with-friends',
+  '/words-with-friends-alternative',
+  '/free-multiplayer-word-game',
+  '/scrabble-alternative-online',
+  '/word-craft-landing',
+  // Locale-specific landings
+  '/hebrew-classroom-vocabulary-games',
+  '/hebrew-multiplayer-word-game',
+  '/swedish-multiplayer-word-game',
+  '/japanese-word-game',
+  '/juego-de-palabras-multijugador',
+  '/juegos-vocabulario-aula',
+  // Competitor comparison landings
+  '/lexiclash-vs-apalabrados',
+  '/lexiclash-vs-cabanagrams',
+  '/lexiclash-vs-kahoot',
+  '/lexiclash-vs-kahoot-gimkit-vocabulary',
+  '/lexiclash-vs-popple',
+  '/lexiclash-vs-puzzly-words',
+  '/lexiclash-vs-quizlet',
+  '/lexiclash-vs-scrabble',
+  '/lexiclash-vs-wordfeud',
+  '/lexiclash-vs-wordle',
+  '/lexiclash-vs-wordwall',
+  '/lexiclash-vs-wordwall-kahoot-quizlet',
+  '/lexiclash-contra-wordle',
+  '/lexiclash-neged-wordle',
+];
+
+/** Exact match or a `prefix + '/'` child, so '/about' never swallows '/aboutus'. */
+function matchesMarketingLanding(stripped: string): boolean {
+  return MARKETING_LANDING_PREFIXES.some(
+    (prefix) => stripped === prefix || stripped.startsWith(prefix + '/'),
+  );
+}
+
+/**
+ * Marketing landing routes where the one-time "pick your style" popup must NOT
+ * auto-open: the locale homepage AND every SEO/marketing doorway page (education
+ * section, word-game/comparison landings, info pages). On all of these the
+ * full-screen popup covers the hero and hurts CWV/SEO. Returning users get
+ * prompted on their next in-app navigation instead.
  */
 export function isLandingRoute(pathname: string | null | undefined): boolean {
-  return isLocaleHome(pathname);
+  if (!pathname) return false;
+  if (isLocaleHome(pathname)) return true;
+  const stripped = pathname.split('?')[0].split('#')[0].replace(LOCALE_PREFIX, '') || '/';
+  return matchesMarketingLanding(stripped);
 }


### PR DESCRIPTION
The one-time "Make LexiClash yours" style popup was auto-opening over
public SEO doorway pages (reported on /education/esl-word-games), burying
the hero for search visitors and hurting CWV/SEO. isLandingRoute only
matched the locale homepage, so every other landing page leaked the popup.

Extend isLandingRoute to also recognise the SEO/marketing landing
doorways (education section, word-game + competitor-comparison landings,
info pages), mirroring the "SEO landings" taxonomy in GlobalBottomNav.
Blog/editorial content and in-app/game routes are intentionally excluded
so returning users are still prompted on their next in-app navigation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FGos7FWSQicJP4CjtU5dAQ