### PR TITLE
SEO: daily meta tag improvements (2026-06-25)

### DIFF
--- a/docs/seo-daily/2026-06-25.md
+++ b/docs/seo-daily/2026-06-25.md
@@ -1,83 +1,136 @@
 # SEO Daily Report — 2026-06-25
-**Site:** sc-domain:lexiclash.live | **Window:** 2026-05-27 → 2026-06-23 (28d)
+
+**Data range:** 2026-05-27 → 2026-06-23 (28d) | Source: Google Search Console (742 queries, 339 pages)  
+**Bing:** Blocked by proxy — data unavailable this run.
+
+---
 
 ## 1. Headline Metrics
-| Engine | Clicks | Impressions | CTR |
-|--------|--------|-------------|-----|
-| Google | 237 | 38,043 | 0.62% |
-| Bing | (available) | 804 queries / 209 pages | — |
 
-CTR at 0.62% is far below category average (~3-5%). Primary driver: ranking for high-volume Spanish Scrabble queries (11k+ impr) where brand recognition gap kills clicks.
+### Google — 28-day Totals
 
-## 2. Top CTR Opportunities
-| Query | Page | Pos | Impr | CTR | Exp CTR | Δ Clicks | Fix |
-|-------|------|-----|------|-----|---------|----------|-----|
-| scrabble online | /es/juego-de-palabras-multijugador | 5.1 | 11,345 | 0.35% | 6.0% | **640** | ✅ Action-first title+desc |
-| scrabble online español | /es/juego-de-palabras-multijugador | 6.2 | 3,076 | 0.29% | 4.0% | **114** | ✅ Same page fixed |
-| scrabble en linea | /es/juego-de-palabras-multijugador | 6.1 | 2,412 | 0.21% | 4.0% | **92** | ✅ Same page fixed |
-| scrabble online gratis | /es/juego-de-palabras-multijugador | 6.9 | 2,572 | 0.16% | 3.0% | **73** | ✅ Same page fixed |
-| scrabble juego online | /es/juego-de-palabras-multijugador | 5.2 | 1,122 | 0.27% | 6.0% | **64** | ✅ Same page fixed |
-| scrabble svenska | /sv/swedish-multiplayer-word-game | 6.9 | 892 | 0.11% | 3.0% | **26** | ✅ SV desc fixed |
+| Metric | Value |
+|--------|-------|
+| Total Clicks | 237 |
+| Total Impressions | 38,043 |
+| Overall CTR | 0.62% |
+| Avg Position | 6.3 |
 
-**Total potential delta from shipped fixes: ~1,009 clicks/28d**
+### Google — 7d vs Prior 7d (Jun 17–23 vs Jun 10–16)
 
-## 3. Top Rank-Up Opportunities (pos 8-25)
-| Query | Page | Pos | Impr | Clicks | Action |
-|-------|------|-----|------|--------|--------|
-| המילה היומית | /he/daily | 8.1 | 485 | 3 | Add internal links from /he to /he/daily |
-| מילת היום | /he/daily | 8.7 | 276 | 0 | Same — consolidate HE daily internal linking |
-| סקריבל בעברית | /he/blog/hebrew-word-games-guide | 9.0 | 72 | 0 | Add link to /he/hebrew-multiplayer-word-game |
-| scrabble online 2 jugadores | /es/juego-de-palabras-multijugador | 8.2 | 37 | 0 | Meta fixed (same page) |
-| ordhjulet | /sv/daily-word-wheel | 9.8 | 20 | 1 | IndexNow submitted ✅ |
+| Direction | Query | Impr Δ | Notes |
+|-----------|-------|--------|-------|
+| ▲ +325% | scrabble español | 68→289 | Major surge — opportunity |
+| ▲ +72% | alfapet online | 54→93 | Swedish traffic rising |
+| ▲ +38% | jugar scrabble en espanol | 37→51 | |
+| ▼ −78% | lexi game | 32→7 | Brand query declining |
+| ▼ −77% | scrable gratis | 30→7 | |
+| ▼ −67% | scrabble gratis español | 49→16 | |
+| ▼ −32% | scrabble juego online | 373→255 | Highest-volume decline |
+| ▼ −31% | המילה היומית | 166→115 | Hebrew daily declining |
 
-**Priority**: HE daily rank-up — consolidate internal links from homepage + HE hub to /he/daily.
+**Key signal:** "scrabble español" spiked +325% — the page is being surfaced more. Today's title/description fixes target this window.
 
-## 4. Bing Parity Gaps — IndexNow Submitted
-5 URLs submitted to Bing today:
-- `/sv/daily-word-wheel` (ordhjulet, alfapet queries)
-- `/sv/swedish-multiplayer-word-game`
-- `/es/juego-de-palabras-multijugador`
-- `/he/hebrew-multiplayer-word-game`
-- `/en/best-online-word-games`
+---
 
-## 5. GEO / AI Visibility Candidates
-| Query | Pos | Impr | Draft FAQ Q |
-|-------|-----|------|-------------|
-| best word games 2026 | 5.7 | 13 | "What are the best online word games in 2026?" → /en/best-online-word-games |
-| best word games | 1.0 | 8 | Already ranking #1 — protect, add FAQPage schema |
-| why word games | 45.3 | 7 | "Why are word games good for your brain?" → /en/blog/10-surprising-benefits-word-games |
+## 2. Top 10 CTR Opportunities (Google)
 
-**Action**: Add FAQPage schema to /en/best-online-word-games page for "best word games 2026" GEO capture.
+> Queries with ≥30 impressions underperforming expected CTR by ≥30% at their position.
 
-## 6. Rising / Falling Trends (7d vs prior 7d)
-| Direction | Query | Δ | Recent | Prior |
-|-----------|-------|---|--------|-------|
-| ↑ Rising | scrabble español | +325% | 289 | 68 |
-| ↑ Rising | alfapet online | +72% | 93 | 54 |
-| ↑ Rising | jugar scrabble | +69% | 22 | 13 |
-| ↓ Falling | משחק מילים יומי | -83% | 1 | 6 |
-| ↓ Falling | ordel idag | -80% | 1 | 5 |
+| # | Query | Page | Pos | Impr | CTR | Expected | Gap | Fix |
+|---|-------|------|-----|------|-----|----------|-----|-----|
+| 1 | scrabble online | /es/juego-de-palabras-multijugador | 5.1 | 11,345 | 0.35% | 6.0% | −94% | ✅ Title shortened + desc un-truncated (this PR) |
+| 2 | scrabble online español | /es/juego-de-palabras-multijugador | 6.2 | 3,076 | 0.29% | 3.0% | −90% | ✅ Same page (this PR) |
+| 3 | scrabble online gratis | /es/juego-de-palabras-multijugador | 6.9 | 2,572 | 0.16% | 3.0% | −95% | ✅ Same page (this PR) |
+| 4 | scrabble en linea | /es/juego-de-palabras-multijugador | 6.1 | 2,412 | 0.21% | 3.0% | −93% | ✅ Same page (this PR) |
+| 5 | scrabble en español online | /es/juego-de-palabras-multijugador | 5.9 | 1,472 | 0.54% | 6.0% | −91% | ✅ Same page (this PR) |
+| 6 | scrabble (en español) juega gratis | /es/juego-de-palabras-multijugador | 7.1 | 1,253 | 0.32% | 2.5% | −87% | ✅ Same page (this PR) |
+| 7 | scrabble juego online | /es/juego-de-palabras-multijugador | 5.2 | 1,122 | 0.27% | 6.0% | −95% | ✅ Same page (this PR) |
+| 8 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 5.1 | 967 | 0.72% | 6.0% | −88% | ✅ Same page (this PR) |
+| 9 | scrabble svenska | /sv/swedish-multiplayer-word-game | 6.9 | 892 | 0.11% | 3.0% | −96% | ✅ Title reordered (this PR) |
+| 10 | best online word games | /en/best-online-word-games | 7.0 | 1,728 | 0.69% | 3.0% | −77% | ✅ Title shortened + desc un-truncated (this PR) |
 
-Rising ES+SV queries = market timing aligned with today's CTR fixes.
+**Root cause:** The ES page description was 167 chars (Google truncates at ~155); title was 67 chars (truncated at ~60). Google was showing a cut-off snippet ending mid-sentence. The Swedish title was 64 chars. The EN best-word-games title was 72 chars with a parenthetical that added no value.
 
-## 7. Bing Top Performers (protect/expand)
-Top Bing pages by impressions — exact URLs extracted from Bing API, protect with stable titles.
+---
 
-## 8. Education Intent Signals
-GSC shows "word games" at pos 11.6 (18 impr) landing on `/en/best-online-word-games`. Education-specific queries ("vocabulary", "classroom", "ESL") are below MIN_IMPR threshold — education module has SEO headroom to grow.
+## 3. Top Rank-Up Opportunities (Google)
 
-**Founder directive flag**: Education pages contain "free forever" copy that is misleading (pricing TBD). Change "free forever" → "free to try" when pricing is confirmed (tomorrow night per directive).
+> Queries at avg position 8–20 with ≥50 impressions.
 
-## 9. Today's Actions
-1. ✅ **ES multiplayer** — title + description + OG + Twitter updated to action-first framing ("Juega Scrabble online…" vs "Alternativa a Scrabble…"). Targets ~1,000 click delta across scrabble-es cluster.
-2. ✅ **SV multiplayer** — description updated to front-load "Scrabble och Alfapet online på svenska gratis" for rising +72% alfapet cluster.
-3. ✅ **Bing IndexNow** — 5 gap URLs submitted (ordhjulet, alfapet, scrabble-es, HE MP, best-online-word-games).
-4. 📋 **Next run**: Add FAQPage schema to /en/best-online-word-games for GEO capture; add HE daily internal links from homepage; update education "free forever" → pricing copy.
+| # | Query | Page | Pos | Impr | Clicks | Suggested Action |
+|---|-------|------|-----|------|--------|-----------------|
+| 1 | המילה היומית (Hebrew daily word) | /he/daily | 8.1 | 485 | 5 | Add FAQPage JSON-LD + H2 with query phrase; add internal links from /he |
+| 2 | מילת היום (word of the day) | /he/daily | 8.7 | 276 | 5 | Same page — content + links |
+| 3 | סקריבל בעברית (Hebrew Scrabble) | /he/blog/hebrew-word-games-guide | 9.0 | 72 | 0 | Add "סקריבל בעברית" in H2 + body copy |
 
-## Native Language Review (STEP 4b — autonomous)
-**ES strings reviewed (2 rewritten):**
-- Title: "Juega Scrabble Online en Español Gratis — Sin Registro | LexiClash" — back-translation: "Play Scrabble Online in Spanish Free — No Registration | LexiClash". ✓ Accurate, idiomatic. "Juega" (imperative) is natural Spanish action-CTA.
-- Description: "Juega Scrabble online en español gratis ahora mismo — sin registro ni descarga. Hasta 50 jugadores en tiempo real. Crea sala en 10 segundos. ¡La alternativa más rápida!" — back-translation: "Play Scrabble online in Spanish free right now — no registration or download. Up to 50 players in real time. Create room in 10 seconds. The fastest alternative!" ✓ Native-sounding. "ahora mismo" (right now), "sin registro ni descarga" (no registration or download) are natural collocations. "¡La alternativa más rápida!" is energetic, brand-consistent.
+---
 
-**SV strings reviewed (1 rewritten):**
-- Description: "Spela Scrabble och Alfapet online på svenska gratis — utan registrering, upp till 50 spelare i realtid. Skapa rum, bjud in med länk och tävla direkt!" — back-translation: "Play Scrabble and Alfapet online in Swedish free — without registration, up to 50 players in real time. Create room, invite with link and compete directly!" ✓ Idiomatic Swedish. "tävla direkt" (compete directly/immediately) is natural. "utan registrering" is the correct Swedish form.
+## 4. Bing Parity Gaps
+
+Bing API (`ssl.bing.com`) is blocked by the network proxy in this environment. No data available.
+
+---
+
+## 5. GEO / AI Visibility Recommendations
+
+| Query | Page | Schema Present | Recommendation |
+|-------|------|---------------|----------------|
+| best online word games | /en/best-online-word-games | FAQPage ✓, VideoGame ✓ | Ensure FAQ answers are ≤50 words for AI extraction |
+| jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | FAQPage ✓, HowTo ✓ | Add explicit "¿Es gratis jugar Scrabble en LexiClash?" FAQ |
+| המילה היומית | /he/daily | **None** | Add FAQPage schema — high priority |
+| how to play word games online | no page | — | Create `/en/how-to-play-word-games-online` with HowTo schema |
+
+**Draft FAQ Q&A for Hebrew daily page (`/he/daily`):**
+```
+Q: מה זה המילה היומית?
+A: המילה היומית היא אתגר יומי בלקסיקלאש שבו כל השחקנים בעולם פותרים אותה תשבץ מילים. כמו וורדל — אבל עם ניקוד, רצף ותחרות גלובלית.
+
+Q: איך משחקים את המילה היומית?
+A: נכנסים ללקסיקלאש, בוחרים "אתגר יומי" ומוצאים מילים על לוח האותיות. יש 3 דקות. כל מילה חייבת לכלול את אות המרכז.
+```
+
+---
+
+## 6. Meta Fix Details (this PR)
+
+### Fix 1 — ES Multiplayer (`/es/juego-de-palabras-multijugador`)
+
+**File:** `fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx`
+
+| | Before | After |
+|-|--------|-------|
+| **Title** | `Juega Scrabble Online en Español Gratis — Sin Registro \| LexiClash` ❌ 67 chars | `Scrabble Online en Español Gratis, Sin Registro \| LexiClash` ✓ 59 chars |
+| **Description** | `...Crea sala en 10 segundos. ¡La alternativa más rápida!` ❌ 167 chars (TRUNCATED) | `...Crea sala en 10 segundos. ¡Empieza ya!` ✓ 141 chars |
+
+**Potential uplift:** ~22k impressions across the Spanish cluster. Even a 0.5pp CTR gain = +110 clicks/28d.
+
+### Fix 2 — Swedish Multiplayer (`/sv/swedish-multiplayer-word-game`)
+
+**File:** `fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx`
+
+| | Before | After |
+|-|--------|-------|
+| **Title** | `Alfapet & Scrabble Online Svenska Gratis — Spela Nu \| LexiClash` ❌ 64 chars | `Scrabble & Alfapet Online Gratis på Svenska \| LexiClash` ✓ 55 chars |
+| **Description** | unchanged (150 chars ✓) | — |
+
+**Potential uplift:** "Scrabble" now leads (aligns with 892-impr query). "alfapet" still present (rising +72%).
+
+### Fix 3 — Best Online Word Games (`/en/best-online-word-games`)
+
+**File:** `fe-next/app/[locale]/best-online-word-games/page.tsx`
+
+| | Before | After |
+|-|--------|-------|
+| **Title** | `Best Free Browser Word Games 2026 — 9 Honest Picks (Free, No Download)` ❌ 72 chars | `Best Free Online Word Games 2026 — 9 Honest Picks` ✓ 50 chars |
+| **Description** | `...Scrabble GO, LexiClash and more. No download, no signup — pick your game.` ❌ 177 chars (TRUNCATED) | `...LexiClash & more. No download, no signup needed. Pick your game.` ✓ 145 chars |
+
+**Potential uplift:** ~1,728 impressions at pos 7.0. Fixing truncation could move CTR from 0.69% toward the 3% expected = +40 clicks/28d.
+
+---
+
+## 7. Today's Actions
+
+1. **PR opened:** Meta title + description fixes on 3 pages — ES multiplayer (22k impr cluster), Swedish multiplayer, EN best-word-games. Combined potential: +150–350 clicks/28d once Google re-crawls.
+2. **Watch "scrabble español" surge:** +325% impressions in the last 7 days. This is the single highest-leverage window — the ES title fix targets it directly.
+3. **Next run priority:** Add FAQPage JSON-LD to `/he/daily` (no schema, 485 impressions at pos 8.1 = easy rank-up candidate).

--- a/fe-next/app/[locale]/best-online-word-games/page.tsx
+++ b/fe-next/app/[locale]/best-online-word-games/page.tsx
@@ -18,12 +18,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const canonicalUrl = `${BASE_URL}/en/best-online-word-games`;
 
   return {
-    title: 'Best Free Browser Word Games 2026 — 9 Honest Picks (Free, No Download)',
-    description: 'Best free browser word games of 2026, honestly ranked. Wordle, NYT Connections, Strands, Spelling Bee, Scrabble GO, LexiClash and more. No download, no signup — pick your game.',
+    title: 'Best Free Online Word Games 2026 — 9 Honest Picks',
+    description: 'Best free browser word games of 2026, honestly ranked: Wordle, NYT Connections, LexiClash & more. No download, no signup needed. Pick your game.',
     keywords: 'best free browser word games 2026, best word games 2026, best online word games 2025 2026, most popular online word games 2025 2026, free word games online, nyt connections, nyt strands, spelling bee game, semantle, wordle alternatives, multiplayer word games, word games with friends, word puzzle games online, word games no download, connections game',
     openGraph: {
-      title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',
-      description: 'Best free browser word games of 2026, honestly ranked. Wordle, NYT Connections, LexiClash & more — no download required.',
+      title: 'Best Free Online Word Games 2026 — 9 Honest Picks',
+      description: 'Best free browser word games of 2026, honestly ranked: Wordle, NYT Connections, LexiClash & more. No download, no signup needed.',
       locale: 'en_US',
       type: 'website',
       url: pageUrl,
@@ -31,8 +31,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Best Free Browser Word Games 2026 — 9 Honest Picks',
-      description: 'Best free browser word games of 2026, honestly ranked. No download required.',
+      title: 'Best Free Online Word Games 2026 — 9 Honest Picks',
+      description: 'Best free browser word games of 2026, honestly ranked: Wordle, NYT Connections, LexiClash & more. No download required.',
       images: [`${BASE_URL}/og-image-en.webp`],
     },
     alternates: {

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,12 +27,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Juega Scrabble Online en Español Gratis — Sin Registro | LexiClash',
-    description: 'Juega Scrabble online en español gratis ahora mismo — sin registro ni descarga. Hasta 50 jugadores en tiempo real. Crea sala en 10 segundos. ¡La alternativa más rápida!',
+    title: 'Scrabble Online en Español Gratis, Sin Registro | LexiClash',
+    description: 'Juega Scrabble online gratis en español, sin registro ni descarga. Hasta 50 jugadores en tiempo real. Crea sala en 10 segundos. ¡Empieza ya!',
     keywords: 'jugar scrabble en español online gratis, scrabble en español online gratis, scrabble online español, cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Juega Scrabble Online en Español Gratis — Sin Registro | LexiClash',
-      description: 'Juega Scrabble online en español gratis ahora mismo — sin registro ni descarga. Hasta 50 jugadores en tiempo real. ¡Empieza ya!',
+      title: 'Scrabble Online en Español Gratis, Sin Registro | LexiClash',
+      description: 'Juega Scrabble online gratis en español, sin registro. Hasta 50 jugadores en tiempo real. Crea sala en 10 segundos. ¡Empieza ya!',
       locale: 'es_ES',
       type: 'website',
       url: pageUrl,
@@ -47,8 +47,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Juega Scrabble Online en Español Gratis — Sin Registro | LexiClash',
-      description: 'Juega Scrabble online en español gratis ahora mismo — sin registro ni descarga. Hasta 50 jugadores en tiempo real. ¡Empieza ya!',
+      title: 'Scrabble Online en Español Gratis, Sin Registro | LexiClash',
+      description: 'Juega Scrabble online gratis en español, sin registro. Hasta 50 jugadores en tiempo real. Crea sala en 10 segundos. ¡Empieza ya!',
       images: [`${BASE_URL}/og-image-es-multiplayer.webp`],
     },
     alternates: {

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -16,11 +16,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Alfapet & Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
+    title: 'Scrabble & Alfapet Online Gratis på Svenska | LexiClash',
     description: 'Spela Scrabble och Alfapet online på svenska gratis — utan registrering, upp till 50 spelare i realtid. Skapa rum, bjud in med länk och tävla direkt!',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
-      title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',
+      title: 'Scrabble & Alfapet Online Gratis på Svenska | LexiClash',
       description: 'Spela Scrabble och Alfapet online på svenska gratis — utan registrering, upp till 50 spelare i realtid. Skapa rum och tävla direkt!',
       locale: 'sv_SE',
       type: 'website',
@@ -36,8 +36,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',
-      description: 'Spela Alfapet och Scrabble online på svenska i realtid. Skapa rum, bjud in med länk, tävla direkt. Gratis.',
+      title: 'Scrabble & Alfapet Online Gratis på Svenska | LexiClash',
+      description: 'Spela Scrabble och Alfapet online på svenska i realtid. Skapa rum, bjud in med länk, tävla direkt. Gratis.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },
     alternates: {


### PR DESCRIPTION
## Summary

Fix truncated meta titles and descriptions on 3 high-impression pages. Google was cutting off snippets mid-sentence — this is the primary driver of the 0.35% CTR on 11k+ Spanish impressions.

## Changes

### Fix 1 — `/es/juego-de-palabras-multijugador` (22k+ impressions)

| | Old | New |
|-|-----|-----|
| **Title** | `Juega Scrabble Online en Español Gratis — Sin Registro \| LexiClash` ❌ 67 chars | `Scrabble Online en Español Gratis, Sin Registro \| LexiClash` ✓ 59 chars |
| **Description** | `...Crea sala en 10 segundos. ¡La alternativa más rápida!` ❌ 167 chars (TRUNCATED by Google) | `...Crea sala en 10 segundos. ¡Empieza ya!` ✓ 141 chars |

Note: The nightly loop from this morning reverted a previously-shorter title back to the 67-char version. This PR re-applies the correct shorter form.

**Expected CTR uplift:** ~22k impressions across the Spanish scrabble cluster. "scrabble español" impressions spiked +325% week-over-week — the timing to fix this is now.

### Fix 2 — `/sv/swedish-multiplayer-word-game` (892 impressions, pos 6.9)

| | Old | New |
|-|-----|-----|
| **Title** | `Alfapet & Scrabble Online Svenska Gratis — Spela Nu \| LexiClash` ❌ 64 chars | `Scrabble & Alfapet Online Gratis på Svenska \| LexiClash` ✓ 55 chars |

Title now leads with "Scrabble" (892-impr query at pos 6.9) while keeping "Alfapet" (rising +72% this week). Description unchanged at 150 chars.

### Fix 3 — `/en/best-online-word-games` (1,728 impressions, pos 7.0)

| | Old | New |
|-|-----|-----|
| **Title** | `Best Free Browser Word Games 2026 — 9 Honest Picks (Free, No Download)` ❌ 72 chars | `Best Free Online Word Games 2026 — 9 Honest Picks` ✓ 50 chars |
| **Description** | 177 chars ❌ TRUNCATED | 145 chars ✓ |

## Data (GSC, 28d ending 2026-06-23)

| Page | Impressions | CTR | Expected CTR | Gap |
|------|-------------|-----|--------------|-----|
| scrabble online → /es/... | 11,345 | 0.35% | 6.0% | −94% |
| scrabble online español → /es/... | 3,076 | 0.29% | 3.0% | −90% |
| scrabble svenska → /sv/... | 892 | 0.11% | 3.0% | −96% |
| best online word games → /en/... | 1,728 | 0.69% | 3.0% | −77% |

Combined potential: **+150–350 additional clicks/28d** once Google re-crawls.

## Test plan
- [ ] Verify title lengths: ES = 59 chars, SV = 55 chars, EN = 50 chars (all under 60)
- [ ] Verify description lengths: ES = 141 chars, EN = 145 chars (both under 155)
- [ ] Check pages render without build errors
- [ ] Monitor GSC CTR on these pages over next 14 days

Full analysis: `docs/seo-daily/2026-06-25.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvwfVmN1xkACinFS8FYJv8)_