### PR TITLE
fix(word-wheel): restore radial gradient backdrop behind the wheel

### DIFF
--- a/fe-next/components/daily/WordWheelGame.tsx
+++ b/fe-next/components/daily/WordWheelGame.tsx
@@ -981,6 +981,23 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
         onPointerCancel={handlePointerUp}
         onPointerLeave={handlePointerUp}
       >
+        {/* Depth backdrop disc — an always-on radial gradient centred on the
+            wheel. The orbit box carries no fill of its own and the stage's
+            radial gradient peaks above the wheel, so without this the disc
+            behind the letters read as flat solid black. Elevated navy center
+            (#2a2a4e) fading out to transparent lifts the disc above the navy
+            edge while still blending into the stage. zIndex -10 keeps it behind
+            the pixi layer, the rings, and every letter. */}
+        <div
+          data-testid="wheel-backdrop"
+          aria-hidden
+          className="absolute -inset-6 rounded-full pointer-events-none"
+          style={{
+            zIndex: -10,
+            background:
+              'radial-gradient(circle at center, var(--neo-navy-elevated) 0%, var(--neo-navy) 58%, transparent 78%)',
+          }}
+        />
         {/* PixiJS wheel decorations: orbital rings + connection lines */}
         <WordWheelPixiRing
           selectedIndices={builtLetters.map(bl => bl.wheelIndex)}

--- a/fe-next/components/daily/__tests__/WordWheelGame.wheelBackdrop.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelGame.wheelBackdrop.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Wheel backdrop depth regression.
+ *
+ * Bug: the circular play area behind the letter wheel read as flat solid
+ * black. The wheel-orbit box itself carries no background — it relied on the
+ * stage-level radial gradient showing through. But the wheel sits lower than
+ * the stage gradient's bright center and is ringed by additive glow, so the
+ * disc behind the letters read as near-black instead of the gradient depth it
+ * used to have.
+ *
+ * Fix contract: the wheel-orbit must contain an always-on radial-gradient
+ * backdrop disc (centered on the wheel) so the letters sit on visible depth
+ * regardless of the stage gradient or pixi layer.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/utils/growthTracking', () => ({
+  trackGameStart: vi.fn(),
+  trackGameEnd: vi.fn(),
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ language: 'en', t: (k: string) => k }),
+}));
+
+vi.mock('@/contexts/SoundEffectsContext', () => ({
+  useSoundEffects: () => ({
+    playTileSelectSound: vi.fn(),
+    playWordAcceptedSound: vi.fn(),
+    playWordRejectedSound: vi.fn(),
+    playComboSound: vi.fn(),
+    playLegendaryWordSound: vi.fn(),
+    playEpicVictorySound: vi.fn(),
+    playCountdownBeep: vi.fn(),
+    playBoardShuffleSound: vi.fn(),
+    playButtonClickSound: vi.fn(),
+    playWordLengthSound: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useWordWheelKeyboard', () => ({
+  useWordWheelKeyboard: () => ({ keyboardFocused: false }),
+}));
+
+vi.mock('@/hooks/useEquippedCosmetic', () => ({
+  useEquippedCosmetic: () => null,
+}));
+
+vi.mock('../WordWheelPixiRing', () => ({
+  __esModule: true,
+  default: () => <div data-testid="pixi-ring-stub" />,
+}));
+
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => () => <div data-testid="dynamic-stub" />,
+}));
+
+vi.mock('@/utils/dailyChallenge/wordWheelGeneration', () => ({
+  isValidWordWheelWord: () => true,
+}));
+
+vi.mock('@/utils/dailyChallenge/wordWheelScoring', () => ({
+  scoreWord: (w: string) => w.length,
+}));
+
+import WordWheelGame from '../WordWheelGame';
+
+const puzzle = {
+  centerLetter: 'A',
+  outerLetters: ['C', 'T', 'R', 'S', 'N', 'E'],
+  allLetters: ['A', 'C', 'T', 'R', 'S', 'N', 'E'],
+} as unknown as Parameters<typeof WordWheelGame>[0]['puzzle'];
+
+describe('WordWheelGame — wheel backdrop depth', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  it('renders an always-on radial-gradient backdrop disc behind the wheel', () => {
+    const { container } = render(
+      <WordWheelGame
+        puzzle={puzzle}
+        duration={120}
+        onComplete={vi.fn()}
+        onValidateWord={vi.fn().mockResolvedValue(true)}
+        onEffect={vi.fn()}
+        language="en"
+      />,
+    );
+
+    const orbit = container.querySelector('[data-testid="wheel-orbit"]')!;
+    expect(orbit).toBeTruthy();
+
+    const backdrop = orbit.querySelector('[data-testid="wheel-backdrop"]') as HTMLElement | null;
+    expect(backdrop).toBeTruthy();
+
+    // A radial gradient that lifts the disc center above the flat-black navy
+    // edge — NOT a solid fill.
+    expect(backdrop!.style.background).toContain('radial-gradient');
+    expect(backdrop!.style.background).toContain('--neo-navy-elevated');
+  });
+});


### PR DESCRIPTION
The circular play area behind the letter wheel read as flat solid black.
The wheel-orbit box carries no fill of its own and relied on the
stage-level radial gradient showing through — but the wheel sits below
the stage gradient's bright center and is ringed by additive glow, so the
disc behind the letters read as near-black instead of the gradient depth.

Add an always-on radial-gradient backdrop disc centered on the wheel
(elevated navy center fading to transparent, zIndex -10 so it stays behind
the pixi layer, rings, and letters). TDD test added.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BbM7uiPZaCZS9YSaWC4UWG