### PR TITLE
fix(word-wheel): real ambient backdrop — root-cause the flat-black stage

### DIFF
--- a/fe-next/components/daily/WordWheelChallenge.tsx
+++ b/fe-next/components/daily/WordWheelChallenge.tsx
@@ -77,6 +77,29 @@ function CensorTile({ seed, avoid }: { seed: number; avoid?: string }) {
 
 const WORD_WHEEL_DURATION = 120; // 2 minutes
 
+// Always-on ambient backdrop for the Word Wheel stage.
+//
+// Root cause this replaces: depth used to lean on (a) a navy-only radial
+// gradient whose center sat only ~16 luminance above the edge — imperceptible
+// on-device, so it read as flat black no matter which navy token was the
+// center; and (b) the pixi bokeh, which only paints during `phase==='playing'`
+// and is faint. Neither delivered perceptible, phase-independent ambient depth,
+// so the stage kept regressing to "black".
+//
+// This is a layered CSS backdrop, painted top-most layer first:
+//   1. lime glow blooming from the top (brand primary)
+//   2. cyan glow rising from the bottom
+//   3. soft violet glow lower-right for color depth
+//   4. depth gradient: elevated-navy center → navy → abyss (#0a0a1a) at the
+//      edges, a real vignette that makes the board pop.
+// Always-on + phase-independent → genuine ambient feel on ready/playing/results
+// without depending on the pixi layer.
+const STAGE_AMBIENT_BG =
+  'radial-gradient(125% 75% at 50% -8%, rgba(191,255,0,0.10) 0%, transparent 55%),' +
+  'radial-gradient(115% 70% at 50% 108%, rgba(0,255,255,0.08) 0%, transparent 55%),' +
+  'radial-gradient(70% 55% at 85% 82%, rgba(139,92,246,0.07) 0%, transparent 60%),' +
+  'radial-gradient(circle at 50% 42%, var(--neo-navy-elevated) 0%, var(--neo-navy) 55%, var(--neo-abyss) 100%)';
+
 // ==========================================
 // Word Wheel Challenge Orchestrator
 // ==========================================
@@ -429,10 +452,7 @@ const WordWheelChallenge: React.FC = () => {
     return (
       <div
         className="flex-1 flex items-center justify-center bg-neo-navy"
-        style={{
-          background:
-            'radial-gradient(circle at center, var(--neo-navy-elevated) 0%, var(--neo-navy) 70%)',
-        }}
+        style={{ background: STAGE_AMBIENT_BG }}
       >
         <PageLoader size="lg" text={t('wordWheel.loading')} />
       </div>
@@ -444,19 +464,12 @@ const WordWheelChallenge: React.FC = () => {
       ref={containerRef}
       data-testid="word-wheel-stage"
       className="relative flex-1 flex flex-col bg-neo-navy min-h-0 overflow-hidden"
-      // Depth background: a radial gradient from --neo-navy-elevated (#2a2a4e,
-      // center) out to --neo-navy (#1a1a2e, edges). The pixi bokeh layer only
-      // paints during play and fades in slowly, so without an always-on CSS
-      // backdrop the stage exposed flat near-black navy on the ready/loading
-      // screens and the first moments of play. An earlier pass used
-      // --neo-navy-radial (#1e1e3f) as the center, but it sits only ~5
-      // luminance above the navy edge — imperceptible, so the stage still read
-      // as solid black. The elevated center (~17 luminance above the edge)
-      // gives genuine, phase-independent depth.
-      style={{
-        background:
-          'radial-gradient(circle at center, var(--neo-navy-elevated) 0%, var(--neo-navy) 70%)',
-      }}
+      // Layered, always-on ambient backdrop (see STAGE_AMBIENT_BG): a
+      // depth-to-abyss vignette plus soft brand-colored glows. Replaces the
+      // old navy-only gradient, whose elevated/radial center sat too close to
+      // the navy edge to register on-device — so the stage kept reading as
+      // flat black with no ambient feel regardless of which navy token it used.
+      style={{ background: STAGE_AMBIENT_BG }}
     >
       {/* Subtle dot pattern — adds texture/depth over the gradient */}
       <div

--- a/fe-next/components/daily/__tests__/WordWheelChallenge.background.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelChallenge.background.test.tsx
@@ -1,21 +1,21 @@
 /**
- * Background depth regression.
+ * Background depth + ambient regression (root-cause fix).
  *
- * Bug: the Word Wheel play area read as a flat solid black background. The
- * container was a plain `bg-neo-navy` (#1a1a2e) and the only ambient depth
- * came from the pixi bokeh layer — which only renders during `phase==='playing'`
- * and fades in slowly, so the ready/loading screens (and the first moments of
- * play) exposed flat near-black navy.
+ * Bug: the Word Wheel play area read as a flat solid black background with no
+ * ambient feel. Depth relied on two inadequate sources:
+ *   1. A navy-only radial gradient. Successive fixes swapped its center token
+ *      (`--neo-navy-radial` #1e1e3f → `--neo-navy-elevated` #2a2a4e) but both
+ *      sit too close to the `--neo-navy` (#1a1a2e) edge to register on-device,
+ *      so the stage kept reading as flat black — the regression kept returning.
+ *   2. The PixiJS bokeh layer, which only paints during `phase==='playing'` and
+ *      is sparse/faint, so the broad "ambient feel" was effectively absent.
  *
- * An earlier fix added a radial gradient but ran it from `--neo-navy-radial`
- * (#1e1e3f) to `--neo-navy` (#1a1a2e) — only ~5 relative-luminance apart, i.e.
- * imperceptible, so the stage STILL read as flat black and the regression kept
- * coming back.
- *
- * Fix: run the radial gradient from a perceptibly-elevated center
- * (`--neo-navy-elevated`, #2a2a4e, ~17 luminance above the navy edge) out to
- * `--neo-navy`. This is CSS, always-on, and phase-independent, so the board
- * reads with real depth instead of flat black regardless of the pixi layer.
+ * Root-cause fix: stop leaning on an imperceptible navy delta and a play-only
+ * particle layer. The stage now carries a layered, always-on ambient backdrop:
+ *   - a depth gradient from the elevated navy center out to `--neo-abyss`
+ *     (#0a0a1a) at the edges — a real vignette that makes the board pop, and
+ *   - soft brand-colored glows (lime + cyan + violet) that give genuine ambient
+ *     energy on EVERY phase (ready / playing / results), independent of pixi.
  */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -113,16 +113,23 @@ afterEach(() => {
 import WordWheelChallenge from '../WordWheelChallenge';
 
 describe('WordWheelChallenge background', () => {
-  it('gives the stage a radial depth gradient with a perceptibly-elevated center', async () => {
+  it('gives the stage a layered ambient backdrop: depth-to-abyss vignette + brand glows', async () => {
     render(<WordWheelChallenge />);
 
     const stage = await waitFor(() => screen.getByTestId('word-wheel-stage'));
+    const bg = stage.style.background;
 
-    // The container must carry a radial depth gradient whose center is the
-    // elevated navy (#2a2a4e) — NOT navy-radial (#1e1e3f), which sits only ~5
-    // luminance above the navy edge and so reads as flat black.
-    expect(stage.style.background).toContain('radial-gradient');
-    expect(stage.style.background).toContain('--neo-navy-elevated');
-    expect(stage.style.background).not.toContain('--neo-navy-radial');
+    // Depth layer: elevated navy center vignetting out to the deep-space abyss
+    // edge (#0a0a1a) — a perceptible vignette, NOT the old navy-only delta that
+    // sat too close to the edge and read as flat black.
+    expect(bg).toContain('radial-gradient');
+    expect(bg).toContain('--neo-navy-elevated');
+    expect(bg).toContain('--neo-abyss');
+    expect(bg).not.toContain('--neo-navy-radial');
+
+    // Ambient color: soft brand glows give phase-independent "ambient feel"
+    // instead of leaning on the play-only pixi bokeh. Lime + cyan at minimum.
+    expect(bg).toContain('rgba(191,255,0'); // lime glow
+    expect(bg).toContain('rgba(0,255,255'); // cyan glow
   });
 });


### PR DESCRIPTION
The daily Word Wheel stage read as flat black with no ambient feel. Depth
leaned on two inadequate sources:
  1. a navy-only radial gradient whose center (--neo-navy-radial, then
     --neo-navy-elevated) sat only ~16 luminance above the --neo-navy edge —
     imperceptible on-device, so it kept reading as flat black no matter which
     navy token was the center (hence the repeat "fix black bg" commits); and
  2. the pixi bokeh layer, which only paints during phase==='playing' and is
     sparse/faint, so the broad ambient feel was effectively absent.

Root-cause fix: give the stage a layered, always-on ambient backdrop —
a depth-to-abyss vignette (elevated-navy center → navy → #0a0a1a edges) plus
soft brand glows (lime top, cyan bottom, violet lower-right). Perceptible and
phase-independent (ready / playing / results) without depending on pixi.
Applied to both the loading and main stage so every phase shares the backdrop.

TDD: WordWheelChallenge.background.test.tsx updated to lock the new
contract — depth vignette to --neo-abyss + lime/cyan ambient glows.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F4drqXK3XDoQFJbNC9vM2e