### PR TITLE
feat(mp-lobby): on-avatar emotes, expandable mode cards, leaner top/ads

### DIFF
--- a/fe-next/app/[locale]/multiplayer/PageClient.tsx
+++ b/fe-next/app/[locale]/multiplayer/PageClient.tsx
@@ -592,7 +592,11 @@ export default function MultiplayerPageClient(): React.JSX.Element {
               </>
             )
           ) : (
-            <AutoHideHeader />
+            // Active lobby/in-game uses a full-bleed immersive layout with its
+            // own sticky header — the AutoHideHeader spacer would just stack dead
+            // space above the lobby's top accent bar. Drop it while active (keep
+            // it for the room list + results so their CLS reservation holds).
+            (isActive && !showResults) ? null : <AutoHideHeader />
           )}
           {renderView()}
           <HostLeftGraceModal

--- a/fe-next/host/__tests__/HostPreGameView.classroomMode.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.classroomMode.test.tsx
@@ -20,7 +20,7 @@ const { setHostSelectedGameModeMock } = vi.hoisted(() => ({
 }));
 
 const emitMock = vi.fn();
-const mockSocket = { emit: emitMock } as unknown as { emit: (...args: unknown[]) => void };
+const mockSocket = { emit: emitMock, on: vi.fn(), off: vi.fn() } as unknown as { emit: (...args: unknown[]) => void };
 
 vi.mock('../../utils/SocketContext', () => ({ useSocket: () => ({ socket: mockSocket }) }));
 vi.mock('../../contexts/AuthContext', () => ({

--- a/fe-next/host/__tests__/HostPreGameView.lobbyReactions.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.lobbyReactions.test.tsx
@@ -1,10 +1,10 @@
 import { vi } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import HostPreGameView from '../components/HostPreGameView';
 
 const emitMock = vi.fn();
-const mockSocket = { emit: emitMock } as unknown as { emit: (...args: unknown[]) => void };
+const mockSocket = { emit: emitMock, on: vi.fn(), off: vi.fn() } as unknown as { emit: (...args: unknown[]) => void };
 
 vi.mock('../../utils/SocketContext', () => ({
   useSocket: () => ({ socket: mockSocket }),
@@ -66,7 +66,11 @@ vi.mock('../components/pre-game/PresetSelector', () => ({
     challenge: { timer: 5, difficulty: 'HARD', nameKey: 'hostView.presetPro' },
   },
 }));
-vi.mock('../components/pre-game/PlayerRoster', () => ({ PlayerRoster: () => null }));
+// Render the roster's self-actions slot so the host emote tray flows through.
+vi.mock('../components/pre-game/PlayerRoster', () => ({
+  PlayerRoster: ({ selfActions }: { selfActions?: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'roster-mock' }, selfActions as React.ReactNode),
+}));
 vi.mock('../components/pre-game/BattleModeCard', () => ({ BattleModeCard: () => null }));
 vi.mock('../components/pre-game/StartButton', () => ({ StartButton: () => null }));
 vi.mock('../components/pre-game/MobileBottomNav', () => ({ MobileBottomNav: () => null }));
@@ -74,22 +78,15 @@ vi.mock('../components/pre-game/MobileShareSection', () => ({ MobileShareSection
 vi.mock('../components/pre-game/LobbyAudioButton', () => ({ LobbyAudioButton: () => null }));
 vi.mock('../components/pre-game/PresetInfoDrawer', () => ({ PresetInfoDrawer: () => null }));
 vi.mock('../components/pre-game/desktop', () => ({
-  DesktopLobbyLayout: () => null,
+  DesktopLobbyLayout: ({ leftContent }: { leftContent?: React.ReactNode }) =>
+    React.createElement('div', null, leftContent as React.ReactNode),
   SettingsPanel: () => null,
   InviteCard: () => null,
   EnhancedPlayerList: () => null,
 }));
-
-// Capture the props HostPreGameView passes to LobbyReactions.
-const lobbyReactionsProps: Array<Record<string, unknown>> = [];
-vi.mock('@/components/lobby/LobbyReactions', () => ({
-  LobbyReactions: (props: Record<string, unknown>) => {
-    lobbyReactionsProps.push(props);
-    return null;
-  },
-}));
-vi.mock('@/components/lobby/LobbyRewardCluster', () => ({ LobbyRewardCluster: () => null }));
-vi.mock('../components/HostPreGameView.useAvatarPremium', () => ({ useAvatarPremium: () => ({ allowed: true }) }), { virtual: true });
+// Avatar-part reward is the relocated lobby ad — stubbed (heavy deps) so the
+// emote-tray assertions stay focused.
+vi.mock('@/components/avatar/LobbyAvatarRewardButton', () => ({ LobbyAvatarRewardButton: () => null }));
 
 const mockT = (key: string) => key;
 
@@ -126,43 +123,28 @@ const baseProps = {
   tournamentCreating: false,
 };
 
-describe('HostPreGameView lobby emote (LobbyReactions send tray)', () => {
+describe('HostPreGameView lobby emote (avatar emotion picker)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    lobbyReactionsProps.length = 0;
   });
 
-  it('lets a PLAYING host send reactions (receiveOnly falsy) when hostPlaying=true', () => {
-    render(<HostPreGameView {...baseProps} hostPlaying />);
-
-    const props = lobbyReactionsProps.at(-1);
-    expect(props).toBeDefined();
-    expect(props!.username).toBe('Host');
-    // Playing host is a competitor → must be able to fling emoji, not just watch.
-    expect(props!.receiveOnly).toBeFalsy();
-  });
-
-  it('lets a scoreboard host (hostPlaying=false) send reactions too', () => {
-    // HostPreGameView always runs on the host's own interactive device (true
-    // cast-to-TV is the separate tv-broadcast/ components). A scoreboard host is
-    // still a present person watching the lobby, so they must be able to fling
-    // emoji like everyone else — not be stuck in receive-only.
-    render(<HostPreGameView {...baseProps} hostPlaying={false} />);
-
-    const props = lobbyReactionsProps.at(-1);
-    expect(props).toBeDefined();
-    expect(props!.receiveOnly).toBeFalsy();
-  });
-
-  it('anchors the emote trigger as a fixed floating button, not an in-flow orphan', () => {
-    // The trigger used to render bare at the end of the root div, dropping into
-    // document flow below the sticky start bar — a lone emoji floating bottom-left
-    // that broke the layout. It must be a deliberate fixed-position FAB instead.
+  it('removes the old floating emoji FAB', () => {
     render(<HostPreGameView {...baseProps} />);
+    // The reaction toy was replaced by an on-avatar emote picker — no orphan FAB.
+    expect(screen.queryByTestId('host-lobby-emote-fab')).toBeNull();
+  });
 
-    const fab = screen.getByTestId('host-lobby-emote-fab');
-    expect(fab.className).toContain('fixed');
-    // Mirrors the chat bubble (bottom corner), so the two FABs frame the start bar.
-    expect(fab.className).toMatch(/bottom-/);
+  it('renders an emote tray so the host can change their avatar emotion', () => {
+    render(<HostPreGameView {...baseProps} />);
+    // EmoteTray is fed through the roster self-actions slot.
+    expect(screen.getAllByTestId('emote-tray').length).toBeGreaterThan(0);
+  });
+
+  it('emits a lobbyEmote over the socket when the host picks an emote', () => {
+    render(<HostPreGameView {...baseProps} />);
+    // Tap the first emote face → server-echoed lobbyEmote drives the face-swap.
+    const laugh = screen.getAllByLabelText('lobby.emote.laugh')[0];
+    fireEvent.click(laugh);
+    expect(emitMock).toHaveBeenCalledWith('lobbyEmote', { emote: 'emoteLaugh' });
   });
 });

--- a/fe-next/host/__tests__/HostPreGameView.quickPlay.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.quickPlay.test.tsx
@@ -4,7 +4,7 @@ import { act, render } from '@testing-library/react';
 import HostPreGameView from '../components/HostPreGameView';
 
 const emitMock = vi.fn();
-const mockSocket = { emit: emitMock } as unknown as { emit: (...args: unknown[]) => void };
+const mockSocket = { emit: emitMock, on: vi.fn(), off: vi.fn() } as unknown as { emit: (...args: unknown[]) => void };
 
 vi.mock('../../utils/SocketContext', () => ({
   useSocket: () => ({ socket: mockSocket }),

--- a/fe-next/host/__tests__/HostPreGameView.soloHostStart.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.soloHostStart.test.tsx
@@ -4,7 +4,7 @@ import { act, render, screen } from '@testing-library/react';
 import HostPreGameView from '../components/HostPreGameView';
 
 const emitMock = vi.fn();
-const mockSocket = { emit: emitMock } as unknown as { emit: (...args: unknown[]) => void };
+const mockSocket = { emit: emitMock, on: vi.fn(), off: vi.fn() } as unknown as { emit: (...args: unknown[]) => void };
 
 // Capture the props the StartButton is rendered with so we can assert its
 // disabled state AND invoke its onStartGame exactly as a real click would.

--- a/fe-next/host/components/HostPreGameView.tsx
+++ b/fe-next/host/components/HostPreGameView.tsx
@@ -8,7 +8,9 @@ import { useCrazyGames } from '@/components/CrazyGamesSDK';
 import { useSocket } from '../../utils/SocketContext';
 import { useGameActions, useGameMode, useHostSelectedGameMode } from '@/hooks/gameState';
 import { useAuth } from '@/contexts/AuthContext';
-import { LobbyRewardCluster } from '@/components/lobby/LobbyRewardCluster';
+import { LobbyAvatarRewardButton } from '@/components/avatar/LobbyAvatarRewardButton';
+import { EmoteTray } from '@/player/components/lobby/EmoteTray';
+import { useLobbyEmotes } from '@/hooks/useLobbyEmotes';
 import { useLobbyAdGate } from '@/hooks/useLobbyAdGate';
 import { QuickLanguageSwitcher } from '@/components/QuickLanguageSwitcher';
 
@@ -26,7 +28,6 @@ import { DesktopLobbyLayout, InviteCard } from './pre-game/desktop';
 import { GameInstructions } from './pre-game/GameInstructions';
 import TvTutorialOverlay, { isTvTutorialComplete } from './tv-broadcast/TvTutorialOverlay';
 import { ChatBubble } from './pre-game/ChatBubble';
-import { LobbyReactions } from '@/components/lobby/LobbyReactions';
 import dynamic from 'next/dynamic';
 const AvatarBuilderModal = dynamic(() => import('@/components/avatar/AvatarBuilderModal'), { ssr: false });
 import { useAvatarPremium } from '@/hooks/useAvatarPremium';
@@ -193,6 +194,27 @@ function HostPreGameView({
   }, [username, onNameChange]);
 
   const handleOpenAvatarBuilder = useCallback(() => setIsAvatarBuilderOpen(true), []);
+
+  // Lobby emotes — the host changes their OWN avatar's emotion (face-swap) and
+  // the server echoes it to the whole room. Replaces the old floating-emoji FAB:
+  // the expression lives ON the avatar, the same affordance every player has.
+  const { sendEmote, cooldownActive } = useLobbyEmotes({ socket });
+
+  // Self-only lobby actions rendered beneath the roster avatars: an emote picker
+  // (change your avatar's emotion) + the rewarded daily-avatar-part claim. The
+  // avatar-part ad replaces the redundant "+20 gold" lobby ad — an ad that earns
+  // a piece of the avatar, surfaced right where the avatar lives.
+  const selfRosterActions = (
+    <div className="flex flex-col items-center gap-2 pt-1">
+      <div className="w-full space-y-1.5">
+        <h4 className="px-1 text-center text-[10px] font-bold uppercase tracking-widest text-neo-cream/50">
+          {t('lobby.emote.title')}
+        </h4>
+        <EmoteTray onEmote={sendEmote} t={t} disabled={cooldownActive} />
+      </div>
+      <LobbyAvatarRewardButton />
+    </div>
+  );
 
   const [hasInitialized, setHasInitialized] = useState(false);
   const [showTvTutorial, setShowTvTutorial] = useState(false);
@@ -610,6 +632,7 @@ function HostPreGameView({
                     onSelfNameChange={handleSelfNameChange}
                     canEditSelfName={!isAuthenticated}
                     headerExtra={tvModeToggle}
+                    selfActions={selfRosterActions}
                   />
                 </div>
                 <div className="animate-fade-in-up" style={{ animationDelay: '80ms' }}>
@@ -650,7 +673,6 @@ function HostPreGameView({
               </p>
             )}
             <div className="flex items-center gap-3">
-              <LobbyRewardCluster surface="host_waiting" />
               <div className="flex-1">
                 <StartButton
                   onStartGame={handleStartClick}
@@ -684,6 +706,7 @@ function HostPreGameView({
                 onSelfAvatarClick={handleOpenAvatarBuilder}
                 onSelfNameChange={handleSelfNameChange}
                 canEditSelfName={!isAuthenticated}
+                selfActions={selfRosterActions}
               />
               <BattleModeCard
                 selectedGameMode={selectedGameMode}
@@ -710,9 +733,6 @@ function HostPreGameView({
               </p>
             )}
             <div className="max-w-[600px] mx-auto flex flex-col short:flex-row short:items-stretch gap-2">
-              <div className="short:shrink-0 short:w-auto">
-                <LobbyRewardCluster surface="host_waiting" />
-              </div>
               <div className="short:flex-1 short:min-w-0">
                 <StartButton
                   onStartGame={handleStartClick}
@@ -737,18 +757,6 @@ function HostPreGameView({
         premium={avatarPremium}
       />
       <ChatBubble gameCode={gameCode} username={username} isHost t={t} />
-      {/* The host is a present person on their own device (true cast-to-TV is the
-          separate tv-broadcast/ components), so they can fling emoji whether they
-          play or just run the scoreboard — same ambient delight as every player.
-          Anchor the trigger as a fixed floating button mirroring the chat bubble on
-          the opposite (start) corner — otherwise it drops into document flow and
-          orphans as a lone emoji below the sticky start bar, breaking the layout. */}
-      <div
-        data-testid="host-lobby-emote-fab"
-        className="fixed bottom-20 start-4 lg:bottom-6 lg:start-6 z-40"
-      >
-        <LobbyReactions username={username} />
-      </div>
     </div>
   );
 }

--- a/fe-next/host/components/pre-game/BattleModeCard.tsx
+++ b/fe-next/host/components/pre-game/BattleModeCard.tsx
@@ -126,10 +126,12 @@ export function BattleModeCard({
       <h3 className="text-[10px] font-bold uppercase tracking-widest text-neo-cream/50 px-0.5">
         {t('hostView.battleMode')}
       </h3>
-      {/* Showcase cards: each mode shows its own icon + name + one-line rule.
-          2-col on mobile, 3-col on wide rails — the per-card vertical layout
-          gives long labels (e.g. Spanish "CAZA DE PALABRAS") room to wrap, so
-          they no longer overflow as they did in the old single-row chips. */}
+      {/* Compact picker: every mode is a short icon + name chip, so the whole
+          grid stays low. ONLY the selected mode expands to reveal its one-line
+          rule — tapping a card both selects it and shows the details, instead of
+          every card permanently spending two lines on a description. 2-col on
+          mobile, 3-col on wide rails; long labels (e.g. Spanish "CAZA DE
+          PALABRAS") still wrap without overflowing. */}
       <div className="grid grid-cols-2 lg:grid-cols-3 gap-1.5">
         {visibleModes.map(({ mode, icon, nameKey, activeBg }) => {
             const isActive = selectedGameMode === mode;
@@ -138,12 +140,13 @@ export function BattleModeCard({
               <m.button
                 key={mode}
                 type="button"
+                layout
                 whileTap={{ scale: 0.97 }}
                 onClick={() => handleSelect(mode)}
                 data-testid={`game-mode-${mode}`}
                 aria-pressed={isActive}
                 className={cn(
-                  'flex flex-col items-start gap-1.5 p-2.5 rounded-xl border-2 text-left transition-all',
+                  'flex flex-col items-start gap-1 p-2 rounded-xl border-2 text-left transition-colors',
                   isActive
                     ? `${activeBg} border-neo-black shadow-hard-lg`
                     : 'bg-white/5 border-neo-white/15 hover:border-neo-white/30 hover:bg-white/10'
@@ -180,14 +183,21 @@ export function BattleModeCard({
                     )}
                   </AnimatePresence>
                 </div>
-                <span
-                  className={cn(
-                    'text-[10px] leading-snug line-clamp-2',
-                    isActive ? 'text-neo-black/70' : 'text-neo-cream/45'
+                {/* Details reveal only for the selected mode — keeps the grid short. */}
+                <AnimatePresence initial={false}>
+                  {isActive && (
+                    <m.span
+                      key="desc"
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: 'auto' }}
+                      exit={{ opacity: 0, height: 0 }}
+                      transition={{ duration: 0.18 }}
+                      className="block overflow-hidden text-[10px] leading-snug text-neo-black/70"
+                    >
+                      {getModeDescription(mode, t)}
+                    </m.span>
                   )}
-                >
-                  {getModeDescription(mode, t)}
-                </span>
+                </AnimatePresence>
               </m.button>
             );
           })}

--- a/fe-next/host/components/pre-game/PlayerRoster.tsx
+++ b/fe-next/host/components/pre-game/PlayerRoster.tsx
@@ -39,6 +39,8 @@ interface PlayerRosterProps {
   canEditSelfName?: boolean;
   /** Optional element rendered on the right side of the header row (e.g., TV/projector toggle) */
   headerExtra?: React.ReactNode;
+  /** Optional self-only controls rendered beneath the avatar grid (e.g., emote picker + avatar reward) */
+  selfActions?: React.ReactNode;
   /** Usernames the server reports as lobby-ready (non-host). Shows check badges + a count. */
   readyUsernames?: string[];
 }
@@ -89,7 +91,7 @@ const reducedMotionVariants = {
   exit: { opacity: 0, transition: { duration: 0 } },
 };
 
-export const PlayerRoster = memo(function PlayerRoster({ players, username, gameCode, maxPlayers, t, compact = false, onSelfAvatarClick, onSelfNameChange, canEditSelfName = false, headerExtra, readyUsernames = [] }: PlayerRosterProps): React.ReactElement {
+export const PlayerRoster = memo(function PlayerRoster({ players, username, gameCode, maxPlayers, t, compact = false, onSelfAvatarClick, onSelfNameChange, canEditSelfName = false, headerExtra, selfActions, readyUsernames = [] }: PlayerRosterProps): React.ReactElement {
   const { socket } = useSocket();
 
   // Receive lobby emotes from players and render them on the roster avatars.
@@ -390,6 +392,8 @@ export const PlayerRoster = memo(function PlayerRoster({ players, username, game
           </div>
         )}
       </div>
+
+      {selfActions ? <div className="pt-1">{selfActions}</div> : null}
 
       <ConfirmationDialog
         open={pendingKick !== null}

--- a/fe-next/host/components/pre-game/__tests__/BattleModeCard.test.tsx
+++ b/fe-next/host/components/pre-game/__tests__/BattleModeCard.test.tsx
@@ -14,10 +14,16 @@ vi.mock('framer-motion', () => {
       <div ref={ref} {...props}>{children}</div>
     ),
   );
+  const Span = React.forwardRef<HTMLSpanElement, React.ComponentProps<'span'> & Record<string, unknown>>(
+    ({ children, initial, animate, exit, transition, ...props }, ref) => (
+      <span ref={ref} {...props}>{children}</span>
+    ),
+  );
   Btn.displayName = 'MotionBtn';
   Div.displayName = 'MotionDiv';
+  Span.displayName = 'MotionSpan';
   return {
-    m: { button: Btn, div: Div },
+    m: { button: Btn, div: Div, span: Span },
     AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   };
 });
@@ -58,30 +64,40 @@ describe('BattleModeCard — Blast visibility', () => {
   });
 });
 
-describe('BattleModeCard — Showcase cards (per-mode description)', () => {
+describe('BattleModeCard — Showcase cards (expand selected on click)', () => {
   const baseProps = {
     selectedGameMode: 'classic' as const,
     setSelectedGameMode: vi.fn(),
     t,
   };
 
-  // Each mode card surfaces its own one-line rule via getModeDescription(),
-  // which routes through the existing gameModes.*.description i18n keys.
-  // With the identity `t`, the description renders as its key string.
-  it('renders a description line for every visible mode', () => {
+  // To keep the grid short, ONLY the selected mode reveals its one-line rule;
+  // the other cards stay compact (icon + name). getModeDescription() routes
+  // through the gameModes.*.description i18n keys, so with the identity `t` the
+  // description renders as its key string.
+  it('shows the description only for the selected mode', () => {
     render(<BattleModeCard {...baseProps} isAdmin={false} />);
-    expect(screen.getByText('gameModes.randomDescription')).toBeInTheDocument();
+    // Selected = classic → its description is visible…
     expect(screen.getByText('gameModes.classic.description')).toBeInTheDocument();
-    expect(screen.getByText('gameModes.wordHunt.description')).toBeInTheDocument();
-    expect(screen.getByText('gameModes.wheelRush.description')).toBeInTheDocument();
-    expect(screen.getByText('gameModes.blast.description')).toBeInTheDocument();
+    // …while unselected modes do NOT spend vertical space on a description.
+    expect(screen.queryByText('gameModes.randomDescription')).toBeNull();
+    expect(screen.queryByText('gameModes.wordHunt.description')).toBeNull();
+    expect(screen.queryByText('gameModes.blast.description')).toBeNull();
   });
 
-  it('keeps the mode name alongside its description', () => {
+  it('keeps every mode name visible even when collapsed', () => {
     render(<BattleModeCard {...baseProps} isAdmin={false} />);
-    // name key + description key both present for classic
     expect(screen.getByText('gameModes.classic.name')).toBeInTheDocument();
-    expect(screen.getByText('gameModes.classic.description')).toBeInTheDocument();
+    expect(screen.getByText('gameModes.random')).toBeInTheDocument();
+    expect(screen.getByText('gameModes.wordHunt.name')).toBeInTheDocument();
+    expect(screen.getByText('gameModes.blast.name')).toBeInTheDocument();
+  });
+
+  it('reveals a freshly selected mode’s description', () => {
+    // Re-render with blast selected → blast now shows its rule, classic collapses.
+    render(<BattleModeCard {...baseProps} selectedGameMode={'blast'} isAdmin={false} />);
+    expect(screen.getByText('gameModes.blast.description')).toBeInTheDocument();
+    expect(screen.queryByText('gameModes.classic.description')).toBeNull();
   });
 
   it('still fires setSelectedGameMode when a mode card is clicked', () => {


### PR DESCRIPTION
Host pre-game lobby UX refinements (mobile-first):

- Emotes: drop the floating reaction FAB; the host now changes their own
  avatar's emotion via an on-avatar emote tray (reuses the lobby emote
  face-swap path), mirroring the player waiting view.
- Battle mode cards: only the selected mode expands to reveal its one-line
  rule; the rest stay compact (icon + name), cutting the grid height.
- Ads: remove the redundant "+20 gold" lobby ad. Surface the rewarded
  daily-avatar-part claim next to the avatar instead — an ad that earns a
  piece of the avatar, where the avatar lives.
- Top spacing: skip the AutoHideHeader spacer while in an active lobby/game
  so the colorful accent bar sits at the top (no dead band above it); the
  room list + results keep the spacer for CLS stability.

Tests updated for the new behavior; incomplete socket mocks given on/off.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016MDK3nFEcA7AEq67dHstxb