### PR TITLE
fix(wheel-rush): stop action bar overlapping found-words chips on short screens

### DIFF
--- a/fe-next/components/multiplayer/WheelRushView.tsx
+++ b/fe-next/components/multiplayer/WheelRushView.tsx
@@ -580,7 +580,7 @@ export const WheelRushView: React.FC<Props> = ({ socket, username, leaderboard, 
       {/* Word builder (shared shake + motion). Fixed height (not min-h) mirrors
           the daily challenge so the row never grows as tiles wrap. */}
       <m.div
-        className="relative w-full h-[52px] sm:h-[72px] flex items-center justify-center"
+        className="relative w-full h-[52px] sm:h-[72px] short:h-[44px] flex items-center justify-center"
         animate={
           wordBuilderShake && !prefersReduced
             ? { x: [-4, 4, -3, 3, -1, 0] }
@@ -668,7 +668,7 @@ export const WheelRushView: React.FC<Props> = ({ socket, username, leaderboard, 
       {/* Wheel + actions cluster — kept tight together, vertically centered.
           container-type:size lets the wheel's max-* height cap (below) read the
           cluster's block size via cqb. */}
-      <div className="@container/wheel [container-type:size] flex-1 flex flex-col items-center justify-center w-full min-h-0 gap-2 py-1" data-testid="wheel-cluster">
+      <div className="@container/wheel [container-type:size] flex-1 flex flex-col items-center justify-center w-full min-h-0 gap-2 py-1 short:gap-0.5 short:py-0" data-testid="wheel-cluster">
         {/* Tap-to-remove + double-tap-to-submit hint — reserved-height slot
             (mirrors the daily challenge) so the wheel never shifts when the
             hint text mounts/unmounts. */}
@@ -689,7 +689,12 @@ export const WheelRushView: React.FC<Props> = ({ socket, username, leaderboard, 
             // challenge wheel for visual parity; floor 176px.
             isDesktopCanvas
               ? "w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96"
-              : "w-64 h-64 sm:w-80 sm:h-80 md:w-96 md:h-96 max-w-[max(176px,calc(100cqb-116px))] max-h-[max(176px,calc(100cqb-116px))]",
+              // On short viewports (<=600px tall) drop the floor to 132px and
+              // the reserve to 72px so the wheel keeps shrinking instead of
+              // overflowing the `justify-center` cluster — which spilled the
+              // action bar onto the found-words chips below. Mirrors
+              // WordWheelGame.tsx:977.
+              : "w-64 h-64 sm:w-80 sm:h-80 md:w-96 md:h-96 max-w-[max(176px,calc(100cqb-116px))] max-h-[max(176px,calc(100cqb-116px))] short:max-w-[max(132px,min(calc(100cqb-72px),46svh))] short:max-h-[max(132px,min(calc(100cqb-72px),46svh))]",
           )}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
@@ -747,7 +752,7 @@ export const WheelRushView: React.FC<Props> = ({ socket, username, leaderboard, 
 
         {/* Actions (Clear / Submit / Remove-last) — sit directly under the wheel
             so the player's thumb stays in the wheel's gravity well. */}
-        <div data-testid="word-wheel-action-bar" className="w-full flex items-center justify-center gap-3 shrink-0 mt-1">
+        <div data-testid="word-wheel-action-bar" className="w-full flex items-center justify-center gap-3 shrink-0 mt-1 short:mt-0">
         <m.button
           type="button"
           onClick={handleClear}

--- a/fe-next/components/multiplayer/__tests__/WheelRushView.layoutStability.test.tsx
+++ b/fe-next/components/multiplayer/__tests__/WheelRushView.layoutStability.test.tsx
@@ -150,6 +150,29 @@ describe('WheelRushView — daily-style rival hint', () => {
     }
   });
 
+  it('caps the wheel with a short-viewport height variant so the action bar never overlaps the chips on short screens', () => {
+    const socket = makeMockSocket();
+    render(
+      <WheelRushView
+        socket={socket}
+        username="alice"
+        leaderboard={[{ username: 'alice', score: 10 }]}
+        onQuit={vi.fn()}
+        t={tStub}
+      />,
+    );
+    act(() => { socket.fire('wheelRushInit', { puzzle, startedAt: Date.now() }); });
+
+    // The wheel must carry a `short:` max-height cap so it shrinks below the
+    // 176px floor on <=600px-tall viewports. Without it the wheel overflows
+    // the `flex-1 justify-center` cluster and the action bar (Submit) spills
+    // downward, colliding with the found-words chip strip below — the
+    // overlap seen in the bug report screenshot. Mirrors WordWheelGame.tsx.
+    const cluster = screen.getByTestId('wheel-cluster');
+    const shortCapped = cluster.querySelector('[class*="short:max-h-"]');
+    expect(shortCapped).toBeTruthy();
+  });
+
   it('does not show the rival pill when self is the leader', () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
The multiplayer Wheel Rush view was missing the `short:` responsive
variants that the daily-challenge WordWheelGame uses. On short viewports
(<=600px tall) the wheel could not shrink below its 176px floor, so it
overflowed the `flex-1 justify-center` cluster and the action bar (Submit)
spilled downward, painting under the found-words chip strip — the overlap
seen in the bug report.

Add the same short-viewport caps WordWheelGame already ships:
- wheel: floor 132px / reserve 72px under `short:`
- cluster gaps/padding tightened under `short:`
- word-builder height + action-bar margin tightened under `short:`

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014xYNa25yVqKPzMmRAPLC6v