### PR TITLE
fix(results): show dictionary-building modal once, delayed ~10s

### DIFF
--- a/fe-next/components/results/__tests__/useResultsSocketEvents.test.ts
+++ b/fe-next/components/results/__tests__/useResultsSocketEvents.test.ts
@@ -83,10 +83,22 @@ describe('useResultsSocketEvents', () => {
   let mockSocket: ReturnType<typeof createMockSocket>;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     mockSocket = createMockSocket();
     vi.clearAllMocks();
     mockShowToast.mockClear();
   });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The dictionary-building modal is intentionally delayed ~10s before it shows.
+  const advanceWordFeedbackDelay = () => {
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+  };
 
   describe('Initialization', () => {
     it('should return initial state with all values set to defaults', () => {
@@ -199,7 +211,7 @@ describe('useResultsSocketEvents', () => {
   });
 
   describe('Word Feedback Events', () => {
-    it('should update state when showWordFeedback event is received', () => {
+    it('should update state when showWordFeedback event is received (after delay)', () => {
       // GIVEN
       const { result } = renderHook(() =>
         useResultsSocketEvents({ socket: mockSocket as unknown as Socket })
@@ -216,6 +228,7 @@ describe('useResultsSocketEvents', () => {
           language: 'en',
         });
       });
+      advanceWordFeedbackDelay();
 
       // THEN
       expect(result.current.showWordFeedback).toBe(true);
@@ -228,6 +241,82 @@ describe('useResultsSocketEvents', () => {
         gameCode: 'ABC123',
         language: 'en',
       });
+    });
+
+    it('should NOT show the modal until the ~10s delay has elapsed', () => {
+      // GIVEN
+      const { result } = renderHook(() =>
+        useResultsSocketEvents({ socket: mockSocket as unknown as Socket })
+      );
+
+      // WHEN
+      act(() => {
+        triggerSocketEvent(mockSocket, 'showWordFeedback', {
+          word: 'HELLO',
+          submittedBy: 'testUser',
+          gameCode: 'ABC123',
+          language: 'en',
+        });
+      });
+
+      // THEN - still hidden right after the event
+      expect(result.current.showWordFeedback).toBe(false);
+      expect(result.current.wordToVote).toBeNull();
+
+      // WHEN - not quite enough time has passed
+      act(() => {
+        vi.advanceTimersByTime(9_000);
+      });
+
+      // THEN - still hidden
+      expect(result.current.showWordFeedback).toBe(false);
+
+      // WHEN - the full delay elapses
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+
+      // THEN - now visible
+      expect(result.current.showWordFeedback).toBe(true);
+    });
+
+    it('should only show word feedback once per results page', () => {
+      // GIVEN
+      const { result } = renderHook(() =>
+        useResultsSocketEvents({ socket: mockSocket as unknown as Socket })
+      );
+
+      // WHEN - first event shows the modal, then the user skips it
+      act(() => {
+        triggerSocketEvent(mockSocket, 'showWordFeedback', {
+          word: 'HELLO',
+          submittedBy: 'testUser',
+          gameCode: 'ABC123',
+          language: 'en',
+        });
+      });
+      advanceWordFeedbackDelay();
+      expect(result.current.showWordFeedback).toBe(true);
+
+      act(() => {
+        result.current.handleFeedbackSkip();
+      });
+      expect(result.current.showWordFeedback).toBe(false);
+
+      // WHEN - a second event arrives later
+      act(() => {
+        triggerSocketEvent(mockSocket, 'showWordFeedback', {
+          word: 'WORLD',
+          submittedBy: 'otherUser',
+          gameCode: 'ABC123',
+          language: 'en',
+        });
+      });
+      advanceWordFeedbackDelay();
+
+      // THEN - it must not re-appear
+      expect(result.current.showWordFeedback).toBe(false);
+      expect(result.current.wordToVote).toBeNull();
     });
 
     it('should limit word queue to 2 items', () => {
@@ -251,6 +340,7 @@ describe('useResultsSocketEvents', () => {
           ],
         });
       });
+      advanceWordFeedbackDelay();
 
       // THEN - Queue should be limited to 2
       expect(result.current.wordQueue).toHaveLength(2);
@@ -274,6 +364,7 @@ describe('useResultsSocketEvents', () => {
           language: 'en',
         });
       });
+      advanceWordFeedbackDelay();
 
       // THEN
       expect(result.current.wordToVote?.voteInfo).toEqual({
@@ -500,6 +591,7 @@ describe('useResultsSocketEvents', () => {
             language: 'en',
           });
         });
+        advanceWordFeedbackDelay();
 
         // WHEN
         act(() => {
@@ -550,6 +642,7 @@ describe('useResultsSocketEvents', () => {
             language: 'en',
           });
         });
+        advanceWordFeedbackDelay();
 
         expect(result.current.showWordFeedback).toBe(true);
 

--- a/fe-next/components/results/useResultsSocketEvents.ts
+++ b/fe-next/components/results/useResultsSocketEvents.ts
@@ -21,6 +21,11 @@ import type { ReferralMilestone } from '@/shared/types/socket';
 import type { WordToVote, XpGainedData, LevelUpData } from '@/types/components';
 import type { OneMoreGamePrompt } from '@/shared/types/engagement';
 
+// Delay before the "Build our dictionary" voting modal appears on the results
+// page. Showing it immediately covers the rematch / next-round flow, so we wait
+// ~10s and only ever show it once per results page.
+const WORD_FEEDBACK_DELAY_MS = 10_000;
+
 export interface ResultsSocketEventsState {
   // Word feedback state
   showWordFeedback: boolean;
@@ -78,6 +83,8 @@ export function useResultsSocketEvents({
   const [nearMisses, setNearMisses] = useState<NearMiss[]>([]);
 
   const hasShownLevelUpRef = useRef<boolean>(false); // Prevent duplicate level-up celebrations
+  const hasShownWordFeedbackRef = useRef<boolean>(false); // Show the dictionary-building modal only once per results page
+  const wordFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null); // Delays the dictionary modal so it never covers the rematch flow
 
   // Referral milestone state
   const [referralMilestone, setReferralMilestone] = useState<ReferralMilestone | null>(null);
@@ -103,12 +110,21 @@ export function useResultsSocketEvents({
     }) => {
       logger.log('[RESULTS] Received word feedback request:', data);
 
+      // Only ever surface the dictionary-building modal once per results page —
+      // repeated socket emissions (or re-entry) must not re-pop it.
+      if (hasShownWordFeedbackRef.current) {
+        logger.log('[RESULTS] Word feedback already shown on this page — ignoring');
+        return;
+      }
+      hasShownWordFeedbackRef.current = true;
+
       // Handle new word queue format (self-healing system)
       // Limit to 2 words to avoid overwhelming the user with modals
-      if (data.wordQueue && data.wordQueue.length > 0) {
-        const limitedQueue = data.wordQueue.slice(0, 2);
-        setWordQueue(limitedQueue);
-        logger.log('[RESULTS] Word queue limited to', limitedQueue.length, 'of', data.wordQueue.length, 'words for voting');
+      const limitedQueue = (data.wordQueue && data.wordQueue.length > 0)
+        ? data.wordQueue.slice(0, 2)
+        : null;
+      if (limitedQueue) {
+        logger.log('[RESULTS] Word queue limited to', limitedQueue.length, 'of', data.wordQueue!.length, 'words for voting');
       }
 
       // Transform voteInfo to match expected VoteInfo interface
@@ -117,16 +133,21 @@ export function useResultsSocketEvents({
         disapprovalCount: data.voteInfo.votesAgainst ?? data.voteInfo.disapprovalCount
       } : undefined;
 
-      setWordToVote({
-        word: data.word,
-        submittedBy: data.submittedBy,
-        submitterAvatar: data.submitterAvatar,
-        voteInfo: transformedVoteInfo,
-        timeoutSeconds: data.timeoutSeconds || 10,
-        gameCode: data.gameCode,
-        language: data.language
-      });
-      setShowWordFeedback(true);
+      // Delay so the modal never lands on top of the rematch / next-round flow.
+      if (wordFeedbackTimerRef.current) clearTimeout(wordFeedbackTimerRef.current);
+      wordFeedbackTimerRef.current = setTimeout(() => {
+        if (limitedQueue) setWordQueue(limitedQueue);
+        setWordToVote({
+          word: data.word,
+          submittedBy: data.submittedBy,
+          submitterAvatar: data.submitterAvatar,
+          voteInfo: transformedVoteInfo,
+          timeoutSeconds: data.timeoutSeconds || 10,
+          gameCode: data.gameCode,
+          language: data.language
+        });
+        setShowWordFeedback(true);
+      }, WORD_FEEDBACK_DELAY_MS);
     };
 
     const handleVoteRecorded = (data: { success: boolean; message?: string }) => {
@@ -199,6 +220,10 @@ export function useResultsSocketEvents({
       socket.off('engagement:referralMilestone', handleReferralMilestone);
       socket.off('engagement:oneMoreGame', handleOneMoreGame);
       socket.off('weeklyQuestCompleted', handleWeeklyQuestCompleted);
+      if (wordFeedbackTimerRef.current) {
+        clearTimeout(wordFeedbackTimerRef.current);
+        wordFeedbackTimerRef.current = null;
+      }
     };
   }, [socket, t]);
 
@@ -256,6 +281,10 @@ export function useResultsSocketEvents({
   // Handle word feedback skip/timeout
   const handleFeedbackSkip = useCallback(() => {
     logger.log('[RESULTS] Skipping word feedback');
+    if (wordFeedbackTimerRef.current) {
+      clearTimeout(wordFeedbackTimerRef.current);
+      wordFeedbackTimerRef.current = null;
+    }
     setShowWordFeedback(false);
     setWordToVote(null);
     setWordQueue([]);


### PR DESCRIPTION
The 'Build our dictionary' (CONSTRUYE NUESTRO DICCIONARIO) voting modal was
popping up immediately on the results page, landing on top of the rematch /
next-round flow, and could re-appear on repeated socket emissions.

- Delay the modal ~10s after the showWordFeedback event so it never covers
  the rematch UI.
- Guard with a ref so it only ever shows once per results page.
- Clear the pending timer on skip/timeout and on unmount.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014GJV2UAF8uH1jgsyueySgD