### PR TITLE
fix(results): show dictionary help once per session after 7s of interaction

### DIFF
--- a/fe-next/components/singleplayer/results/hooks/__tests__/useWordValidation.test.ts
+++ b/fe-next/components/singleplayer/results/hooks/__tests__/useWordValidation.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for useWordValidation hook
+ *
+ * The dictionary-help voting modal must:
+ * 1. Only ask the player about ONE word (not cycle through several).
+ * 2. Auto-show only after the player has interacted with the page for 7s.
+ * 3. Show at most once per browser session.
+ */
+
+import { vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWordValidation } from '../useWordValidation';
+
+const baseParams = {
+  botWordsForValidation: ['toe', 'rate', 'cone'],
+  gameSessionId: 'sess-1',
+  language: 'es',
+};
+
+describe('useWordValidation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('limits the validation queue to a single word', () => {
+    const { result } = renderHook(() => useWordValidation(baseParams));
+    expect(result.current.wordValidationQueue).toEqual(['toe']);
+  });
+
+  it('does not auto-show before 7s even after interaction', () => {
+    const { result } = renderHook(() => useWordValidation(baseParams));
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+      window.dispatchEvent(new MouseEvent('click'));
+    });
+
+    expect(result.current.showWordValidation).toBe(false);
+  });
+
+  it('auto-shows after 7s of interaction', () => {
+    const { result } = renderHook(() => useWordValidation(baseParams));
+
+    act(() => {
+      vi.advanceTimersByTime(7000);
+      window.dispatchEvent(new MouseEvent('click'));
+    });
+
+    expect(result.current.showWordValidation).toBe(true);
+  });
+
+  it('shows at most once per session (does not re-show on a fresh results screen)', () => {
+    const first = renderHook(() => useWordValidation(baseParams));
+    act(() => {
+      vi.advanceTimersByTime(7000);
+      window.dispatchEvent(new MouseEvent('click'));
+    });
+    expect(first.result.current.showWordValidation).toBe(true);
+    first.unmount();
+
+    // A new game -> a new results screen mounts the hook again in the same session.
+    const second = renderHook(() => useWordValidation(baseParams));
+    act(() => {
+      vi.advanceTimersByTime(7000);
+      window.dispatchEvent(new MouseEvent('click'));
+    });
+    expect(second.result.current.showWordValidation).toBe(false);
+  });
+});

--- a/fe-next/components/singleplayer/results/hooks/useWordValidation.ts
+++ b/fe-next/components/singleplayer/results/hooks/useWordValidation.ts
@@ -5,6 +5,30 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAutoShowWithInteraction } from '@/hooks/useAutoShowWithInteraction';
 
+/**
+ * Session-scoped flag so the dictionary-help prompt is shown at most once per
+ * browser session, no matter how many games the player finishes in that session.
+ */
+const SESSION_SHOWN_KEY = 'lc_dictionary_help_shown';
+
+function hasShownThisSession(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.sessionStorage.getItem(SESSION_SHOWN_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function markShownThisSession(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(SESSION_SHOWN_KEY, '1');
+  } catch {
+    // sessionStorage unavailable (private mode / blocked) — fail open, no crash.
+  }
+}
+
 interface UseWordValidationParams {
   botWordsForValidation?: string[];
   gameSessionId?: string;
@@ -28,17 +52,26 @@ export function useWordValidation({
   const [wordValidationQueue, setWordValidationQueue] = useState<string[]>([]);
   const [showWordValidation, setShowWordValidation] = useState(false);
 
-  // Initialize queue from bot words
+  // Initialize queue from bot words — only ever ask about a single word so the
+  // prompt is "show once", not a multi-word sequence.
   useEffect(() => {
     if (!botWordsForValidation || botWordsForValidation.length === 0) return;
-    setWordValidationQueue(botWordsForValidation.slice(0, 2));
+    setWordValidationQueue(botWordsForValidation.slice(0, 1));
   }, [botWordsForValidation]);
 
-  // Auto-show validation modal after interaction delay
+  // Auto-show validation modal only after the player has interacted with the
+  // page for 7s, and at most once per browser session.
   useAutoShowWithInteraction({
-    enabled: !disabled && wordValidationQueue.length > 0 && !showWordValidation,
-    delayMs: 5000,
-    onTrigger: () => setShowWordValidation(true),
+    enabled:
+      !disabled &&
+      wordValidationQueue.length > 0 &&
+      !showWordValidation &&
+      !hasShownThisSession(),
+    delayMs: 7000,
+    onTrigger: () => {
+      markShownThisSession();
+      setShowWordValidation(true);
+    },
   });
 
   const handleWordVote = useCallback(async (voteType: 'like' | 'dislike', word?: string) => {


### PR DESCRIPTION
The crowd-sourced dictionary voting modal (WordFeedbackModal) was auto-showing
after only 5s and cycling through 2 bot words, and re-appeared on every new
results screen — feeling repetitive/nagging.

- Bump the auto-show delay to 7s of page interaction
- Ask about a single word only ("show once", no multi-word sequence)
- Gate behind a sessionStorage flag so it shows at most once per browser session

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GhaGEhZQ97f9chugKwsNzu