### PR TITLE
feat(leaderboard): cap in-game leaderboard to a 3-row window around the player

### DIFF
--- a/fe-next/components/game/in-game/components/GameLeaderboard.tsx
+++ b/fe-next/components/game/in-game/components/GameLeaderboard.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useMemo, useRef, useEffect, useState } from 'react';
 import { AdaptiveMotion } from '@/components/motion/AdaptiveMotion';
-import { Trophy, Crown, TrendingUp, TrendingDown, Flame } from 'lucide-react';
+import { Trophy, Crown, TrendingUp, TrendingDown, Flame, ChevronUp, ChevronDown } from 'lucide-react';
 import Avatar from '@/components/Avatar';
 import { useReactiveAvatarMood } from '@/hooks/useReactiveAvatarMood';
 import { moodToOverlay } from '@/lib/avatar/avatarOverlay';
@@ -52,6 +52,39 @@ interface LeaderboardRowProps {
   t: TranslationFn;
   rankChange: number; // positive = moved up, negative = moved down
   scoreChange: number;
+}
+
+/**
+ * How many rows the in-game leaderboard shows at once. Capped to a tight window
+ * (rival above → you → rival below) so the player's own position is always
+ * centred and visible instead of being buried in a long, scrolling roster.
+ */
+const LEADERBOARD_WINDOW = 3;
+
+/**
+ * Window the (pre-sorted) roster down to `size` rows centred on the current
+ * player so their position is always visible without scrolling. Returns the
+ * visible slice plus how many players are hidden above/below so the UI can show
+ * a "+N" cue. When the player isn't on the board (spectator) the window falls
+ * back to the top of the roster.
+ */
+export function windowAroundUser<T>(
+  players: T[],
+  meIndex: number,
+  size = LEADERBOARD_WINDOW,
+): { slice: T[]; start: number; hiddenAbove: number; hiddenBelow: number } {
+  if (players.length <= size) {
+    return { slice: players, start: 0, hiddenAbove: 0, hiddenBelow: 0 };
+  }
+  const half = Math.floor((size - 1) / 2);
+  const anchor = meIndex < 0 ? 0 : meIndex - half;
+  const start = Math.min(Math.max(anchor, 0), players.length - size);
+  return {
+    slice: players.slice(start, start + size),
+    start,
+    hiddenAbove: start,
+    hiddenBelow: players.length - (start + size),
+  };
 }
 
 /** Combo badge thresholds and styling */
@@ -112,7 +145,7 @@ const LeaderboardRow = memo<LeaderboardRowProps>(function LeaderboardRow({
         hover:-translate-x-px hover:-translate-y-px hover:shadow-hard
         focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-neo-cyan focus-visible:ring-offset-1
         ${player.rankStyle} ${dir === 'rtl' ? 'flex-row-reverse' : ''}
-        ${player.isMe ? 'ring-2 ring-neo-cyan/60' : ''}`}
+        ${player.isMe ? 'ring-2 ring-neo-cyan ring-offset-2 ring-offset-neo-cream shadow-hard scale-[1.02] z-10' : ''}`}
     >
       {/* Rank badge with change indicator */}
       <div className="relative shrink-0">
@@ -247,6 +280,18 @@ export const GameLeaderboard = memo<GameLeaderboardProps>(function GameLeaderboa
     [leaderboard, username]
   );
 
+  // Cap the visible roster to a tight window centred on the current player so
+  // their position is always front-and-centre (their neighbours are their real
+  // rivals; distant players are summarised by the "+N" cues above/below).
+  const myIndex = useMemo(
+    () => memoizedLeaderboard.findIndex((p) => p.isMe),
+    [memoizedLeaderboard],
+  );
+  const { slice: visiblePlayers, hiddenAbove, hiddenBelow } = useMemo(
+    () => windowAroundUser(memoizedLeaderboard, myIndex, LEADERBOARD_WINDOW),
+    [memoizedLeaderboard, myIndex],
+  );
+
   // Compute rank and score changes
   const changes = useMemo(() => {
     const map = new Map<string, { rankChange: number; scoreChange: number }>();
@@ -319,10 +364,21 @@ export const GameLeaderboard = memo<GameLeaderboardProps>(function GameLeaderboa
         </div>
       )}
 
-      {/* Content */}
+      {/* Content — only a 3-row window around the current player is shown; the
+          "+N" chevron cues summarise everyone ranked further above/below. */}
       <div className={cn('p-2.5', compact ? 'overflow-y-auto custom-scrollbar' : 'overflow-y-auto flex-1 custom-scrollbar')}>
         <div className="space-y-1.5" role="list">
-          {memoizedLeaderboard.map((player) => {
+          {hiddenAbove > 0 && (
+            <div
+              data-testid="leaderboard-more-above"
+              className="flex items-center justify-center gap-1 text-[10px] font-black text-neo-black/55 tabular-nums select-none"
+            >
+              <ChevronUp className="w-3 h-3 shrink-0" />
+              <span>+{hiddenAbove}</span>
+            </div>
+          )}
+
+          {visiblePlayers.map((player) => {
             const change = changes.get(player.username);
             return (
               <LeaderboardRow
@@ -336,6 +392,16 @@ export const GameLeaderboard = memo<GameLeaderboardProps>(function GameLeaderboa
               />
             );
           })}
+
+          {hiddenBelow > 0 && (
+            <div
+              data-testid="leaderboard-more-below"
+              className="flex items-center justify-center gap-1 text-[10px] font-black text-neo-black/55 tabular-nums select-none"
+            >
+              <ChevronDown className="w-3 h-3 shrink-0" />
+              <span>+{hiddenBelow}</span>
+            </div>
+          )}
 
           {leaderboard.length === 0 && (
             <p className="text-center text-neo-black/90 py-6 text-sm font-bold">

--- a/fe-next/components/game/in-game/components/__tests__/GameLeaderboard.window.test.tsx
+++ b/fe-next/components/game/in-game/components/__tests__/GameLeaderboard.window.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * GameLeaderboard — 3-player window around the current player
+ *
+ * Instead of rendering the full roster (which on mobile pushes the player's own
+ * row off-screen and buries their position), the in-game leaderboard is capped
+ * to three rows centred on the current player: the rival directly above, the
+ * player themselves, and the rival directly below. Real ranks are preserved and
+ * a small "+N" chevron indicator shows how many players are hidden above/below.
+ */
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { GameLeaderboard, windowAroundUser } from '../GameLeaderboard';
+import type { ExtendedLeaderboardPlayer } from '@/shared/types/view';
+
+vi.mock('@/components/motion/AdaptiveMotion', () => ({
+  AdaptiveMotion: {
+    div: ({ children, className }: React.PropsWithChildren<{ className?: string }>) => (
+      <div className={className}>{children}</div>
+    ),
+  },
+}));
+
+vi.mock('@/components/Avatar', () => ({
+  default: ({ size }: { size: string }) => <div data-testid="avatar" data-size={size} />,
+}));
+
+vi.mock('@/components/ui/PlayerProfileTooltip', () => ({
+  default: ({ children }: React.PropsWithChildren) => <div data-testid="profile-tooltip">{children}</div>,
+}));
+
+vi.mock('@/components/PresenceIndicator', () => ({
+  default: ({ status }: { status: string }) => <div data-testid="presence-indicator" data-status={status} />,
+}));
+
+vi.mock('@/hooks/useReactiveAvatarMood', () => ({ useReactiveAvatarMood: () => 'neutral' }));
+vi.mock('@/hooks/gameState/selectors', () => ({ useLiveScoreFor: () => undefined }));
+
+const mockT = (key: string, params?: Record<string, string | number>) =>
+  params ? `${key}:${JSON.stringify(params)}` : key;
+
+function player(over: Partial<ExtendedLeaderboardPlayer> & { username: string; score: number }): ExtendedLeaderboardPlayer {
+  return {
+    wordCount: 0,
+    isHost: false,
+    avatar: undefined,
+    presenceStatus: 'active' as const,
+    isWindowFocused: true,
+    isBot: false,
+    disconnected: false,
+    comboLevel: 0,
+    ...over,
+  } as ExtendedLeaderboardPlayer;
+}
+
+// 6 players, pre-sorted by score (rank === index)
+function roster() {
+  return [
+    player({ username: 'P1', score: 120 }),
+    player({ username: 'P2', score: 100 }),
+    player({ username: 'P3', score: 80 }),
+    player({ username: 'P4', score: 60 }),
+    player({ username: 'P5', score: 40 }),
+    player({ username: 'P6', score: 20 }),
+  ];
+}
+
+describe('windowAroundUser', () => {
+  it('returns all players unchanged when the roster fits within the window', () => {
+    const players = ['a', 'b', 'c'];
+    const w = windowAroundUser(players, 1, 3);
+    expect(w.slice).toEqual(['a', 'b', 'c']);
+    expect(w.hiddenAbove).toBe(0);
+    expect(w.hiddenBelow).toBe(0);
+  });
+
+  it('centres the window on the current player', () => {
+    const players = ['a', 'b', 'c', 'd', 'e', 'f'];
+    const w = windowAroundUser(players, 3, 3); // me = 'd'
+    expect(w.slice).toEqual(['c', 'd', 'e']);
+    expect(w.hiddenAbove).toBe(2); // a, b
+    expect(w.hiddenBelow).toBe(1); // f
+  });
+
+  it('clamps to the top when the player leads', () => {
+    const players = ['a', 'b', 'c', 'd', 'e', 'f'];
+    const w = windowAroundUser(players, 0, 3); // me = 'a'
+    expect(w.slice).toEqual(['a', 'b', 'c']);
+    expect(w.hiddenAbove).toBe(0);
+    expect(w.hiddenBelow).toBe(3);
+  });
+
+  it('clamps to the bottom when the player is last', () => {
+    const players = ['a', 'b', 'c', 'd', 'e', 'f'];
+    const w = windowAroundUser(players, 5, 3); // me = 'f'
+    expect(w.slice).toEqual(['d', 'e', 'f']);
+    expect(w.hiddenAbove).toBe(3);
+    expect(w.hiddenBelow).toBe(0);
+  });
+
+  it('falls back to the top of the roster when there is no current player', () => {
+    const players = ['a', 'b', 'c', 'd', 'e', 'f'];
+    const w = windowAroundUser(players, -1, 3);
+    expect(w.slice).toEqual(['a', 'b', 'c']);
+    expect(w.hiddenAbove).toBe(0);
+    expect(w.hiddenBelow).toBe(3);
+  });
+});
+
+describe('GameLeaderboard — windowed rows', () => {
+  it('renders only three rows centred on the current player', () => {
+    render(<GameLeaderboard leaderboard={roster()} username="P4" isHost={false} t={mockT} dir="ltr" />);
+
+    const rows = screen.getAllByRole('listitem');
+    expect(rows).toHaveLength(3);
+
+    // Neighbours of P4 are shown…
+    expect(screen.getByText('P3')).toBeInTheDocument();
+    expect(screen.getByText('P4')).toBeInTheDocument();
+    expect(screen.getByText('P5')).toBeInTheDocument();
+    // …distant players are hidden.
+    expect(screen.queryByText('P1')).not.toBeInTheDocument();
+    expect(screen.queryByText('P6')).not.toBeInTheDocument();
+  });
+
+  it('preserves the real rank number of the windowed player', () => {
+    render(<GameLeaderboard leaderboard={roster()} username="P4" isHost={false} t={mockT} dir="ltr" />);
+    // P4 is 4th overall → its badge reads "#4", not "#2" (its index within the window)
+    const p4Row = screen.getByText('P4').closest('[role="listitem"]')!;
+    expect(within(p4Row as HTMLElement).getByText('#4')).toBeInTheDocument();
+  });
+
+  it('shows hidden-count indicators above and below the window', () => {
+    render(<GameLeaderboard leaderboard={roster()} username="P4" isHost={false} t={mockT} dir="ltr" />);
+
+    const above = screen.getByTestId('leaderboard-more-above');
+    const below = screen.getByTestId('leaderboard-more-below');
+    expect(above).toHaveTextContent('2'); // P1, P2 hidden above
+    expect(below).toHaveTextContent('1'); // P6 hidden below
+  });
+
+  it('does not render hidden-count indicators when nothing is hidden', () => {
+    const small = [player({ username: 'A', score: 10 }), player({ username: 'B', score: 5 })];
+    render(<GameLeaderboard leaderboard={small} username="A" isHost={false} t={mockT} dir="ltr" />);
+
+    expect(screen.queryByTestId('leaderboard-more-above')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('leaderboard-more-below')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
The in-game leaderboard rendered the full roster, which on phones pushed the
player's own row off-screen and made their position hard to read. It now shows
a tight window centred on the current player — the rival directly above, you,
and the rival directly below — with "+N" chevron cues summarising everyone
hidden further up/down. Real ranks are preserved and the "you" row gets a
stronger ring + lift so position and score read at a glance.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LkStiVYUTyQCRWyinnowh6