### PR TITLE
feat(word-wheel): compact results, drop fixed timer, fix wheel depth + confetti

### DIFF
--- a/fe-next/components/daily/WordWheelGame.tsx
+++ b/fe-next/components/daily/WordWheelGame.tsx
@@ -994,8 +994,14 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
           className="absolute -inset-6 rounded-full pointer-events-none"
           style={{
             zIndex: -10,
+            // Two stacked layers so the disc reads as lit depth — not flat black —
+            // even on high-contrast mobile OLED where the navy-elevated→navy delta
+            // alone was imperceptible:
+            //   1. a soft brand glow (lime→cyan) blooming from the center, and
+            //   2. the elevated-navy depth disc fading to transparent at the rim.
             background:
-              'radial-gradient(circle at center, var(--neo-navy-elevated) 0%, var(--neo-navy) 58%, transparent 78%)',
+              'radial-gradient(circle at 50% 45%, rgba(191,255,0,0.08) 0%, rgba(0,255,255,0.05) 38%, transparent 62%),' +
+              'radial-gradient(circle at center, var(--neo-navy-elevated) 0%, var(--neo-navy) 60%, transparent 80%)',
           }}
         />
         {/* PixiJS wheel decorations: orbital rings + connection lines */}

--- a/fe-next/components/daily/WordWheelResults.tsx
+++ b/fe-next/components/daily/WordWheelResults.tsx
@@ -207,14 +207,16 @@ const WordWheelResults: React.FC<WordWheelResultsProps> = ({
 
   return (
     <m.div
-      className="relative flex flex-col items-center gap-5 w-full max-w-md mx-auto px-4 py-8 overflow-hidden"
+      className="relative flex flex-col items-center gap-3 w-full max-w-md mx-auto px-4 py-5 overflow-hidden"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
     >
-      {/* DOM Confetti */}
+      {/* DOM Confetti — rendered ABOVE the result cards (pointer-events-none) so
+          it rains in front of the content instead of hiding behind the opaque
+          stat/leaderboard cards, where it was effectively invisible on mobile. */}
       {showConfetti && (
-        <div className="absolute inset-0 overflow-hidden pointer-events-none z-0">
+        <div className="absolute inset-0 overflow-hidden pointer-events-none z-30">
           {CONFETTI_CONFIGS.slice(0, confettiCount).map((config, i) => (
             <ConfettiParticle
               key={`confetti-${i}`}
@@ -244,40 +246,43 @@ const WordWheelResults: React.FC<WordWheelResultsProps> = ({
         animate={{ y: 0, opacity: 1 }}
         transition={{ delay: 0.1 }}
       >
-        <h2 className="font-neo-display font-black text-2xl text-neo-white mb-1">
+        <h2 className="font-neo-display font-black text-xl text-neo-white">
           {t('wordWheel.results.title')}
         </h2>
-        <span className="text-neo-white text-sm">#{puzzleNumber}</span>
+        <span className="text-neo-white/70 text-xs">#{puzzleNumber}</span>
       </m.div>
 
-      {/* Score circle */}
+      {/* Score circle — solid elevated-navy fill + tier glow + tier-colored
+          number. The previous translucent `tier.bg` (e.g. bg-neo-lime/10) tinted
+          the disc a muddy olive over the navy stage; a clean navy fill keeps the
+          colored score crisp. */}
       <m.div
         className={cn(
-          'relative flex flex-col items-center justify-center w-36 h-36 rounded-full',
-          'border-3 border-neo-black shadow-hard-lg z-10',
-          tier.bg, tier.glowColor,
+          'relative flex flex-col items-center justify-center w-28 h-28 rounded-full',
+          'border-3 border-neo-black bg-neo-navy-light shadow-hard-lg z-10',
+          tier.glowColor,
         )}
         initial={{ scale: 0, rotate: -180 }}
         animate={{ scale: 1, rotate: 0 }}
         transition={{ type: 'spring', stiffness: 200, damping: 15, delay: 0.2 }}
       >
         <m.div
-          className={tier.color}
+          className={cn(tier.color, '[&>svg]:w-6 [&>svg]:h-6')}
           initial={{ scale: 0 }}
           animate={{ scale: 1 }}
           transition={{ delay: 0.5, type: 'spring' }}
         >
           {tier.icon}
         </m.div>
-        <span className={cn('font-neo-display font-black text-4xl', tier.color)}>
+        <span className={cn('font-neo-display font-black text-3xl leading-none', tier.color)}>
           {animatedScore}
         </span>
-        <span className="text-neo-white text-xs">{t('wordWheel.scoreLabel')}</span>
+        <span className="text-neo-white/70 text-[10px] uppercase tracking-wide">{t('wordWheel.scoreLabel')}</span>
       </m.div>
 
       {/* Tier message */}
       <m.p
-        className={cn('font-neo-display font-bold text-xl z-10', tier.color)}
+        className={cn('font-neo-display font-bold text-lg z-10', tier.color)}
         initial={{ scale: 0 }}
         animate={{ scale: [0, 1.2, 1] }}
         transition={{ delay: 0.8, duration: 0.4 }}
@@ -351,23 +356,18 @@ const WordWheelResults: React.FC<WordWheelResultsProps> = ({
         </m.div>
       )}
 
-      {/* Stats */}
+      {/* Words-found stat — the single performance stat worth surfacing. The run
+          timer was dropped: every Word Wheel run is a fixed 2:00, so showing it
+          was constant noise that only added height. Compact inline pill. */}
       <m.div
-        className="grid grid-cols-2 gap-3 w-full z-10"
+        data-testid="word-wheel-words-stat"
+        className="z-10 inline-flex items-center gap-2 px-4 py-1.5 rounded-neo border-2 border-neo-black bg-neo-navy-light shadow-hard"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.4 }}
       >
-        <div className="flex flex-col items-center p-3 rounded-neo border-2 border-neo-black bg-neo-navy-light shadow-hard">
-          <span className="text-neo-lime font-black text-xl">{result.wordsFound.length}</span>
-          <span className="text-neo-white text-xs">{t('wordWheel.results.wordsFound')}</span>
-        </div>
-        <div className="flex flex-col items-center p-3 rounded-neo border-2 border-neo-black bg-neo-navy-light shadow-hard">
-          <span className="text-neo-cyan font-black text-xl">
-            {Math.floor(result.timeSeconds / 60)}:{(result.timeSeconds % 60).toString().padStart(2, '0')}
-          </span>
-          <span className="text-neo-white text-xs">{t('wordWheel.results.time')}</span>
-        </div>
+        <span className="text-neo-lime font-black text-xl leading-none">{result.wordsFound.length}</span>
+        <span className="text-neo-white/80 text-xs">{t('wordWheel.results.wordsFound')}</span>
       </m.div>
 
       {/* Daily Insight Cards — personalized analytics on challenge performance */}

--- a/fe-next/components/daily/__tests__/WordWheelGame.wheelBackdrop.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelGame.wheelBackdrop.test.tsx
@@ -102,5 +102,11 @@ describe('WordWheelGame — wheel backdrop depth', () => {
     // edge — NOT a solid fill.
     expect(backdrop!.style.background).toContain('radial-gradient');
     expect(backdrop!.style.background).toContain('--neo-navy-elevated');
+
+    // A soft brand glow over the navy disc so it reads as lit depth — not flat
+    // black — even on high-contrast mobile OLED where the navy delta alone is
+    // imperceptible. Lime + cyan tint at minimum.
+    expect(backdrop!.style.background).toContain('rgba(191,255,0');
+    expect(backdrop!.style.background).toContain('rgba(0,255,255');
   });
 });

--- a/fe-next/components/daily/__tests__/WordWheelResults.compactLayout.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelResults.compactLayout.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * WordWheelResults compact layout.
+ *
+ * Design asks:
+ *  - The run timer is a FIXED 2:00 for every Word Wheel game, so surfacing it on
+ *    the results page is noise — it never varies. The time stat must NOT render.
+ *  - Words-found stays as the single performance stat (score lives in the circle).
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import WordWheelResults from '../WordWheelResults';
+import type { WordWheelGameResult } from '../WordWheelGame';
+
+vi.mock('framer-motion', () => ({
+  m: new Proxy({}, {
+    get: () => ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div>,
+  }),
+  animate: () => ({ stop: () => {} }),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../TabbedDailyLeaderboard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="leaderboard-stub" />,
+}));
+
+vi.mock('@/contexts/SoundEffectsContext', () => ({
+  useSoundEffects: () => ({ playSound: vi.fn() }),
+}));
+
+vi.mock('@/components/CrazyGamesSDK', () => ({
+  useCrazyGames: () => ({ submitLeaderboardScore: vi.fn() }),
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({
+    t: (k: string, fb?: string) => (typeof fb === 'string' ? fb : k),
+    language: 'en',
+  }),
+}));
+
+vi.mock('@/hooks/usePracticeFlag', () => ({
+  usePracticeFlag: () => false,
+}));
+
+vi.mock('../DailyInsightStack', () => ({
+  __esModule: true,
+  default: () => <div data-testid="insight-stack" />,
+}));
+
+const result: WordWheelGameResult = { score: 40, wordsFound: ['ABC', 'DEFGH'], timeSeconds: 120 };
+
+const renderResults = () =>
+  render(
+    <WordWheelResults
+      result={result}
+      puzzleNumber={42}
+      puzzleDate="2026-05-18"
+      language="en"
+      hasPlayedWordHunt={false}
+    />,
+  );
+
+describe('WordWheelResults — compact layout', () => {
+  it('does NOT render the fixed run timer stat', () => {
+    renderResults();
+    expect(screen.queryByText('wordWheel.results.time')).toBeNull();
+    // 120s would format as 2:00 — must not appear as a stat.
+    expect(screen.queryByText('2:00')).toBeNull();
+  });
+
+  it('still shows the words-found performance stat', () => {
+    renderResults();
+    expect(screen.getByTestId('word-wheel-words-stat')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Results page: shrink score circle (36→28), tighten gaps/padding, and use a
  solid elevated-navy fill instead of the translucent tier tint that read as a
  muddy olive disc — so the page no longer eats so much vertical space.
- Drop the run-timer stat: every Word Wheel run is a fixed 2:00, so it was
  constant noise. Words-found is now a single compact pill.
- Bring the celebration confetti above the result cards (z-30) so it rains in
  front instead of hiding behind opaque cards — invisible on mobile before.
- Wheel backdrop: layer a soft lime/cyan brand glow over the navy disc so it
  reads as lit depth instead of flat black on high-contrast mobile OLED.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nh7qFNemwF1T8Kc9VqfnEY