### PR TITLE
fix(word-hunt): keep daily clue tiles on a single row

### DIFF
--- a/fe-next/components/daily/survival/SurvivalClueBoxes.tsx
+++ b/fe-next/components/daily/survival/SurvivalClueBoxes.tsx
@@ -53,8 +53,8 @@ function tileSizeClass(wordLength: number, compact?: boolean): string {
     : wordLength <= 6
       ? 'w-10 h-10 sm:w-11 sm:h-11 text-base sm:text-lg [@media(max-height:560px)]:w-6 [@media(max-height:560px)]:h-6 [@media(max-height:560px)]:text-[10px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none'
       : wordLength <= 8
-        ? 'w-9 h-9 sm:w-10 sm:h-10 text-sm sm:text-base [@media(max-height:560px)]:w-6 [@media(max-height:560px)]:h-6 [@media(max-height:560px)]:text-[10px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none'
-        : 'w-8 h-8 sm:w-9 sm:h-9 text-xs sm:text-sm [@media(max-height:560px)]:w-5 [@media(max-height:560px)]:h-5 [@media(max-height:560px)]:text-[9px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none';
+        ? 'w-8 h-8 sm:w-10 sm:h-10 text-sm sm:text-base [@media(max-height:560px)]:w-6 [@media(max-height:560px)]:h-6 [@media(max-height:560px)]:text-[10px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none'
+        : 'w-7 h-7 sm:w-9 sm:h-9 text-xs sm:text-sm [@media(max-height:560px)]:w-5 [@media(max-height:560px)]:h-5 [@media(max-height:560px)]:text-[9px] [@media(max-height:560px)]:rounded [@media(max-height:560px)]:border [@media(max-height:560px)]:shadow-none';
 }
 
 /**
@@ -251,7 +251,7 @@ const FeedbackOverlay: React.FC<FeedbackOverlayProps> = ({ feedback, targetWordL
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.95 }}
       transition={{ duration: 0.15 }}
-      className="flex justify-center flex-wrap gap-2 sm:gap-2.5"
+      className="flex justify-center flex-nowrap gap-1.5 sm:gap-2.5"
     >
       {normalizedFeedback.map((letterFb, idx) => {
         const isClue = letterFb.feedback === 'green' || letterFb.feedback === 'yellow';
@@ -327,7 +327,7 @@ const HintBoxes: React.FC<HintBoxesProps> = ({
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.95 }}
       transition={{ duration: 0.15 }}
-      className="flex justify-center flex-wrap gap-2 sm:gap-2.5"
+      className="flex justify-center flex-nowrap gap-1.5 sm:gap-2.5"
     >
       {hintChars.map((char, idx) => {
         const accumulatedClue = accumulatedClues.get(idx);

--- a/fe-next/components/daily/survival/__tests__/SurvivalClueBoxes.noWrap.test.tsx
+++ b/fe-next/components/daily/survival/__tests__/SurvivalClueBoxes.noWrap.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Single-row guard for the Word Hunt clue tiles.
+ *
+ * BUG: the clue tile rows used `flex-wrap`, so a 7-letter target (the max daily
+ * target length) overflowed the panel width on narrow phones and wrapped its
+ * last tile onto a second row. That doubled the clue-box height and shifted the
+ * whole layout below it — visibly "jumpy" and ugly (see daily Word Hunt report).
+ *
+ * FIX: the tile rows never wrap (`flex-nowrap`). Tile size + gap are tuned so a
+ * full 7-tile row fits one line even on the narrowest phones.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SurvivalClueBoxes } from '../SurvivalClueBoxes';
+import type { AccumulatedClue } from '../types';
+import type { LetterFeedback } from '@/utils/wordHuntFeedback';
+
+vi.mock('framer-motion', () => ({
+  m: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
+      const { initial, animate, exit, transition, whileHover, whileTap, ...domProps } = props;
+      return <div {...domProps}>{children}</div>;
+    },
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+const baseProps = {
+  currentHint: { level: 0, hint: '_ _ _ _ _ _ _', revealed: 0, unlockCost: 0 },
+  targetWord: '???????',
+  attempts: [],
+  accumulatedClues: new Map<number, AccumulatedClue>(),
+  revealedLetters: new Set<number>(),
+  knownLetters: new Set<string>(),
+  latestAttemptFeedback: null,
+  showFeedbackOverlay: false,
+  isClueGaining: false,
+  skipAnimations: true,
+  gameDir: 'ltr' as const,
+  t: (key: string) => key,
+};
+
+describe('SurvivalClueBoxes - clue tiles stay on one row (no wrap)', () => {
+  it('hint-box row never wraps for a 7-letter target', () => {
+    render(<SurvivalClueBoxes {...baseProps} />);
+    const row = screen.getAllByText('?')[0].parentElement as HTMLElement;
+    expect(row.className).toContain('flex-nowrap');
+    expect(row.className).not.toContain('flex-wrap');
+  });
+
+  it('feedback-overlay row never wraps for a 7-letter target', () => {
+    const feedback: LetterFeedback[] = [
+      { letter: 'A', feedback: 'green', position: 0 },
+      { letter: 'B', feedback: 'gray', position: 1 },
+      { letter: 'C', feedback: 'yellow', position: 2 },
+      { letter: 'D', feedback: 'gray', position: 3 },
+      { letter: 'E', feedback: 'gray', position: 4 },
+      { letter: 'F', feedback: 'gray', position: 5 },
+      { letter: 'G', feedback: 'green', position: 6 },
+    ];
+    render(
+      <SurvivalClueBoxes
+        {...baseProps}
+        latestAttemptFeedback={feedback}
+        showFeedbackOverlay
+      />
+    );
+    const tile = screen.getByText('A');
+    const row = tile.parentElement as HTMLElement;
+    expect(row.className).toContain('flex-nowrap');
+    expect(row.className).not.toContain('flex-wrap');
+  });
+});


### PR DESCRIPTION
The clue tile rows used `flex-wrap`, so a 7-letter target (the max daily
target length) overflowed the panel width on narrow phones and wrapped its
last tile onto a second row. That doubled the clue-box height and shifted
the whole layout below it, looking broken.

Switch both tile rows (HintBoxes + FeedbackOverlay) to `flex-nowrap`,
tighten the small-screen gap, and shrink the 7-letter tile a touch so a
full row always fits one line on the narrowest phones. Larger breakpoints
and the short-landscape/compact treatments are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HgaMqYrm1cdZ3dKJneeGu7