### PR TITLE
fix(word-tower): unstick toasts, raise crane, move wrecking ball up, block duplicate drops

### DIFF
--- a/fe-next/components/wordTower/WordTowerCrane.tsx
+++ b/fe-next/components/wordTower/WordTowerCrane.tsx
@@ -251,7 +251,7 @@ const WordTowerCrane = forwardRef<WordTowerCraneHandle, WordTowerCraneProps>(fun
 
   return (
     <div
-      className="pointer-events-auto absolute inset-x-0 top-[32%] z-30 flex flex-col items-center gap-3 px-4"
+      className="pointer-events-auto absolute inset-x-0 top-[20%] z-30 flex flex-col items-center gap-3 px-4"
       role="group"
       aria-label={t('wordTower.crane.place')}
     >

--- a/fe-next/components/wordTower/WordTowerPlay.tsx
+++ b/fe-next/components/wordTower/WordTowerPlay.tsx
@@ -138,11 +138,20 @@ interface PlayProps {
 }
 
 function usePrefersReducedMotion(): boolean {
-  const ref = useRef(false);
+  // Reactive STATE, not a ref: a ref mutation never re-renders, so the old
+  // version silently reported `false` forever — reduced-motion users still got
+  // every tween (and the snappy exitMs=0 dismiss path was never taken). Reading
+  // it as state means the preference is actually honoured, and it tracks live
+  // toggles via the media-query change event.
+  const [reduced, setReduced] = useState(false);
   useEffect(() => {
-    ref.current = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(mq.matches);
+    const onChange = () => setReduced(mq.matches);
+    mq.addEventListener?.('change', onChange);
+    return () => mq.removeEventListener?.('change', onChange);
   }, []);
-  return ref.current;
+  return reduced;
 }
 
 export function WordTowerPlay({ language, isInDictionary, dictionary, initialGame, personalBestM, onOpenLeaderboard, rivals = [], daily = false, onDailyEngaged, perkSeed = '', onNewDailyBest }: PlayProps) {
@@ -920,7 +929,7 @@ export function WordTowerPlay({ language, isInDictionary, dictionary, initialGam
           lime → gold "ON FIRE" so the streak reads at a glance. */}
       {crane.perfectStreak >= 2 && (
         <div
-          className={`pointer-events-none absolute start-2 top-[11%] z-[8] flex items-center gap-1 rounded-neo border-neo-thick border-black px-2 py-1 shadow-hard ${reducedMotion ? '' : 'animate-neo-pop'} ${
+          className={`pointer-events-none absolute start-2 top-28 z-[8] flex items-center gap-1 rounded-neo border-neo-thick border-black px-2 py-1 shadow-hard ${reducedMotion ? '' : 'animate-neo-pop'} ${
             crane.perfectStreak >= 5
               ? 'bg-gradient-to-b from-neo-yellow to-neo-orange text-black'
               : crane.perfectStreak >= 4

--- a/fe-next/components/wordTower/WordTowerSabotageBay.tsx
+++ b/fe-next/components/wordTower/WordTowerSabotageBay.tsx
@@ -96,16 +96,18 @@ export function WordTowerSabotageBay({
 
   return (
     <>
-      {/* Floating token chip — sits above the bottom HUD on the start (LTR=left)
-          side, opposite the (end-side) hazards. Tap to open the picker.
-          ONLY shown when tokens > 0 ("the wrecking ball should only show on the screen when the player has it"). */}
+      {/* Floating token chip — sits in the TOP section on the start side, just
+          under the header (founder ask: "the wrecking ball should show on top and
+          not in the bottom section when it exists"). Tap to open the picker. ONLY
+          shown when tokens > 0 ("the wrecking ball should only show on the screen
+          when the player has it"). */}
       {hasTokens && (
         <button
           type="button"
           onClick={onOpen}
           aria-label={t('wordTower.sabotage.chip')}
           className={cn(
-            'pointer-events-auto absolute start-3 bottom-[230px] z-40 flex items-center gap-1.5 rounded-neo border-neo-thick border-black bg-neo-pink px-2.5 py-1.5 font-neo-display text-sm font-black uppercase text-neo-white shadow-hard transition-transform hover:scale-105 active:translate-y-px',
+            'pointer-events-auto absolute start-3 top-16 z-40 flex items-center gap-1.5 rounded-neo border-neo-thick border-black bg-neo-pink px-2.5 py-1.5 font-neo-display text-sm font-black uppercase text-neo-white shadow-hard transition-transform hover:scale-105 active:translate-y-px',
             !reducedMotion && 'animate-neo-pop',
           )}
         >
@@ -128,7 +130,7 @@ export function WordTowerSabotageBay({
           aria-label={t('wordTower.sabotage.watchAd')}
           className={cn(
             'pointer-events-auto absolute start-3 z-40 flex items-center gap-1 rounded-neo border-neo border-black px-2 py-1 font-neo-display text-xs font-bold uppercase shadow-hard transition-transform',
-            hasTokens ? 'bottom-[190px]' : 'bottom-[230px]',
+            hasTokens ? 'top-28' : 'top-16',
             adLoading
               ? 'bg-neo-navy/60 text-neo-white/40'
               : 'bg-neo-cyan text-black hover:scale-105 active:translate-y-px',
@@ -146,7 +148,7 @@ export function WordTowerSabotageBay({
           role="status"
           aria-live="polite"
           className={cn(
-            'pointer-events-none absolute start-3 bottom-[240px] z-40 rounded-neo border-neo-thick border-black bg-neo-cyan px-3 py-1.5 text-start shadow-hard',
+            'pointer-events-none absolute start-3 top-40 z-40 rounded-neo border-neo-thick border-black bg-neo-cyan px-3 py-1.5 text-start shadow-hard',
             !reducedMotion && 'animate-neo-pop',
           )}
         >
@@ -162,7 +164,7 @@ export function WordTowerSabotageBay({
           role="status"
           aria-live="polite"
           className={cn(
-            'pointer-events-none absolute start-3 bottom-[280px] z-40 rounded-neo border-neo-thick border-black bg-neo-yellow px-3 py-1.5 text-start shadow-hard',
+            'pointer-events-none absolute start-3 top-40 z-40 rounded-neo border-neo-thick border-black bg-neo-yellow px-3 py-1.5 text-start shadow-hard',
             !reducedMotion && 'animate-neo-pop',
           )}
         >

--- a/fe-next/components/wordTower/__tests__/useExitReveal.test.tsx
+++ b/fe-next/components/wordTower/__tests__/useExitReveal.test.tsx
@@ -41,10 +41,11 @@ describe('useExitReveal — hold a toast through a cool exit after its source cl
     expect(result.current.value).toBe('On Fire!'); // the stale exit timer didn't kill it
   });
 
-  it('exitMs=0 unmounts on the next tick (reduced-motion path, no lingering anim)', () => {
+  it('exitMs=0 unmounts SYNCHRONOUSLY (reduced-motion path) — no timer to starve', () => {
     const { result, rerender } = renderHook(({ s }) => useExitReveal(s, 0), { initialProps: { s: 'Hi' as string | null } });
     rerender({ s: null });
-    act(() => { vi.advanceTimersByTime(1); });
+    // Cleared in the effect body, not via a 0ms timer — gone without advancing time.
     expect(result.current.value).toBeNull();
+    expect(result.current.exiting).toBe(false);
   });
 });

--- a/fe-next/components/wordTower/useAutoDismiss.ts
+++ b/fe-next/components/wordTower/useAutoDismiss.ts
@@ -54,6 +54,18 @@ export function useAutoDismiss(token: unknown, clear: () => void, ms: number): v
       };
       raf = requestAnimationFrame(tick);
     }
-    return () => { done = true; clearTimeout(timer); if (raf) cancelAnimationFrame(raf); };
+    // Backgrounding the app (app-switch / screen-lock) PAUSES both setTimeout and
+    // rAF, so a banner shown right before the switch can still be on screen on
+    // return — the founder's "notifications stay stuck" report, repro'd by
+    // photographing the game after coming back to it. The moment we're visible
+    // again, fire if the lifespan already elapsed while hidden.
+    const onVisible = () => { if (document.visibilityState === 'visible' && now() - start >= ms) fire(); };
+    if (typeof document !== 'undefined') document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      done = true;
+      clearTimeout(timer);
+      if (raf) cancelAnimationFrame(raf);
+      if (typeof document !== 'undefined') document.removeEventListener('visibilitychange', onVisible);
+    };
   }, [token, ms]);
 }

--- a/fe-next/components/wordTower/useExitReveal.ts
+++ b/fe-next/components/wordTower/useExitReveal.ts
@@ -32,6 +32,13 @@ export function useExitReveal<T>(source: T | null | undefined, exitMs = 420): { 
       // Live (or refreshed) content — show it now, cancel any pending exit.
       setValue(source);
       setExiting(false);
+    } else if (valueRef.current != null && exitMs <= 0) {
+      // Reduced-motion path: no exit animation, so clear SYNCHRONOUSLY instead of
+      // via setTimeout(0). A busy webview frame can starve that 0ms timer, leaving
+      // the toast stuck — the founder's "notifications stay stuck" report. Clearing
+      // in the effect body removes the timer dependency entirely.
+      setValue(null);
+      setExiting(false);
     } else if (valueRef.current != null) {
       // Source cleared while something is showing → run the exit, keep the last
       // value on screen until the animation finishes, then unmount it.

--- a/fe-next/lib/wordTower/__tests__/useWordTower.test.ts
+++ b/fe-next/lib/wordTower/__tests__/useWordTower.test.ts
@@ -114,6 +114,27 @@ describe('useWordTower', () => {
       expect(result.current.state.lastHazard?.kind).toBe('wobble');
     });
 
+    it('commitPlacement refuses a word already used — no double-place from a stale hold', () => {
+      // Repro of the "same word over and over" exploit: a word is held on the
+      // crane, the SAME word gets committed by another accept path, then dropping
+      // the now-stale held word must NOT place a duplicate floor.
+      const { result } = setup(acceptAll);
+      pick(result, [0, 1, 2]);
+      act(() => result.current.hold());
+      expect(result.current.state.pendingWord).not.toBeNull();
+
+      // The identical word lands via the immediate submit path.
+      pick(result, [0, 1, 2]);
+      act(() => result.current.submit());
+      expect(result.current.state.game.floors).toHaveLength(1);
+
+      // Dropping the stale held word is rejected as a duplicate — still 1 floor.
+      act(() => result.current.commitPlacement(1));
+      expect(result.current.state.game.floors).toHaveLength(1);
+      expect(result.current.state.pendingWord).toBeNull();
+      expect(result.current.state.lastError).toBe('duplicate');
+    });
+
     it('cancelPlacement drops the held word without committing', () => {
       const { result } = setup(acceptAll);
       pick(result, [0, 1, 2]);

--- a/fe-next/lib/wordTower/useWordTower.ts
+++ b/fe-next/lib/wordTower/useWordTower.ts
@@ -13,6 +13,7 @@ import type { Language } from '@/shared/types/game';
 import {
   initWordTowerState,
   validateTowerWord,
+  isTowerWordUsed,
   applyTowerWord,
   scrambleTray,
   spinWheelPaid,
@@ -115,6 +116,14 @@ function reducer(state: WordTowerUIState, action: Action): WordTowerUIState {
     case 'commitPlacement': {
       // Crane step 2: drop. Apply the held word scaled by the placement quality.
       if (!state.pendingWord) return state;
+      // Defense-in-depth against the "same word over and over" report: `hold`
+      // validated this word, but the drop is otherwise an unguarded apply. If the
+      // word was already placed by another path between hold and drop (or a stale
+      // drop re-fires), refuse it here so a duplicate can NEVER land twice. Normal
+      // play is unaffected — a freshly-held word is never in usedWords yet.
+      if (isTowerWordUsed(state.game, state.pendingWord)) {
+        return { ...state, pendingWord: null, lastError: 'duplicate', errorKey: state.errorKey + 1 };
+      }
       const { state: nextGame, result } = applyTowerWord(state.game, state.pendingWord, action.multiplier);
       return {
         ...state,

--- a/fe-next/lib/wordTower/wordTowerManager.ts
+++ b/fe-next/lib/wordTower/wordTowerManager.ts
@@ -314,6 +314,18 @@ export function validateTowerWord(
   return { accepted: true };
 }
 
+/**
+ * True when `word` (in any form) has already been placed this run — the SAME
+ * dedup key {@link validateTowerWord} uses. Exposed so the crane's commit path
+ * can re-check defensively: `hold` validates, but the drop (`commitPlacement`)
+ * is otherwise an UNGUARDED apply, so a word committed by another path between
+ * hold and drop could be re-placed ("the same word over and over"). The commit
+ * re-runs this so a duplicate can never land twice.
+ */
+export function isTowerWordUsed(state: WordTowerPlayerState, word: string): boolean {
+  return state.usedWords.has(canon(word, state.language));
+}
+
 export interface ApplyResult {
   floorAdded: true;
   meters: number;


### PR DESCRIPTION
Founder report (2026-06-27):
- Notifications (+m / "perfect" verdict) still stuck on screen sometimes.
- Crane sits too low; lots of wasted sky above it.
- Wrecking-ball token chip showed in the bottom section instead of on top.
- Some users could place the same word over and over.

Changes:
- useAutoDismiss: flush on visibilitychange — backgrounding the app pauses both
  setTimeout and rAF, so a banner shown right before an app-switch could stay on
  screen on return. Fire the moment we're visible again if its lifespan elapsed.
- useExitReveal: clear synchronously on the reduced-motion path (exitMs<=0)
  instead of via a setTimeout(0) a busy webview frame can starve.
- usePrefersReducedMotion: read as reactive state, not a ref — the ref version
  never re-rendered, so the preference was silently ignored (and the snappy
  exitMs=0 dismiss path was never taken).
- WordTowerCrane: raise the crane overlay (top-32% -> top-20%) to use the sky.
- WordTowerSabotageBay: move the wrecking-ball chip + its toasts from the bottom
  section to the top; nudge the steady-hands flow chip down so the start-side
  column stacks cleanly.
- commitPlacement: re-check the dedup before applying. `hold` validates, but the
  drop was an otherwise-unguarded apply — a word committed by another path
  between hold and drop could re-place the same word. New isTowerWordUsed helper
  + regression test.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HuuscvHvdJ5eq4uM6VbdUd