### PR TITLE
fix(word-wheel): make stage + wheel-disc ambient backdrops actually visible

### DIFF
--- a/fe-next/components/daily/WordWheelChallenge.tsx
+++ b/fe-next/components/daily/WordWheelChallenge.tsx
@@ -96,9 +96,9 @@ const WORD_WHEEL_DURATION = 120; // 2 minutes
 // Always-on + phase-independent → genuine ambient feel on ready/playing/results
 // without depending on the pixi layer.
 const STAGE_AMBIENT_BG =
-  'radial-gradient(125% 75% at 50% -8%, rgba(191,255,0,0.10) 0%, transparent 55%),' +
-  'radial-gradient(115% 70% at 50% 108%, rgba(0,255,255,0.08) 0%, transparent 55%),' +
-  'radial-gradient(70% 55% at 85% 82%, rgba(139,92,246,0.07) 0%, transparent 60%),' +
+  'radial-gradient(125% 75% at 50% -8%, rgba(191,255,0,0.18) 0%, transparent 58%),' +
+  'radial-gradient(115% 70% at 50% 108%, rgba(0,255,255,0.14) 0%, transparent 58%),' +
+  'radial-gradient(70% 55% at 85% 82%, rgba(139,92,246,0.12) 0%, transparent 62%),' +
   'radial-gradient(circle at 50% 42%, var(--neo-navy-elevated) 0%, var(--neo-navy) 55%, var(--neo-abyss) 100%)';
 
 // ==========================================

--- a/fe-next/components/daily/WordWheelGame.tsx
+++ b/fe-next/components/daily/WordWheelGame.tsx
@@ -1072,7 +1072,7 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
             //   1. a soft brand glow (lime→cyan) blooming from the center, and
             //   2. the elevated-navy depth disc fading to transparent at the rim.
             background:
-              'radial-gradient(circle at 50% 45%, rgba(191,255,0,0.08) 0%, rgba(0,255,255,0.05) 38%, transparent 62%),' +
+              'radial-gradient(circle at 50% 45%, rgba(191,255,0,0.22) 0%, rgba(0,255,255,0.13) 38%, transparent 64%),' +
               'radial-gradient(circle at center, var(--neo-navy-elevated) 0%, var(--neo-navy) 60%, transparent 80%)',
           }}
         />

--- a/fe-next/components/daily/__tests__/WordWheelChallenge.background.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelChallenge.background.test.tsx
@@ -131,5 +131,13 @@ describe('WordWheelChallenge background', () => {
     // instead of leaning on the play-only pixi bokeh. Lime + cyan at minimum.
     expect(bg).toContain('rgba(191,255,0'); // lime glow
     expect(bg).toContain('rgba(0,255,255'); // cyan glow
+
+    // Perceptibility floor. The first pass used ~0.07–0.10 alphas, which over a
+    // navy→abyss vignette still read as flat black on-device. The glows must be
+    // strong enough to give genuine ambient color, not an imperceptible tint.
+    const limeAlpha = Number(bg.match(/rgba\(191,255,0,\s*([0-9.]+)/)?.[1]);
+    const cyanAlpha = Number(bg.match(/rgba\(0,255,255,\s*([0-9.]+)/)?.[1]);
+    expect(limeAlpha).toBeGreaterThanOrEqual(0.16);
+    expect(cyanAlpha).toBeGreaterThanOrEqual(0.12);
   });
 });

--- a/fe-next/components/daily/__tests__/WordWheelGame.wheelBackdrop.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelGame.wheelBackdrop.test.tsx
@@ -108,5 +108,18 @@ describe('WordWheelGame — wheel backdrop depth', () => {
     // imperceptible. Lime + cyan tint at minimum.
     expect(backdrop!.style.background).toContain('rgba(191,255,0');
     expect(backdrop!.style.background).toContain('rgba(0,255,255');
+
+    // Perceptibility floor. Single-digit alphas (the old 0.08 lime / 0.05 cyan)
+    // bloom over a near-black disc and vanish on mobile OLED — the recurring
+    // "imperceptible delta" regression where the disc kept reading flat black.
+    // The glow must be strong enough to actually register as colored depth.
+    const limeAlpha = Number(
+      backdrop!.style.background.match(/rgba\(191,255,0,\s*([0-9.]+)/)?.[1],
+    );
+    const cyanAlpha = Number(
+      backdrop!.style.background.match(/rgba\(0,255,255,\s*([0-9.]+)/)?.[1],
+    );
+    expect(limeAlpha).toBeGreaterThanOrEqual(0.18);
+    expect(cyanAlpha).toBeGreaterThanOrEqual(0.1);
   });
 });


### PR DESCRIPTION
The Word Wheel play area kept reading as flat black on mobile OLED. Prior
fixes added a depth gradient + brand glows but pinned the glow alphas too
low (stage lime 0.10 / cyan 0.08 / violet 0.07; wheel disc lime 0.08 /
cyan 0.05), so they bloomed over the near-black navy->abyss vignette and
vanished on-device — the recurring "imperceptible delta" trap.

Raise the glow alphas to a perceptible floor so the backgrounds read as lit,
colored depth instead of solid black:
- stage: lime 0.18 / cyan 0.14 / violet 0.12
- wheel disc: lime 0.22 / cyan 0.13

Tests now assert a minimum glow alpha so a future near-zero value regresses.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013PwpMeDn1Hk61Ey3mbeaDb