### PR TITLE
fix(results): adjust desktop MP results ready bar to a horizontal layout

### DIFF
--- a/fe-next/components/results/StickyReadyBar.tsx
+++ b/fe-next/components/results/StickyReadyBar.tsx
@@ -343,7 +343,7 @@ export default function StickyReadyBar({
     const btnBase = 'w-full h-14 border-3 border-black rounded-xl shadow-hard font-black text-base uppercase tracking-tight flex items-center justify-center gap-3';
 
     return (
-      <div className="flex flex-col gap-2 flex-1 min-w-0">
+      <div className={cn('flex flex-col gap-2 flex-1 min-w-0', desktopProminent && 'max-w-md mx-auto')}>
         {/* Series Winner Banner */}
         <m.div
           initial={{ scale: 0.9, opacity: 0 }}
@@ -380,14 +380,13 @@ export default function StickyReadyBar({
     );
   }
 
-  return (
-    <div className="flex flex-col gap-2 flex-1 min-w-0 pb-[env(safe-area-inset-bottom)]">
-        {/* Host mode selector — always-visible horizontal pills.
-            On desktop (desktopProminent) the bar is wide, so the pills grow,
-            gain a labelled heading, and the active mode gets a high-contrast
-            ring + lift so switching modes reads clearly. */}
-        {isHost && selectedGameMode !== undefined && onSelectGameMode && (
-          <div className="flex flex-col gap-1 min-w-0">
+  /* Host mode selector — always-visible horizontal pills.
+     On desktop (desktopProminent) the bar is wide, so the pills grow,
+     gain a labelled heading, and the active mode gets a high-contrast
+     ring + lift so switching modes reads clearly. */
+  const modeSelectorBlock =
+    isHost && selectedGameMode !== undefined && onSelectGameMode ? (
+          <div className={cn('flex flex-col gap-1 min-w-0', desktopProminent && 'flex-1 justify-center')}>
             {desktopProminent && (
               <div className="text-center text-[10px] font-black uppercase tracking-widest text-neo-white/60">
                 {t('results.nextRoundMode')}
@@ -449,13 +448,11 @@ export default function StickyReadyBar({
               })()}
             </div>
           </div>
-        )}
+    ) : null;
 
-        {/* Contextual CTA button */}
-        {renderCtaButton()}
-
-        {/* Status Footer — ready avatar stack (excludes host — host clicks Start, not Ready) */}
-        {totalPlayers > 0 && (
+  /* Status Footer — ready avatar stack (excludes host — host clicks Start, not Ready) */
+  const readyFooterBlock =
+    totalPlayers > 0 ? (
           <div className="flex items-center justify-center gap-4" aria-live="polite" aria-label={`${readyCount}/${totalPlayers}`}>
             {/* Avatar dots with colored rings — bots always show as ready */}
             <div className="flex -space-x-1.5 rtl:space-x-reverse">
@@ -483,7 +480,33 @@ export default function StickyReadyBar({
               {readyCount} / {totalPlayers} {t('results.ready')}
             </span>
           </div>
+    ) : null;
+
+  // Desktop (desktopProminent): lay the mode selector and the CTA+ready group
+  // side-by-side so the wide bottom bar uses the horizontal space instead of
+  // stretching the action button edge-to-edge. Mobile keeps the stacked column.
+  return (
+    <div
+      data-testid="sticky-ready-bar"
+      className={cn(
+        'min-w-0 pb-[env(safe-area-inset-bottom)]',
+        desktopProminent
+          ? 'flex flex-row items-stretch gap-6 flex-1'
+          : 'flex flex-col gap-2 flex-1'
+      )}
+    >
+      {modeSelectorBlock}
+      <div
+        data-testid="ready-cta-group"
+        className={cn(
+          'flex flex-col gap-2 justify-center',
+          desktopProminent ? 'max-w-sm min-w-[18rem] shrink-0 mx-auto' : 'w-full min-w-0'
         )}
+      >
+        {/* Contextual CTA button */}
+        {renderCtaButton()}
+        {readyFooterBlock}
+      </div>
     </div>
   );
 }

--- a/fe-next/components/results/__tests__/StickyReadyBar.modeSelectorDesktop.test.tsx
+++ b/fe-next/components/results/__tests__/StickyReadyBar.modeSelectorDesktop.test.tsx
@@ -106,4 +106,30 @@ describe('StickyReadyBar desktop mode selector', () => {
     const active = screen.getByRole('button', { name: /label-blast/i });
     expect(active.className).toMatch(/ring-/);
   });
+
+  it('lays the desktop bar out horizontally so it uses the wide viewport', () => {
+    render(<StickyReadyBar {...baseProps} desktopProminent />);
+    const root = screen.getByTestId('sticky-ready-bar');
+    expect(root.className).toMatch(/flex-row/);
+  });
+
+  it('keeps the mobile bar stacked vertically (full-width column)', () => {
+    render(<StickyReadyBar {...baseProps} />);
+    const root = screen.getByTestId('sticky-ready-bar');
+    expect(root.className).toMatch(/flex-col/);
+    expect(root.className).not.toMatch(/flex-row/);
+  });
+
+  it('constrains the CTA group on desktop so the action button is not full-bleed', () => {
+    render(<StickyReadyBar {...baseProps} desktopProminent />);
+    const group = screen.getByTestId('ready-cta-group');
+    expect(group.className).toMatch(/max-w-/);
+  });
+
+  it('lets the CTA span the full width on mobile', () => {
+    render(<StickyReadyBar {...baseProps} />);
+    const group = screen.getByTestId('ready-cta-group');
+    expect(group.className).toMatch(/w-full/);
+    expect(group.className).not.toMatch(/max-w-/);
+  });
 });

--- a/fe-next/components/views/ResultsPage.tsx
+++ b/fe-next/components/views/ResultsPage.tsx
@@ -1271,7 +1271,7 @@ const ResultsPage: React.FC<ResultsPageProps> = ({ finalScores, gameCode, onRetu
           Portaled for the same ancestor-transform reason as mobile. */}
       {gameCode && onReturnToRoom && isDesktopViewport && typeof document !== 'undefined' && createPortal(
         <div ref={setStickyBarRef} className="fixed bottom-0 inset-x-0 z-[100] bg-neo-navy text-neo-white border-t-4 border-neo-black safe-area-pb">
-          <div className="max-w-6xl mx-auto px-4 py-2.5">
+          <div className="max-w-5xl mx-auto px-4 py-2.5">
             <StickyReadyBar
               isHost={isHost}
               isCurrentPlayerReady={isCurrentPlayerReady}


### PR DESCRIPTION
On desktop the multiplayer results StickyReadyBar stacked the mode
selector, CTA, and ready row in a full-width column spanning max-w-6xl,
so the rematch button stretched edge-to-edge as a thin bar that ignored
the wide viewport. Lay the desktop (desktopProminent) bar out as a row:
mode selector flexes on the start side, the CTA + ready group is
width-constrained (max-w-sm) on the end. Align the bar container to the
content column (max-w-5xl) and constrain the series-complete branch too.
Mobile keeps its stacked full-width column unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Kk9Tk7Vc6YqcU1KxvBy1yD