### PR TITLE
fix(daily): remove empty header band at top of Word Hunt screen

### DIFF
--- a/fe-next/components/AutoHideHeader.tsx
+++ b/fe-next/components/AutoHideHeader.tsx
@@ -9,6 +9,16 @@ interface AutoHideHeaderProps {
   className?: string;
   /** Callback when header visibility changes */
   onVisibilityChange?: (isVisible: boolean) => void;
+  /**
+   * Drop the CLS-protecting spacer (render nothing) when the header is hidden
+   * for gameplay / TV fullscreen. Opt-in for focused, full-screen game surfaces
+   * (e.g. the daily Word Hunt) where the reserved-but-empty band reads as a blank
+   * gap at the top. Safe there because entering the game happens behind a user tap,
+   * so the upward content shift falls inside the input-exclusion window (no CLS hit).
+   * Leave OFF (default) on pages like /multiplayer where collapsing the spacer
+   * regressed CLS to 0.29.
+   */
+  collapseSpacerWhenHidden?: boolean;
 }
 
 /**
@@ -23,7 +33,7 @@ interface AutoHideHeaderProps {
  *   the fixed-header + spacer pattern produced on CG.
  * In landscape mode it uses static positioning (handled by the Header component's landscape:static class).
  */
-export function AutoHideHeader({ className, onVisibilityChange }: AutoHideHeaderProps) {
+export function AutoHideHeader({ className, onVisibilityChange, collapseSpacerWhenHidden = false }: AutoHideHeaderProps) {
   const isTvFullscreen = useTvFullscreenListener();
   const { isInGame } = useNavigation();
   const { isOnCrazyGamesPlatform } = useCrazyGames();
@@ -39,6 +49,11 @@ export function AutoHideHeader({ className, onVisibilityChange }: AutoHideHeader
   // as the spacer-height slot collapses and content shifts up by 60–124px.
   if (isTvFullscreen || isInGame) {
     if (onVisibilityChange) onVisibilityChange(false);
+    // Focused full-screen game surfaces opt out of the reserved spacer so the
+    // hidden header leaves no empty band at the top (see prop docs above).
+    if (collapseSpacerWhenHidden) {
+      return null;
+    }
     return (
       <div
         aria-hidden="true"

--- a/fe-next/components/__tests__/AutoHideHeader.test.tsx
+++ b/fe-next/components/__tests__/AutoHideHeader.test.tsx
@@ -68,4 +68,27 @@ describe('AutoHideHeader', () => {
     render(<AutoHideHeader onVisibilityChange={onVisibilityChange} />);
     expect(onVisibilityChange).toHaveBeenCalledWith(false);
   });
+
+  it('collapses the spacer (returns null) during gameplay when collapseSpacerWhenHidden is set — no empty band on focused game screens', () => {
+    mockIsInGame = true;
+    const { queryByTestId, container } = render(
+      <AutoHideHeader collapseSpacerWhenHidden />,
+    );
+    expect(queryByTestId('header-mounted')).toBeNull();
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('collapses the spacer (returns null) during TV fullscreen when collapseSpacerWhenHidden is set', () => {
+    mockIsTvFullscreen = true;
+    const { queryByTestId, container } = render(
+      <AutoHideHeader collapseSpacerWhenHidden />,
+    );
+    expect(queryByTestId('header-mounted')).toBeNull();
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('still renders Header normally (lobby) when collapseSpacerWhenHidden is set but not in game', () => {
+    const { queryByTestId } = render(<AutoHideHeader collapseSpacerWhenHidden />);
+    expect(queryByTestId('header-mounted')).not.toBeNull();
+  });
 });

--- a/fe-next/components/daily/DailyChallenge.tsx
+++ b/fe-next/components/daily/DailyChallenge.tsx
@@ -566,7 +566,9 @@ const DailyChallenge: React.FC = () => {
     <div
       className={`flex-1 flex flex-col min-h-0 h-dvh max-h-dvh bg-gray-100 dark:bg-neo-navy relative overflow-x-clip overflow-hidden ${seasonSkin}`}
     >
-      <AutoHideHeader />
+      {/* Collapse the in-game header spacer so the focused Word Hunt screen has no
+          empty band at the top (the header is hidden during play anyway). */}
+      <AutoHideHeader collapseSpacerWhenHidden />
 
       <AnimatePresence mode="wait">
         {phase === 'loading' && (


### PR DESCRIPTION
The daily Word Hunt screen showed a tall blank band above the score
header. During gameplay AutoHideHeader hides the fixed app header but
kept its CLS-protecting spacer div, which on a focused full-screen game
reads as wasted empty space at the top.

Add an opt-in `collapseSpacerWhenHidden` prop to AutoHideHeader that
drops the spacer (renders nothing) when the header is hidden for
gameplay/TV fullscreen, and enable it on DailyChallenge. Multiplayer
keeps the spacer (default off) to preserve its CLS guard — entering the
daily game happens behind a user tap, so the upward shift falls inside
the input-exclusion window and incurs no CLS penalty.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R9m2rdoGTUYwjCzgxvuK4g