### PR TITLE
feat: auto-submit on desktop after 1s idle in all modes

### DIFF
--- a/fe-next/components/grid/__tests__/useGridInteraction.comboAutoSubmit.test.ts
+++ b/fe-next/components/grid/__tests__/useGridInteraction.comboAutoSubmit.test.ts
@@ -81,9 +81,12 @@ describe('useGridInteraction — combo auto-submit gating', () => {
       result.current.handleTouchMove({ clientX: 250, clientY: 50, cancelable: true, preventDefault: vi.fn() } as unknown as MouseEvent);
     });
 
-    // Player pauses for ~1s while still holding mouse. Combo timer (500ms)
-    // would fire if the gate were absent. With the gate, mouse pointer = no fire.
-    act(() => { vi.advanceTimersByTime(1500); });
+    // Player pauses while still holding mouse, up to just before the 1s desktop
+    // idle-auto-submit default. The combo timer (500ms) would fire in this
+    // window if the gate were absent; with the gate, a mouse pointer never trips
+    // it. (The idle-auto-submit path that DOES fire at 1000ms is covered in
+    // useGridInteraction.idleAutoSubmit.test.ts.)
+    act(() => { vi.advanceTimersByTime(999); });
 
     expect(onWordSubmit).not.toHaveBeenCalled();
   });

--- a/fe-next/components/grid/__tests__/useGridInteraction.idleAutoSubmit.test.ts
+++ b/fe-next/components/grid/__tests__/useGridInteraction.idleAutoSubmit.test.ts
@@ -3,10 +3,12 @@
  *
  * Founder report (desktop practice): building a word leaves it stuck selected;
  * players think they must click elsewhere to submit. Industry standard is
- * release-to-submit (drag) + auto-submit-on-idle (click-build). We add an
- * opt-in `autoSubmitIdleMs`: on desktop, once ≥3 letters are selected and the
- * player stalls for that long, submit automatically. Mobile keeps
- * release-to-submit (idle disabled so a paused finger never fires early).
+ * release-to-submit (drag) + auto-submit-on-idle (click-build). Desktop idle
+ * auto-submit is now ON BY DEFAULT in every mode: once ≥3 letters are selected
+ * and the player stalls for the default window (`DEFAULT_DESKTOP_AUTOSUBMIT_MS`,
+ * 1s), submit automatically. `autoSubmitIdleMs` still overrides the window per
+ * caller. Mobile keeps release-to-submit (idle disabled so a paused finger
+ * never fires early).
  */
 import { renderHook, act } from '@testing-library/react';
 import { useGridInteraction } from '../useGridInteraction';
@@ -102,7 +104,7 @@ describe('useGridInteraction — desktop idle auto-submit', () => {
     expect(onWordSubmit).not.toHaveBeenCalled();
   });
 
-  it('does NOT auto-submit when autoSubmitIdleMs is unset (MP/daily behavior preserved)', () => {
+  it('auto-submits after the default 1s window when autoSubmitIdleMs is unset (default-on, all modes)', () => {
     const onWordSubmit = vi.fn();
     const gridRef = buildRef();
     const { result } = renderHook(() =>
@@ -113,9 +115,12 @@ describe('useGridInteraction — desktop idle auto-submit', () => {
     );
 
     clickBuild(result, [[0, 0, 'A'], [0, 1, 'B'], [0, 2, 'C']]);
-    act(() => { vi.advanceTimersByTime(3000); });
+    act(() => { vi.advanceTimersByTime(999); });
+    expect(onWordSubmit).not.toHaveBeenCalled(); // still within the default idle window
 
-    expect(onWordSubmit).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(1); }); // crosses the 1000ms default
+    expect(onWordSubmit).toHaveBeenCalledTimes(1);
+    expect(onWordSubmit.mock.calls[0][0]).toBe('ABC');
   });
 
   it('does NOT idle-auto-submit during a real touch drag (mobile lifts a finger to submit)', () => {

--- a/fe-next/components/grid/submitHintVisibility.ts
+++ b/fe-next/components/grid/submitHintVisibility.ts
@@ -13,6 +13,16 @@
 export const DESKTOP_IDLE_AUTOSUBMIT_MS = 1500;
 
 /**
+ * Default desktop idle-auto-submit window (ms), applied by `useGridInteraction`
+ * to EVERY mode unless a caller overrides `autoSubmitIdleMs`. Once a desktop
+ * player has selected enough tiles (≥3) and stops for this long, the word
+ * submits automatically — no release/double-click needed. 1s is the founder-
+ * requested feel: long enough not to fire mid-build, short enough to feel
+ * hands-free. Touch is excluded in the hook (a paused finger must not submit).
+ */
+export const DEFAULT_DESKTOP_AUTOSUBMIT_MS = 1000;
+
+/**
  * Gate for the desktop "double-click last letter to submit" hint.
  *
  * Tap-to-build (click-select) words don't submit on their own on desktop — the

--- a/fe-next/components/grid/useGridInteraction.ts
+++ b/fe-next/components/grid/useGridInteraction.ts
@@ -22,6 +22,7 @@ import { createVelocityTracker } from './velocityTracker';
 import { getSelectionEscalation } from './selectionEscalation';
 import { useGridKeyboardHandler } from './useGridKeyboardHandler';
 import { useGridClickHandler } from './useGridClickHandler';
+import { DEFAULT_DESKTOP_AUTOSUBMIT_MS } from './submitHintVisibility';
 
 interface UseGridInteractionProps {
   grid: LetterGrid;
@@ -41,12 +42,13 @@ interface UseGridInteractionProps {
   /** Optional adjacency override — return true if cell2 is reachable from cell1 (e.g. portal teleportation). */
   isAdjacent?: (cell1: GridPosition, cell2: GridPosition) => boolean;
   /**
-   * Desktop-only idle auto-submit. When set (ms), a selection of ≥3 cells that
-   * sits unchanged for this long on a non-touch device submits automatically —
-   * so click-built words and drag-then-stall don't leave the word stuck
-   * (founder report: players thought they had to "click elsewhere" to submit).
-   * Undefined = off (multiplayer/daily keep release/tap-to-submit only).
-   * Mobile is excluded so a paused finger never fires early.
+   * Desktop-only idle auto-submit window (ms). A selection of ≥3 cells that sits
+   * unchanged for this long on a non-touch device submits automatically — so
+   * click-built words and drag-then-stall don't leave the word stuck (founder
+   * report: players thought they had to "click elsewhere" to submit).
+   * Defaults to {@link DEFAULT_DESKTOP_AUTOSUBMIT_MS} (1s) so EVERY mode gets
+   * hands-free desktop submit; callers may override the window. Mobile is
+   * excluded so a paused finger never fires early.
    */
   autoSubmitIdleMs?: number;
 }
@@ -89,7 +91,7 @@ export function useGridInteraction({
   disableLetterKeyInput = false,
   cellFilter,
   isAdjacent: isAdjacentOverride,
-  autoSubmitIdleMs,
+  autoSubmitIdleMs = DEFAULT_DESKTOP_AUTOSUBMIT_MS,
 }: UseGridInteractionProps): UseGridInteractionReturn {
   const [internalSelectedCells, setInternalSelectedCells] = useState<SelectedCell[]>([]);
   const [fadingCells, setFadingCells] = useState<GridPosition[]>([]);


### PR DESCRIPTION
Desktop idle auto-submit was opt-in (only practice sandboxes and legacy
BlastBoard wired `autoSubmitIdleMs`), so in the main MP/SP/daily game
modes a desktop player who selected enough tiles and paused was left with
the word stuck until they released/double-clicked.

Make it default-on in the shared `useGridInteraction` hook: when
`autoSubmitIdleMs` is unset it now falls back to a new
`DEFAULT_DESKTOP_AUTOSUBMIT_MS` (1s). Because every game grid (classic,
blast, word-hunt, wheel-rush, daily, survival, drills) routes through this
hook, all modes get hands-free desktop submit from one source of truth —
no per-call-site prop threading that could miss a mode. Mobile is still
excluded (a paused finger must not fire) and explicit callers keep their
override.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X7F5gB7i21NuVvTEmLYMwH