### PR TITLE
fix(word-wheel): scope live rivals to the played day and exclude self

### DIFF
--- a/fe-next/components/daily/WordWheelChallenge.tsx
+++ b/fe-next/components/daily/WordWheelChallenge.tsx
@@ -627,6 +627,9 @@ const WordWheelChallenge: React.FC = () => {
               language={language}
               practice={isPractice}
               isDesktop={isDesktop || isTv}
+              puzzleDate={catchupDate || getDailyChallengeDate()}
+              currentPlayerId={isAuthenticated && profile ? profile.id : null}
+              currentGuestFingerprint={!isAuthenticated ? guestFingerprint : null}
             />
           </m.div>
         )}

--- a/fe-next/components/daily/WordWheelGame.tsx
+++ b/fe-next/components/daily/WordWheelGame.tsx
@@ -53,6 +53,17 @@ interface WordWheelGameProps {
   onWordFound?: (word: string, wordsFound: string[]) => void;
   /** Desktop layout (1024w + 700h) — 3-column grid with ranks/wheel/words. */
   isDesktop?: boolean;
+  /**
+   * The puzzle date being played (YYYY-MM-DD). Drives which day's leaderboard
+   * the live rival pill reads from — on a catch-up replay this must be the
+   * PAST date, not today, or the player sees today's rivals on yesterday's
+   * board. Defaults to today when omitted.
+   */
+  puzzleDate?: string;
+  /** Current player id — filtered out of rivals so a replay can't show "you" as the player to beat. */
+  currentPlayerId?: string | null;
+  /** Current guest fingerprint — same self-filter for unauthenticated players. */
+  currentGuestFingerprint?: string | null;
 }
 
 
@@ -62,11 +73,13 @@ interface RivalScore {
   avatarImage: string | null;
   customAvatar: import('@/shared/types/customAvatar').CustomAvatarConfig | null;
   playerId: string | null;
+  guestFingerprint: string | null;
 }
 
 const WordWheelGame: React.FC<WordWheelGameProps> = ({
   puzzle, duration, onComplete, onValidateWord, onEffect, language, paused = false, practice = false,
   hideCompetitive = false, onWordFound, isDesktop = false,
+  puzzleDate, currentPlayerId = null, currentGuestFingerprint = null,
 }) => {
   const { t } = useLanguage();
   // `useReducedMotion` returns `true` when the user has set the OS-level
@@ -124,20 +137,31 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
     let interval: ReturnType<typeof setInterval> | null = null;
     const fetchRivals = async () => {
       try {
-        const today = new Date().toISOString().split('T')[0];
-        const res = await fetch(`/api/daily-challenge/word-wheel/leaderboard/${today}/${language}?limit=100`);
+        // Scope to the day being played, not always today — on a catch-up replay
+        // `puzzleDate` is a past date and today's board would be the wrong rivals.
+        const date = puzzleDate || new Date().toISOString().split('T')[0];
+        const res = await fetch(`/api/daily-challenge/word-wheel/leaderboard/${date}/${language}?limit=100`);
         if (!res.ok) return;
         const json = await res.json();
         if (cancelled) return;
         const list: RivalScore[] = (json.data || [])
           .filter((r: { score?: number; display_name?: string }) => typeof r.score === 'number' && r.display_name)
-          .map((r: { score: number; display_name: string; avatar_image?: string | null; custom_avatar?: import('@/shared/types/customAvatar').CustomAvatarConfig | null; player_id?: string | null }) => ({
+          .map((r: { score: number; display_name: string; avatar_image?: string | null; custom_avatar?: import('@/shared/types/customAvatar').CustomAvatarConfig | null; player_id?: string | null; guest_fingerprint?: string | null }) => ({
             name: r.display_name,
             score: r.score,
             avatarImage: r.avatar_image ?? null,
             customAvatar: r.custom_avatar ?? null,
             playerId: r.player_id ?? null,
+            guestFingerprint: r.guest_fingerprint ?? null,
           }))
+          // Never surface the current player as their own rival. On a replay the
+          // player's prior score already sits on that day's board, so without this
+          // they'd see themselves in the "player to beat" pill.
+          .filter((r: RivalScore) => {
+            if (currentPlayerId) return r.playerId !== currentPlayerId;
+            if (currentGuestFingerprint) return r.guestFingerprint !== currentGuestFingerprint;
+            return true;
+          })
           .sort((a: RivalScore, b: RivalScore) => a.score - b.score);
         setRivals(list);
       } catch { /* leaderboard is best-effort */ }
@@ -170,7 +194,7 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
         document.removeEventListener('visibilitychange', handleVisibility);
       }
     };
-  }, [language, hideCompetitive]);
+  }, [language, hideCompetitive, puzzleDate, currentPlayerId, currentGuestFingerprint]);
 
   // Closest rival above me + pass detection
   const nextRival = useMemo(
@@ -834,7 +858,11 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
           gap to preserve vertical budget). */}
       <m.div
         data-testid="word-builder"
-        className="relative w-full mt-2 short:mt-1 h-[52px] sm:h-[72px] short:h-[44px] flex items-center justify-center"
+        // z-20 lifts the whole builder (and its `-bottom-7` feedback toast) above
+        // the next-rival pill that sits in the reserved slot directly below — the
+        // toast hangs into that slot's band, so without this the error/score toast
+        // renders partially behind the rival avatar.
+        className="relative z-20 w-full mt-2 short:mt-1 h-[52px] sm:h-[72px] short:h-[44px] flex items-center justify-center"
         animate={
           wordBuilderShake
             ? { x: [-4, 4, -3, 3, -1, 0] }

--- a/fe-next/components/daily/__tests__/WordWheelGame.rivalSelfFilter.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelGame.rivalSelfFilter.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * The live "next rival" pill must reflect the day actually being played and must
+ * never surface the current player as their own rival.
+ *
+ * Two bugs this guards:
+ *  1. Wrong day on catch-up — the leaderboard fetch was hardcoded to `today`, so
+ *     replaying a previous day showed today's rivals instead of that day's.
+ *  2. Self as rival — when replaying a past day the player's own prior score is
+ *     already on that day's board, so they saw themselves as "the player to beat".
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/utils/growthTracking', () => ({
+  trackGameStart: vi.fn(),
+  trackGameEnd: vi.fn(),
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  // Interpolate `name` so the rival pill text is assertable.
+  useLanguage: () => ({
+    language: 'en',
+    t: (k: string, params?: Record<string, unknown>) =>
+      params && 'name' in params ? String(params.name) : k,
+  }),
+}));
+
+vi.mock('@/contexts/SoundEffectsContext', () => ({
+  useSoundEffects: () => ({
+    playTileSelectSound: vi.fn(),
+    playWordAcceptedSound: vi.fn(),
+    playWordRejectedSound: vi.fn(),
+    playComboSound: vi.fn(),
+    playLegendaryWordSound: vi.fn(),
+    playEpicVictorySound: vi.fn(),
+    playCountdownBeep: vi.fn(),
+    playButtonClickSound: vi.fn(),
+    playWordLengthSound: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useWordWheelKeyboard', () => ({
+  useWordWheelKeyboard: () => ({ keyboardFocused: false }),
+}));
+
+vi.mock('../WordWheelPixiRing', () => ({
+  __esModule: true,
+  default: () => <div data-testid="pixi-ring-stub" />,
+}));
+
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => () => <div data-testid="dynamic-stub" />,
+}));
+
+vi.mock('@/utils/dailyChallenge/wordWheelGeneration', () => ({
+  isValidWordWheelWord: () => true,
+}));
+
+vi.mock('@/utils/dailyChallenge/wordWheelScoring', () => ({
+  scoreWord: (w: string) => w.length,
+}));
+
+// Keep the rival avatar trivial so the pill text is the only thing rendered.
+vi.mock('@/components/Avatar', () => ({
+  __esModule: true,
+  default: () => <span data-testid="avatar-stub" />,
+}));
+
+import WordWheelGame from '../WordWheelGame';
+import type { WordWheelPuzzle } from '@/utils/dailyChallenge/wordWheelGeneration';
+
+const puzzle: WordWheelPuzzle = {
+  centerLetter: 'A',
+  outerLetters: ['B', 'C', 'D', 'E', 'F', 'G'],
+  allLetters: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+  validWords: ['CAB'],
+  language: 'en',
+} as unknown as WordWheelPuzzle;
+
+const renderGame = (props: Partial<React.ComponentProps<typeof WordWheelGame>> = {}) =>
+  render(
+    <WordWheelGame
+      puzzle={puzzle}
+      duration={60}
+      onComplete={vi.fn()}
+      onValidateWord={vi.fn().mockResolvedValue(true)}
+      onEffect={vi.fn()}
+      language="en"
+      {...props}
+    />,
+  );
+
+const mockLeaderboard = (rows: unknown[]) => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: rows }),
+  }) as unknown as typeof fetch;
+};
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch;
+});
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('WordWheelGame rival self-filter + day scoping', () => {
+  it('fetches the leaderboard for the puzzle date being played, not today', async () => {
+    mockLeaderboard([]);
+    renderGame({ puzzleDate: '2026-06-20' });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const url = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain('/leaderboard/2026-06-20/');
+  });
+
+  it('excludes the current player (by id) from the next-rival pill', async () => {
+    mockLeaderboard([
+      { score: 50, display_name: 'SelfPlayer', player_id: 'me' },
+      { score: 80, display_name: 'RealRival', player_id: 'other' },
+    ]);
+    renderGame({ puzzleDate: '2026-06-20', currentPlayerId: 'me' });
+    await waitFor(() => expect(screen.getByText('RealRival')).toBeInTheDocument());
+    expect(screen.queryByText('SelfPlayer')).toBeNull();
+  });
+
+  it('excludes the current guest (by fingerprint) from the next-rival pill', async () => {
+    mockLeaderboard([
+      { score: 50, display_name: 'SelfGuest', player_id: null, guest_fingerprint: 'fp1' },
+      { score: 80, display_name: 'RealRival', player_id: 'other', guest_fingerprint: 'fp2' },
+    ]);
+    renderGame({ puzzleDate: '2026-06-20', currentGuestFingerprint: 'fp1' });
+    await waitFor(() => expect(screen.getByText('RealRival')).toBeInTheDocument());
+    expect(screen.queryByText('SelfGuest')).toBeNull();
+  });
+});


### PR DESCRIPTION
The "player to beat" pill (and desktop live-ranks panel) read the
leaderboard hardcoded to today's date, so a catch-up replay of a previous
day showed today's rivals instead of that day's. On a replay the player's
own prior score already sits on that day's board, so they also saw
themselves as their own rival.

Now WordWheelGame takes the puzzleDate being played and the current
player id / guest fingerprint: it fetches that day's leaderboard and
filters the current player out of the rival list. Also lift the word
builder (z-20) so its feedback toast renders in front of the rival
avatar pill below instead of partially behind it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014gCajJw1hKN7DmnoVRPdQ5