### PR TITLE
fix(practice): replayable completed tiles, multiplayer funnel, drop frozen wheel timer

### DIFF
--- a/fe-next/app/[locale]/practice/PageClient.tsx
+++ b/fe-next/app/[locale]/practice/PageClient.tsx
@@ -269,24 +269,27 @@ export default function PracticeHubClient({ locale }: Props) {
               </>
             );
 
-            // Finished stages are status, not navigation — render them as a
-            // non-interactive card. But make that "done" state feel *earned*:
-            // full-saturation art, a gold trophy ribbon, and a soft mode-color
-            // glow layered over the hard shadow — a claimed badge, not a
-            // greyed-out dead tile.
+            // Finished stages still feel *earned* — full-saturation art, a gold
+            // trophy ribbon, and a soft mode-color glow layered over the hard
+            // shadow. They remain tappable so a player can REPLAY a finished
+            // mode: an inert "done" tile that swallowed taps was a silent no-op
+            // and a rage-click magnet (founder report). `?play=1` skips the
+            // tutorial they've already seen and drops straight into the sandbox.
             if (isDone) {
               return (
-                <div
+                <Link
                   key={mode}
+                  href={`/${locale}/practice/${mode}?play=1`}
+                  onClick={handleTileTap}
                   data-testid={`practice-tile-${mode}`}
                   data-complete="true"
                   data-next="false"
                   aria-label={`${t(`gameModes.${mode}.name`)} — ${t('practiceHub.completedBadge')}`}
-                  className={`${baseClass} ${accent.doneTile} cursor-default`}
+                  className={`${baseClass} ${accent.doneTile} active:translate-y-px md:hover:-translate-y-1`}
                   style={{ boxShadow: `2px 2px 0 #000, 0 0 18px rgba(${accent.glowRgb}, 0.28)` }}
                 >
                   {inner}
-                </div>
+                </Link>
               );
             }
 

--- a/fe-next/app/[locale]/practice/__tests__/PageClient.test.tsx
+++ b/fe-next/app/[locale]/practice/__tests__/PageClient.test.tsx
@@ -75,12 +75,15 @@ describe('PracticeHubClient tutorial simplification', () => {
     expect(tile).toHaveAttribute('href', '/en/practice/classic');
   });
 
-  it('renders a completed mode as a non-interactive, clearly-done card (not a button)', () => {
+  it('renders a completed mode as a replayable link (tapping a finished mode replays it, never a dead no-op)', () => {
+    // Root-cause fix for rage-clicks: completed tiles used to be inert <div>s, so
+    // a player who finished a mode and tapped it again got ZERO response. It now
+    // links back into the mode with ?play=1 (skip the tutorial they already saw).
     mockCompleted.current = new Set(['classic']);
     wrap(<PracticeHubClient locale="en" />);
     const tile = screen.getByTestId('practice-tile-classic');
-    expect(tile.tagName).not.toBe('A');
-    expect(tile).not.toHaveAttribute('href');
+    expect(tile.tagName).toBe('A');
+    expect(tile).toHaveAttribute('href', '/en/practice/classic?play=1');
     expect(tile).toHaveAttribute('data-complete', 'true');
   });
 
@@ -93,12 +96,12 @@ describe('PracticeHubClient tutorial simplification', () => {
 });
 
 describe('PracticeHubClient completed-tile celebration', () => {
-  it('renders a finished mode as a celebratory trophy card — not a dimmed/disabled tile', () => {
+  it('renders a finished mode as a celebratory, REPLAYABLE trophy card — not a dead no-op tile', () => {
     mockCompleted.current = new Set(['classic']);
     wrap(<PracticeHubClient locale="en" />);
     const tile = screen.getByTestId('practice-tile-classic');
-    // Still a non-interactive status card (deliberate: status, not navigation).
-    expect(tile.tagName).not.toBe('A');
+    // Replayable (a finished mode that does nothing on tap = rage-click bait).
+    expect(tile.tagName).toBe('A');
     expect(tile).toHaveAttribute('data-complete', 'true');
     // Satisfying, not greyed-out: no dimming, and a trophy badge celebrates it.
     expect(tile.className).not.toContain('opacity-80');

--- a/fe-next/components/daily/WordWheelGame.tsx
+++ b/fe-next/components/daily/WordWheelGame.tsx
@@ -758,11 +758,16 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
 
       {/* ── Timer & Score Bar ── */}
       <div className="w-full space-y-1.5">
-        <div className="flex items-center justify-between w-full gap-2">
-          <div className={cn('flex items-center gap-1.5 font-neo-display font-black text-lg sm:text-xl shrink-0', timerColor, timerPulse)}>
-            <Clock className="w-4 h-4 sm:w-5 sm:h-5" />
-            <span className="tabular-nums">{minutes}:{seconds.toString().padStart(2, '0')}</span>
-          </div>
+        <div className={cn('flex items-center w-full gap-2', practice ? 'justify-center' : 'justify-between')}>
+          {/* Countdown clock — only in the timed game. Practice has no timer, so
+              a static "2:00" that never moves just reads as broken; we drop it
+              entirely (the "End run" CTA below replaces the progress bar). */}
+          {!practice && (
+            <div data-testid="wheel-timer" className={cn('flex items-center gap-1.5 font-neo-display font-black text-lg sm:text-xl shrink-0', timerColor, timerPulse)}>
+              <Clock className="w-4 h-4 sm:w-5 sm:h-5" />
+              <span className="tabular-nums">{minutes}:{seconds.toString().padStart(2, '0')}</span>
+            </div>
+          )}
           <div className="flex items-center gap-2 sm:gap-3 min-w-0">
             {/* Combo counter — reserved slot avoids horizontal layout shift in top bar.
                 Dropped entirely in the practice hub (hideCompetitive) — no combo pressure. */}

--- a/fe-next/components/daily/__tests__/WordWheelGame.practice.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelGame.practice.test.tsx
@@ -87,6 +87,36 @@ describe('WordWheelGame practice mode', () => {
     expect(onComplete).not.toHaveBeenCalled();
   });
 
+  it('hides the countdown timer in practice mode (a frozen 2:00 that never ticks looks broken)', () => {
+    const { rerender } = render(
+      <WordWheelGame
+        puzzle={puzzle}
+        duration={120}
+        onComplete={vi.fn()}
+        onValidateWord={vi.fn().mockResolvedValue(false)}
+        onEffect={vi.fn()}
+        language="en"
+        practice
+      />
+    );
+    // Practice has no countdown, so the static clock must not render.
+    expect(screen.queryByTestId('wheel-timer')).toBeNull();
+    expect(screen.queryByText('2:00')).toBeNull();
+
+    // The real (timed) game still shows the countdown clock.
+    rerender(
+      <WordWheelGame
+        puzzle={puzzle}
+        duration={120}
+        onComplete={vi.fn()}
+        onValidateWord={vi.fn().mockResolvedValue(false)}
+        onEffect={vi.fn()}
+        language="en"
+      />
+    );
+    expect(screen.getByTestId('wheel-timer')).toBeInTheDocument();
+  });
+
   it('renders an "end practice" CTA in practice mode that fires onComplete', () => {
     const onComplete = vi.fn();
     render(

--- a/fe-next/components/practice/__tests__/PracticeBailoutCta.test.tsx
+++ b/fe-next/components/practice/__tests__/PracticeBailoutCta.test.tsx
@@ -17,13 +17,13 @@ import PracticeBailoutCta from '../PracticeBailoutCta';
 
 describe('PracticeBailoutCta', () => {
   it('renders the mode-correct bailout key when not yet done', () => {
-    render(<PracticeBailoutCta mode="classic" done={false} href="/en/singleplayer?practice=1" />);
+    render(<PracticeBailoutCta mode="classic" done={false} href="/en/multiplayer" />);
     const cta = screen.getByTestId('practice-bailout-cta');
     expect(cta).toHaveTextContent('practice.classic.bailoutCta');
   });
 
   it('renders the mode-correct play-for-real key when done — classic (regression)', () => {
-    render(<PracticeBailoutCta mode="classic" done href="/en/singleplayer?practice=1" />);
+    render(<PracticeBailoutCta mode="classic" done href="/en/multiplayer" />);
     const cta = screen.getByTestId('practice-bailout-cta');
     expect(cta).toHaveTextContent('practice.classic.playRealCta');
     // The old bug rendered the wordHunt key on the classic screen.
@@ -47,15 +47,15 @@ describe('PracticeBailoutCta', () => {
   });
 
   it('links to the provided real-game href', () => {
-    render(<PracticeBailoutCta mode="classic" done={false} href="/en/singleplayer?practice=1" />);
+    render(<PracticeBailoutCta mode="classic" done={false} href="/en/multiplayer" />);
     expect(screen.getByTestId('practice-bailout-cta')).toHaveAttribute(
       'href',
-      '/en/singleplayer?practice=1',
+      '/en/multiplayer',
     );
   });
 
   it('is visually quiet — no saturated pink fill / heavy border (it is an escape, not the hero)', () => {
-    render(<PracticeBailoutCta mode="classic" done={false} href="/en/singleplayer?practice=1" />);
+    render(<PracticeBailoutCta mode="classic" done={false} href="/en/multiplayer" />);
     const cta = screen.getByTestId('practice-bailout-cta');
     expect(cta.className).not.toMatch(/bg-neo-pink/);
     expect(cta.className).not.toMatch(/border-3/);
@@ -65,7 +65,7 @@ describe('PracticeBailoutCta', () => {
     // Founder ask: the skip-to-real-game escape was a faint underline link that
     // players missed. It must read as an actual button — a visible border + rounded
     // frame — without becoming the loud hero CTA (still no pink / border-3 above).
-    render(<PracticeBailoutCta mode="classic" done={false} href="/en/singleplayer?practice=1" />);
+    render(<PracticeBailoutCta mode="classic" done={false} href="/en/multiplayer" />);
     const cta = screen.getByTestId('practice-bailout-cta');
     expect(cta.className).toMatch(/border-2/);
     expect(cta.className).toMatch(/rounded-neo/);
@@ -73,7 +73,7 @@ describe('PracticeBailoutCta', () => {
 
   it('always shows the forward arrow (clear "go play" affordance, not just done state)', () => {
     const { container } = render(
-      <PracticeBailoutCta mode="classic" done={false} href="/en/singleplayer?practice=1" />,
+      <PracticeBailoutCta mode="classic" done={false} href="/en/multiplayer" />,
     );
     expect(container.querySelector('svg')).toBeTruthy();
   });

--- a/fe-next/lib/practice/__tests__/practiceRoute.test.ts
+++ b/fe-next/lib/practice/__tests__/practiceRoute.test.ts
@@ -17,8 +17,14 @@ describe('practiceTargetUrl', () => {
     expect(practiceTargetUrl('wheelRush', 'es')).toBe('/es/daily/word-wheel?practice=1');
   });
 
-  it('maps classic to /singleplayer with practice flag', () => {
-    expect(practiceTargetUrl('classic', 'ja')).toBe('/ja/singleplayer?practice=1');
+  it('maps classic to /multiplayer (practice never funnels players into single-player mode)', () => {
+    expect(practiceTargetUrl('classic', 'ja')).toBe('/ja/multiplayer');
+  });
+
+  it('never routes any practice mode into single-player mode', () => {
+    PRACTICE_MODES.forEach((mode) => {
+      expect(practiceTargetUrl(mode, 'en')).not.toContain('/singleplayer');
+    });
   });
 
   it('preserves locale across all practice modes', () => {

--- a/fe-next/lib/practice/practiceRoute.ts
+++ b/fe-next/lib/practice/practiceRoute.ts
@@ -13,7 +13,11 @@ export function practiceTargetUrl(mode: PracticeMode, locale: string): string {
       return `/${locale}/daily/word-wheel?practice=1`;
     case 'classic':
     default:
-      return `/${locale}/singleplayer?practice=1`;
+      // Practice always funnels into MULTIPLAYER — never single-player mode.
+      // Classic practice used to point at `/singleplayer`, which contradicted
+      // the product rule "practice graduates players into multiplayer, not solo
+      // play". The Arena (/multiplayer) is the real-game destination.
+      return `/${locale}/multiplayer`;
   }
 }
 


### PR DESCRIPTION
Three practice-mode fixes from a player session report:

- Rage-click root cause: finished mode tiles in the practice hub were
  rendered as inert <div>s ("status, not navigation"), so tapping a
  completed mode did nothing — a silent no-op and rage-click magnet.
  They are now replayable links (?play=1 skips the already-seen
  tutorial) while keeping the celebratory trophy styling.

- Never funnel practice into single-player mode: classic practice's
  "play for real" CTA pointed at /singleplayer. It now routes to
  /multiplayer (the Arena) like every other practice graduation path.

- Wheel practice looked broken: it showed a static 2:00 countdown that
  never ticks (practice has no timer). The clock is now hidden in
  practice mode; the "End run" CTA already replaces the progress bar.

Tests updated/added for all three; full practice + wheel suites green
(471 passing).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DJto3px72rLtDWmiUKW5B2