### PR TITLE
fix(player-style): only surface style popup at natural breaks, never mid-game

### DIFF
--- a/fe-next/app/components/PlayerStyleOnboardingWrapper.tsx
+++ b/fe-next/app/components/PlayerStyleOnboardingWrapper.tsx
@@ -11,6 +11,8 @@ import dynamic from 'next/dynamic';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { isLandingRoute } from '@/lib/onboarding/allowedRoutes';
+import { isGameplayPath } from '@/lib/gameplayRoutes';
+import { useGameActive, useWaitingForResults } from '@/hooks/gameState/store';
 import { hasCompletedOnboarding } from '@/utils/onboardingStorage';
 import {
   getStoredPlayerStyle,
@@ -50,6 +52,23 @@ export default function PlayerStyleOnboardingWrapper() {
   const profileShownAt = profile?.player_style_modal_shown_at ?? null;
   const profileStyle = profile?.player_style ?? null;
 
+  // Natural-break signals (global Zustand singleton — readable here, and the
+  // selectors re-render this wrapper when a game starts/ends so the gate is
+  // re-evaluated at the moment the game is over).
+  const gameActive = useGameActive();
+  const waitingForResults = useWaitingForResults();
+  const onGameplayRoute = isGameplayPath(pathname);
+  // A game has actually started this mount. Distinguishes "results screen" (a
+  // game finished → natural break) from "pre-game" (never started → still mid-
+  // flow) on a gameplay route, where both read gameActive === false.
+  const hasPlayedRef = useRef(false);
+  useEffect(() => {
+    if (gameActive) hasPlayedRef.current = true;
+  }, [gameActive]);
+  // On a gameplay route, the popup may only open once the game is over: either a
+  // game was played and is now finished, or the results are being computed.
+  const resultsShowing = (hasPlayedRef.current || waitingForResults) && !gameActive;
+
   useEffect(() => {
     if (!isMounted) return;
     // Don't fight the profile-customization modal; small settle delay.
@@ -78,6 +97,12 @@ export default function PlayerStyleOnboardingWrapper() {
         // Never trap a JS-rendering crawler behind the full-screen style modal —
         // it must index the deep-route page content, not the overlay.
         isCrawler: isCrawler(),
+        // Natural-break gating: never open mid-game, and on a gameplay route hold
+        // until the results screen ("after game"). Off gameplay routes the user
+        // is idle (menu/home) so it may open straight away.
+        gameActive,
+        onGameplayRoute,
+        resultsShowing,
       });
       // Only ever OPEN from the effect; dismissal owns closing. This prevents a
       // dep change while the modal is open from yanking it shut mid-choice, and
@@ -96,6 +121,13 @@ export default function PlayerStyleOnboardingWrapper() {
     profileLoaded,
     profileShownAt,
     profileStyle,
+    // Re-evaluate at natural breaks: when a game ends (gameActive flips false),
+    // results land, or the user navigates to a different surface.
+    gameActive,
+    waitingForResults,
+    onGameplayRoute,
+    resultsShowing,
+    pathname,
   ]);
 
   const markShown = useCallback(async () => {

--- a/fe-next/app/components/__tests__/PlayerStyleOnboardingWrapper.markOnShow.test.tsx
+++ b/fe-next/app/components/__tests__/PlayerStyleOnboardingWrapper.markOnShow.test.tsx
@@ -34,6 +34,7 @@ let pathname = '/en/practice';
 vi.mock('next/navigation', () => ({ usePathname: () => pathname }));
 
 import PlayerStyleOnboardingWrapper from '../PlayerStyleOnboardingWrapper';
+import { useGameStore } from '@/hooks/gameState/store';
 
 function renderAndSettle() {
   render(<PlayerStyleOnboardingWrapper />);
@@ -45,6 +46,7 @@ function renderAndSettle() {
 describe('PlayerStyleOnboardingWrapper — mark on show + migrate on login', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    useGameStore.getState().resetAll();
     markPlayerStyleModalShown.mockClear();
     hasPlayerStyleModalBeenShown.mockReturnValue(false);
     getStoredPlayerStyle.mockReturnValue(null);
@@ -56,11 +58,14 @@ describe('PlayerStyleOnboardingWrapper — mark on show + migrate on login', () 
       updateProfile,
       loading: false,
     };
-    pathname = '/en/practice';
+    // A non-gameplay in-app screen: the popup may surface here at once (no
+    // results gate), keeping these mark-on-show cases independent of game state.
+    pathname = '/en/leaderboard';
   });
   afterEach(() => {
     vi.runOnlyPendingTimers();
     vi.useRealTimers();
+    useGameStore.getState().resetAll();
   });
 
   it('writes the device-level "shown" flag the moment the popup is shown (not on dismiss)', () => {

--- a/fe-next/app/components/__tests__/PlayerStyleOnboardingWrapper.route.test.tsx
+++ b/fe-next/app/components/__tests__/PlayerStyleOnboardingWrapper.route.test.tsx
@@ -31,14 +31,17 @@ let pathname = '/en/practice';
 vi.mock('next/navigation', () => ({ usePathname: () => pathname }));
 
 import PlayerStyleOnboardingWrapper from '../PlayerStyleOnboardingWrapper';
+import { useGameStore } from '@/hooks/gameState/store';
 
 describe('PlayerStyleOnboardingWrapper route gate', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    useGameStore.getState().resetAll();
   });
   afterEach(() => {
     vi.runOnlyPendingTimers();
     vi.useRealTimers();
+    useGameStore.getState().resetAll();
   });
 
   function renderAndSettle() {
@@ -63,10 +66,52 @@ describe('PlayerStyleOnboardingWrapper route gate', () => {
     expect(screen.queryByTestId('style-popup')).not.toBeInTheDocument();
   });
 
-  it('renders the style popup on an in-app route (eligible guest)', () => {
+  it('does NOT render on a gameplay route before a game is played (pre-game/lobby)', () => {
+    // The "wrong moment" fix: on /practice etc. the popup must not open over the
+    // pre-game setup. It waits for the game to finish (results screen).
     pathname = '/en/practice';
     renderAndSettle();
+    expect(screen.queryByTestId('style-popup')).not.toBeInTheDocument();
+  });
+
+  it('renders on a gameplay route once a game has ended (results screen)', () => {
+    pathname = '/en/practice';
+    render(<PlayerStyleOnboardingWrapper />);
+    act(() => {
+      vi.advanceTimersByTime(900); // pre-game decision → stays hidden
+    });
+    expect(screen.queryByTestId('style-popup')).not.toBeInTheDocument();
+    // A game is played, then ends → results screen is the natural break.
+    act(() => {
+      useGameStore.getState().setGameActive(true);
+    });
+    act(() => {
+      useGameStore.getState().setGameActive(false);
+    });
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
     expect(screen.getByTestId('style-popup')).toBeInTheDocument();
+  });
+
+  it('renders on a non-gameplay in-app screen when idle (menu/leaderboard)', () => {
+    // Off gameplay routes the user is already at rest — nothing to interrupt — so
+    // the popup may surface without waiting for a results screen.
+    pathname = '/en/leaderboard';
+    renderAndSettle();
+    expect(screen.getByTestId('style-popup')).toBeInTheDocument();
+  });
+
+  it('does NOT render while a game is actively being played', () => {
+    pathname = '/en/multiplayer';
+    render(<PlayerStyleOnboardingWrapper />);
+    act(() => {
+      useGameStore.getState().setGameActive(true);
+    });
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(screen.queryByTestId('style-popup')).not.toBeInTheDocument();
   });
 
   it('does NOT render when a style is already stored locally (e.g. /daily after picking)', async () => {

--- a/fe-next/lib/playerStyle/shouldShowStylePopup.test.ts
+++ b/fe-next/lib/playerStyle/shouldShowStylePopup.test.ts
@@ -115,6 +115,40 @@ describe('shouldShowStylePopup', () => {
     });
   });
 
+  describe('natural break points (never interrupt active play)', () => {
+    it('never shows while a game is actively being played, in EITHER auth state', () => {
+      // The popup is a full-screen blocking overlay. Opening it mid-game would
+      // cover a live board and, in multiplayer, a running timer you cannot pause
+      // — the "shows at the wrong moment" report. Suppress whenever a game runs.
+      expect(shouldShowStylePopup({ ...base, gameActive: true })).toBe(false);
+      expect(
+        shouldShowStylePopup({ ...base, isAuthenticated: true, gameActive: true }),
+      ).toBe(false);
+    });
+
+    it('does not show on a gameplay route until the game is over (skips pre-game/lobby)', () => {
+      // On /practice, /multiplayer, … the moments BEFORE a game ends — pre-game
+      // setup, lobby, countdown — are still the wrong moment. Wait for results.
+      expect(
+        shouldShowStylePopup({ ...base, onGameplayRoute: true, resultsShowing: false }),
+      ).toBe(false);
+    });
+
+    it('shows on a gameplay route once the results screen is up (after the game)', () => {
+      expect(
+        shouldShowStylePopup({ ...base, onGameplayRoute: true, resultsShowing: true }),
+      ).toBe(true);
+    });
+
+    it('still shows on a non-gameplay in-app screen when idle (menu/home), no results needed', () => {
+      // Off gameplay routes (leaderboard, profile, …) the user is already at rest,
+      // so there is nothing to interrupt — the results gate does not apply.
+      expect(
+        shouldShowStylePopup({ ...base, onGameplayRoute: false, resultsShowing: false }),
+      ).toBe(true);
+    });
+  });
+
   it('never re-shows once the device-level "shown" flag is set, in EITHER auth state', () => {
     // `guestShown` is the localStorage marker, written the moment the popup is
     // shown (any auth state). It is a DEVICE-level "shown once" flag, so it must

--- a/fe-next/lib/playerStyle/shouldShowStylePopup.ts
+++ b/fe-next/lib/playerStyle/shouldShowStylePopup.ts
@@ -59,6 +59,26 @@ export interface StylePopupGateInput {
    * content — the same content humans see once dismissed. See lib/seo/isCrawler.
    */
   isCrawler?: boolean;
+  /**
+   * A game is actively being played right now (`useGameActive()`). The popup is
+   * a full-screen blocking overlay, so opening it mid-game covers a live board —
+   * and in multiplayer a running timer the player cannot pause. Never the right
+   * moment. True → never show; the popup waits for a natural break.
+   */
+  gameActive?: boolean;
+  /**
+   * The current route is an active-gameplay screen (`isGameplayPath()`:
+   * /practice, /multiplayer, /daily, …). On these routes the only acceptable
+   * moment to prompt is AFTER the game (`resultsShowing`) — the pre-game setup,
+   * lobby and countdown are still mid-flow. Off these routes (menus, profile,
+   * leaderboard) the user is already idle, so no results gate applies.
+   */
+  onGameplayRoute?: boolean;
+  /**
+   * A game has finished and its results/game-over screen is up. Gates the prompt
+   * on a gameplay route to the post-game moment the user explicitly chose.
+   */
+  resultsShowing?: boolean;
 }
 
 /**
@@ -77,6 +97,14 @@ export function shouldShowStylePopup(input: StylePopupGateInput): boolean {
   // Wait for auth to settle before deciding — otherwise the transient
   // "not-yet-authenticated" window flashes the popup at returning users.
   if (!input.authSettled) return false;
+  // Never interrupt active play. The full-screen overlay would cover a live
+  // board (and a running, unpausable multiplayer timer). Only surface the popup
+  // at a natural break — the "showing at the wrong moment" fix.
+  if (input.gameActive) return false;
+  // On a gameplay route, hold the popup until the game is over (results screen).
+  // Pre-game setup / lobby / countdown are still mid-flow. Off gameplay routes
+  // (menus, profile, leaderboard) the user is already idle, so this gate is moot.
+  if (input.onGameplayRoute && !input.resultsShowing) return false;
   if (!input.featureEnabled) return false;
   if (input.needsProfileCustomization) return false;
   // Already picked a style (local truth) → never prompt, in either auth state.


### PR DESCRIPTION
The one-time "choose your style" popup fired on a blind 800ms timer on any
gameplay route, checking the route but never the game state. It could open
over a live board — and over a running, unpausable multiplayer timer — and
during pre-game setup. The "shows once" guards were already solid; the
*moment* was the bug.

Teach the show-gate about game state:
- never show while a game is active (gameActive)
- on a gameplay route, hold until the results screen (after the game)
- off gameplay routes (menus/leaderboard/profile — idle) it surfaces as before

The wrapper now reads the global game store (useGameActive/useWaitingForResults),
tracks whether a game was played this mount to tell "results" from "pre-game",
and re-evaluates when a game ends. All existing re-show guards untouched.

Marketing landing/homepage stays suppressed (deliberate SEO/CWV guard).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011jymPRBHDuXv7NzXjn8tVN