### PR TITLE
fix(results): fold coins into stats strip, native Hebrew brag copy, drop top header gap

### DIFF
--- a/fe-next/app/[locale]/multiplayer/PageClient.tsx
+++ b/fe-next/app/[locale]/multiplayer/PageClient.tsx
@@ -626,9 +626,12 @@ export default function MultiplayerPageClient(): React.JSX.Element {
           ) : (
             // Active lobby/in-game uses a full-bleed immersive layout with its
             // own sticky header — the AutoHideHeader spacer would just stack dead
-            // space above the lobby's top accent bar. Drop it while active (keep
-            // it for the room list + results so their CLS reservation holds).
-            (isActive && !showResults) ? null : <AutoHideHeader />
+            // space above the lobby's top accent bar. Drop it while active. On the
+            // results screen the header is hidden (isInGame) but its CLS spacer
+            // was still reserving a header-tall empty band at the top — collapse
+            // it there so results content starts under the floating mute FAB
+            // instead of below dead space. The room list keeps the spacer.
+            (isActive && !showResults) ? null : <AutoHideHeader collapseSpacerWhenHidden={showResults} />
           )}
           {renderView()}
           <HostLeftGraceModal

--- a/fe-next/components/results/ResultsMainContent.tsx
+++ b/fe-next/components/results/ResultsMainContent.tsx
@@ -3,7 +3,7 @@
 import React, { memo, useMemo, useState, useEffect } from 'react';
 import { useReducedMotion } from 'framer-motion';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { Sparkles, Type, Star, ChevronDown, ChevronUp } from 'lucide-react';
+import { Sparkles, Type, Star, Coins, ChevronDown, ChevronUp } from 'lucide-react';
 import type { Player, WordObject } from '@/components/results/types';
 import { assignConsolationCrowns } from '@/utils/consolationCrowns';
 import { selectUniqueWords } from '@/lib/results/selectUniqueWords';
@@ -22,7 +22,6 @@ import type { XpGainedData, LevelUpData } from '@/types/components';
 import type { GameModeOption } from '@/components/GameModeSelector';
 import type { SeriesStanding } from '@/hooks/useSeriesTracker';
 import SeriesStandingsBanner from '@/components/results/SeriesStandingsBanner';
-import RewardsSummary from '@/components/results/RewardsSummary';
 import type { CoinReward } from '@/components/results/CoinRewardDisplay';
 
 import { ResultsWordsSection } from '@/components/results/ResultsWordsSection';
@@ -258,8 +257,20 @@ export const ResultsMainContent: React.FC<ResultsMainContentProps> = memo(functi
         color: 'text-neo-cyan',
       });
     }
+    // Coins fold into this stats strip instead of owning a near-empty full-width
+    // row of their own (the old standalone RewardsSummary card). Only for signed-in
+    // players who actually earned coins — guests don't earn, so a "+N" there would
+    // mislead (their conversion path is the signup nudge sheet, not this chip).
+    if (isAuthenticated && coinReward && coinReward.awarded > 0) {
+      stats.push({
+        label: t('results.coinsEarned') || 'Coins',
+        value: `+${coinReward.awarded}`,
+        icon: <Coins className="w-3 h-3" />,
+        color: 'text-neo-lime',
+      });
+    }
     return stats;
-  }, [currentPlayerData, currentPlayerValidWords, uniqueWordsCount, t, language, showRivals]);
+  }, [currentPlayerData, currentPlayerValidWords, uniqueWordsCount, t, language, showRivals, isAuthenticated, coinReward]);
 
   // Share params for the share button
   const shareParams = useMemo(() => {
@@ -418,10 +429,11 @@ export const ResultsMainContent: React.FC<ResultsMainContentProps> = memo(functi
         <HighlightsBar stats={highlightStats} />
       )}
 
-      {/* ── 4. WHAT YOU EARNED — XP / level / streak, then coins, read as one
-          progress beat. ImprovementPanel renders nothing for guests w/ no
-          progress; the rewards row only appears when there's a coin reward
-          (MP) or a solo/daily share button. */}
+      {/* ── 4. WHAT YOU EARNED — XP / level / streak. ImprovementPanel renders
+          nothing for guests w/ no progress. Coins no longer get their own
+          near-empty full-width card here — they fold into the HighlightsBar
+          stats strip above (see highlightStats). The solo/daily share button
+          is the only thing left that earns this row. */}
       <ImprovementPanel
         xp={xpGainedData ?? null}
         levelUp={levelUpData ?? null}
@@ -429,21 +441,9 @@ export const ResultsMainContent: React.FC<ResultsMainContentProps> = memo(functi
         t={t}
         reducedMotion={reducedMotion}
       />
-      {(coinReward || (shareParams && !isMultiplayer)) && (
+      {shareParams && !isMultiplayer && (
         <div className="flex flex-wrap items-stretch gap-2">
-          {coinReward && (
-            <div className="flex-1 min-w-0 [&>*]:h-full">
-              <RewardsSummary
-                coinReward={coinReward}
-                isAuthenticated={isAuthenticated}
-                winStreak={null}
-                isWinner={isCurrentUserWinner}
-              />
-            </div>
-          )}
-          {shareParams && !isMultiplayer && (
-            <ShareButton params={shareParams} t={t} className="shrink-0" />
-          )}
+          <ShareButton params={shareParams} t={t} className="shrink-0" />
         </div>
       )}
 

--- a/fe-next/components/results/__tests__/ResultsMainContent.rewardsSummary.test.tsx
+++ b/fe-next/components/results/__tests__/ResultsMainContent.rewardsSummary.test.tsx
@@ -1,6 +1,8 @@
 /**
- * TDD RED: Verify RewardsSummary is wired into ResultsMainContent
- * when coinReward is provided, and hidden when null/undefined.
+ * Coins no longer own a standalone full-width RewardsSummary row in the MP
+ * results body. They fold into the HighlightsBar stats strip ("Coins Earned")
+ * for signed-in players who actually earned coins. Guests / zero / null get no
+ * coin stat (and there is no separate rewards card to render).
  */
 
 import React from 'react';
@@ -8,59 +10,43 @@ import { render, screen } from '@testing-library/react';
 
 vi.mock('framer-motion', async () => {
   const actual = await vi.importActual('framer-motion');
-  return {
-    ...actual,
-    useReducedMotion: () => false,
-  };
+  return { ...actual, useReducedMotion: () => false };
 });
 
 vi.mock('@/contexts/LanguageContext', () => ({
   useLanguage: () => ({ t: (k: string) => k, language: 'en', dir: 'ltr' }),
 }));
 
+vi.mock('@/hooks/useExperiment', () => ({ useExperiment: () => ({ variant: 'control' }) }));
+vi.mock('@/utils/growthTracking', () => ({ trackGrowthEvent: () => {} }));
+
 // Mock heavy sub-components to keep test focused
-vi.mock('@/components/results/ResultsHeroSection', () => ({
-  __esModule: true,
-  default: () => <div data-testid="results-hero" />,
-}));
-vi.mock('@/components/results/ResultsPodium', () => ({
-  __esModule: true,
-  default: () => null,
-}));
-vi.mock('@/components/results/ConsolationRows', () => ({
-  __esModule: true,
-  default: () => null,
-}));
+vi.mock('@/components/results/ResultsHeroSection', () => ({ __esModule: true, default: () => <div data-testid="results-hero" /> }));
+vi.mock('@/components/results/ResultsPodium', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/ConsolationRows', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/ResultsRivalsPanel', () => ({ __esModule: true, default: () => <div data-testid="rivals" /> }));
+vi.mock('@/components/results/ResultsRevengeSection', () => ({ ResultsRevengeSection: () => null }));
+vi.mock('@/components/results/SeriesStandingsBanner', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/ResultsWordsSection', () => ({ ResultsWordsSection: () => null }));
+vi.mock('@/components/results/MpBragCard', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/ImprovementPanel', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/feedback/GameFeedback', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/multiplayer/NearRankTeaser', () => ({ NearRankTeaser: () => null }));
+vi.mock('@/utils/consolationCrowns', () => ({ assignConsolationCrowns: () => [] }));
+
+// HighlightsBar rendered for real-ish: expose the stat labels it received so we
+// can assert the coins stat is folded in (or not).
 vi.mock('@/components/results/HighlightsBar', () => ({
   __esModule: true,
-  default: () => null,
-}));
-vi.mock('@/components/results/ResultsRevengeSection', () => ({
-  ResultsRevengeSection: () => null,
-}));
-vi.mock('@/components/results/SeriesStandingsBanner', () => ({
-  __esModule: true,
-  default: () => null,
-}));
-vi.mock('@/components/results/ResultsWordsSection', () => ({
-  ResultsWordsSection: () => null,
-}));
-vi.mock('@/utils/consolationCrowns', () => ({
-  assignConsolationCrowns: () => [],
-}));
-
-// Mock RewardsSummary — render stub with testid so we can assert presence
-vi.mock('@/components/results/RewardsSummary', () => ({
-  __esModule: true,
-  default: (props: any) => (
-    <div data-testid="rewards-summary" data-coin-reward={JSON.stringify(props.coinReward)} />
+  default: ({ stats }: { stats: Array<{ label: string }> }) => (
+    <div data-testid="highlights">{stats.map(s => s.label).join('|')}</div>
   ),
 }));
 
 import { ResultsMainContent } from '../ResultsMainContent';
 import type { CoinReward } from '../CoinRewardDisplay';
 
-describe('ResultsMainContent — RewardsSummary wiring', () => {
+describe('ResultsMainContent — coins fold into the stats strip', () => {
   const baseProps = {
     sortedScores: [
       { username: 'alice', score: 500, allWords: [] },
@@ -84,32 +70,40 @@ describe('ResultsMainContent — RewardsSummary wiring', () => {
     readyUsernames: [],
     duplicateRuleDisabled: false,
     t: (k: string) => k,
-  };
+  } as any;
 
   const sampleReward: CoinReward = {
     awarded: 75,
     breakdown: { base: 20, scoreBonus: 30, placement: 15, streakBonus: 10 },
   };
 
-  it('renders RewardsSummary when coinReward is provided', () => {
+  it('adds a coins stat to HighlightsBar when a signed-in player earned coins', () => {
     render(<ResultsMainContent {...baseProps} coinReward={sampleReward} />);
-    expect(screen.getByTestId('rewards-summary')).toBeInTheDocument();
+    expect(screen.getByTestId('highlights').textContent).toContain('results.coinsEarned');
   });
 
-  it('does not render RewardsSummary when coinReward is null', () => {
+  it('omits the coins stat when coinReward is null', () => {
     render(<ResultsMainContent {...baseProps} coinReward={null} />);
-    expect(screen.queryByTestId('rewards-summary')).not.toBeInTheDocument();
+    expect(screen.getByTestId('highlights').textContent).not.toContain('results.coinsEarned');
   });
 
-  it('does not render RewardsSummary when coinReward is omitted', () => {
+  it('omits the coins stat when coinReward is omitted', () => {
     render(<ResultsMainContent {...baseProps} />);
-    expect(screen.queryByTestId('rewards-summary')).not.toBeInTheDocument();
+    expect(screen.getByTestId('highlights').textContent).not.toContain('results.coinsEarned');
   });
 
-  it('passes coinReward data through to RewardsSummary', () => {
+  it('omits the coins stat for guests (they do not earn coins)', () => {
+    render(<ResultsMainContent {...baseProps} isAuthenticated={false} coinReward={sampleReward} />);
+    expect(screen.getByTestId('highlights').textContent).not.toContain('results.coinsEarned');
+  });
+
+  it('omits the coins stat when zero coins were awarded', () => {
+    render(<ResultsMainContent {...baseProps} coinReward={{ awarded: 0 }} />);
+    expect(screen.getByTestId('highlights').textContent).not.toContain('results.coinsEarned');
+  });
+
+  it('no longer renders a standalone RewardsSummary card', () => {
     render(<ResultsMainContent {...baseProps} coinReward={sampleReward} />);
-    const el = screen.getByTestId('rewards-summary');
-    const passed = JSON.parse(el.getAttribute('data-coin-reward') || 'null');
-    expect(passed).toEqual(sampleReward);
+    expect(screen.queryByTestId('rewards-summary')).not.toBeInTheDocument();
   });
 });

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -12817,11 +12817,11 @@ const he = {
   },
   "brag": {
     "headline": {
-      "crushed": "סליחה {name} 💀",
-      "topped": "{name} +{count} עוד. נכחדו! 💪",
-      "won": "{count} יריבים. אפס ניצולים.",
-      "revenge": "{name} - רק מזל. רוץ שוב! 🔥",
-      "challenge": "בטוח שתעשה יותר?"
+      "crushed": "ל{name} לא היה צ׳אנס 💀",
+      "topped": "{name} ועוד {count} — כולם מאחור 💪",
+      "won": "{count} יריבים, מנצח אחד 🏆",
+      "revenge": "ל{name} היה מזל. עוד סיבוב? 🔥",
+      "challenge": "בטוחים שתעשו את זה יותר טוב? 🔥"
     },
     "hero": {
       "points": "נקודות של תהילה",


### PR DESCRIPTION
Three multiplayer-results UX fixes from a Hebrew screenshot review:

- Coins no longer own a near-empty full-width RewardsSummary row. They fold
  into the HighlightsBar stats strip ("Coins Earned") for signed-in players who
  actually earned coins. Guests keep their signup-nudge conversion path.
- Rewrite the Hebrew brag-card headlines so they read native instead of
  literal-translated ("רוץ שוב" → "עוד סיבוב?", etc.) and clearer.
- Collapse the AutoHideHeader CLS spacer on the results screen so content
  starts under the floating mute FAB instead of below a header-tall empty band
  (the room list keeps its spacer to preserve CLS).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VP83mH4jp7gKZubcKar1No