### PR TITLE
fix(cosmetics): notify each unlock once per account + redesign the toast

### DIFF
--- a/fe-next/components/cosmetics/CosmeticUnlockToast.tsx
+++ b/fe-next/components/cosmetics/CosmeticUnlockToast.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+/**
+ * CosmeticUnlockToast — the celebratory capsule shown when a player unlocks a
+ * new cosmetic (via a rank-up or streak milestone).
+ *
+ * Replaces the old bare `toast.success(...)` green-check popover, which rendered
+ * as a flat, off-brand dark pill that stacked ugly duplicates. This is a proper
+ * neo-styled capsule: rarity-tinted border + glow, a sparkle icon, the cosmetic
+ * name, a rarity badge, and a clear "tap to equip" CTA. The whole capsule is a
+ * deep-link to the collection so the unlock turns into an equip instead of a
+ * dead-end announcement.
+ *
+ * Dedup: each toast is keyed `cosmetic-unlock-<id>` so a re-fire for the same
+ * cosmetic replaces (never stacks) the existing capsule.
+ */
+
+import { m } from 'framer-motion';
+import toast from 'react-hot-toast';
+import { Sparkles } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { Cosmetic, CosmeticRarity } from '@/lib/cosmetics';
+
+type Translate = (key: string, params?: Record<string, string | number>) => string;
+
+// Rarity → neo accent palette. `accent` drives border + glow; `chip` is the
+// rarity-badge fill. Kept inline (not CSS vars) so the glow boxShadow can use it.
+const RARITY_ACCENT: Record<CosmeticRarity, { accent: string; glow: string }> = {
+  common: { accent: '#9aa0b4', glow: 'rgba(154,160,180,0.55)' },
+  rare: { accent: '#00FFFF', glow: 'rgba(0,255,255,0.55)' },
+  epic: { accent: '#9370DB', glow: 'rgba(147,112,219,0.6)' },
+  legendary: { accent: '#BFFF00', glow: 'rgba(191,255,0,0.6)' },
+};
+
+interface CosmeticUnlockToastContentProps {
+  cosmetic: Cosmetic;
+  href: string;
+  isVisible: boolean;
+  isRtl: boolean;
+  t: Translate;
+  onDismiss: () => void;
+}
+
+function CosmeticUnlockToastContent({
+  cosmetic,
+  href,
+  isVisible,
+  isRtl,
+  t,
+  onDismiss,
+}: CosmeticUnlockToastContentProps) {
+  const { accent, glow } = RARITY_ACCENT[cosmetic.rarity];
+  const name = t(cosmetic.name);
+  const rarityLabel = t(`cosmetics.rarity.${cosmetic.rarity}`);
+
+  return (
+    <m.a
+      href={href}
+      onClick={onDismiss}
+      initial={{ y: -24, opacity: 0, scale: 0.94 }}
+      animate={isVisible ? { y: 0, opacity: 1, scale: 1 } : { y: -16, opacity: 0, scale: 0.96 }}
+      transition={{ type: 'spring', stiffness: 440, damping: 24, mass: 0.6 }}
+      className={cn(
+        'group relative flex items-center gap-3 overflow-hidden no-underline',
+        'rounded-neo-lg border-3 border-neo-black bg-neo-navy/95',
+        'ps-3 pe-4 py-2.5',
+      )}
+      style={{
+        boxShadow: `${isRtl ? '-4px 4px' : '4px 4px'} 0 0 rgb(var(--neo-black)), 0 0 18px ${glow}`,
+        minWidth: '248px',
+        maxWidth: '340px',
+        pointerEvents: 'auto',
+      }}
+      role="status"
+      aria-live="polite"
+      data-testid="cosmetic-unlock-toast"
+    >
+      {/* Shine sweep across the capsule on entrance */}
+      <m.span
+        aria-hidden
+        initial={{ x: isRtl ? 280 : -280, opacity: 0 }}
+        animate={{ x: isRtl ? -280 : 280, opacity: [0, 0.7, 0] }}
+        transition={{ delay: 0.14, duration: 0.95, ease: 'easeOut' }}
+        className="pointer-events-none absolute inset-y-0 w-20"
+        style={{
+          background: `linear-gradient(${isRtl ? '-75deg' : '75deg'}, transparent, ${glow}, transparent)`,
+          mixBlendMode: 'screen',
+        }}
+      />
+
+      {/* Sparkle icon in a rarity-tinted ring */}
+      <div className="relative flex-shrink-0">
+        <m.span
+          aria-hidden
+          animate={{ boxShadow: [`0 0 0 0 ${glow}`, `0 0 0 7px transparent`, `0 0 0 0 ${glow}`] }}
+          transition={{ duration: 1.7, repeat: Infinity, ease: 'easeOut' }}
+          className="absolute inset-0 rounded-full"
+        />
+        <m.div
+          initial={{ scale: 0, rotate: -160 }}
+          animate={{ scale: 1, rotate: 0 }}
+          transition={{ delay: 0.05, type: 'spring', stiffness: 340, damping: 13 }}
+          className="relative flex h-10 w-10 items-center justify-center rounded-full border-2 border-neo-black"
+          style={{ backgroundColor: accent }}
+        >
+          <Sparkles className="h-5 w-5 text-neo-black" aria-hidden />
+        </m.div>
+      </div>
+
+      {/* Text column */}
+      <div className="relative flex min-w-0 flex-1 flex-col leading-tight">
+        <span className="flex items-center gap-1.5">
+          <span className="text-[10px] font-black uppercase tracking-[0.12em] text-neo-white/70">
+            {t('cosmetics.unlockedLabel')}
+          </span>
+          <span
+            className="rounded-sm px-1.5 py-px text-[9px] font-black uppercase tracking-wider text-neo-black"
+            style={{ backgroundColor: accent, boxShadow: `0 0 6px ${glow}` }}
+          >
+            {rarityLabel}
+          </span>
+        </span>
+        <span
+          className="truncate font-neo-display text-sm font-black"
+          style={{ color: accent }}
+        >
+          {name}
+        </span>
+        <span className="mt-0.5 inline-flex items-center gap-1 text-xs font-bold text-neo-white/80 underline-offset-2 group-hover:underline">
+          {t('cosmetics.equipCta')}
+          <span aria-hidden>{isRtl ? '←' : '→'}</span>
+        </span>
+      </div>
+    </m.a>
+  );
+}
+
+interface ShowCosmeticUnlockToastArgs {
+  cosmetic: Cosmetic;
+  language: string;
+  isRtl: boolean;
+  t: Translate;
+}
+
+/**
+ * Fire the cosmetic-unlock capsule. Stable per-cosmetic id means a repeat call
+ * for the same cosmetic replaces the existing toast rather than stacking a
+ * duplicate.
+ */
+export function showCosmeticUnlockToast({
+  cosmetic,
+  language,
+  isRtl,
+  t,
+}: ShowCosmeticUnlockToastArgs): string {
+  const href = `/${language}/profile?tab=collection`;
+  const id = `cosmetic-unlock-${cosmetic.id}`;
+  return toast.custom(
+    (instance) => (
+      <CosmeticUnlockToastContent
+        cosmetic={cosmetic}
+        href={href}
+        isVisible={instance.visible}
+        isRtl={isRtl}
+        t={t}
+        onDismiss={() => toast.dismiss(instance.id)}
+      />
+    ),
+    { id, duration: 6000, position: 'top-center' },
+  );
+}
+
+export default CosmeticUnlockToastContent;

--- a/fe-next/components/cosmetics/UnlockNotifierMount.tsx
+++ b/fe-next/components/cosmetics/UnlockNotifierMount.tsx
@@ -16,8 +16,16 @@ import { getGlobalLeaderboardTier } from '@/lib/ranked/leaderboardTiers';
  *
  * Renders nothing.
  */
-function ActiveNotifier({ rankTier, streakDays }: { rankTier: string; streakDays: number }) {
-  useUnlockNotifier({ rankTier, streakDays });
+function ActiveNotifier({
+  rankTier,
+  streakDays,
+  accountId,
+}: {
+  rankTier: string;
+  streakDays: number;
+  accountId?: string;
+}) {
+  useUnlockNotifier({ rankTier, streakDays, accountId });
   return null;
 }
 
@@ -26,7 +34,7 @@ export function UnlockNotifierMount() {
   const { streak, loading } = useEngagementStatus();
   // Wait for BOTH a real profile AND a resolved streak before mounting the
   // notifier. useEngagementStatus starts at streak=0 (loading) then resolves;
-  // feeding the transient 0 in would snapshot 0 and then fire false "unlocked"
+  // feeding the transient 0 in would seed 0 and then fire false "unlocked"
   // toasts for streak cosmetics the instant the real streak lands (Class 1:
   // dual-source + async resolution). Tier comes from total_score (on profile,
   // resolves with it) so only the streak axis needs the loading gate.
@@ -35,6 +43,7 @@ export function UnlockNotifierMount() {
     <ActiveNotifier
       rankTier={getGlobalLeaderboardTier(profile.total_score ?? 0).id}
       streakDays={streak}
+      accountId={profile.id}
     />
   );
 }

--- a/fe-next/components/cosmetics/__tests__/CosmeticUnlockToast.test.tsx
+++ b/fe-next/components/cosmetics/__tests__/CosmeticUnlockToast.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * CosmeticUnlockToast — the redesigned unlock capsule (replaces the old bare
+ * green-check toast.success). Verifies it renders the cosmetic name, the equip
+ * CTA, a rarity badge, and deep-links to the collection.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CosmeticUnlockToastContent from '../CosmeticUnlockToast';
+import { COSMETICS } from '@/lib/cosmetics';
+
+const t = (key: string) => key;
+
+describe('CosmeticUnlockToast', () => {
+  const cosmetic = COSMETICS.find((c) => c.id === 'tile-neon')!;
+
+  function renderToast(isRtl = false) {
+    return render(
+      <CosmeticUnlockToastContent
+        cosmetic={cosmetic}
+        href="/en/profile?tab=collection"
+        isVisible
+        isRtl={isRtl}
+        t={t}
+        onDismiss={vi.fn()}
+      />,
+    );
+  }
+
+  it('shows the cosmetic name, unlocked label and equip CTA', () => {
+    renderToast();
+    expect(screen.getByText(cosmetic.name)).toBeInTheDocument();
+    expect(screen.getByText('cosmetics.unlockedLabel')).toBeInTheDocument();
+    expect(screen.getByText('cosmetics.equipCta')).toBeInTheDocument();
+  });
+
+  it('renders a rarity badge for the cosmetic', () => {
+    renderToast();
+    expect(screen.getByText(`cosmetics.rarity.${cosmetic.rarity}`)).toBeInTheDocument();
+  });
+
+  it('deep-links the whole capsule to the cosmetics collection', () => {
+    renderToast();
+    const link = screen.getByTestId('cosmetic-unlock-toast');
+    expect(link).toHaveAttribute('href', '/en/profile?tab=collection');
+  });
+});

--- a/fe-next/components/cosmetics/__tests__/UnlockNotifierMount.test.tsx
+++ b/fe-next/components/cosmetics/__tests__/UnlockNotifierMount.test.tsx
@@ -48,17 +48,17 @@ describe('UnlockNotifierMount', () => {
     expect(notifierMock).not.toHaveBeenCalled();
   });
 
-  it('runs the notifier with the score-derived tier and engagement streak', () => {
+  it('runs the notifier with the score-derived tier, engagement streak and account id', () => {
     // total_score 12000 → Gold tier (>= 10000). Streak from player_engagement.
-    authMock.mockReturnValue({ profile: { total_score: 12000 } });
+    authMock.mockReturnValue({ profile: { id: 'acc-1', total_score: 12000 } });
     engagementMock.mockReturnValue({ streak: 12, loading: false });
     render(<UnlockNotifierMount />);
-    expect(notifierMock).toHaveBeenCalledWith({ rankTier: 'gold', streakDays: 12 });
+    expect(notifierMock).toHaveBeenCalledWith({ rankTier: 'gold', streakDays: 12, accountId: 'acc-1' });
   });
 
   it('falls back to Stone/0 when total_score is missing', () => {
-    authMock.mockReturnValue({ profile: {} });
+    authMock.mockReturnValue({ profile: { id: 'acc-2' } });
     render(<UnlockNotifierMount />);
-    expect(notifierMock).toHaveBeenCalledWith({ rankTier: 'stone', streakDays: 0 });
+    expect(notifierMock).toHaveBeenCalledWith({ rankTier: 'stone', streakDays: 0, accountId: 'acc-2' });
   });
 });

--- a/fe-next/hooks/__tests__/useUnlockNotifier.test.ts
+++ b/fe-next/hooks/__tests__/useUnlockNotifier.test.ts
@@ -1,36 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
-const toastSuccessMock = vi.fn();
-vi.mock('react-hot-toast', () => ({
-  __esModule: true,
-  default: { success: (...args: unknown[]) => toastSuccessMock(...args) },
+const showToastMock = vi.fn();
+vi.mock('@/components/cosmetics/CosmeticUnlockToast', () => ({
+  showCosmeticUnlockToast: (...args: unknown[]) => showToastMock(...args),
 }));
 vi.mock('@/contexts/LanguageContext', () => ({
   useLanguage: () => ({
     language: 'en',
+    dir: 'ltr',
     t: (key: string, params?: Record<string, string | number>) =>
       params ? `${key}:${JSON.stringify(params)}` : key,
   }),
 }));
 
-import { isValidElement } from 'react';
 import { useUnlockNotifier } from '../useUnlockNotifier';
 
-/** Walk a React element tree collecting any `href` props. */
-function collectHrefs(node: unknown): string[] {
-  if (!isValidElement(node)) return [];
-  const props = node.props as { href?: string; children?: unknown };
-  const here = typeof props.href === 'string' ? [props.href] : [];
-  const kids = Array.isArray(props.children) ? props.children : [props.children];
-  return kids.reduce<string[]>((acc, k) => acc.concat(collectHrefs(k)), here);
-}
-
-const SNAPSHOT_KEY = 'lexiclash_cosmetics_snapshot_v2';
+const NOTIFIED_KEY = 'lexiclash_cosmetics_notified_v1';
 
 describe('useUnlockNotifier', () => {
   beforeEach(() => {
-    toastSuccessMock.mockReset();
+    showToastMock.mockReset();
     localStorage.clear();
   });
 
@@ -38,48 +28,79 @@ describe('useUnlockNotifier', () => {
     localStorage.clear();
   });
 
-  it('does not fire toast on first mount when no prior snapshot exists', () => {
-    renderHook(() => useUnlockNotifier({ rankTier: 'Bronze', streakDays: 0 }));
-    expect(toastSuccessMock).not.toHaveBeenCalled();
+  it('does not fire a toast on first encounter — it silently seeds owned cosmetics', () => {
+    renderHook(() => useUnlockNotifier({ rankTier: 'bronze', streakDays: 0 }));
+    expect(showToastMock).not.toHaveBeenCalled();
+    // The seed records every currently-unlocked id so they are never announced.
+    expect(localStorage.getItem(NOTIFIED_KEY)).not.toBeNull();
   });
 
-  it('fires toast for each newly-unlocked cosmetic when rank advances', () => {
-    // Seed a prior snapshot at Bronze
+  it('fires a toast for each genuinely new cosmetic when rank advances', () => {
+    // Seed: a player who had only the Bronze tier already acknowledged.
     localStorage.setItem(
-      SNAPSHOT_KEY,
-      JSON.stringify({ rankTier: 'Bronze', streakDays: 0 }),
+      NOTIFIED_KEY,
+      JSON.stringify(['tile-default', 'board-classic', 'victory-confetti', 'frame-none', 'frame-bronze']),
     );
-    renderHook(() => useUnlockNotifier({ rankTier: 'Silver', streakDays: 0 }));
-    // Silver unlocks tile-neon + frame-silver → 2 toasts
-    expect(toastSuccessMock).toHaveBeenCalledTimes(2);
+    renderHook(() => useUnlockNotifier({ rankTier: 'silver', streakDays: 0 }));
+    // Silver newly unlocks tile-neon + frame-silver → 2 toasts.
+    expect(showToastMock).toHaveBeenCalledTimes(2);
   });
 
-  it('updates snapshot after firing so the same unlock is not announced twice', () => {
+  it('never announces the same cosmetic twice — even when streak resets and re-climbs', () => {
+    // Seed everything below the 7-day streak as already known.
     localStorage.setItem(
-      SNAPSHOT_KEY,
-      JSON.stringify({ rankTier: 'Bronze', streakDays: 0 }),
+      NOTIFIED_KEY,
+      JSON.stringify(['tile-default', 'board-classic', 'victory-confetti', 'frame-none']),
+    );
+    const { rerender } = renderHook(
+      ({ streak }: { streak: number }) => useUnlockNotifier({ rankTier: 'stone', streakDays: streak }),
+      { initialProps: { streak: 7 } },
+    );
+    // 7-day streak unlocks board-ocean → 1 toast.
+    expect(showToastMock).toHaveBeenCalledTimes(1);
+    showToastMock.mockReset();
+
+    // Streak breaks (back to 0)…
+    rerender({ streak: 0 });
+    expect(showToastMock).not.toHaveBeenCalled();
+    // …then re-climbs past 7. The OLD diff-based notifier re-fired here; the
+    // id-set notifier stays silent because board-ocean was already announced.
+    rerender({ streak: 7 });
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+
+  it('does not re-toast on a plain re-render with unchanged inputs', () => {
+    localStorage.setItem(
+      NOTIFIED_KEY,
+      JSON.stringify(['tile-default', 'board-classic', 'victory-confetti', 'frame-none', 'frame-bronze']),
     );
     const { rerender } = renderHook(
       ({ rank }: { rank: string }) => useUnlockNotifier({ rankTier: rank, streakDays: 0 }),
-      { initialProps: { rank: 'Silver' } },
+      { initialProps: { rank: 'silver' } },
     );
-    expect(toastSuccessMock).toHaveBeenCalledTimes(2);
-    toastSuccessMock.mockReset();
-    // Re-render with same rank — should NOT re-toast
-    rerender({ rank: 'Silver' });
-    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(showToastMock).toHaveBeenCalledTimes(2);
+    showToastMock.mockReset();
+    rerender({ rank: 'silver' });
+    expect(showToastMock).not.toHaveBeenCalled();
   });
 
-  it('renders a clickable toast that deep-links to the cosmetics collection', () => {
+  it('scopes the notified record per account', () => {
+    renderHook(() => useUnlockNotifier({ rankTier: 'silver', streakDays: 0, accountId: 'user-a' }));
+    // Seeded silently under the account-scoped key, not the bare key.
+    expect(localStorage.getItem(`${NOTIFIED_KEY}:user-a`)).not.toBeNull();
+    expect(localStorage.getItem(NOTIFIED_KEY)).toBeNull();
+  });
+
+  it('passes the cosmetic and locale through to the toast', () => {
     localStorage.setItem(
-      SNAPSHOT_KEY,
-      JSON.stringify({ rankTier: 'Bronze', streakDays: 0 }),
+      NOTIFIED_KEY,
+      JSON.stringify(['tile-default', 'board-classic', 'victory-confetti', 'frame-none', 'frame-bronze']),
     );
-    renderHook(() => useUnlockNotifier({ rankTier: 'Silver', streakDays: 0 }));
-    expect(toastSuccessMock).toHaveBeenCalled();
-    const payload = toastSuccessMock.mock.calls[0][0];
-    const hrefs = collectHrefs(payload);
-    expect(hrefs.some((h) => h.endsWith('/profile?tab=collection'))).toBe(true);
-    expect(hrefs.some((h) => h.startsWith('/en/'))).toBe(true);
+    renderHook(() => useUnlockNotifier({ rankTier: 'silver', streakDays: 0 }));
+    expect(showToastMock).toHaveBeenCalled();
+    const arg = showToastMock.mock.calls[0][0] as { cosmetic: { id: string }; language: string; isRtl: boolean };
+    expect(typeof arg.cosmetic.id).toBe('string');
+    expect(arg.language).toBe('en');
+    expect(arg.isRtl).toBe(false);
   });
 });

--- a/fe-next/hooks/useUnlockNotifier.ts
+++ b/fe-next/hooks/useUnlockNotifier.ts
@@ -1,108 +1,98 @@
-import { createElement, useEffect, useRef } from 'react';
-import toast from 'react-hot-toast';
-import { diffNewlyUnlocked, type PlayerCosmeticState } from '@/lib/cosmetics';
+import { useEffect } from 'react';
+import { getUnlockedCosmetics, type PlayerCosmeticState } from '@/lib/cosmetics';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { showCosmeticUnlockToast } from '@/components/cosmetics/CosmeticUnlockToast';
 
-// v2: the unlock axis changed from the never-fetched profile.rank_tier (which
-// snapshotted a bogus capitalized 'Bronze'/0 for everyone) to the score-based
-// leaderboard tier. Bumping the key discards stale baselines so the first load
-// after the fix re-seeds cleanly instead of firing a burst of "unlocked" toasts.
-const SNAPSHOT_KEY = 'lexiclash_cosmetics_snapshot_v2';
+// Per-account record of cosmetic ids we have ALREADY announced. This is the
+// source of truth for "notify once". The previous implementation kept only a
+// {rankTier, streakDays} snapshot and re-derived "newly unlocked" from a diff —
+// which re-fired the SAME unlock every time the streak dropped and re-climbed
+// past a milestone (broke streak → recover) or the tier value churned. Tracking
+// the announced ids directly makes each cosmetic fire exactly once per account,
+// regardless of how rank/streak fluctuate afterwards.
+const NOTIFIED_KEY = 'lexiclash_cosmetics_notified_v1';
 
 interface NotifierInput {
   rankTier: string;
   streakDays: number;
   /** Optional already-purchased ids — defaults to []. Purchase notifications fire elsewhere. */
   purchasedIds?: string[];
+  /** Account id — scopes the "already notified" record so different accounts on
+   *  the same device dedup independently and never inherit each other's history. */
+  accountId?: string;
 }
 
-interface Snapshot {
-  rankTier: string;
-  streakDays: number;
+function storageKey(accountId?: string): string {
+  return accountId ? `${NOTIFIED_KEY}:${accountId}` : NOTIFIED_KEY;
 }
 
-function readSnapshot(): Snapshot | null {
+function readNotified(key: string): Set<string> | null {
   try {
-    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(SNAPSHOT_KEY) : null;
-    return raw ? (JSON.parse(raw) as Snapshot) : null;
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
+    if (raw == null) return null;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? new Set(parsed.filter((v): v is string => typeof v === 'string')) : null;
   } catch {
     return null;
   }
 }
 
-function writeSnapshot(snap: Snapshot): void {
+function writeNotified(key: string, ids: Set<string>): void {
   try {
     if (typeof localStorage !== 'undefined') {
-      localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(snap));
+      localStorage.setItem(key, JSON.stringify([...ids]));
     }
   } catch { /* storage unavailable */ }
 }
 
 /**
- * Detects newly-unlocked cosmetics between the persisted last-seen snapshot
- * and the current player state, and fires a toast for each one.
+ * Detects newly-unlocked cosmetics and fires a toast for each one — exactly
+ * once per account, ever.
  *
- * Mount this once in a top-level shell (e.g. profile page or app root) so
- * rank-ups and streak milestones surface a notification without the player
- * having to dig through the cosmetics tab.
+ * Mount this once in a top-level shell (e.g. the app root) so rank-ups and
+ * streak milestones surface a notification without the player having to dig
+ * through the cosmetics tab.
+ *
+ * First encounter for an account is a SILENT seed: every cosmetic the player
+ * already owns is recorded without a toast, so we never blast a burst of
+ * "unlocked!" capsules for things they earned long ago. After that, only
+ * genuinely new ids produce a toast.
  */
 export function useUnlockNotifier(input: NotifierInput): void {
-  const { t, language } = useLanguage();
-  const lastNotifiedRef = useRef<string>('');
-  const { rankTier, streakDays, purchasedIds } = input;
+  const { t, language, dir } = useLanguage();
+  const { rankTier, streakDays, purchasedIds, accountId } = input;
 
   useEffect(() => {
-    const prior = readSnapshot();
-    const current: Snapshot = { rankTier, streakDays };
-    const currentKey = `${current.rankTier}|${current.streakDays}`;
+    const key = storageKey(accountId);
 
-    if (lastNotifiedRef.current === currentKey) return;
-
-    if (!prior) {
-      writeSnapshot(current);
-      lastNotifiedRef.current = currentKey;
-      return;
-    }
-
-    if (prior.rankTier === current.rankTier && prior.streakDays === current.streakDays) {
-      return;
-    }
-
-    const ownedIds = purchasedIds ?? [];
-    const baseState: PlayerCosmeticState = {
-      rankTier: prior.rankTier,
-      streakDays: prior.streakDays,
+    const state: PlayerCosmeticState = {
+      rankTier,
+      streakDays,
       coins: 0,
       seasonRewards: [],
-      purchasedIds: ownedIds,
+      // Purchases are announced by their own flow; default to none so this
+      // notifier only ever surfaces rank/streak (and default) unlocks.
+      purchasedIds: purchasedIds ?? [],
       equippedIds: {},
     };
-    const nextState: PlayerCosmeticState = {
-      ...baseState,
-      rankTier: current.rankTier,
-      streakDays: current.streakDays,
-    };
 
-    const newly = diffNewlyUnlocked(baseState, nextState);
-    const href = `/${language}/profile?tab=collection`;
-    for (const c of newly) {
-      // Clickable toast — deep-links to the collection so the unlock turns into
-      // an equip, instead of a dead-end announcement the player can't act on.
-      toast.success(
-        createElement(
-          'a',
-          {
-            href,
-            className: 'flex flex-col gap-0.5 font-neo-body text-neo-black no-underline',
-          },
-          createElement('span', { className: 'text-sm font-bold' }, t('cosmetics.unlockedToast', { name: t(c.name) })),
-          createElement('span', { className: 'text-xs underline opacity-80' }, t('cosmetics.equipCta')),
-        ),
-        { duration: 6000 },
-      );
+    const unlocked = getUnlockedCosmetics(state);
+    const notified = readNotified(key);
+
+    // First ever load for this account → seed silently, announce nothing.
+    if (!notified) {
+      writeNotified(key, new Set(unlocked.map((c) => c.id)));
+      return;
     }
 
-    writeSnapshot(current);
-    lastNotifiedRef.current = currentKey;
-  }, [rankTier, streakDays, purchasedIds, t, language]);
+    const fresh = unlocked.filter((c) => !notified.has(c.id));
+    if (fresh.length === 0) return;
+
+    for (const c of fresh) {
+      showCosmeticUnlockToast({ cosmetic: c, language, isRtl: dir === 'rtl', t });
+      notified.add(c.id);
+    }
+
+    writeNotified(key, notified);
+  }, [rankTier, streakDays, purchasedIds, accountId, t, language, dir]);
 }

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -4833,6 +4833,7 @@ const en = {
     "purchase": "Buy ({{cost}} gold)",
     "close": "Close",
     "unlockedToast": "✨ New cosmetic unlocked: {{name}}",
+    "unlockedLabel": "New cosmetic unlocked",
     "equipCta": "Tap to equip it",
     "progress": {
       "streak": "{{current}}/{{target}} day streak",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -4426,6 +4426,7 @@ const es = {
     "purchase": "Comprar ({{cost}} oro)",
     "close": "Cerrar",
     "unlockedToast": "✨ Nuevo cosmético desbloqueado: {{name}}",
+    "unlockedLabel": "Nuevo cosmético desbloqueado",
     "equipCta": "Toca para equiparlo",
     "progress": {
       "streak": "Racha de {{current}}/{{target}} días",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -4936,6 +4936,7 @@ const he = {
     "purchase": "קנה ({{cost}} זהב)",
     "close": "סגור",
     "unlockedToast": "✨ קוסמטיקה חדשה נפתחה: {{name}}",
+    "unlockedLabel": "קוסמטיקה חדשה נפתחה",
     "equipCta": "הקישו כדי לצייד",
     "progress": {
       "streak": "{{current}}/{{target}} ימי רצף",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -4440,6 +4440,7 @@ const ja = {
     "purchase": "購入（{{cost}}ゴールド）",
     "close": "閉じる",
     "unlockedToast": "✨ 新しいコスメティック解放: {{name}}",
+    "unlockedLabel": "新しいコスメティック解放",
     "equipCta": "タップして装備",
     "progress": {
       "streak": "{{current}}/{{target}}日連続",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -4598,6 +4598,7 @@ const sv = {
     "purchase": "Köp ({{cost}} guld)",
     "close": "Stäng",
     "unlockedToast": "✨ Ny kosmetik upplåst: {{name}}",
+    "unlockedLabel": "Ny kosmetik upplåst",
     "equipCta": "Tryck för att utrusta",
     "progress": {
       "streak": "{{current}}/{{target}} dagar i rad",


### PR DESCRIPTION
The cosmetic-unlock notifier announced the same unlock repeatedly and the
toast itself was an off-brand bare green-check pill that stacked ugly
duplicates (see report screenshot).

Dedup: the notifier kept only a {rankTier, streakDays} snapshot and
re-derived "newly unlocked" from a diff — so the SAME cosmetic re-fired
whenever the streak dropped and re-climbed past a milestone, or the tier
value churned. Now it persists the set of already-announced cosmetic ids,
scoped per account, so each cosmetic fires exactly once and never again
regardless of how rank/streak fluctuate. First encounter is a silent seed.

Design: replace toast.success(...) with a neo-styled capsule
(CosmeticUnlockToast) — rarity-tinted border + glow, sparkle icon, rarity
badge, and a clear "tap to equip" CTA, RTL-aware, the whole capsule
deep-links to the collection. Stable per-cosmetic toast id so a re-fire
replaces rather than stacks.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XhhCKgMX3TPrXriYk5iqDu