### PR TITLE
fix(daily): scope daily-challenge leaderboards to the player's language

### DIFF
--- a/fe-next/backend/routes/dailyChallenge.ts
+++ b/fe-next/backend/routes/dailyChallenge.ts
@@ -161,19 +161,21 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
         throw new Error('Database connection unavailable');
       }
 
-      // Cross-language (global) leaderboard: no `.eq('language', …)` filter — players
-      // from every language compete together. The view's rank_position is per-language,
-      // so we order by the scoring columns directly and renumber globally below.
+      // Per-language leaderboard: each language plays a DIFFERENT board, so players are
+      // only ranked against — and only see the words of — others who played the same
+      // language. The view's rank_position counts guests + replays, so we re-sort and
+      // renumber below.
       const { data, error } = await supabase
         .from('daily_puzzle_leaderboard')
         .select('*')
         .eq('puzzle_date', date)
+        .eq('language', language)
         .not('player_id', 'is', null)
         .order('score', { ascending: false, nullsFirst: false })
         .order('word_count', { ascending: false, nullsFirst: false })
         .order('time_seconds', { ascending: true, nullsFirst: false })
         // Over-fetch: view has one row per ATTEMPT, so a player occupies many slots
-        // (replays + languages). Pull extra so dedup-to-one-per-player still yields `limit`.
+        // (same-language replays). Pull extra so dedup-to-one-per-player still yields `limit`.
         // ponytail: ×10 cap 500 covers current worst case; move to DISTINCT ON in the view if replays climb.
         .limit(Math.min(limit * 10, 500));
 
@@ -185,6 +187,7 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
         .from('daily_puzzle_attempts')
         .select('*', { count: 'exact', head: true })
         .eq('puzzle_date', date)
+        .eq('language', language)
         .not('player_id', 'is', null);
 
       if (countError) {
@@ -194,7 +197,8 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       const { count: totalCount, error: totalCountError } = await supabase
         .from('daily_puzzle_attempts')
         .select('*', { count: 'exact', head: true })
-        .eq('puzzle_date', date);
+        .eq('puzzle_date', date)
+        .eq('language', language);
 
       if (totalCountError) {
         logger.warn('API', `Daily leaderboard total count error: ${totalCountError.message}`);
@@ -204,6 +208,7 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
         .from('daily_puzzle_attempts')
         .select('*', { count: 'exact', head: true })
         .eq('puzzle_date', date)
+        .eq('language', language)
         .is('player_id', null)
         .not('guest_fingerprint', 'is', null);
 
@@ -211,10 +216,10 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
         logger.warn('API', `Daily leaderboard guest count error: ${guestCountError.message}`);
       }
 
-      // Sort by global scoring order, collapse each player to their single best row
-      // (view has one row per ATTEMPT — replays + languages), trim to limit, then
-      // renumber 1..N. The view's rank_position is partitioned per (puzzle_date,
-      // language) and includes guests/replays, so it can't be trusted here.
+      // Sort by the scoring order, collapse each player to their single best row
+      // (view has one row per ATTEMPT — same-language replays), trim to limit, then
+      // renumber 1..N. The view's rank_position includes guests/replays, so it can't
+      // be trusted directly here.
       const rerankedData = rerankSequential(
         dedupeByPlayerKeepBest(sortClassicPuzzleRowsGlobally(data || [])).slice(0, limit),
       );

--- a/fe-next/backend/routes/dailyChallenge/__tests__/leaderboardLanguageFilter.test.ts
+++ b/fe-next/backend/routes/dailyChallenge/__tests__/leaderboardLanguageFilter.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Daily-challenge leaderboards must be scoped to a SINGLE language.
+ *
+ * Each language plays a DIFFERENT board/target word, so merging languages into one
+ * leaderboard means a player sees (and is told they "missed") words from boards they
+ * never played. The fix filters every per-puzzle leaderboard query by `language`.
+ *
+ * These tests pin that filter on all three daily leaderboard routes (Word Hunt,
+ * Word Wheel, classic daily puzzle) so the cross-language regression cannot return.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { type Router } from 'express';
+import request from 'supertest';
+
+// Recording Supabase mock (built inside vi.hoisted so it exists before the hoisted
+// vi.mock factory runs). Every builder method returns the same chainable builder and
+// records its `eq(field, value)` calls; the builder is thenable so `await query`
+// resolves to an empty result set / zero count.
+const h = vi.hoisted(() => {
+  const queries: Array<{ table: string; eqs: Array<[string, unknown]> }> = [];
+  function makeBuilder(table: string) {
+    const record = { table, eqs: [] as Array<[string, unknown]> };
+    queries.push(record);
+    const b: Record<string, unknown> = {};
+    const mk = (name: string) => (...args: unknown[]) => {
+      if (name === 'eq') record.eqs.push(args as [string, unknown]);
+      return b;
+    };
+    for (const n of ['select', 'eq', 'not', 'is', 'gt', 'lt', 'order', 'limit', 'maybeSingle', 'single']) {
+      b[n] = mk(n);
+    }
+    b.then = (resolve: (v: unknown) => unknown) => resolve({ data: [], error: null, count: 0 });
+    return b;
+  }
+  return { queries, supabaseMock: { from: vi.fn((t: string) => makeBuilder(t)) } };
+});
+
+vi.mock('../../../modules/supabaseServer', () => ({
+  getSupabase: vi.fn(() => h.supabaseMock),
+  isSupabaseConfigured: vi.fn(() => true),
+}));
+
+// Classic route reads/writes a redis-backed leaderboard cache. Force a miss + no-op
+// write so the route falls through to the DB query we want to assert on.
+vi.mock('../../../redisClient', async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>);
+  return {
+    ...actual,
+    getCachedDailyPuzzle: vi.fn(() => Promise.resolve(null)),
+    getCachedDailyLeaderboard: vi.fn(() => Promise.resolve(null)),
+    cacheDailyLeaderboard: vi.fn(() => Promise.resolve()),
+  };
+});
+
+import wordHuntRoutes from '../wordHuntRoutes';
+import wordWheelRoutes from '../wordWheelRoutes';
+import dailyChallengeRoutes from '../../dailyChallenge';
+
+const LANG = 'sv';
+const DATE = '2026-06-27';
+
+async function getLeaderboard(router: Router) {
+  const app = express();
+  app.use(express.json());
+  app.use('/', router);
+  return request(app).get(`/leaderboard/${DATE}/${LANG}`);
+}
+
+function viewQuery(viewTable: string) {
+  const match = h.queries.find(q => q.table === viewTable);
+  expect(match, `expected a query against ${viewTable}`).toBeTruthy();
+  return match!;
+}
+
+describe('daily-challenge leaderboards are language-scoped', () => {
+  beforeEach(() => {
+    h.queries.length = 0;
+    h.supabaseMock.from.mockClear();
+  });
+
+  it('Word Hunt leaderboard filters the view by language', async () => {
+    await getLeaderboard(wordHuntRoutes);
+    const q = viewQuery('daily_word_hunt_leaderboard');
+    expect(q.eqs).toContainEqual(['language', LANG]);
+    expect(q.eqs).toContainEqual(['puzzle_date', DATE]);
+  });
+
+  it('Word Hunt participant counts are language-scoped', async () => {
+    await getLeaderboard(wordHuntRoutes);
+    const counts = h.queries.filter(q => q.table === 'daily_word_hunt_attempts');
+    expect(counts.length).toBeGreaterThan(0);
+    for (const c of counts) {
+      expect(c.eqs).toContainEqual(['language', LANG]);
+    }
+  });
+
+  it('Word Wheel leaderboard filters the view by language', async () => {
+    await getLeaderboard(wordWheelRoutes);
+    expect(viewQuery('daily_word_wheel_leaderboard').eqs).toContainEqual(['language', LANG]);
+  });
+
+  it('classic daily leaderboard filters the view by language', async () => {
+    await getLeaderboard(dailyChallengeRoutes);
+    expect(viewQuery('daily_puzzle_leaderboard').eqs).toContainEqual(['language', LANG]);
+  });
+});

--- a/fe-next/backend/routes/dailyChallenge/leaderboardSort.ts
+++ b/fe-next/backend/routes/dailyChallenge/leaderboardSort.ts
@@ -1,13 +1,14 @@
 /**
  * Pure ordering + reranking helpers for the daily-challenge leaderboards.
  *
- * The daily-challenge leaderboard spans ALL languages: every language plays a
- * different puzzle, but players are merged into a single global ranking by the
- * same scoring criteria used inside the per-language SQL views.
+ * Each daily-challenge leaderboard is scoped to a SINGLE language: every language
+ * plays a different board, so players are only ranked against — and only see the
+ * words of — others who played the same language.
  *
- * The SQL views' `rank_position` is partitioned per language, so once the route
- * drops the `.eq('language', …)` filter it can no longer rely on that column —
- * it must re-sort the merged rows here and renumber them 1..N globally.
+ * The SQL views emit one row per ATTEMPT and their `rank_position` also counts
+ * guests + replays, so even within one language the route can't trust that column
+ * directly — it re-sorts the rows here, collapses replays to one row per player,
+ * and renumbers them 1..N.
  *
  * These helpers are intentionally pure (no DB, no I/O) so the ordering contract
  * is unit-testable and shared across every daily-challenge leaderboard route.
@@ -24,9 +25,9 @@ export function rerankSequential<T>(rows: T[]): (T & { rank_position: number })[
  * sortXGlobally helpers) so "first" == "best".
  *
  * Why: the per-language SQL views emit one row per ATTEMPT, and players replay the
- * same puzzle many times (and across languages) — so the same player shows up
- * repeatedly, including lower-scored duplicates that misread as "their real score".
- * Dedup by player_id alone fixes both same-language replays and cross-language rows.
+ * same puzzle many times — so the same player shows up repeatedly, including
+ * lower-scored duplicates that misread as "their real score". Dedup by player_id
+ * collapses those same-language replays to the single best row.
  *
  * Rows with a null/missing player_id (guests) are never collapsed together.
  */

--- a/fe-next/backend/routes/dailyChallenge/wordHuntRoutes.ts
+++ b/fe-next/backend/routes/dailyChallenge/wordHuntRoutes.ts
@@ -511,20 +511,22 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       return;
     }
 
-    // Cross-language (global) leaderboard: no `.eq('language', …)` filter — players
-    // from every language compete together. The view's rank_position is per-language,
-    // so we order by the scoring columns directly and renumber globally below.
+    // Per-language leaderboard: each language plays a DIFFERENT board/target word,
+    // so players are only ranked against — and only see the discovered words of —
+    // others who played the same language. The view's rank_position is per-language,
+    // but it also counts guests + replays, so we still re-sort and renumber below.
     const { data, error } = await supabase
       .from('daily_word_hunt_leaderboard')
       .select('*')
       .eq('puzzle_date', date)
+      .eq('language', language)
       .eq('solved', true)
       .not('player_id', 'is', null)
       .order('efficiency_score', { ascending: false, nullsFirst: false })
       .order('attempts_used', { ascending: true, nullsFirst: false })
       .order('completed_at', { ascending: true, nullsFirst: false })
       // Over-fetch: the view has one row per ATTEMPT, so a player can occupy many
-      // slots (replays + multiple languages). Pull extra so that after collapsing to
+      // slots (same-language replays). Pull extra so that after collapsing to
       // one row per player we still have `limit` distinct players.
       // ponytail: ×10 cap 500 covers the current worst case (~8 attempts/player); if
       // replay counts climb, move the dedup into the view via DISTINCT ON (player_id).
@@ -555,6 +557,7 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       .from('daily_word_hunt_attempts')
       .select('*', { count: 'exact', head: true })
       .eq('puzzle_date', date)
+      .eq('language', language)
       .eq('solved', true)
       .not('player_id', 'is', null);
 
@@ -565,7 +568,8 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
     const { count: totalPlayersCount, error: totalPlayersError } = await supabase
       .from('daily_word_hunt_attempts')
       .select('*', { count: 'exact', head: true })
-      .eq('puzzle_date', date);
+      .eq('puzzle_date', date)
+      .eq('language', language);
 
     if (totalPlayersError) {
       logger.debug('API', `Word Hunt total players count error: ${totalPlayersError.message || totalPlayersError.code || 'Unknown'}`);
@@ -575,6 +579,7 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       .from('daily_word_hunt_attempts')
       .select('*', { count: 'exact', head: true })
       .eq('puzzle_date', date)
+      .eq('language', language)
       .eq('solved', true);
 
     if (totalSolvedError) {
@@ -585,6 +590,7 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       .from('daily_word_hunt_attempts')
       .select('*', { count: 'exact', head: true })
       .eq('puzzle_date', date)
+      .eq('language', language)
       .eq('solved', true)
       .is('player_id', null)
       .not('guest_fingerprint', 'is', null);
@@ -593,11 +599,10 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       logger.warn('API', `Word Hunt guest solved count error: ${guestSolvedError.message || guestSolvedError.code || 'Unknown'}`, { code: guestSolvedError.code, details: guestSolvedError.details });
     }
 
-    // Sort the merged cross-language rows by the global scoring order, collapse each
-    // player to their single best row (one per ATTEMPT in the view → dedup), trim to
-    // the requested limit, then renumber rank_position sequentially 1..N. The view's
-    // rank_position is partitioned per language (and includes guests + replays), so it
-    // can't be trusted here.
+    // Sort the same-language rows by the scoring order, collapse each player to their
+    // single best row (the view emits one per ATTEMPT → dedup replays), trim to the
+    // requested limit, then renumber rank_position sequentially 1..N. The view's
+    // rank_position counts guests + replays, so it can't be trusted directly here.
     const rerankedData = rerankSequential(
       dedupeByPlayerKeepBest(sortWordHuntRowsGlobally(data || [])).slice(0, limit),
     );

--- a/fe-next/backend/routes/dailyChallenge/wordWheelRoutes.ts
+++ b/fe-next/backend/routes/dailyChallenge/wordWheelRoutes.ts
@@ -325,19 +325,21 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       return;
     }
 
-    // Cross-language (global) leaderboard: no `.eq('language', …)` filter — players
-    // from every language compete together. The view's rank_position is per-language,
-    // so we order by the scoring columns directly and renumber globally below.
+    // Per-language leaderboard: each language plays a DIFFERENT wheel, so players are
+    // only ranked against — and only see the submitted words of — others who played the
+    // same language. The view's rank_position counts guests + replays, so we re-sort
+    // and renumber below.
     const { data, error } = await supabase
       .from('daily_word_wheel_leaderboard')
       .select('*')
       .eq('puzzle_date', date)
+      .eq('language', language)
       .not('player_id', 'is', null)
       .order('score', { ascending: false, nullsFirst: false })
       .order('word_count', { ascending: false, nullsFirst: false })
       .order('completed_at', { ascending: true, nullsFirst: false })
       // Over-fetch: view has one row per ATTEMPT, so a player occupies many slots
-      // (replays + languages). Pull extra so dedup-to-one-per-player still yields `limit`.
+      // (same-language replays). Pull extra so dedup-to-one-per-player still yields `limit`.
       // ponytail: ×10 cap 500 covers current worst case; move to DISTINCT ON in the view if replays climb.
       .limit(Math.min(limit * 10, 500));
 
@@ -347,7 +349,7 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       return;
     }
 
-    // Sort by global scoring order, collapse each player to their single best row
+    // Sort by scoring order, collapse each player to their single best row
     // (view has one row per ATTEMPT), trim to limit, then renumber 1..N.
     const rerankedData = rerankSequential(
       dedupeByPlayerKeepBest(sortWordWheelRowsGlobally(data || [])).slice(0, limit),
@@ -356,12 +358,14 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
     const { count: totalCount } = await supabase
       .from('daily_word_wheel_attempts')
       .select('*', { count: 'exact', head: true })
-      .eq('puzzle_date', date);
+      .eq('puzzle_date', date)
+      .eq('language', language);
 
     const { count: guestCount } = await supabase
       .from('daily_word_wheel_attempts')
       .select('*', { count: 'exact', head: true })
       .eq('puzzle_date', date)
+      .eq('language', language)
       .is('player_id', null)
       .not('guest_fingerprint', 'is', null);
 
@@ -370,6 +374,7 @@ router.get('/leaderboard/:date/:language', async (req: Request<LeaderboardParams
       .from('daily_word_wheel_attempts')
       .select('*', { count: 'exact', head: true })
       .eq('puzzle_date', date)
+      .eq('language', language)
       .gt('word_count', 0);
 
     res.set('Cache-Control', 'public, max-age=20, s-maxage=20, stale-while-revalidate=60');

--- a/fe-next/components/friends/FriendsList.tsx
+++ b/fe-next/components/friends/FriendsList.tsx
@@ -544,33 +544,33 @@ const FriendsList: React.FC<FriendsListProps> = ({
   // Full view
   return (
     <div className={cn('space-y-4', className)}>
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Users className={cn('w-5 h-5', isDark ? 'text-cyan-400' : 'text-cyan-600')} />
-          <h2 className={cn('font-black text-lg uppercase', isDark ? 'text-white' : 'text-gray-900')}>
+      {/* Header — wraps on narrow screens so the action buttons never overflow off-canvas */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Users className={cn('w-5 h-5 shrink-0', isDark ? 'text-cyan-400' : 'text-cyan-600')} />
+          <h2 className={cn('font-black text-lg uppercase truncate', isDark ? 'text-white' : 'text-gray-900')}>
             {t('friends.title')}
           </h2>
           {(notificationCount > 0 || unreadCount > 0) && (
-            <span className="flex items-center justify-center w-6 h-6 text-xs font-bold bg-neo-pink text-white rounded-full animate-pulse">
+            <span className="flex items-center justify-center w-6 h-6 text-xs font-bold bg-neo-pink text-white rounded-full animate-pulse shrink-0">
               {notificationCount + unreadCount > 9 ? '9+' : notificationCount + unreadCount}
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          <EnhancedButton onClick={() => setShowPactSelector(true)} size="sm" haptic animation="pop" className="bg-neo-pink text-white">
+        <div className="flex flex-wrap items-center justify-end gap-2 shrink-0">
+          <EnhancedButton onClick={() => setShowPactSelector(true)} size="sm" haptic animation="pop" className="bg-neo-pink text-white" aria-label={t('wordPact.formPact')}>
             <Handshake className="w-4 h-4" />
-            {t('wordPact.formPact')}
+            <span className="hidden xs:inline">{t('wordPact.formPact')}</span>
           </EnhancedButton>
-          <EnhancedButton onClick={() => setShowAddFriend(true)} size="sm" haptic animation="pop" className="bg-neo-cyan text-neo-black">
+          <EnhancedButton onClick={() => setShowAddFriend(true)} size="sm" haptic animation="pop" className="bg-neo-cyan text-neo-black" aria-label={t('friends.add')}>
             <UserPlus className="w-4 h-4" />
-            {t('friends.add')}
+            <span className="hidden xs:inline">{t('friends.add')}</span>
           </EnhancedButton>
         </div>
       </div>
 
       {/* Tab Navigation (Q-18: proper ARIA tab semantics) */}
-      <div role="tablist" aria-label={t('friends.title')} className="flex gap-2 border-b-2 border-neo-black">
+      <div role="tablist" aria-label={t('friends.title')} className="flex gap-2 border-b-2 border-neo-black overflow-x-auto scrollbar-thin">
         {(['friends', 'requests', 'messages'] as const).map((tab) => {
           const isActive = activeTab === tab;
           const icons = { friends: Users, requests: Bell, messages: MessageCircle };
@@ -589,7 +589,7 @@ const FriendsList: React.FC<FriendsListProps> = ({
               aria-controls={`friends-panel-${tab}`}
               onClick={() => setActiveTab(tab)}
               className={cn(
-                'flex items-center gap-2 px-4 py-2 font-bold text-sm transition-all',
+                'flex items-center gap-2 px-3 sm:px-4 py-2 font-bold text-sm transition-all whitespace-nowrap shrink-0',
                 isActive
                   ? 'bg-neo-cyan text-neo-black border-2 border-neo-black border-b-0 -mb-0.5'
                   : isDark ? 'text-gray-400 hover:text-white' : 'text-gray-600 hover:text-gray-900'


### PR DESCRIPTION
Each language plays a different daily board/target word, but the Word Hunt,
Word Wheel, and classic daily leaderboards merged all languages into one
ranking. That meant a player could see (and be told they 'missed') words from
boards they never played, and was ranked against players who solved a different
puzzle. The per-language stats routes were already correct — only the
leaderboard reads dropped the language filter.

Add .eq('language', language) to every per-puzzle leaderboard + participant
count query so players only ever see and compete with others who played the
same language. Same-language replay dedup/rerank is unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AuYpwCNazNMoqmgVEGWScR