### PR TITLE
feat: break admin live connections down by page

### DIFF
--- a/fe-next/app/providers.tsx
+++ b/fe-next/app/providers.tsx
@@ -32,6 +32,7 @@ import WinnerOnboardingWrapper from './components/WinnerOnboardingWrapper';
 import ProfileCustomizationWrapper from './components/ProfileCustomizationWrapper';
 import ComebackBonusWrapper from './components/ComebackBonusWrapper';
 import BoostAckListener from '@/components/boosts/BoostAckListener';
+import SocketPageReporter from '@/components/SocketPageReporter';
 import { EssentialProviders } from './essential-providers';
 
 import type { Language } from '@/shared/types/game';
@@ -109,6 +110,7 @@ export function GameSpecificProviders({ children }: GameSpecificProvidersProps) 
             <NativeAppProvider>
                 <CrazyGamesSettingsBridge>
                     <SocketProvider>
+                        <SocketPageReporter />
                         <SocketEventBusProvider>
                             <CoreGameProviders>
                                 {children}

--- a/fe-next/backend/handlers/__tests__/connectionPageHandler.test.ts
+++ b/fe-next/backend/handlers/__tests__/connectionPageHandler.test.ts
@@ -1,0 +1,78 @@
+/**
+ * connectionPageHandler tests
+ * Covers: pageView event stores normalized route on socket.data.page
+ */
+
+vi.mock('../../utils/rateLimiter', () => ({
+  checkRateLimit: vi.fn().mockReturnValue(true),
+  default: { checkRateLimit: vi.fn().mockReturnValue(true) },
+}));
+
+import { vi, type MockedFunction } from 'vitest';
+import { registerConnectionPageHandler } from '../connectionPageHandler';
+import { checkRateLimit } from '../../utils/rateLimiter';
+
+const mockCheckRateLimit = checkRateLimit as MockedFunction<typeof checkRateLimit>;
+
+function createTestHarness() {
+  const handlers = new Map<string, Function>();
+  const socket: any = {
+    id: 'socket-1',
+    data: {},
+    emit: vi.fn(),
+    on: vi.fn((event: string, handler: Function) => {
+      handlers.set(event, handler);
+    }),
+  };
+  const io: any = { to: vi.fn().mockReturnThis(), emit: vi.fn() };
+
+  registerConnectionPageHandler(io, socket);
+
+  const trigger = (event: string, data?: any) => {
+    const handler = handlers.get(event);
+    if (!handler) throw new Error(`No handler for ${event}`);
+    return handler(data);
+  };
+
+  return { socket, io, trigger, handlers };
+}
+
+describe('connectionPageHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue(true);
+  });
+
+  it('registers a pageView handler', () => {
+    const { handlers } = createTestHarness();
+    expect(handlers.has('pageView')).toBe(true);
+  });
+
+  it('stores the normalized path on socket.data.page', () => {
+    const { socket, trigger } = createTestHarness();
+    trigger('pageView', { path: '/he/multiplayer?foo=1' });
+    expect(socket.data.page).toBe('/multiplayer');
+  });
+
+  it('collapses dynamic id segments', () => {
+    const { socket, trigger } = createTestHarness();
+    trigger('pageView', { path: '/profile/8f3c1a2b9d4e' });
+    expect(socket.data.page).toBe('/profile/:id');
+  });
+
+  it('sets page to null when no valid path is supplied', () => {
+    const { socket, trigger } = createTestHarness();
+    trigger('pageView', {});
+    expect(socket.data.page).toBeNull();
+    trigger('pageView', { path: 123 });
+    expect(socket.data.page).toBeNull();
+  });
+
+  it('ignores the event when rate limited (keeps prior page)', () => {
+    const { socket, trigger } = createTestHarness();
+    trigger('pageView', { path: '/daily' });
+    mockCheckRateLimit.mockReturnValue(false);
+    trigger('pageView', { path: '/multiplayer' });
+    expect(socket.data.page).toBe('/daily');
+  });
+});

--- a/fe-next/backend/handlers/connectionPageHandler.ts
+++ b/fe-next/backend/handlers/connectionPageHandler.ts
@@ -1,0 +1,36 @@
+/**
+ * Connection Page Handler
+ *
+ * Records which route each connected client is currently viewing, so the admin
+ * live monitor can break down the otherwise-opaque socket connection count by
+ * page. The client emits `pageView` on connect and on every route change; we
+ * stash the normalized path on socket.data.page (read back in the
+ * /api/admin/live-games endpoint). No broadcast, no game lookup — purely a
+ * per-socket annotation.
+ */
+
+import type { Server, Socket } from 'socket.io';
+
+import { normalizePagePath } from '../../lib/presence/normalizePagePath';
+import { checkRateLimit } from '../utils/rateLimiter.js';
+
+interface PageViewPayload {
+  path?: unknown;
+}
+
+/**
+ * Register the pageView handler for a socket.
+ * @param _io - Socket.IO server instance (unused; kept for handler signature parity)
+ * @param socket - Socket.IO socket instance
+ */
+function registerConnectionPageHandler(_io: Server, socket: Socket): void {
+  socket.on('pageView', (data: PageViewPayload) => {
+    // Light rate limit — pageView is low-frequency (connect + route changes).
+    if (!checkRateLimit(socket.id, 0.2)) return;
+
+    const path = data && typeof data.path === 'string' ? data.path : null;
+    socket.data.page = path ? normalizePagePath(path) : null;
+  });
+}
+
+export { registerConnectionPageHandler };

--- a/fe-next/backend/handlers/index.ts
+++ b/fe-next/backend/handlers/index.ts
@@ -11,6 +11,7 @@ import { registerChatHandlers } from './chatHandler.js';
 import { registerBotHandlers } from './botHandler.js';
 import { registerTournamentHandlers } from './tournamentHandler.js';
 import { registerPresenceHandlers, startConnectionHealthCheck } from './presenceHandler.js';
+import { registerConnectionPageHandler } from './connectionPageHandler.js';
 import { registerFriendsHandlers } from './friendsHandler.js';
 import { registerFriendMessagingHandlers } from './friendMessagingHandler.js';
 import { registerFriendChallengeHandlers } from './friendChallengeHandler.js';
@@ -52,6 +53,7 @@ function registerAllHandlers(io: Server, socket: Socket): void {
   registerBotHandlers(io, socket);
   registerTournamentHandlers(io, socket);
   registerPresenceHandlers(io, socket);
+  registerConnectionPageHandler(io, socket);
   registerFriendsHandlers(io, socket);
   registerFriendMessagingHandlers(io, socket);
   registerFriendChallengeHandlers(io, socket);

--- a/fe-next/backend/routes/admin/gameRoutes.ts
+++ b/fe-next/backend/routes/admin/gameRoutes.ts
@@ -9,6 +9,7 @@ import logger from '../../utils/logger';
 import { getActiveSinglePlayerCount, getActiveSinglePlayerSessions } from '../singlePlayer';
 import { getActivePagePresence } from '../presence';
 import { playersOnOtherPages } from '../../../lib/admin/liveMonitor/playersOnOtherPages';
+import { summarizeConnectionsByPage } from '../../../lib/admin/liveMonitor/connectionsByPage';
 
 interface DetailedGamePlayerLite {
   isBot: boolean;
@@ -243,10 +244,24 @@ router.get('/live-games', async (req: AdminRequest, res: Response): Promise<void
     });
     const playersOnPages = pagePresence.reduce((sum, g) => sum + g.count, 0);
 
+    // Break the raw socket connection count down by the route each client is
+    // viewing (reported via the `pageView` socket event → socket.data.page).
+    // Explains the otherwise-opaque connection number; unreported sockets
+    // (just-connected / native / embed clients) bucket under "unknown".
+    const connectionPages: Array<string | null> = [];
+    if (io) {
+      for (const [, s] of io.sockets.sockets) {
+        const data = (s as { data?: { page?: string | null } }).data;
+        connectionPages.push(data?.page ?? null);
+      }
+    }
+    const connectionsByPage = summarizeConnectionsByPage(connectionPages);
+
     res.json({
       games: detailedGames,
       singlePlayers,
       pagePresence,
+      connectionsByPage,
       stats: {
         activeGames,
         playersInGames,

--- a/fe-next/components/SocketPageReporter.tsx
+++ b/fe-next/components/SocketPageReporter.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+/**
+ * SocketPageReporter
+ *
+ * Reports the client's current route over the (already-open) game socket so the
+ * admin live monitor can break the raw socket connection count down by page.
+ * Mounted inside the SocketProvider tree, so it only runs where a socket exists
+ * (game/realtime routes) — exactly the connections the admin sees counted.
+ *
+ * Fires on first connect, on reconnect (isConnected flips true), and on every
+ * route change. The server stashes the normalized path on socket.data.page.
+ */
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { useSocketOptional } from '@/utils/SocketContext';
+
+export default function SocketPageReporter() {
+  const pathname = usePathname();
+  const ctx = useSocketOptional();
+  const socket = ctx?.socket ?? null;
+  const isConnected = ctx?.isConnected ?? false;
+
+  useEffect(() => {
+    if (!socket || !isConnected || !pathname) return;
+    socket.emit('pageView', { path: pathname });
+  }, [socket, isConnected, pathname]);
+
+  return null;
+}

--- a/fe-next/components/admin/LiveMonitor.tsx
+++ b/fe-next/components/admin/LiveMonitor.tsx
@@ -12,6 +12,7 @@ import { PageLoader } from '@/components/ui/PageLoader';
 import Avatar from '@/components/Avatar';
 import { presenceBreakdown, isStalled, hostName, playerComposition, roomStatusKey, type RoomStatusKey } from '@/lib/admin/liveMonitor/liveGameInsights';
 import type { OtherPageGroup } from '@/lib/admin/liveMonitor/playersOnOtherPages';
+import { UNKNOWN_CONNECTION_PAGE, type ConnectionPageGroup } from '@/lib/admin/liveMonitor/connectionsByPage';
 import { gameModeLabel } from '@/lib/admin/gameLog/gameDisplay';
 
 // Types matching backend DetailedGame and DetailedGamePlayer
@@ -56,6 +57,7 @@ interface LiveGamesResponse {
   games: LiveGame[];
   singlePlayers?: LiveSinglePlayerSession[];
   pagePresence?: OtherPageGroup[];
+  connectionsByPage?: ConnectionPageGroup[];
   stats: {
     activeGames: number;
     playersInGames: number;
@@ -221,10 +223,11 @@ export function LiveMonitor({ authToken, onTokenExpired }: LiveMonitorProps) {
     );
   }
 
-  const { games = [], singlePlayers = [], pagePresence = [], stats } = data || {
+  const { games = [], singlePlayers = [], pagePresence = [], connectionsByPage = [], stats } = data || {
     games: [],
     singlePlayers: [] as LiveSinglePlayerSession[],
     pagePresence: [] as OtherPageGroup[],
+    connectionsByPage: [] as ConnectionPageGroup[],
     stats: { activeGames: 0, playersInGames: 0, botsInGames: 0, socketConnections: 0, singlePlayerCount: 0, playersOnPages: 0 },
   };
   const hasAnyLive = games.length > 0 || singlePlayers.length > 0 || pagePresence.length > 0;
@@ -312,6 +315,37 @@ export function LiveMonitor({ authToken, onTokenExpired }: LiveMonitorProps) {
           {t('admin.live.refresh')}
         </Button>
       </div>
+
+      {/* Connections by page — explains the raw socket connection count.
+          Rendered outside the hasAnyLive gate so it still shows when sockets are
+          connected but nobody is in a game (the common "13 connections, 0 games"
+          case). */}
+      {connectionsByPage.length > 0 && (
+        <div className="bg-neo-navy-light/50 rounded-neo border-neo border-black p-4 shadow-hard">
+          <div className="flex items-center gap-2 mb-3">
+            <Wifi className="w-4 h-4 text-green-400" />
+            <h2 className="text-sm font-neo-display text-neo-white">
+              {t('admin.live.connectionsByPage', 'Connections by page')}
+            </h2>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+            {connectionsByPage.map((c) => (
+              <div
+                key={c.path}
+                className="flex items-center justify-between gap-2 bg-neo-navy-elevated/40 rounded px-3 py-2"
+              >
+                <span className={cn(
+                  'font-mono text-xs truncate',
+                  c.path === UNKNOWN_CONNECTION_PAGE ? 'text-slate-500 italic' : 'text-slate-300'
+                )}>
+                  {connectionPageLabel(c.path, t)}
+                </span>
+                <span className="text-sm font-bold text-neo-white shrink-0">{c.count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Games Grid or Empty State */}
       {!hasAnyLive ? (
@@ -688,6 +722,12 @@ function SinglePlayerRow({
 function pageLabel(path: string, t: (path: string, fallback?: string) => string): string {
   if (path === '/') return t('admin.live.pageLanding', 'Landing Page');
   return path;
+}
+
+// Friendly label for a connection-page bucket (adds the "unknown" sentinel).
+function connectionPageLabel(path: string, t: (path: string, fallback?: string) => string): string {
+  if (path === UNKNOWN_CONNECTION_PAGE) return t('admin.live.unknownPage', 'Unknown / not reported');
+  return pageLabel(path, t);
 }
 
 // Page Presence Card — users online on a given page but not in a game.

--- a/fe-next/lib/admin/liveMonitor/__tests__/connectionsByPage.test.ts
+++ b/fe-next/lib/admin/liveMonitor/__tests__/connectionsByPage.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  summarizeConnectionsByPage,
+  UNKNOWN_CONNECTION_PAGE,
+} from '../connectionsByPage';
+
+describe('summarizeConnectionsByPage', () => {
+  it('returns an empty array when there are no connections', () => {
+    expect(summarizeConnectionsByPage([])).toEqual([]);
+  });
+
+  it('groups connections by their reported page and counts them', () => {
+    const result = summarizeConnectionsByPage([
+      '/multiplayer',
+      '/multiplayer',
+      '/profile',
+    ]);
+    expect(result).toEqual([
+      { path: '/multiplayer', count: 2 },
+      { path: '/profile', count: 1 },
+    ]);
+  });
+
+  it('sorts by descending count so the busiest page is first', () => {
+    const result = summarizeConnectionsByPage([
+      '/daily',
+      '/multiplayer',
+      '/multiplayer',
+      '/multiplayer',
+      '/daily',
+    ]);
+    expect(result[0]).toEqual({ path: '/multiplayer', count: 3 });
+    expect(result[1]).toEqual({ path: '/daily', count: 2 });
+  });
+
+  it('normalizes locale prefixes and dynamic ids so pages group together', () => {
+    const result = summarizeConnectionsByPage([
+      '/he/multiplayer',
+      '/en/multiplayer',
+      '/profile/8f3c1a2b9d4e?tab=stats',
+      '/profile/0011223344aa',
+    ]);
+    const mp = result.find((g) => g.path === '/multiplayer');
+    const profile = result.find((g) => g.path === '/profile/:id');
+    expect(mp?.count).toBe(2);
+    expect(profile?.count).toBe(2);
+  });
+
+  it('buckets sockets that never reported a page as unknown', () => {
+    const result = summarizeConnectionsByPage([null, undefined, '', '/daily']);
+    const unknown = result.find((g) => g.path === UNKNOWN_CONNECTION_PAGE);
+    expect(unknown?.count).toBe(3);
+    expect(result.find((g) => g.path === '/daily')?.count).toBe(1);
+  });
+});

--- a/fe-next/lib/admin/liveMonitor/connectionsByPage.ts
+++ b/fe-next/lib/admin/liveMonitor/connectionsByPage.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure grouping for the admin live-monitor "Connections by page" view.
+ *
+ * The live card shows a raw Socket.IO connection count (io.sockets.sockets.size)
+ * that is otherwise opaque: an admin sees "13 connections" with no idea what
+ * those sockets are doing. Each connected client reports its current route over
+ * the socket (see the `pageView` event), which the server stashes on
+ * socket.data.page. This function turns those per-socket pages into a per-page
+ * breakdown so the connection number becomes explainable.
+ *
+ * Sockets that never reported a page (just-connected, or non-web clients such as
+ * native webviews / embeds that don't run the reporter) are bucketed under
+ * `unknown` — surfacing them is the point, not hiding them.
+ *
+ * No React, no side effects — safe to unit test and to call on the server.
+ */
+
+import { normalizePagePath } from '../../presence/normalizePagePath';
+
+export interface ConnectionPageGroup {
+  /** Normalized page path, or UNKNOWN_CONNECTION_PAGE for unreported sockets. */
+  path: string;
+  count: number;
+}
+
+/** Bucket label for sockets that have not reported a page. */
+export const UNKNOWN_CONNECTION_PAGE = 'unknown';
+
+export function summarizeConnectionsByPage(
+  pages: Array<string | null | undefined>
+): ConnectionPageGroup[] {
+  const counts = new Map<string, number>();
+
+  for (const raw of pages) {
+    // Falsy (null/undefined/'') = socket never reported a page → unknown bucket.
+    const path = raw ? normalizePagePath(raw) : UNKNOWN_CONNECTION_PAGE;
+    counts.set(path, (counts.get(path) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([path, count]) => ({ path, count }))
+    .sort((a, b) => b.count - a.count);
+}

--- a/fe-next/shared/types/socket.ts
+++ b/fe-next/shared/types/socket.ts
@@ -77,6 +77,9 @@ export interface ClientToServerEvents {
   ping: () => void;
   presenceUpdate: (data: { status: 'active' | 'idle' | 'afk' }) => void;
   presenceHeartbeat: () => void;
+  // Reports the client's current route so the admin live monitor can break the
+  // raw socket connection count down by page.
+  pageView: (data: { path: string }) => void;
 
   // Host events
   hostKeepAlive: () => void;

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -13739,6 +13739,8 @@ const en = {
       "auth": "Authenticated",
       "bots": "bots",
       "connectedPlayers": "Connected Players",
+      "connectionsByPage": "Connections by page",
+      "unknownPage": "Unknown / not reported",
       "disconnected": "disconnected",
       "onOtherPages": "On Other Pages",
       "onPages": "browsing",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -7903,6 +7903,8 @@ const es = {
         "finished": "Finalizado"
       },
       "connectedPlayers": "Jugadores Conectados",
+      "connectionsByPage": "Conexiones por página",
+      "unknownPage": "Desconocida / no informada",
       "player": "Jugador",
       "game": "Juego",
       "status": "Estado",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -8008,6 +8008,8 @@ const he = {
         "finished": "הסתיים"
       },
       "connectedPlayers": "שחקנים מחוברים",
+      "connectionsByPage": "חיבורים לפי דף",
+      "unknownPage": "לא ידוע / לא דווח",
       "player": "שחקן",
       "game": "משחק",
       "status": "סטטוס",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -8003,6 +8003,8 @@ const ja = {
         "finished": "終了"
       },
       "connectedPlayers": "接続中のプレイヤー",
+      "connectionsByPage": "ページ別の接続数",
+      "unknownPage": "不明 / 未報告",
       "player": "プレイヤー",
       "game": "ゲーム",
       "status": "ステータス",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -8031,6 +8031,8 @@ const sv = {
         "finished": "Avslutat"
       },
       "connectedPlayers": "Anslutna Spelare",
+      "connectionsByPage": "Anslutningar per sida",
+      "unknownPage": "Okänd / ej rapporterad",
       "player": "Spelare",
       "game": "Spel",
       "status": "Status",


### PR DESCRIPTION
The live monitor showed a raw Socket.IO connection count (e.g. "13
connections") with no visibility into what those sockets were doing,
making it look inconsistent with "0 games / 0 players". Connections,
games, and players are separate layers, and the existing HTTP page-
presence view is decoupled from the socket count, so it could not
explain it.

Each client now reports its current route over the socket (pageView ->
socket.data.page); the /api/admin/live-games endpoint groups the live
sockets into a per-page breakdown (connectionsByPage), and the live card
renders a "Connections by page" section even when there are no active
games. Sockets that never report a page (just-connected / native /
embed clients) bucket under "unknown" so the previously-opaque gap is
surfaced rather than hidden.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AAAPHCXNeMbqhTXwaRjpM1