### PR TITLE
fix(adventure): streak quest now credits the streak length reached

### DIFF
--- a/fe-next/components/adventure/hooks/__tests__/useAdventureQuestTracking.test.ts
+++ b/fe-next/components/adventure/hooks/__tests__/useAdventureQuestTracking.test.ts
@@ -2,8 +2,9 @@
 /**
  * useAdventureQuestTracking Tests
  *
- * Verifies combo streak and streak master fire only on threshold crossings,
- * not on every comboCount increment.
+ * Verifies the streakMaster chapter quest records the *streak length reached*
+ * (max semantics) so "Reach a {target}-word streak" completes when a single
+ * combo hits the target — not after N separate combos are started.
  */
 
 import { vi } from 'vitest';
@@ -38,37 +39,53 @@ describe('useAdventureQuestTracking', () => {
     vi.clearAllMocks();
   });
 
-  describe('streakMaster chapter quest (M4 fix)', () => {
-    it('fires streakMaster only on 0→positive transition', () => {
+  describe('streakMaster chapter quest', () => {
+    it('records the streak length on every combo increase', () => {
       const { rerender } = renderHook(
         (props) => useAdventureQuestTracking(props),
         { initialProps: defaultProps }
       );
 
-      // Combo starts
+      // A single growing streak reports its length as it climbs, so the quest
+      // can store the highest streak reached (max semantics).
       rerender({ ...defaultProps, comboCount: 1 });
+      expect(mockChapterQuests.recordStreakMaster).toHaveBeenCalledWith(1);
+
+      rerender({ ...defaultProps, comboCount: 2 });
+      expect(mockChapterQuests.recordStreakMaster).toHaveBeenCalledWith(2);
+
+      rerender({ ...defaultProps, comboCount: 3 });
+      expect(mockChapterQuests.recordStreakMaster).toHaveBeenCalledWith(3);
+
+      expect(mockChapterQuests.recordStreakMaster).toHaveBeenCalledTimes(3);
+    });
+
+    it('does NOT fire when the combo resets to 0', () => {
+      const { rerender } = renderHook(
+        (props) => useAdventureQuestTracking(props),
+        { initialProps: { ...defaultProps, comboCount: 3 } }
+      );
       expect(mockChapterQuests.recordStreakMaster).toHaveBeenCalledTimes(1);
 
-      // Subsequent increments should NOT fire again
-      rerender({ ...defaultProps, comboCount: 2 });
-      rerender({ ...defaultProps, comboCount: 3 });
+      // Combo breaks — no record on the way down.
+      rerender({ ...defaultProps, comboCount: 0 });
       expect(mockChapterQuests.recordStreakMaster).toHaveBeenCalledTimes(1);
     });
 
-    it('fires again after combo resets to 0', () => {
+    it('records again as a fresh streak grows past previous lengths', () => {
       const { rerender } = renderHook(
         (props) => useAdventureQuestTracking(props),
-        { initialProps: { ...defaultProps, comboCount: 1 } }
+        { initialProps: { ...defaultProps, comboCount: 2 } }
       );
+      expect(mockChapterQuests.recordStreakMaster).toHaveBeenLastCalledWith(2);
 
-      expect(mockChapterQuests.recordStreakMaster).toHaveBeenCalledTimes(1);
-
-      // Combo breaks
+      // Combo breaks, then a new streak begins and climbs.
       rerender({ ...defaultProps, comboCount: 0 });
-      // New streak starts
       rerender({ ...defaultProps, comboCount: 1 });
-
-      expect(mockChapterQuests.recordStreakMaster).toHaveBeenCalledTimes(2);
+      expect(mockChapterQuests.recordStreakMaster).toHaveBeenLastCalledWith(1);
+      rerender({ ...defaultProps, comboCount: 2 });
+      rerender({ ...defaultProps, comboCount: 3 });
+      expect(mockChapterQuests.recordStreakMaster).toHaveBeenLastCalledWith(3);
     });
 
     it('does NOT fire when comboCount stays at 0', () => {

--- a/fe-next/components/adventure/hooks/useAdventureQuestTracking.ts
+++ b/fe-next/components/adventure/hooks/useAdventureQuestTracking.ts
@@ -21,7 +21,7 @@ interface UseAdventureQuestTrackingParams {
   chapterQuests: {
     recordWordsFound: (count: number) => void;
     recordLongWord: () => void;
-    recordStreakMaster: () => void;
+    recordStreakMaster: (streakLength: number) => void;
     recordFlashChallengeMaster: () => void;
     recordWorldMechanicUse: () => void;
   };
@@ -87,13 +87,16 @@ export function useAdventureQuestTracking(params: UseAdventureQuestTrackingParam
     prevQuestWordsRef.current = wordsFound.length;
   }, [wordsFound]);
 
-  // Chapter quest: streak master — fire when a new streak begins
-  // (transition from 0 to positive), not on every word within a streak
+  // Chapter quest: streak master — "Reach a {target}-word streak".
+  // Record the streak length each time the combo grows; the quest stores the
+  // highest value (max semantics), so a single long combo completes it.
+  // Counting streak *starts* (the old 0→positive trigger) under-counted: a
+  // 10-word combo only credited 1 toward the target.
   const prevComboRef = useRef(0);
   useEffect(() => {
     const prev = prevComboRef.current;
-    if (comboCount > 0 && prev === 0) {
-      chapterQuestsRef.current.recordStreakMaster();
+    if (comboCount > 0 && comboCount > prev) {
+      chapterQuestsRef.current.recordStreakMaster(comboCount);
     }
     prevComboRef.current = comboCount;
   }, [comboCount]);

--- a/fe-next/contexts/ProgressionContext.tsx
+++ b/fe-next/contexts/ProgressionContext.tsx
@@ -185,8 +185,12 @@ interface ProgressionContextType {
   getLevelAttempt: (worldId: number, levelId: number) => LevelAttempt | undefined;
   /** Purchase upgrade by ID — server validates cost, optimistic + reconcile */
   updateCurrency: (upgradeId: string, optimisticGold: number, optimisticUpgrades: Record<string, number>) => Promise<void>;
-  /** Update chapter quest progress — persists to server */
-  updateChapterQuestProgress: (questType: string, amount: number, questIds: string[]) => void;
+  /**
+   * Update chapter quest progress — persists to server.
+   * mode 'add' (default) accumulates (word counts, scores, etc.);
+   * mode 'max' keeps the highest value (e.g. streak length reached).
+   */
+  updateChapterQuestProgress: (questType: string, amount: number, questIds: string[], mode?: 'add' | 'max') => void;
   /** Add words to the word album — deduplicates and persists */
   updateWordAlbum: (newWords: string[]) => void;
   /** Update rune inventory (forge/equip/unequip) — optimistic local update */
@@ -219,7 +223,7 @@ interface ProgressionActionsContextType {
   getLevelCompletion: (worldId: number, levelId: number) => LevelCompletion | undefined;
   getLevelAttempt: (worldId: number, levelId: number) => LevelAttempt | undefined;
   updateCurrency: ProgressionContextType['updateCurrency'];
-  updateChapterQuestProgress: (questType: string, amount: number, questIds: string[]) => void;
+  updateChapterQuestProgress: (questType: string, amount: number, questIds: string[], mode?: 'add' | 'max') => void;
   updateWordAlbum: (newWords: string[]) => void;
   updateRunes: ProgressionContextType['updateRunes'];
 }
@@ -789,13 +793,15 @@ export function ProgressionProvider({ children }: ProgressionProviderProps) {
 
   // Update chapter quest progress — optimistic local update + debounced server persist
   const updateChapterQuestProgress = useCallback(
-    (_questType: string, amount: number, questIds: string[]) => {
+    (_questType: string, amount: number, questIds: string[], mode: 'add' | 'max' = 'add') => {
       setProgression((prev) => {
         if (!prev) return prev;
         const current = prev.chapterQuestProgress ?? {};
         const updated = { ...current };
         for (const id of questIds) {
-          updated[id] = (updated[id] ?? 0) + amount;
+          updated[id] = mode === 'max'
+            ? Math.max(updated[id] ?? 0, amount)
+            : (updated[id] ?? 0) + amount;
         }
         // Stage for debounced persist (2s window batches rapid word-find updates)
         pendingQuestProgressRef.current = updated;

--- a/fe-next/contexts/__tests__/ProgressionContext.test.tsx
+++ b/fe-next/contexts/__tests__/ProgressionContext.test.tsx
@@ -825,4 +825,43 @@ describe('ProgressionContext', () => {
       expect(saved).toBe(false);
     });
   });
+
+  describe('updateChapterQuestProgress', () => {
+    it('adds to existing progress in default (add) mode', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/adventure/state')) {
+          return Promise.resolve({ ok: true, json: async () => ({ progression: createMockProgression(), attempts: [] }) });
+        }
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      });
+
+      const { result } = renderHook(() => useProgression(), { wrapper });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => { result.current.updateChapterQuestProgress('wordCountChapter', 5, ['q-add']); });
+      act(() => { result.current.updateChapterQuestProgress('wordCountChapter', 3, ['q-add']); });
+
+      expect(result.current.progression?.chapterQuestProgress?.['q-add']).toBe(8);
+    });
+
+    it('keeps the highest value in max mode (streak length, not sum)', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/api/adventure/state')) {
+          return Promise.resolve({ ok: true, json: async () => ({ progression: createMockProgression(), attempts: [] }) });
+        }
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      });
+
+      const { result } = renderHook(() => useProgression(), { wrapper });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      // A streak that climbs to 6 then a later shorter streak of 2 must not
+      // reduce progress, and repeated maxes must not accumulate.
+      act(() => { result.current.updateChapterQuestProgress('streakMaster', 4, ['q-max'], 'max'); });
+      act(() => { result.current.updateChapterQuestProgress('streakMaster', 6, ['q-max'], 'max'); });
+      act(() => { result.current.updateChapterQuestProgress('streakMaster', 2, ['q-max'], 'max'); });
+
+      expect(result.current.progression?.chapterQuestProgress?.['q-max']).toBe(6);
+    });
+  });
 });

--- a/fe-next/hooks/__tests__/useChapterQuests.test.ts
+++ b/fe-next/hooks/__tests__/useChapterQuests.test.ts
@@ -54,7 +54,8 @@ describe('useChapterQuests', () => {
     expect(mockUpdateChapterQuestProgress).toHaveBeenCalledWith(
       'wordCountChapter',
       5,
-      ['w1c1-words']
+      ['w1c1-words'],
+      'add'
     );
   });
 
@@ -64,7 +65,8 @@ describe('useChapterQuests', () => {
     expect(mockUpdateChapterQuestProgress).toHaveBeenCalledWith(
       'longWordCount',
       1,
-      ['w1c1-long']
+      ['w1c1-long'],
+      'add'
     );
   });
 
@@ -74,7 +76,20 @@ describe('useChapterQuests', () => {
     expect(mockUpdateChapterQuestProgress).toHaveBeenCalledWith(
       'perfectLevels',
       1,
-      ['w1c1-perfect']
+      ['w1c1-perfect'],
+      'add'
+    );
+  });
+
+  it('recordStreakMaster delegates with max mode and the streak length', () => {
+    // World 4 / chapter 1 has a streakMaster quest (target 5, id w4c1-streak).
+    const { result } = renderHook(() => useChapterQuests({ worldId: 4, chapterNumber: 1 }));
+    act(() => { result.current.recordStreakMaster(5); });
+    expect(mockUpdateChapterQuestProgress).toHaveBeenCalledWith(
+      'streakMaster',
+      5,
+      ['w4c1-streak'],
+      'max'
     );
   });
 

--- a/fe-next/hooks/useChapterQuests.ts
+++ b/fe-next/hooks/useChapterQuests.ts
@@ -18,12 +18,15 @@ interface UseChapterQuestsReturn {
   recordBossDefeatedNoHint: () => void;
   recordLongWord: () => void;
   recordWorldMechanicUse: () => void;
-  recordStreakMaster: () => void;
+  /** Record the streak length reached — quest stores the max ("reach an N-word streak"). */
+  recordStreakMaster: (streakLength: number) => void;
   recordBossHighHealth: () => void;
   recordFlashChallengeMaster: () => void;
   recordScoreChallenge: (score: number) => void;
   recordFullComboLevel: () => void;
 }
+
+type QuestUpdateMode = 'add' | 'max';
 
 export function useChapterQuests({ worldId, chapterNumber }: UseChapterQuestsProps): UseChapterQuestsReturn {
   const quests = getQuestsForChapter(worldId, chapterNumber);
@@ -59,13 +62,15 @@ export function useChapterQuests({ worldId, chapterNumber }: UseChapterQuestsPro
     }
   }, [progress, updateChapterQuestProgress]);
 
-  // Increment matching quests by type — delegates persistence to ProgressionContext
-  const increment = useCallback((type: string, amount = 1) => {
+  // Increment matching quests by type — delegates persistence to ProgressionContext.
+  // mode 'max' is used for quests that track a peak value (streak length reached)
+  // rather than a running total.
+  const increment = useCallback((type: string, amount = 1, mode: QuestUpdateMode = 'add') => {
     const matchingIds = quests
       .filter(q => q.type === type)
       .map(q => q.id);
     if (matchingIds.length === 0) return;
-    updateChapterQuestProgress(type, amount, matchingIds);
+    updateChapterQuestProgress(type, amount, matchingIds, mode);
   }, [quests, updateChapterQuestProgress]);
 
   // Stable callbacks — prevent re-renders in consumers that depend on these
@@ -74,7 +79,9 @@ export function useChapterQuests({ worldId, chapterNumber }: UseChapterQuestsPro
   const recordBossDefeatedNoHint = useCallback(() => increment('defeatBossNoHint'), [increment]);
   const recordLongWord = useCallback(() => increment('longWordCount'), [increment]);
   const recordWorldMechanicUse = useCallback(() => increment('worldMechanicUse'), [increment]);
-  const recordStreakMaster = useCallback(() => increment('streakMaster'), [increment]);
+  // "Reach a {target}-word streak" — record the streak length reached and keep
+  // the highest (max), so a single long combo completes the quest.
+  const recordStreakMaster = useCallback((streakLength: number) => increment('streakMaster', streakLength, 'max'), [increment]);
   const recordBossHighHealth = useCallback(() => increment('bossHighHealth'), [increment]);
   const recordFlashChallengeMaster = useCallback(() => increment('flashChallengeMaster'), [increment]);
   const recordScoreChallenge = useCallback((score: number) => increment('scoreChallenge', score), [increment]);


### PR DESCRIPTION
The "Streak Master" chapter quest ("Reach a {target}-word streak") only
credited +1 each time a combo *started* (the 0→positive transition), so a
single 10-word combo advanced the quest by just 1 — players who clearly
built a long combo saw no progress and the quest rarely triggered.

Track the streak length instead and store the highest value (max), matching
both the quest wording and the server's existing Math.max merge in
/api/adventure/quest-progress. Add a 'max' mode to updateChapterQuestProgress
and route recordStreakMaster through it, recording comboCount as the combo
grows.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019cBMYRM4RsXbi8fHYVtXFb