### PR TITLE
fix(settings,deeplink): scrollable settings + reliable cold-start deep links

### DIFF
--- a/fe-next/app/[locale]/settings/PageClient.tsx
+++ b/fe-next/app/[locale]/settings/PageClient.tsx
@@ -342,7 +342,7 @@ export default function SettingsPageClient(): React.JSX.Element {
             )}>
               {t('playerStyle.settings.description')}
             </p>
-            <StylePicker confirmLabelKey="playerStyle.picker.apply" />
+            <StylePicker layout="inline" confirmLabelKey="playerStyle.picker.apply" />
           </m.section>
           )}
           </div>{/* end left column */}

--- a/fe-next/components/DeepLinkHandler.tsx
+++ b/fe-next/components/DeepLinkHandler.tsx
@@ -151,41 +151,83 @@ export default function DeepLinkHandler() {
       }
     };
 
+    // Cold-start retry budget: the native bridge can take a beat to register
+    // @capacitor/app after the WebView mounts, so we poll a few times rather
+    // than reading the launch URL exactly once and giving up.
+    const COLD_START_MAX_ATTEMPTS = 10;
+    const COLD_START_RETRY_MS = 150;
+    const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
     const handleColdStartLaunchUrl = async () => {
       try {
-        try {
-          if (window.sessionStorage.getItem(LAUNCH_HANDLED_KEY) === '1') return;
-        } catch { /* sessionStorage unavailable — fall through, best-effort */ }
+        if (window.sessionStorage.getItem(LAUNCH_HANDLED_KEY) === '1') return;
+      } catch { /* sessionStorage unavailable — fall through, best-effort */ }
 
+      // The native bridge can register @capacitor/app slightly AFTER this
+      // component mounts (cold-start WebView race, Sentry JAVASCRIPT-NEXTJS-12A).
+      // Reading the launch URL once and bailing would silently drop every
+      // cold-start deep link onto the home page, so retry until the bridge
+      // answers. A *resolved* value — even `undefined` for a launcher-icon
+      // start — is a definitive answer that ends the loop; only a missing
+      // plugin or a rejected call (bridge not ready) triggers a retry.
+      for (let attempt = 0; attempt < COLD_START_MAX_ATTEMPTS && mounted; attempt++) {
         const AppPlugin = getSyncAppPlugin() ?? (await getAppPlugin());
-        if (!AppPlugin || typeof AppPlugin.getLaunchUrl !== 'function') return;
+        if (!AppPlugin || typeof AppPlugin.getLaunchUrl !== 'function') {
+          await delay(COLD_START_RETRY_MS);
+          continue;
+        }
 
-        const launch = await AppPlugin.getLaunchUrl();
-        const launchUrl = launch?.url;
-        if (!launchUrl || !launchUrlHasTarget(launchUrl) || !mounted) return;
+        let launchUrl: string | undefined;
+        try {
+          const launch = await AppPlugin.getLaunchUrl();
+          launchUrl = launch?.url;
+        } catch (error) {
+          // Bridge not ready yet — back off and retry.
+          logger.debug('getLaunchUrl not ready, retrying:', error);
+          await delay(COLD_START_RETRY_MS);
+          continue;
+        }
+
+        // Definitive answer received. Route only when it carries a real target;
+        // a bare origin / missing URL means "launched normally" → stay home.
+        if (!mounted) return;
+        if (!launchUrl || !launchUrlHasTarget(launchUrl)) return;
 
         // Mark consumed BEFORE awaiting the route so a fast remount mid-await
         // cannot double-fire (appUrlOpen may also replay the same URL).
         try { window.sessionStorage.setItem(LAUNCH_HANDLED_KEY, '1'); } catch { /* ignore */ }
         await handleAppUrlOpen({ url: launchUrl });
-      } catch (error) {
-        logger.debug('Cold-start launch URL handling failed:', error);
+        return;
       }
     };
 
-    // Guard against the Android WebView race: isNative() can be true before the
-    // native bridge has registered @capacitor/app (Sentry JAVASCRIPT-NEXTJS-12A).
-    const cap = (globalThis as unknown as CapGlobal).Capacitor;
-    const appPluginAvailable = typeof cap?.isPluginAvailable !== 'function' || cap.isPluginAvailable('App');
-
-    if (appPluginAvailable) {
-      // Register synchronously if plugin is available (covers test env & native Capacitor bridge)
-      const syncApp = getSyncAppPlugin();
-      if (syncApp) {
+    // Register the warm-start appUrlOpen listener. We deliberately do NOT gate
+    // this on Capacitor.isPluginAvailable('App'): during the cold-start WebView
+    // race that check can report false before the bridge finishes registering
+    // the plugin, which permanently skipped deep-link handling and dropped users
+    // on the home page (silent failure). Acquisition already degrades gracefully
+    // (sync plugin → dynamic import) and every call is wrapped in try/catch.
+    const syncApp = getSyncAppPlugin();
+    if (syncApp) {
+      try {
+        const listenerResult = syncApp.addListener('appUrlOpen', handleAppUrlOpen);
+        Promise.resolve(listenerResult)
+          .then((listener) => {
+            if (mounted) cleanup = () => listener.remove();
+          })
+          .catch((error: unknown) => {
+            logger.debug('Deep link listener unavailable:', error);
+          });
+      } catch (error) {
+        logger.debug('Deep link listener unavailable:', error);
+      }
+    } else {
+      // Async fallback for dynamic import path
+      getAppPlugin().then((AppPlugin) => {
+        if (!AppPlugin || !mounted) return;
         try {
-          const listenerResult = syncApp.addListener('appUrlOpen', handleAppUrlOpen);
-          Promise.resolve(listenerResult)
-            .then((listener) => {
+          Promise.resolve(AppPlugin.addListener('appUrlOpen', handleAppUrlOpen))
+            .then((listener: { remove: () => void }) => {
               if (mounted) cleanup = () => listener.remove();
             })
             .catch((error: unknown) => {
@@ -194,27 +236,11 @@ export default function DeepLinkHandler() {
         } catch (error) {
           logger.debug('Deep link listener unavailable:', error);
         }
-      } else {
-        // Async fallback for dynamic import path
-        getAppPlugin().then((AppPlugin) => {
-          if (!AppPlugin || !mounted) return;
-          try {
-            Promise.resolve(AppPlugin.addListener('appUrlOpen', handleAppUrlOpen))
-              .then((listener: { remove: () => void }) => {
-                if (mounted) cleanup = () => listener.remove();
-              })
-              .catch((error: unknown) => {
-                logger.debug('Deep link listener unavailable:', error);
-              });
-          } catch (error) {
-            logger.debug('Deep link listener unavailable:', error);
-          }
-        });
-      }
-
-      // After wiring the warm-start listener, resolve any cold-start launch URL.
-      void handleColdStartLaunchUrl();
+      });
     }
+
+    // After wiring the warm-start listener, resolve any cold-start launch URL.
+    void handleColdStartLaunchUrl();
 
     async function initPush() {
       try {

--- a/fe-next/components/__tests__/DeepLinkHandler.test.tsx
+++ b/fe-next/components/__tests__/DeepLinkHandler.test.tsx
@@ -34,6 +34,8 @@ vi.mock('@/utils/logger', () => ({
   default: {
     log: vi.fn(),
     error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -205,6 +207,37 @@ describe('DeepLinkHandler', () => {
 
       // Still once — the second mount must not re-route the same launch URL.
       expect(mockReplace).toHaveBeenCalledTimes(1);
+    });
+
+    // Regression: on a real cold start the native bridge can register the App
+    // plugin slightly AFTER this component mounts, so `Capacitor.isPluginAvailable('App')`
+    // returns false at mount time. The launch URL handling must NOT be permanently
+    // skipped behind that gate (silent failure) — otherwise every cold-start deep
+    // link lands on the home page. The plugin proxy is still reachable (sync or via
+    // dynamic import), so the launch URL must still route.
+    it('routes the launch URL even when isPluginAvailable("App") is false at mount', async () => {
+      (globalThis as any).Capacitor.isPluginAvailable = vi.fn(() => false);
+      setLaunchUrl('https://www.lexiclash.live/daily');
+
+      render(<DeepLinkHandler />);
+
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/en/daily'));
+    });
+
+    // Bridge-not-ready race: getLaunchUrl rejects on the first call (native bridge
+    // still booting) then resolves with the deep link. A single attempt would drop
+    // the link → home page. The handler must retry until the bridge answers.
+    it('retries getLaunchUrl when the native bridge is not ready yet', async () => {
+      const getLaunchUrl = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('bridge not ready'))
+        .mockResolvedValue({ url: 'lexiclash://connections' });
+      (globalThis as any).Capacitor.Plugins.App.getLaunchUrl = getLaunchUrl;
+
+      render(<DeepLinkHandler />);
+
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/en/connections'));
+      expect(getLaunchUrl.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/fe-next/components/playerStyle/StylePicker.tsx
+++ b/fe-next/components/playerStyle/StylePicker.tsx
@@ -30,6 +30,16 @@ export interface StylePickerProps {
   showConfirm?: boolean;
   /** Extra node pinned in the always-visible footer (e.g. modal "keep default"). */
   footerExtra?: React.ReactNode;
+  /**
+   * Layout mode:
+   * - 'modal' (default): the picker owns its own scroll region with a pinned
+   *   footer. Correct inside the fixed-height modal/onboarding shells.
+   * - 'inline': lays the grid out at its natural height and lets the host page
+   *   scroll. Use on the normally-scrolling Settings page — the internal
+   *   `overflow-y-auto` region otherwise traps the page scroll and makes
+   *   everything below the picker unreachable.
+   */
+  layout?: 'modal' | 'inline';
 }
 
 export function StylePicker({
@@ -37,6 +47,7 @@ export function StylePicker({
   confirmLabelKey = 'playerStyle.picker.confirm',
   showConfirm = true,
   footerExtra,
+  layout = 'modal',
 }: StylePickerProps) {
   const { t } = useLanguage();
   const { updateProfile } = useAuth();
@@ -96,14 +107,22 @@ export function StylePicker({
     }
   }, [selected, styleAvatar, avatarPreview, setStyle, updateProfile, stopSnippet, onConfirm]);
 
+  const isInline = layout === 'inline';
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
-      {/* Scrollable card region — bottom section stays pinned + always visible. */}
+    <div className={isInline ? 'flex flex-col gap-4' : 'flex min-h-0 flex-1 flex-col gap-4'}>
+      {/* Scrollable card region — bottom section stays pinned + always visible
+          in 'modal'. In 'inline' the grid lays out at natural height and the
+          host page owns the scroll (no nested scroll container to trap it). */}
       <div
-        // overscroll-contain + own compositor layer (translateZ) stops the
+        // modal: overscroll-contain + own compositor layer (translateZ) stops the
         // translucent backdrop behind the modal from repaint-flickering as this
         // region scrolls on touch devices.
-        className="grid min-h-0 flex-1 grid-cols-2 content-start gap-3 overflow-y-auto overscroll-contain px-4 pb-1 pt-4 [transform:translateZ(0)] [backface-visibility:hidden] sm:grid-cols-3"
+        className={
+          isInline
+            ? 'grid grid-cols-2 content-start gap-3 px-4 pb-1 pt-4 sm:grid-cols-3'
+            : 'grid min-h-0 flex-1 grid-cols-2 content-start gap-3 overflow-y-auto overscroll-contain px-4 pb-1 pt-4 [transform:translateZ(0)] [backface-visibility:hidden] sm:grid-cols-3'
+        }
         role="radiogroup"
         aria-label={t('playerStyle.picker.title')}
       >

--- a/fe-next/components/playerStyle/__tests__/StylePicker.test.tsx
+++ b/fe-next/components/playerStyle/__tests__/StylePicker.test.tsx
@@ -139,4 +139,33 @@ describe('StylePicker', () => {
     render(<StylePicker showConfirm={false} />);
     expect(screen.queryByText('playerStyle.picker.confirm')).toBeNull();
   });
+
+  // Layout: the default ('modal') variant owns its own scroll region — correct
+  // inside the fixed-height modal/onboarding shells. The 'inline' variant (used
+  // on the normally-scrolling Settings page) must NOT create a nested scroll
+  // container, otherwise the tile grid traps the page scroll and the Settings
+  // page below the picker becomes unreachable.
+  describe('layout variants', () => {
+    it('modal (default) keeps its own internal scroll region', () => {
+      render(<StylePicker />);
+      const region = screen.getByRole('radiogroup');
+      expect(region.className).toContain('overflow-y-auto');
+      expect(region.className).toContain('flex-1');
+    });
+
+    it('inline removes the internal scroll container so the page scrolls', () => {
+      render(<StylePicker layout="inline" />);
+      const region = screen.getByRole('radiogroup');
+      expect(region.className).not.toContain('overflow-y-auto');
+      expect(region.className).not.toContain('flex-1');
+      expect(region.className).not.toContain('min-h-0');
+    });
+
+    it('inline root is not a height-constrained flex column', () => {
+      const { container } = render(<StylePicker layout="inline" />);
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).not.toContain('flex-1');
+      expect(root.className).not.toContain('min-h-0');
+    });
+  });
 });


### PR DESCRIPTION
Settings page wasn't scrollable: the "select style" section embedded
StylePicker, which is built for a fixed-height modal — its inner grid uses
`overflow-y-auto`/`flex-1`/`min-h-0`, creating a nested scroll container that
trapped the page scroll on the normally-scrolling Settings page. Add a
`layout="inline"` variant that drops the internal scroll region so the host
page scrolls, and use it in Settings. Modal/onboarding keep the default
`layout="modal"` behavior.

Deep links always opened the home page on cold start: launch-URL handling was
gated behind `Capacitor.isPluginAvailable('App')`, which can report false
during the cold-start WebView bridge race (Sentry JAVASCRIPT-NEXTJS-12A) — a
silent failure that permanently skipped routing. Remove the gate (acquisition
already degrades sync→dynamic-import with try/catch) and add a bounded retry
loop so the cold-start launch URL is read once the bridge answers, instead of
being dropped onto home.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013MZYeLJx6ztMKjDu4fiQch