### PR TITLE
feat(practice): celebratory all-complete state with home CTA

### DIFF
--- a/fe-next/app/[locale]/practice/PageClient.tsx
+++ b/fe-next/app/[locale]/practice/PageClient.tsx
@@ -166,19 +166,40 @@ export default function PracticeHubClient({ locale }: Props) {
         {completed.size === PRACTICE_MODES.length && (
           <AdaptiveMotion.div
             data-testid="practice-all-complete"
-            initial={{ opacity: 0, scale: 0.95, y: -8 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, ease: 'easeOut' }}
             role="status"
             aria-live="polite"
-            className="mb-6 px-4 py-4 rounded-neo border-3 border-neo-black bg-neo-cozy text-neo-black shadow-hard text-center"
+            className="mb-6 flex flex-col items-center text-center"
           >
-            <p className="font-neo-display font-black text-base mb-1">
+            {/* Celebratory trophy medallion — springs in so the "you did it"
+                moment actually lands. The headline is plain text on the page
+                background (no filled box) so it reads as a banner, never a
+                button; the only tappable thing here is the real-game CTA below. */}
+            <AdaptiveMotion.span
+              aria-hidden
+              initial={{ scale: 0, rotate: -25 }}
+              animate={{ scale: 1, rotate: 0 }}
+              transition={{ type: 'spring', stiffness: 260, damping: 13, delay: 0.12 }}
+              className="inline-flex items-center justify-center w-16 h-16 rounded-full border-3 border-neo-black bg-neo-yellow text-neo-black shadow-hard mb-3"
+            >
+              <Trophy className="w-8 h-8" strokeWidth={2.5} />
+            </AdaptiveMotion.span>
+            <p className="font-neo-display font-black text-2xl sm:text-3xl text-neo-white mb-1">
               {t('practiceHub.allCompleteTitle')}
             </p>
-            <p className="font-neo-body text-xs">
+            <p className="font-neo-body text-sm text-neo-white/80 mb-4">
               {t('practiceHub.allCompleteBody')}
             </p>
+            <Link
+              href={`/${locale}`}
+              onClick={handleTileTap}
+              data-testid="practice-all-complete-cta"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-neo border-3 border-neo-black bg-neo-lime text-neo-black font-neo-display font-black text-base uppercase tracking-wide shadow-hard active:translate-y-px md:hover:-translate-y-0.5 md:hover:shadow-hard-lg transition-transform"
+            >
+              {t('practiceHub.goLive')}
+            </Link>
           </AdaptiveMotion.div>
         )}
 

--- a/fe-next/app/[locale]/practice/__tests__/PageClient.test.tsx
+++ b/fe-next/app/[locale]/practice/__tests__/PageClient.test.tsx
@@ -109,6 +109,41 @@ describe('PracticeHubClient completed-tile celebration', () => {
   });
 });
 
+describe('PracticeHubClient all-complete celebration', () => {
+  beforeEach(() => {
+    mockCompleted.current = new Set(['classic', 'wordHunt', 'wheelRush']);
+  });
+
+  it('shows the all-complete celebration once every mode is finished', () => {
+    wrap(<PracticeHubClient locale="en" />);
+    expect(screen.getByTestId('practice-all-complete')).toBeInTheDocument();
+  });
+
+  it('gives players a clear button CTA into the real game (homepage)', () => {
+    wrap(<PracticeHubClient locale="en" />);
+    const cta = screen.getByTestId('practice-all-complete-cta');
+    expect(cta.tagName).toBe('A');
+    expect(cta).toHaveAttribute('href', '/en');
+  });
+
+  it('does not style the celebration message itself as a button (no solid hard-shadow fill)', () => {
+    // The headline used to be a filled bg-neo-cozy box with a hard shadow, which
+    // read as a tappable button. The celebration message must look like a banner,
+    // not a CTA — the only button is the real-game CTA below it.
+    wrap(<PracticeHubClient locale="en" />);
+    const celebration = screen.getByTestId('practice-all-complete');
+    expect(celebration.className).not.toContain('bg-neo-cozy');
+    expect(celebration.className).not.toContain('shadow-hard');
+  });
+
+  it('hides the celebration while any mode is still incomplete', () => {
+    mockCompleted.current = new Set(['classic']);
+    wrap(<PracticeHubClient locale="en" />);
+    expect(screen.queryByTestId('practice-all-complete')).toBeNull();
+    expect(screen.queryByTestId('practice-all-complete-cta')).toBeNull();
+  });
+});
+
 describe('PracticeHubClient focused-screen chrome', () => {
   it('flips isInGame=true on mount so the hub scroll-locks and drops the footer', () => {
     wrap(<PracticeHubClient locale="en" />);


### PR DESCRIPTION
The 'All practice complete!' banner was a filled bg-neo-cozy box with a
hard shadow, so it read as a tappable button — and there was no actual
call-to-action out of the hub once everything was finished.

Replace it with a real celebration: a spring-in gold trophy medallion plus
a plain-text headline on the page background (banner, not button), and add
a clear neo-brutalist CTA button below that links to the homepage / real
game (reuses the localized practiceHub.goLive copy).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F6TT8QiRy8jxzfmLnzuaoS