### PR TITLE
fix(mp-desktop): single server-synced timer + no-scroll rails

### DIFF
--- a/fe-next/components/blast/legacy/BlastHUD.tsx
+++ b/fe-next/components/blast/legacy/BlastHUD.tsx
@@ -176,6 +176,10 @@ interface BlastHUDProps {
   remainingTime?: number | null;
   /** MP round length in seconds — drives the urgency calc + a11y label. */
   totalTime?: number;
+  /** True when this HUD is the center canvas of the desktop 3-column shell.
+   *  The shell's left-rail badge already renders the (server-synced) countdown,
+   *  so the HUD must NOT render its own — two timers drifted apart otherwise. */
+  isDesktopCanvas?: boolean;
   t: (key: string) => string | undefined;
 }
 
@@ -204,9 +208,11 @@ export function BlastHUD({
   isMultiplayer = false,
   remainingTime = null,
   totalTime,
+  isDesktopCanvas = false,
   t,
 }: BlastHUDProps) {
   const showTimer =
+    !isDesktopCanvas &&
     isMultiplayer && remainingTime !== null && remainingTime !== undefined && (totalTime ?? 0) > 0;
   const clearPct = totalTiles > 0 ? Math.round((tilesCleared / totalTiles) * 100) : 0;
   const isFiniteMoves = isFinite(totalMoves);

--- a/fe-next/components/blast/legacy/__tests__/BlastHUD.test.tsx
+++ b/fe-next/components/blast/legacy/__tests__/BlastHUD.test.tsx
@@ -138,6 +138,14 @@ describe('BlastHUD — multiplayer timer (consolidated into HUD)', () => {
     render(<BlastHUD {...mpProps} remainingTime={55} totalTime={90} />);
     expect(screen.getByTestId('blast-mp-timer').getAttribute('data-urgency')).toBe('normal');
   });
+
+  it('hides the inline MP timer inside the desktop shell (the shell badge owns the only timer)', () => {
+    // On desktop the BlastGame canvas is embedded in the 3-column shell, whose
+    // left-rail badge already renders the (server-synced) countdown. Rendering
+    // the HUD timer too produced two timers that drifted apart — suppress it.
+    render(<BlastHUD {...mpProps} remainingTime={55} totalTime={90} isDesktopCanvas />);
+    expect(screen.queryByTestId('blast-mp-timer')).toBeNull();
+  });
 });
 
 describe('BlastHUD — labelled stat columns (clarity)', () => {

--- a/fe-next/components/multiplayer/desktop/BlastDesktopAdapter.tsx
+++ b/fe-next/components/multiplayer/desktop/BlastDesktopAdapter.tsx
@@ -6,7 +6,7 @@ import { DesktopRivalsRosterRail } from './DesktopRivalsRosterRail';
 import { WordsLadder, type LadderWord } from './WordsLadder';
 import { KeyboardHintStrip } from './KeyboardHintStrip';
 import { ThemedPanel } from './ThemedPanel';
-import CircularTimer from '../../ui/CircularTimer';
+import { ShellBadgeTimer } from './ShellBadgeTimer';
 import { MyStatsCard } from './insights/MyStatsCard';
 import { OpponentInsightFeedConnected } from './insights/OpponentInsightFeedConnected';
 import { PaceDeltaChip } from './insights/PaceDeltaChip';
@@ -54,10 +54,9 @@ export function BlastDesktopAdapter(props: BlastDesktopAdapterProps) {
       modeBadge: (
         <ThemedPanel mode="blast" variant="badge" testId="blast-mode-badge">
           <div className="flex items-center gap-3 animate-mp-shell-fade">
-            <CircularTimer
-              duration={props.totalTime}
-              initialRemainingTime={props.remainingTime}
-              isPlaying
+            <ShellBadgeTimer
+              totalTime={props.totalTime}
+              remainingTime={props.remainingTime}
               size={88}
               colorFamily="lime"
             />

--- a/fe-next/components/multiplayer/desktop/MultiplayerDesktopShell.tsx
+++ b/fe-next/components/multiplayer/desktop/MultiplayerDesktopShell.tsx
@@ -35,23 +35,26 @@ export const MultiplayerDesktopShell = memo<MultiplayerDesktopShellProps>(({ slo
         data-mp-shell
         className="grid gap-4 p-4 h-full grid-cols-1 @[960px]:grid-cols-[minmax(200px,1fr)_minmax(500px,720px)_minmax(200px,1fr)]"
       >
-        {/* Left rail */}
-        <aside className="flex flex-col gap-3 min-w-0" data-slot="left">
+        {/* Left rail. min-h-0 + overflow-hidden bound the column to the shell
+            height; only the flex-1 roster scrolls, so the badge (timer) stays
+            pinned at the top and the stats card at the bottom — no page scroll. */}
+        <aside className="flex flex-col gap-3 min-w-0 min-h-0 overflow-hidden" data-slot="left">
           <div data-slot="left-mode-badge">{slots.left.modeBadge}</div>
-          <div data-slot="left-roster" className="flex-1 min-h-0">{slots.left.roster}</div>
+          <div data-slot="left-roster" className="flex-1 min-h-0 overflow-y-auto">{slots.left.roster}</div>
           <div data-slot="left-secondary" aria-hidden={!slots.left.secondary}>
             {slots.left.secondary ?? <span className="opacity-30">—</span>}
           </div>
         </aside>
 
         {/* Center canvas */}
-        <main className="min-w-0 flex items-stretch justify-center" data-slot="center">
+        <main className="min-w-0 min-h-0 flex items-stretch justify-center" data-slot="center">
           {slots.center}
         </main>
 
-        {/* Right rail */}
-        <aside className="flex flex-col gap-3 min-w-0" data-slot="right">
-          <div data-slot="right-ladder" className="flex-1 min-h-0">{slots.right.wordsLadder}</div>
+        {/* Right rail. Same bounding as the left: the words ladder scrolls in
+            place while the activity stream / chat stay pinned and visible. */}
+        <aside className="flex flex-col gap-3 min-w-0 min-h-0 overflow-hidden" data-slot="right">
+          <div data-slot="right-ladder" className="flex-1 min-h-0 overflow-y-auto">{slots.right.wordsLadder}</div>
           {slots.right.activityStream ? (
             <div data-slot="right-stream">{slots.right.activityStream}</div>
           ) : null}

--- a/fe-next/components/multiplayer/desktop/ShellBadgeTimer.tsx
+++ b/fe-next/components/multiplayer/desktop/ShellBadgeTimer.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { memo, useRef } from 'react';
+import CircularTimer from '../../ui/CircularTimer';
+import { reconcileTimerRing, type TimerRingState } from './timerResync';
+
+export interface ShellBadgeTimerProps {
+  /** Server-authoritative seconds remaining. The single source of truth. */
+  remainingTime: number;
+  /** Total match duration in seconds — drives the ring's full-circle fill. */
+  totalTime: number;
+  /** Ring diameter in px. */
+  size?: number;
+  /** Per-mode ring color (classic=cyan, blast=lime, wheel-rush=pink, …). */
+  colorFamily?: 'lime' | 'pink' | 'cyan' | 'purple';
+}
+
+/**
+ * The one timer the desktop shell shows per mode (left-rail badge). It wraps the
+ * self-driven ring but keeps it honest against the server: the ring sweeps
+ * smoothly on its own RAF, and we only re-seed it (via a changed `timerKey`)
+ * when the server's `remainingTime` has drifted past tolerance — e.g. a
+ * reconnect resend or a backgrounded tab. Without this the ring silently
+ * diverged from the server clock (and, in Blast, from the in-canvas timer),
+ * which is the "two timers that aren't in sync" symptom this fixes.
+ */
+function ShellBadgeTimerImpl({ remainingTime, totalTime, size = 80, colorFamily = 'cyan' }: ShellBadgeTimerProps) {
+  const stateRef = useRef<TimerRingState | null>(null);
+  // Pure + idempotent: a Strict-Mode double render lands on the same state
+  // (second pass sees lastServer === remainingTime → drop 0 → no extra re-seed).
+  stateRef.current = reconcileTimerRing(stateRef.current, remainingTime);
+  const { key, remaining } = stateRef.current;
+
+  return (
+    <CircularTimer
+      duration={totalTime}
+      initialRemainingTime={remaining}
+      timerKey={key}
+      isPlaying
+      size={size}
+      colorFamily={colorFamily}
+    />
+  );
+}
+
+export const ShellBadgeTimer = memo(ShellBadgeTimerImpl);
+ShellBadgeTimer.displayName = 'ShellBadgeTimer';

--- a/fe-next/components/multiplayer/desktop/StandardDesktopAdapter.tsx
+++ b/fe-next/components/multiplayer/desktop/StandardDesktopAdapter.tsx
@@ -6,7 +6,7 @@ import { DesktopRivalsRosterRail } from './DesktopRivalsRosterRail';
 import { WordsLadder, type LadderWord } from './WordsLadder';
 import { KeyboardHintStrip } from './KeyboardHintStrip';
 import { ThemedPanel } from './ThemedPanel';
-import CircularTimer from '../../ui/CircularTimer';
+import { ShellBadgeTimer } from './ShellBadgeTimer';
 import { MyStatsCard } from './insights/MyStatsCard';
 import { OpponentInsightFeedConnected } from './insights/OpponentInsightFeedConnected';
 import { PaceDeltaChip } from './insights/PaceDeltaChip';
@@ -67,10 +67,9 @@ function StandardDesktopAdapterImpl(props: StandardDesktopAdapterProps) {
     () => (
       <ThemedPanel mode="classic" variant="badge" testId="standard-mode-badge" withTexture>
         <div className="flex items-center gap-3 animate-mp-shell-fade">
-          <CircularTimer
-            duration={totalTime}
-            initialRemainingTime={remainingTime}
-            isPlaying
+          <ShellBadgeTimer
+            totalTime={totalTime}
+            remainingTime={remainingTime}
             size={80}
             colorFamily="cyan"
           />

--- a/fe-next/components/multiplayer/desktop/WheelRushDesktopAdapter.tsx
+++ b/fe-next/components/multiplayer/desktop/WheelRushDesktopAdapter.tsx
@@ -6,7 +6,7 @@ import { DesktopRivalsRosterRail } from './DesktopRivalsRosterRail';
 import { WordsLadder, type LadderWord } from './WordsLadder';
 import { KeyboardHintStrip } from './KeyboardHintStrip';
 import { ThemedPanel } from './ThemedPanel';
-import CircularTimer from '../../ui/CircularTimer';
+import { ShellBadgeTimer } from './ShellBadgeTimer';
 import { MyStatsCard } from './insights/MyStatsCard';
 import { OpponentInsightFeedConnected } from './insights/OpponentInsightFeedConnected';
 import { PaceDeltaChip } from './insights/PaceDeltaChip';
@@ -58,10 +58,9 @@ export function WheelRushDesktopAdapter(props: WheelRushDesktopAdapterProps) {
                 <SpinCounter current={props.currentSpin} total={props.totalSpins} />
               )}
             </div>
-            <CircularTimer
-              duration={props.totalTime}
-              initialRemainingTime={props.remainingTime}
-              isPlaying
+            <ShellBadgeTimer
+              totalTime={props.totalTime}
+              remainingTime={props.remainingTime}
               size={88}
               colorFamily="pink"
             />

--- a/fe-next/components/multiplayer/desktop/WordHuntDesktopAdapter.tsx
+++ b/fe-next/components/multiplayer/desktop/WordHuntDesktopAdapter.tsx
@@ -6,7 +6,7 @@ import { DesktopRivalsRosterRail } from './DesktopRivalsRosterRail';
 import { WordsLadder, type LadderWord } from './WordsLadder';
 import { KeyboardHintStrip } from './KeyboardHintStrip';
 import { ThemedPanel } from './ThemedPanel';
-import CircularTimer from '../../ui/CircularTimer';
+import { ShellBadgeTimer } from './ShellBadgeTimer';
 import { MyStatsCard } from './insights/MyStatsCard';
 import { OpponentInsightFeedConnected } from './insights/OpponentInsightFeedConnected';
 import { PaceDeltaChip } from './insights/PaceDeltaChip';
@@ -47,10 +47,9 @@ export function WordHuntDesktopAdapter(props: WordHuntDesktopAdapterProps) {
       modeBadge: (
         <ThemedPanel mode="word-hunt" variant="badge" testId="hunt-mode-badge">
           <div className="flex items-center gap-3 animate-mp-shell-fade">
-            <CircularTimer
-              duration={props.totalTime}
-              initialRemainingTime={props.remainingTime}
-              isPlaying
+            <ShellBadgeTimer
+              totalTime={props.totalTime}
+              remainingTime={props.remainingTime}
               size={80}
               colorFamily="purple"
             />

--- a/fe-next/components/multiplayer/desktop/__tests__/MultiplayerDesktopShell.test.tsx
+++ b/fe-next/components/multiplayer/desktop/__tests__/MultiplayerDesktopShell.test.tsx
@@ -81,4 +81,27 @@ describe('MultiplayerDesktopShell', () => {
     const { container } = render(<MultiplayerDesktopShell slots={mkSlots()} />);
     expect(container.querySelector('[data-slot="left-secondary"]')).toBeInTheDocument();
   });
+
+  it('bounds each rail to the shell height so tall rosters/ladders never push a page scroll', () => {
+    // Grid/flex items default to min-height:auto, so a long roster or words
+    // ladder grew its column past the board row and overflowed the whole shell
+    // (the "scroll to see the rest of the shell" symptom). Each rail must be
+    // height-bounded (min-h-0) and clip its own overflow.
+    const { container } = render(<MultiplayerDesktopShell slots={mkSlots()} />);
+    for (const side of ['left', 'right']) {
+      const rail = container.querySelector(`[data-slot="${side}"]`) as HTMLElement;
+      expect(rail.className).toMatch(/\bmin-h-0\b/);
+      expect(rail.className).toMatch(/\boverflow-hidden\b/);
+    }
+  });
+
+  it('scrolls the long lists inside their column (roster + ladder), keeping fixed panels visible', () => {
+    const { container } = render(<MultiplayerDesktopShell slots={mkSlots()} />);
+    const roster = container.querySelector('[data-slot="left-roster"]') as HTMLElement;
+    const ladder = container.querySelector('[data-slot="right-ladder"]') as HTMLElement;
+    for (const el of [roster, ladder]) {
+      expect(el.className).toMatch(/\bmin-h-0\b/);
+      expect(el.className).toMatch(/\boverflow-y-auto\b/);
+    }
+  });
 });

--- a/fe-next/components/multiplayer/desktop/__tests__/ShellBadgeTimer.test.tsx
+++ b/fe-next/components/multiplayer/desktop/__tests__/ShellBadgeTimer.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+import { ShellBadgeTimer } from '../ShellBadgeTimer';
+
+// Capture the props the underlying self-driven ring receives each render.
+const calls: Array<Record<string, unknown>> = [];
+vi.mock('../../../ui/CircularTimer', () => ({
+  default: (props: Record<string, unknown>) => {
+    calls.push(props);
+    return <div data-testid="ring" data-key={String(props.timerKey)} data-init={String(props.initialRemainingTime)} />;
+  },
+}));
+
+describe('ShellBadgeTimer', () => {
+  beforeEach(() => {
+    calls.length = 0;
+  });
+
+  it('forwards mode color + size to the ring and starts at key 0', () => {
+    const { getByTestId } = render(
+      <ShellBadgeTimer remainingTime={90} totalTime={180} size={80} colorFamily="cyan" />,
+    );
+    const ring = getByTestId('ring');
+    expect(ring.getAttribute('data-key')).toBe('0');
+    const last = calls[calls.length - 1];
+    expect(last.colorFamily).toBe('cyan');
+    expect(last.size).toBe(80);
+    expect(last.duration).toBe(180);
+    expect(last.isPlaying).toBe(true);
+  });
+
+  it('does NOT remount the ring (stable key) across normal 1Hz server ticks', () => {
+    const { rerender, getByTestId } = render(
+      <ShellBadgeTimer remainingTime={90} totalTime={180} size={80} colorFamily="cyan" />,
+    );
+    const k0 = getByTestId('ring').getAttribute('data-key');
+    rerender(<ShellBadgeTimer remainingTime={89} totalTime={180} size={80} colorFamily="cyan" />);
+    rerender(<ShellBadgeTimer remainingTime={88} totalTime={180} size={80} colorFamily="cyan" />);
+    // Normal countdown matches the ring's own prediction → no re-seed.
+    expect(getByTestId('ring').getAttribute('data-key')).toBe(k0);
+  });
+
+  it('re-seeds the ring (new key) when the server time jumps past tolerance', () => {
+    const { rerender, getByTestId } = render(
+      <ShellBadgeTimer remainingTime={90} totalTime={180} size={80} colorFamily="cyan" />,
+    );
+    const k0 = Number(getByTestId('ring').getAttribute('data-key'));
+    // Reconnect: server resends a value far from where the ring believes it is.
+    rerender(<ShellBadgeTimer remainingTime={30} totalTime={180} size={80} colorFamily="cyan" />);
+    const ring = getByTestId('ring');
+    expect(Number(ring.getAttribute('data-key'))).toBeGreaterThan(k0);
+    expect(ring.getAttribute('data-init')).toBe('30');
+  });
+});

--- a/fe-next/components/multiplayer/desktop/__tests__/timerResync.test.ts
+++ b/fe-next/components/multiplayer/desktop/__tests__/timerResync.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { reconcileTimerRing, type TimerRingState } from '../timerResync';
+
+/**
+ * The desktop shell badge ring (react-countdown-circle-timer) seeds its
+ * countdown ONCE and then ticks on its own RAF — it never re-reads the
+ * server's remainingTime, so it drifts (reconnect / tab-throttle). The server
+ * is the source of truth; the ring only displays it. These tests pin the
+ * "re-seed only on a server jump" reconciliation (pure, time-free).
+ */
+describe('reconcileTimerRing', () => {
+  it('seeds the ring at key 0 on the first reading', () => {
+    expect(reconcileTimerRing(null, 90)).toEqual({ remaining: 90, key: 0, lastServer: 90 });
+  });
+
+  it('keeps the ring seed + key stable across normal 1Hz ticks (smooth, no remount)', () => {
+    let s: TimerRingState = reconcileTimerRing(null, 90);
+    s = reconcileTimerRing(s, 89);
+    s = reconcileTimerRing(s, 88);
+    expect(s.key).toBe(0);
+    expect(s.remaining).toBe(90); // ring still counting from its original seed
+    expect(s.lastServer).toBe(88); // but tracks the latest reading
+  });
+
+  it('absorbs a couple of batched ticks without re-keying (sub-threshold drop)', () => {
+    let s = reconcileTimerRing(null, 90);
+    s = reconcileTimerRing(s, 87); // dropped 3 — at the limit, still normal
+    expect(s.key).toBe(0);
+  });
+
+  it('re-seeds (new key) when the server jumps UP — reconnect resend / new round', () => {
+    let s = reconcileTimerRing(null, 40);
+    s = reconcileTimerRing(s, 60);
+    expect(s.key).toBe(1);
+    expect(s.remaining).toBe(60);
+  });
+
+  it('re-seeds when the server drops far in one reading — a throttled tab catching up', () => {
+    let s = reconcileTimerRing(null, 88);
+    s = reconcileTimerRing(s, 70); // 18s gap in one render → snap to truth
+    expect(s.key).toBe(1);
+    expect(s.remaining).toBe(70);
+  });
+
+  it('respects a custom threshold', () => {
+    let s = reconcileTimerRing(null, 30, 0.5);
+    s = reconcileTimerRing(s, 28, 0.5); // dropped 2 > 0.5 → re-seed
+    expect(s.key).toBe(1);
+    expect(s.remaining).toBe(28);
+  });
+
+  it('never re-keys across a clean countdown to zero', () => {
+    let s = reconcileTimerRing(null, 5);
+    for (let r = 4; r >= 0; r--) s = reconcileTimerRing(s, r);
+    expect(s.key).toBe(0);
+    expect(s.remaining).toBe(5); // anchor stays the original seed
+  });
+});

--- a/fe-next/components/multiplayer/desktop/timerResync.ts
+++ b/fe-next/components/multiplayer/desktop/timerResync.ts
@@ -1,0 +1,53 @@
+/**
+ * Drift reconciliation for the desktop shell badge countdown ring.
+ *
+ * The badge ring (`components/ui/CircularTimer`, wrapping
+ * react-countdown-circle-timer) seeds its countdown from `initialRemainingTime`
+ * exactly once and then ticks on its OWN requestAnimationFrame loop — it never
+ * re-reads the server's `remainingTime`. Over a match that diverges from the
+ * server truth on reconnect, tab-throttle, or GC pauses (Recurring Pitfall
+ * Class 3: client and server computing the "same" number independently WILL
+ * drift; the server is the source of truth, the client only displays it).
+ *
+ * react-countdown-circle-timer can't follow a prop after mount, but it DOES
+ * restart when its `key` changes. So we watch consecutive server readings and
+ * only re-seed (bump the key) when the server jumps in a way the ring can't be
+ * tracking on its own: it went UP (reconnect resend / new round), or it dropped
+ * by more than a normal render cadence would explain (a stalled/throttled tab
+ * catching up). Ordinary 1-Hz countdown ticks leave the ring untouched so it
+ * keeps its smooth sweep instead of snapping every second. No wall-clock read is
+ * needed (and none is allowed during render), so this stays a pure function.
+ */
+export interface TimerRingState {
+  /** Seconds value the ring is currently seeded from (its restart point). */
+  remaining: number;
+  /** Key handed to the ring; bumped on each re-seed to force a restart. */
+  key: number;
+  /** Most recent server reading — drift detection only, not shown. */
+  lastServer: number;
+}
+
+/**
+ * Max seconds a single server reading may drop before we treat it as a jump
+ * rather than a normal tick. Generous enough to absorb a couple of batched
+ * 1-Hz ticks, tight enough to catch a throttled tab catching up.
+ */
+export const DEFAULT_RESYNC_THRESHOLD_SEC = 3;
+
+export function reconcileTimerRing(
+  state: TimerRingState | null,
+  serverRemaining: number,
+  thresholdSec: number = DEFAULT_RESYNC_THRESHOLD_SEC,
+): TimerRingState {
+  if (state === null) {
+    return { remaining: serverRemaining, key: 0, lastServer: serverRemaining };
+  }
+  const drop = state.lastServer - serverRemaining; // >0 during normal countdown
+  const jumped = drop < 0 || drop > thresholdSec;
+  if (jumped) {
+    return { remaining: serverRemaining, key: state.key + 1, lastServer: serverRemaining };
+  }
+  // Normal tick: keep the ring's seed + key stable (smooth, no remount); only
+  // record the latest reading so the next comparison is against it.
+  return { remaining: state.remaining, key: state.key, lastServer: serverRemaining };
+}


### PR DESCRIPTION
The desktop shell showed two countdowns that drifted apart. The left-rail
badge uses a self-driven ring (react-countdown-circle-timer) seeded once and
never re-synced to the server, while Blast's HUD also rendered its own
server-driven timer — BlastHUD silently ignored isDesktopCanvas (never
declared in its props), so both showed at once and diverged.

- Add ShellBadgeTimer wrapping the badge ring with pure, time-free drift
  reconciliation (reconcileTimerRing): the ring keeps its smooth sweep on
  normal 1Hz ticks and only re-seeds (key bump) on a server jump
  (reconnect resend / throttled-tab catch-up). Server stays source of truth.
- Wire ShellBadgeTimer into all four mode adapters (classic/blast/
  wheel-rush/word-hunt).
- BlastHUD: declare + honor isDesktopCanvas so the canvas timer is
  suppressed in the shell — the badge is the single timer per mode.
- Shell rails: bound each aside (min-h-0 + overflow-hidden) and scroll the
  long roster/ladder lists within their column, so tall lobbies no longer
  push a full-page scroll; badge/stats/activity stay pinned and visible.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016gm1FhymSC8cmevES6uqeH