### PR TITLE
feat(mp-lobby): hide style picker pre-first-game, longer bot countdown, declutter blast tiles

### DIFF
--- a/fe-next/app/components/PlayerStyleOnboardingWrapper.tsx
+++ b/fe-next/app/components/PlayerStyleOnboardingWrapper.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { isLandingRoute } from '@/lib/onboarding/allowedRoutes';
 import { isGameplayPath } from '@/lib/gameplayRoutes';
 import { useGameActive, useWaitingForResults } from '@/hooks/gameState/store';
+import { useUserStats } from '@/hooks/useUserStats';
 import { hasCompletedOnboarding } from '@/utils/onboardingStorage';
 import {
   getStoredPlayerStyle,
@@ -58,6 +59,13 @@ export default function PlayerStyleOnboardingWrapper() {
   const gameActive = useGameActive();
   const waitingForResults = useWaitingForResults();
   const onGameplayRoute = isGameplayPath(pathname);
+  // FTUE gate: the picker is a personalisation reward, so never surface it to a
+  // player who has not played a single game yet (covers a fresh visitor who
+  // lands straight in the multiplayer lobby). `useUserStats` resolves the guest
+  // localStorage count OR `profiles.total_games`, so this works pre-login too.
+  // Pessimistic while loading (stats null → treat as 0) to avoid an early flash.
+  const { userStats } = useUserStats();
+  const hasPlayedAtLeastOneGame = (userStats?.totalGamesPlayed ?? 0) >= 1;
   // A game has actually started this mount. Distinguishes "results screen" (a
   // game finished → natural break) from "pre-game" (never started → still mid-
   // flow) on a gameplay route, where both read gameActive === false.
@@ -103,6 +111,9 @@ export default function PlayerStyleOnboardingWrapper() {
         gameActive,
         onGameplayRoute,
         resultsShowing,
+        // Hold the picker until the player has at least one game under their belt
+        // (FTUE) — keeps it out of the multiplayer lobby for brand-new players.
+        hasPlayedAtLeastOneGame,
       });
       // Only ever OPEN from the effect; dismissal owns closing. This prevents a
       // dep change while the modal is open from yanking it shut mid-choice, and
@@ -127,6 +138,7 @@ export default function PlayerStyleOnboardingWrapper() {
     waitingForResults,
     onGameplayRoute,
     resultsShowing,
+    hasPlayedAtLeastOneGame,
     pathname,
   ]);
 

--- a/fe-next/components/blast/legacy/BlastBoard.tsx
+++ b/fe-next/components/blast/legacy/BlastBoard.tsx
@@ -70,6 +70,13 @@ export interface BlastBoardProps {
   cascadeHighlightCells?: Array<{ row: number; col: number }>;
   /** Remaining turns of diamond reveal (shows frozen tile inner types) */
   diamondRevealTurns?: number;
+  /**
+   * Multiplayer round — suppress the per-tile explanation tooltips (the mobile
+   * info pop-up + the native `title` hint). In a timed competitive MP game the
+   * descriptions are distracting clutter; single-player keeps them as a learning
+   * aid.
+   */
+  isMultiplayer?: boolean;
 }
 
 /**
@@ -92,6 +99,7 @@ export const BlastBoard = memo(function BlastBoard({
   nearMissCells = [],
   cascadeHighlightCells = [],
   diamondRevealTurns = 0,
+  isMultiplayer = false,
 }: BlastBoardProps) {
   const { t } = useLanguage();
   const equippedBoardTheme = useEquippedCosmetic('boardTheme');
@@ -208,8 +216,11 @@ export const BlastBoard = memo(function BlastBoard({
     return map;
   }, [sequencerState]);
 
-  // Single-tile tooltip: when exactly 1 special tile is selected, show its info
+  // Single-tile tooltip: when exactly 1 special tile is selected, show its info.
+  // Suppressed in multiplayer — the explanations are distracting clutter during a
+  // timed, competitive round.
   const singleTileTooltip = useMemo(() => {
+    if (isMultiplayer) return null;
     if (selectedCells.length !== 1) return null;
     const c = selectedCells[0];
     const tile = tileStates[c.row]?.[c.col];
@@ -217,7 +228,7 @@ export const BlastBoard = memo(function BlastBoard({
     const tooltip = getTileTooltip(tile.type, t);
     if (!tooltip) return null;
     return { ...tooltip, row: c.row, col: c.col };
-  }, [selectedCells, tileStates, t]);
+  }, [isMultiplayer, selectedCells, tileStates, t]);
 
   // Only render overlay once we have tile states
   const hasTileStates = tileStates.length > 0 && tileStates[0]?.length > 0;
@@ -314,6 +325,7 @@ export const BlastBoard = memo(function BlastBoard({
                 innerType={tile.innerType}
                 portalPairIndex={tile.type === 'portal' && tile.portalPairId ? portalPairMap.get(tile.portalPairId) : undefined}
                 isScanTarget={scanTargetKey?.key === key ? scanTargetKey.source : undefined}
+                hideTooltip={isMultiplayer}
                 clearRotate={animState?.clearRotate}
                 col={tile.col}
                 fallOffset={animState?.fallDistance ? animState.fallDistance * cellHeight : undefined}

--- a/fe-next/components/blast/legacy/BlastStage.tsx
+++ b/fe-next/components/blast/legacy/BlastStage.tsx
@@ -414,6 +414,7 @@ export const BlastStage = memo(function BlastStage({
                 nearMissCells={nearMissCells}
                 cascadeHighlightCells={cascadeHighlightCells}
                 diamondRevealTurns={gameState.diamondRevealTurns}
+                isMultiplayer={isMultiplayer}
               />
             </div>
             {/* PixiJS effects layer — overlays DOM board so particles/shockwaves/shatters are visible above tile art. pointer-events-none so taps still reach BlastBoard. */}

--- a/fe-next/components/blast/legacy/BlastTile.tsx
+++ b/fe-next/components/blast/legacy/BlastTile.tsx
@@ -70,6 +70,13 @@ export interface BlastTileProps {
   cakeMaxHp?: number;
   /** True if this tile is part of any cake-bomb cluster (renders the pink wash). */
   isCakeCell?: boolean;
+  /**
+   * Suppress the special-tile explanation tooltip (the native `title` hint). Used
+   * in multiplayer where the per-tile descriptions are distracting during a timed,
+   * competitive round — players already know the mechanics by the time they're in
+   * MP. Single-player keeps them as a learning aid.
+   */
+  hideTooltip?: boolean;
   onClick?: () => void;
 }
 
@@ -230,7 +237,7 @@ export const BlastTile = memo(function BlastTile({
   letter, type, phase, isSelected, isCleared, hitsRemaining,
   fallOffset, clearRotate, spawnOffset, isNearMiss, activationEffect, isComboPreview,
   selectionIndex, selectionTotal, isLocked, countdown, fuseTimer, zonePreview,
-  isDiamondRevealed, innerType, isCascadeHighlight, portalPairIndex, isScanTarget, colorTag, jellyLayers, cakeHp, cakeMaxHp, isCakeCell, onClick, col,
+  isDiamondRevealed, innerType, isCascadeHighlight, portalPairIndex, isScanTarget, colorTag, jellyLayers, cakeHp, cakeMaxHp, isCakeCell, hideTooltip, onClick, col,
 }: BlastTileProps) {
   const reducedMotion = usePrefersReducedMotion();
   const { t } = useLanguage();
@@ -260,8 +267,9 @@ export const BlastTile = memo(function BlastTile({
   }
 
   const visual = TILE_VISUALS[type] ?? TILE_VISUALS.standard;
-  // Skip tooltip lookup entirely for standard tiles (the vast majority) — keeps render fast
-  const tooltip = type !== 'standard' ? getTileTooltip(type, t) : null;
+  // Skip tooltip lookup entirely for standard tiles (the vast majority) — keeps
+  // render fast — and in multiplayer where the explanations are suppressed.
+  const tooltip = type !== 'standard' && !hideTooltip ? getTileTooltip(type, t) : null;
   const effectivePhase = reducedMotion && ANIMATED_PHASES.has(phase) ? 'idle' : phase;
   const phaseStyle = effectivePhase !== 'idle' && effectivePhase !== 'selected'
     ? getPhaseStyles(effectivePhase, type, fallOffset, clearRotate, spawnOffset, col)
@@ -505,6 +513,7 @@ export const BlastTile = memo(function BlastTile({
   prev.isCascadeHighlight === next.isCascadeHighlight &&
   prev.portalPairIndex === next.portalPairIndex &&
   prev.isScanTarget === next.isScanTarget &&
+  prev.hideTooltip === next.hideTooltip &&
   prev.onClick === next.onClick
 );
 

--- a/fe-next/components/blast/legacy/__tests__/BlastTile.tooltip.test.tsx
+++ b/fe-next/components/blast/legacy/__tests__/BlastTile.tooltip.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * BlastTile — special-tile explanation tooltip gating.
+ *
+ * Special tiles (bomb, gold, …) carry a native `title` hint describing their
+ * mechanic — a useful learning aid in single-player. In multiplayer the board
+ * passes `hideTooltip` so these explanations are suppressed: during a timed,
+ * competitive round the per-tile descriptions are distracting clutter.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@/hooks/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => false,
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+import { BlastTile } from '../BlastTile';
+
+const baseProps = {
+  letter: 'A',
+  type: 'bomb' as const,
+  phase: 'idle' as const,
+  isSelected: false,
+  isCleared: false,
+};
+
+describe('BlastTile explanation tooltip', () => {
+  it('renders the special-tile title hint by default (single-player learning aid)', () => {
+    render(<BlastTile {...baseProps} />);
+    expect(screen.getByRole('button')).toHaveAttribute('title');
+  });
+
+  it('suppresses the title hint when hideTooltip is set (multiplayer)', () => {
+    render(<BlastTile {...baseProps} hideTooltip />);
+    expect(screen.getByRole('button')).not.toHaveAttribute('title');
+  });
+});

--- a/fe-next/host/__tests__/HostPreGameView.soloHostStart.test.tsx
+++ b/fe-next/host/__tests__/HostPreGameView.soloHostStart.test.tsx
@@ -206,7 +206,14 @@ describe('HostPreGameView passive bot auto-fill timer (alone host)', () => {
     render(<HostPreGameView {...baseProps} isPrivate={false} />);
 
     act(() => { vi.advanceTimersByTime(15_000); }); // alone timer
-    act(() => { vi.advanceTimersByTime(10_000); }); // bot countdown → 0
+
+    // The visible "starting with bots…" countdown runs a full 20s — long enough
+    // that a host can read it and still invite a friend before bots fill in. Just
+    // shy of 20s it must NOT have fired yet.
+    act(() => { vi.advanceTimersByTime(19_000); });
+    expect(emitMock.mock.calls.find(([evt]) => evt === 'setAutoFill')).toBeUndefined();
+
+    act(() => { vi.advanceTimersByTime(1_000); }); // bot countdown → 0
 
     const setAutoFill = emitMock.mock.calls.find(([evt]) => evt === 'setAutoFill');
     expect(setAutoFill).toBeDefined();
@@ -224,7 +231,7 @@ describe('HostPreGameView passive bot auto-fill timer (alone host)', () => {
     // yet a private room never force-fills: the host is waiting on invited humans.
     // They can still press Start to fill on demand.
     act(() => { vi.advanceTimersByTime(15_000); });
-    act(() => { vi.advanceTimersByTime(10_000); });
+    act(() => { vi.advanceTimersByTime(20_000); });
 
     const setAutoFill = emitMock.mock.calls.find(([evt]) => evt === 'setAutoFill');
     expect(setAutoFill).toBeUndefined();

--- a/fe-next/host/components/HostPreGameView.tsx
+++ b/fe-next/host/components/HostPreGameView.tsx
@@ -332,13 +332,15 @@ function HostPreGameView({
         // Quick Play: skip alone-timer, kick off short "filling bots…" countdown.
         setBotCountdown(3);
       } else if (!isPrivate) {
-        // Passive fallback for a PUBLIC-room host who never presses Start. Halved
-        // from 30s → 15s to shrink the dead lobby wait that drove new-host
-        // abandonment. A human joining cancels this (the else-branch below).
+        // Passive fallback for a PUBLIC-room host who never presses Start. A short
+        // 15s alone-timer first absorbs the "is anyone joining?" window, then a
+        // visible 20s "starting with bots…" countdown gives the host ample time to
+        // read it and still invite a friend before bots fill in (bumped from 10s,
+        // which felt abrupt). A human joining cancels this (the else-branch below).
         // Private (invite / classroom) rooms are excluded — that host is waiting
         // on specific humans and can still press Start to fill bots on demand.
         aloneTimerRef.current = setTimeout(() => {
-          setBotCountdown(10);
+          setBotCountdown(20);
         }, 15_000);
       }
     } else {

--- a/fe-next/lib/playerStyle/shouldShowStylePopup.test.ts
+++ b/fe-next/lib/playerStyle/shouldShowStylePopup.test.ts
@@ -85,6 +85,29 @@ describe('shouldShowStylePopup', () => {
     );
   });
 
+  describe('first game gate (FTUE: never prompt a player who has not played a single game)', () => {
+    // The style picker is a personalisation reward — surfacing it to a player who
+    // has not yet played even one game (e.g. landing straight in the MP lobby)
+    // interrupts them before they have any context for the choice. Hold it until
+    // they have at least one game under their belt. Applies in either auth state.
+    it('never shows before the player has played at least one game', () => {
+      expect(shouldShowStylePopup({ ...base, hasPlayedAtLeastOneGame: false })).toBe(false);
+      expect(
+        shouldShowStylePopup({ ...base, isAuthenticated: true, hasPlayedAtLeastOneGame: false }),
+      ).toBe(false);
+    });
+
+    it('shows once the player has played at least one game (gate is satisfied)', () => {
+      expect(shouldShowStylePopup({ ...base, hasPlayedAtLeastOneGame: true })).toBe(true);
+    });
+
+    it('is backward-compatible: an undefined flag does not block (existing callers)', () => {
+      // Optional gate — only an explicit `false` suppresses. Undefined keeps the
+      // prior behaviour so unrelated call sites are unaffected.
+      expect(shouldShowStylePopup({ ...base, hasPlayedAtLeastOneGame: undefined })).toBe(true);
+    });
+  });
+
   describe('authenticated', () => {
     const authed = { ...base, isAuthenticated: true };
     it('shows once when the popup was never shown and no style chosen', () => {

--- a/fe-next/lib/playerStyle/shouldShowStylePopup.ts
+++ b/fe-next/lib/playerStyle/shouldShowStylePopup.ts
@@ -79,6 +79,15 @@ export interface StylePopupGateInput {
    * on a gameplay route to the post-game moment the user explicitly chose.
    */
   resultsShowing?: boolean;
+  /**
+   * The player has completed at least one game (any mode — guest localStorage
+   * count or `profiles.total_games`). The style picker is a personalisation
+   * reward; surfacing it to someone who has not yet played a single game (e.g. a
+   * fresh visitor who lands straight in the multiplayer lobby) interrupts them
+   * before they have any context for the choice. Optional + only an explicit
+   * `false` suppresses, so existing call sites are unaffected. False → never show.
+   */
+  hasPlayedAtLeastOneGame?: boolean;
 }
 
 /**
@@ -105,6 +114,11 @@ export function shouldShowStylePopup(input: StylePopupGateInput): boolean {
   // Pre-game setup / lobby / countdown are still mid-flow. Off gameplay routes
   // (menus, profile, leaderboard) the user is already idle, so this gate is moot.
   if (input.onGameplayRoute && !input.resultsShowing) return false;
+  // FTUE: never prompt a player who has not played a single game yet. Holds the
+  // picker out of the multiplayer lobby (and every other surface) until the
+  // player has at least one game under their belt. Only an explicit `false`
+  // blocks — undefined leaves prior behaviour intact for callers that omit it.
+  if (input.hasPlayedAtLeastOneGame === false) return false;
   if (!input.featureEnabled) return false;
   if (input.needsProfileCustomization) return false;
   // Already picked a style (local truth) → never prompt, in either auth state.


### PR DESCRIPTION
- Style picker: add a hasPlayedAtLeastOneGame gate to shouldShowStylePopup so
  the personalisation popup never surfaces before a player has completed one
  game (covers landing straight in the MP lobby). Wired via useUserStats, which
  resolves the guest localStorage count or profiles.total_games, so it works
  pre-login too.
- Solo-host auto bot countdown: bump the visible "starting with bots…" timer
  from 10s to 20s so the host has time to read it and still invite a friend.
- Blast multiplayer: suppress the per-tile explanation tooltips (mobile info
  pop-up + native title hint) during a timed competitive round; single-player
  keeps them as a learning aid.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012BUi6vSeyCY5fbMKt8BJnC