### PR TITLE
fix(nav): desktop Quick Play tab routes straight to multiplayer, not the /singleplayer redirect stub

### DIFF
--- a/fe-next/components/DesktopGameNav.tsx
+++ b/fe-next/components/DesktopGameNav.tsx
@@ -13,14 +13,25 @@ interface NavItem {
   id: string;
   labelKey: string;
   icon: typeof Home;
+  /** Path used for active-state matching against the current pathname. */
   route: string;
+  /**
+   * Optional navigation target, used when the canonical destination differs from
+   * `route`. The Quick Play tab matches the `/singleplayer` identity but must
+   * navigate to the real flow directly — `/singleplayer` is a soft-deleted route
+   * whose only job is a server-side `permanentRedirect` (308) to
+   * `/multiplayer?quickPlay=true`. Soft-navigating into that force-dynamic
+   * redirect stub failed the client RSC fetch → browser-level "page couldn't
+   * load". Routing straight to the destination removes the redirect hop.
+   */
+  href?: string;
   color: string;
   activeColor: string;
 }
 
 const NAV_ITEMS: NavItem[] = [
   { id: 'home', labelKey: 'nav.home', icon: Home, route: '', color: 'text-neo-white', activeColor: 'text-neo-lime border-neo-lime' },
-  { id: 'singleplayer', labelKey: 'nav.singleplayer', icon: Zap, route: '/singleplayer', color: 'text-neo-white', activeColor: 'text-neo-cyan border-neo-cyan' },
+  { id: 'singleplayer', labelKey: 'nav.singleplayer', icon: Zap, route: '/singleplayer', href: '/multiplayer?quickPlay=true', color: 'text-neo-white', activeColor: 'text-neo-cyan border-neo-cyan' },
   { id: 'multiplayer', labelKey: 'nav.play', icon: Swords, route: '/multiplayer', color: 'text-neo-white', activeColor: 'text-neo-pink border-neo-pink' },
   { id: 'daily', labelKey: 'nav.daily', icon: Calendar, route: '/daily', color: 'text-neo-white', activeColor: 'text-neo-yellow border-neo-yellow' },
   { id: 'leaderboard', labelKey: 'nav.leaderboard', icon: Trophy, route: '/leaderboard', color: 'text-neo-white', activeColor: 'text-neo-yellow border-neo-yellow' },
@@ -74,7 +85,7 @@ export const DesktopGameNav = memo(function DesktopGameNav() {
             return (
               <button
                 key={item.id}
-                onClick={() => router.push(`/${language}${item.route}`)}
+                onClick={() => router.push(`/${language}${item.href ?? item.route}`)}
                 className={cn(
                   'flex items-center gap-1.5 px-3 py-2.5 text-sm font-bold whitespace-nowrap transition-all duration-150 border-b-3 -mb-[2px]',
                   isActive

--- a/fe-next/components/__tests__/DesktopGameNav.test.tsx
+++ b/fe-next/components/__tests__/DesktopGameNav.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Override the global stub from vitest.setup.ts — this file tests the real component.
@@ -10,6 +10,7 @@ let mockIsInGame = false;
 let mockIsOnCG = false;
 let mockIsVeteran = true;
 let mockPathname = '/en';
+const mockPush = vi.fn();
 
 vi.mock('@/contexts/NavigationContext', () => ({
   useNavigation: () => ({ isInGame: mockIsInGame }),
@@ -22,7 +23,7 @@ vi.mock('@/contexts/LanguageContext', () => ({
 }));
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }));
 vi.mock('@/hooks/useIsPracticeVeteran', () => ({
   useIsPracticeVeteran: () => mockIsVeteran,
@@ -34,6 +35,7 @@ describe('DesktopGameNav practice gate', () => {
     mockIsOnCG = false;
     mockIsVeteran = true;
     mockPathname = '/en';
+    mockPush.mockClear();
   });
 
   it('renders for veterans on home', () => {
@@ -72,5 +74,45 @@ describe('DesktopGameNav practice gate', () => {
     mockPathname = '/en/leaderboard';
     const { container } = render(<DesktopGameNav />);
     expect(container.querySelector('nav')).not.toBeNull();
+  });
+});
+
+describe('DesktopGameNav navigation targets', () => {
+  beforeEach(() => {
+    mockIsInGame = false;
+    mockIsOnCG = false;
+    mockIsVeteran = true;
+    mockPathname = '/en';
+    mockPush.mockClear();
+  });
+
+  // Regression: the "Quick Play" tab used to router.push('/<lang>/singleplayer'),
+  // a soft-deleted route whose only job is a server-side permanentRedirect (308)
+  // to /multiplayer?quickPlay=true. Soft-navigating into a force-dynamic route that
+  // immediately throws a redirect failed the client RSC fetch → browser-level
+  // "page couldn't load". Point the tab at the canonical destination directly so
+  // there is no redirect hop. (Class 3 — asymmetric path through a redirect stub.)
+  it('routes Quick Play straight to the multiplayer quick-play flow (no /singleplayer redirect hop)', () => {
+    const { getByText } = render(<DesktopGameNav />);
+    fireEvent.click(getByText('nav.singleplayer'));
+    expect(mockPush).toHaveBeenCalledWith('/en/multiplayer?quickPlay=true');
+    expect(mockPush).not.toHaveBeenCalledWith('/en/singleplayer');
+  });
+
+  it('routes the remaining tabs to their real pages', () => {
+    const cases: Array<[string, string]> = [
+      ['nav.home', '/en'],
+      ['nav.play', '/en/multiplayer'],
+      ['nav.daily', '/en/daily'],
+      ['nav.leaderboard', '/en/leaderboard'],
+      ['nav.friends', '/en/friends'],
+    ];
+    for (const [label, expected] of cases) {
+      mockPush.mockClear();
+      const { getByText, unmount } = render(<DesktopGameNav />);
+      fireEvent.click(getByText(label));
+      expect(mockPush).toHaveBeenCalledWith(expected);
+      unmount();
+    }
   });
 });


### PR DESCRIPTION
The desktop game nav "Quick Play" tab pushed `/<lang>/singleplayer`, a
soft-deleted route whose only job is a server-side `permanentRedirect`
(308) to `/multiplayer?quickPlay=true`. Soft-navigating into that
`force-dynamic` redirect stub failed the client RSC fetch, surfacing as a
browser-level "page couldn't load."

Point the tab at the canonical destination directly. `route` still holds
`/singleplayer` for active-state matching; a new optional `href` overrides
the navigation target. Removes the redirect hop (and an extra dynamic
server render) on every Quick Play click.

Class 3 (asymmetric path through a redirect stub).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BmgwKZL71a4JdUdbh1ZyED