### PR TITLE
feat(ui): SafeAreaView primitive + responsive-overflow CI guard

### DIFF
--- a/fe-next/app/[locale]/friends/PageClient.tsx
+++ b/fe-next/app/[locale]/friends/PageClient.tsx
@@ -15,6 +15,7 @@ import { useCrazyGamesAuth } from '@/hooks/useCrazyGamesAuth';
 import { useFriends } from '@/hooks/useFriends';
 import { usePullToRefresh } from '@/hooks/usePullToRefresh';
 import { cn } from '@/lib/utils';
+import { buildSafeAreaStyle } from '@/components/layout/SafeAreaView';
 import { captureInviteRef, peekInviteRef } from '@/utils/inviteRef';
 
 const AuthModal = dynamic(() => import('@/components/auth/AuthModal'), { ssr: false });
@@ -107,7 +108,7 @@ export default function FriendsPageClient(): React.JSX.Element {
           'sticky top-0 z-40 px-4 py-3 border-b-3 border-neo-black',
           isDark ? 'bg-neo-navy-light/95 backdrop-blur-sm' : 'bg-white/95 backdrop-blur-sm'
         )}
-        style={{ paddingTop: 'max(0.75rem, env(safe-area-inset-top, 0.75rem))' }}
+        style={buildSafeAreaStyle(['top'], '0.75rem')}
       >
         <div className="max-w-2xl mx-auto flex items-center gap-4">
           <button type="button"

--- a/fe-next/components/layout/SafeAreaView.tsx
+++ b/fe-next/components/layout/SafeAreaView.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export type SafeAreaEdge = 'top' | 'bottom' | 'left' | 'right';
+
+/** Resolved padding expression for a single device edge. */
+function insetValue(edge: SafeAreaEdge, minPad: string): string {
+  return `max(${minPad}, var(--cap-safe-area-${edge}, env(safe-area-inset-${edge}, 0px)))`;
+}
+
+/**
+ * Build the inline padding style for a set of device edges.
+ *
+ * Each edge resolves to:
+ *   max(<minPad>, var(--cap-safe-area-<edge>, env(safe-area-inset-<edge>, 0px)))
+ *
+ * Why this exact expression:
+ * - `var(--cap-safe-area-*)` is the SANITIZED inset published by useSafeArea()
+ *   on native (it clamps the Android-15 WindowInsets double-count bug). Preferring
+ *   it keeps web + native on one source of truth.
+ * - `env(safe-area-inset-*)` is the fallback for web / before the hook resolves
+ *   (requires viewportFit:'cover', set in app/[locale]/layout.tsx).
+ * - `max(minPad, …)` guarantees a minimum gutter even when the inset is 0 (most
+ *   non-notched devices and all of web).
+ *
+ * Exported separately so the logic is unit-testable without fighting jsdom's
+ * CSS value parser (which silently drops env()/max()).
+ */
+export function buildSafeAreaStyle(
+  edges: SafeAreaEdge[],
+  minPad = '0px'
+): React.CSSProperties {
+  const style: React.CSSProperties = {};
+  // Explicit per-edge assignment (not dynamic indexing) keeps each property
+  // strongly typed against React.CSSProperties.
+  if (edges.includes('top')) style.paddingTop = insetValue('top', minPad);
+  if (edges.includes('bottom')) style.paddingBottom = insetValue('bottom', minPad);
+  if (edges.includes('left')) style.paddingLeft = insetValue('left', minPad);
+  if (edges.includes('right')) style.paddingRight = insetValue('right', minPad);
+  return style;
+}
+
+export interface SafeAreaViewProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  /** Which device edges to pad. Defaults to all four. */
+  edges?: SafeAreaEdge[];
+  /** Minimum gutter applied even when the device inset is 0. Defaults to '0px'. */
+  minPad?: string;
+}
+
+/**
+ * SafeAreaView — declarative replacement for hand-written
+ * `style={{ paddingTop: 'max(…, env(safe-area-inset-top))' }}` blocks.
+ *
+ * @example
+ * <SafeAreaView edges={['top']} minPad="0.75rem" className="sticky top-0">
+ *   <Header />
+ * </SafeAreaView>
+ */
+export function SafeAreaView({
+  edges = ['top', 'bottom', 'left', 'right'],
+  minPad = '0px',
+  className,
+  style,
+  children,
+  ...rest
+}: SafeAreaViewProps): React.JSX.Element {
+  return (
+    <div
+      className={cn(className)}
+      style={{ ...buildSafeAreaStyle(edges, minPad), ...style }}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default SafeAreaView;

--- a/fe-next/components/layout/__tests__/SafeAreaView.test.tsx
+++ b/fe-next/components/layout/__tests__/SafeAreaView.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { SafeAreaView, buildSafeAreaStyle } from '../SafeAreaView';
+
+describe('buildSafeAreaStyle', () => {
+  // Given the device-edge logic, When building padding, Then it must prefer the
+  // sanitized Capacitor var and fall back to raw env() — keeping web + native on
+  // one source of truth (see useSafeArea.ts which publishes --cap-safe-area-*).
+  it('maps each edge to max(minPad, var(--cap-safe-area-*, env(safe-area-inset-*)))', () => {
+    const style = buildSafeAreaStyle(['top'], '0.75rem');
+    expect(style.paddingTop).toBe(
+      'max(0.75rem, var(--cap-safe-area-top, env(safe-area-inset-top, 0px)))'
+    );
+  });
+
+  it('includes only the requested edges', () => {
+    const style = buildSafeAreaStyle(['top', 'bottom'], '0px');
+    expect(style.paddingTop).toBeDefined();
+    expect(style.paddingBottom).toBeDefined();
+    expect(style.paddingLeft).toBeUndefined();
+    expect(style.paddingRight).toBeUndefined();
+  });
+
+  it('covers all four edges with correct inset names', () => {
+    const style = buildSafeAreaStyle(['top', 'bottom', 'left', 'right'], '0px');
+    expect(style.paddingTop).toContain('safe-area-inset-top');
+    expect(style.paddingBottom).toContain('safe-area-inset-bottom');
+    expect(style.paddingLeft).toContain('safe-area-inset-left');
+    expect(style.paddingRight).toContain('safe-area-inset-right');
+  });
+
+  it('defaults the minimum gutter to 0px when not provided', () => {
+    const style = buildSafeAreaStyle(['left']);
+    expect(style.paddingLeft).toBe(
+      'max(0px, var(--cap-safe-area-left, env(safe-area-inset-left, 0px)))'
+    );
+  });
+});
+
+describe('SafeAreaView', () => {
+  it('renders its children', () => {
+    render(<SafeAreaView>hello</SafeAreaView>);
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('forwards className and arbitrary props to the root element', () => {
+    render(
+      <SafeAreaView className="custom-class" data-testid="sav" role="region">
+        x
+      </SafeAreaView>
+    );
+    const el = screen.getByTestId('sav');
+    expect(el).toHaveClass('custom-class');
+    expect(el).toHaveAttribute('role', 'region');
+  });
+
+  it('applies all four edges by default', () => {
+    render(<SafeAreaView data-testid="sav">x</SafeAreaView>);
+    const el = screen.getByTestId('sav') as HTMLElement;
+    // jsdom may drop the env()/max() value, but React still sets the property
+    // keys; assert via the same builder the component uses for the source of truth.
+    const expected = buildSafeAreaStyle(['top', 'bottom', 'left', 'right']);
+    expect(Object.keys(expected)).toEqual([
+      'paddingTop',
+      'paddingBottom',
+      'paddingLeft',
+      'paddingRight',
+    ]);
+  });
+});

--- a/fe-next/e2e/responsive-overflow.spec.ts
+++ b/fe-next/e2e/responsive-overflow.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+import { goto, waitForHydration } from './helpers/test-utils';
+
+/**
+ * Responsive overflow guard.
+ *
+ * Regression cover for the friends-header "off-canvas button" bug (commit
+ * b57e2f76): a non-wrapping flex row pushed action buttons past the right
+ * viewport edge on narrow/tall devices (Samsung S25 Ultra). This test would
+ * have caught it.
+ *
+ * The hard assertion is that the PAGE has no horizontal scroll
+ * (`scrollWidth <= innerWidth`). That is the precise "something is pushed
+ * off-canvas" symptom, and — unlike scanning every element's bounding box — it
+ * does NOT false-positive on intentionally horizontally-scrollable strips
+ * (e.g. the friends tab bar uses `overflow-x-auto`), whose clipped overflow
+ * never expands the page.
+ *
+ * Element-level diagnostics are gathered only to make a failure actionable.
+ */
+
+// Extreme widths: 280 = Galaxy Fold cover screen, 320 = smallest modern phone,
+// 360 = common Android, 412 = Pixel/S-series portrait, 480 = the `xs` breakpoint.
+const WIDTHS = [280, 320, 360, 412, 480];
+
+// Public routes that render without auth. /friends renders its header + sign-in
+// card unauthenticated, so its layout is still exercised.
+const ROUTES = ['/', '/friends'];
+
+/** Returns class names of elements whose box extends past the viewport, ignoring
+ *  descendants of horizontally-scrollable (clipped) containers. Diagnostics only. */
+async function offenders(page: import('@playwright/test').Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const vw = window.innerWidth;
+    const inScrollContainer = (el: Element): boolean => {
+      let node: Element | null = el.parentElement;
+      while (node && node !== document.body) {
+        const ox = getComputedStyle(node).overflowX;
+        if (ox === 'auto' || ox === 'scroll' || ox === 'hidden') return true;
+        node = node.parentElement;
+      }
+      return false;
+    };
+    return Array.from(document.body.querySelectorAll('*'))
+      .filter((el) => {
+        const r = el.getBoundingClientRect();
+        if (r.width === 0 || r.height === 0) return false;
+        if (r.right <= vw + 1 && r.left >= -1) return false;
+        return !inScrollContainer(el);
+      })
+      .slice(0, 8)
+      .map((el) => `${el.tagName.toLowerCase()}.${(el.getAttribute('class') || '').slice(0, 80)}`);
+  });
+}
+
+test.describe('Responsive overflow guard', () => {
+  for (const route of ROUTES) {
+    for (const width of WIDTHS) {
+      test(`${route} has no horizontal overflow at ${width}px`, async ({ page }) => {
+        await page.setViewportSize({ width, height: 880 });
+        await goto(page, route);
+        await waitForHydration(page);
+
+        const horizontallyScrolls = await page.evaluate(
+          () => document.documentElement.scrollWidth > window.innerWidth + 1
+        );
+
+        if (horizontallyScrolls) {
+          // Surface the culprits in the failure message.
+          const culprits = await offenders(page);
+          throw new Error(
+            `Horizontal overflow at ${width}px on ${route}. Offending elements:\n` +
+              (culprits.length ? culprits.join('\n') : '(none isolated — check fixed-width children)')
+          );
+        }
+
+        expect(horizontallyScrolls).toBe(false);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Context

The reported "button pushed off-screen on S25 Ultra" bug (the screenshots) was a single non-wrapping flex row in the friends header — **already fixed** in `b57e2f76`. It was *not* evidence that the framework lacks responsiveness: the stack already has a real architecture (Tailwind v4 breakpoints incl. custom `xs:480px`, the `capacitor-plugin-safe-area` + `useSafeArea` hook with its Android-15 inset sanitizer, `viewportFit:'cover'`, and `.pt-safe`/`.pb-safe` utilities).

So instead of an overhaul, this PR does the durable, low-risk thing: **converge the existing patterns into one reusable primitive, and make this whole bug class un-shippable via CI.**

## What changed

- **`components/layout/SafeAreaView.tsx`** — declarative replacement for hand-written `style={{ paddingTop: 'max(…, env(safe-area-inset-top))' }}` blocks, plus a pure `buildSafeAreaStyle()` helper. Each edge resolves to `max(minPad, var(--cap-safe-area-*, env(safe-area-inset-*, 0px)))`, so:
  - web and native share one source of truth;
  - native gets the **sanitized** inset (the hook already clamps the Android-15 WindowInsets double-count bug) with raw `env()` as fallback.
  - Logic is split into a pure helper so it's unit-testable without fighting jsdom's `env()`/`max()` parser.
- **`e2e/responsive-overflow.spec.ts`** — Playwright guard asserting **no page horizontal scroll** at 280/320/360/412/480px on `/` and `/friends`. That is the precise "off-canvas" symptom and (unlike scanning every bounding box) does not false-positive on intentionally horizontally-scrollable strips like the friends tab bar. This test would have caught the original bug.
- **`app/[locale]/friends/PageClient.tsx`** — migrate the header's hand-written `env()` padding to `buildSafeAreaStyle(['top'], '0.75rem')`, giving the new helper a real consumer and upgrading the header to the sanitized native inset var. Behaviour-preserving on web.

## Testing

- `SafeAreaView.test.tsx` — 7 unit tests, written test-first (RED → GREEN), all passing under Vitest.
- ESLint and `tsc --noEmit` clean on all changed files.
- The Playwright spec parses and registers 20 tests (`--list`). **It was not executed in this environment** — the e2e runner needs the full dev server (Supabase env, dict/wasm prebuild) which isn't available here. Please run `npm run -w fe-next test:e2e` (or `playwright test responsive-overflow`) against a running dev server in CI to confirm green.

## Notes / not done here

This intentionally migrates only the friends header as the canonical example. The other ad-hoc `env()` paddings (brain, student lessons) can adopt `SafeAreaView` in follow-ups. No framework rewrite — see PR description rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6fXvK67jR2w6HErfB4CcR)_