### PR TITLE
fix(ci): gate sharded test step on JSON report to tolerate post-success worker crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,21 @@ jobs:
         working-directory: fe-next
         # Vitest is the maintained, source-of-truth frontend suite (npm run
         # test:frontend). It is the gating frontend test run.
-        run: npx vitest run --config vitest.config.ts --shard=${{ matrix.shard }}/6 --reporter=default
+        #
+        # Pass/fail is decided from the JSON report by scripts/ci/assert-vitest-passed.mjs,
+        # NOT vitest's raw exit code. Shard 6 intermittently crashes a worker fork during
+        # teardown ("Worker exited unexpectedly", open-handle/native-module class) AFTER
+        # every test has already passed — that is not a heap OOM (raising the heap had zero
+        # effect, see reverted commit 0c573641) and would otherwise red-flag a green run and
+        # block all merges. The gate tolerates only a post-success crash; any real failed
+        # test (numFailedTests>0) or a suite that didn't run still fails CI.
+        run: |
+          set +e
+          npx vitest run --config vitest.config.ts --shard=${{ matrix.shard }}/6 \
+            --reporter=default --reporter=json --outputFile.json=vitest-shard-${{ matrix.shard }}.json
+          VITEST_RC=$?
+          set -e
+          node scripts/ci/assert-vitest-passed.mjs vitest-shard-${{ matrix.shard }}.json "$VITEST_RC"
         env:
           CI: true
 

--- a/fe-next/scripts/ci/__tests__/assert-vitest-passed.test.ts
+++ b/fe-next/scripts/ci/__tests__/assert-vitest-passed.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SCRIPT = join(__dirname, '..', 'assert-vitest-passed.mjs');
+
+let dir: string;
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'assert-vitest-'));
+});
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Run the gate; returns { code, stdout, stderr }. Never throws on non-zero exit. */
+function runGate(reportArg: string | null, vitestRc = ''): { code: number; out: string } {
+  const args = [SCRIPT];
+  if (reportArg !== null) args.push(reportArg);
+  if (vitestRc !== '') args.push(vitestRc);
+  const r = spawnSync('node', args, { encoding: 'utf8' });
+  return { code: r.status ?? 1, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+function writeReport(name: string, body: object): string {
+  const p = join(dir, name);
+  writeFileSync(p, JSON.stringify(body));
+  return p;
+}
+
+const PASSING = {
+  numTotalTestSuites: 498,
+  numTotalTests: 4559,
+  numPassedTests: 4554,
+  numFailedTests: 0,
+  numFailedTestSuites: 0,
+};
+
+describe('assert-vitest-passed gate', () => {
+  // Given a fully-green report AND vitest itself exited 0, When gated, Then PASS.
+  it('passes when all tests passed and vitest exited 0', () => {
+    const p = writeReport('clean.json', PASSING);
+    const { code } = runGate(p, '0');
+    expect(code).toBe(0);
+  });
+
+  // The core behavior: all tests passed but vitest crashed on teardown (rc=1).
+  // Given zero failed tests, When vitest rc != 0, Then PASS but emit a warning.
+  it('tolerates a post-success worker crash (rc!=0, zero failures) with a warning', () => {
+    const p = writeReport('crash.json', PASSING);
+    const { code, out } = runGate(p, '1');
+    expect(code).toBe(0);
+    expect(out).toContain('::warning::');
+    expect(out).toMatch(/tolerating a post-success worker crash/i);
+  });
+
+  // Given a genuine test failure, When gated, Then FAIL regardless of rc — never masked.
+  it('fails when a test actually failed', () => {
+    const p = writeReport('failed.json', { ...PASSING, numFailedTests: 3 });
+    const { code, out } = runGate(p, '1');
+    expect(code).toBe(1);
+    expect(out).toContain('::error::');
+  });
+
+  it('fails when a whole suite failed', () => {
+    const p = writeReport('suite-failed.json', { ...PASSING, numFailedTestSuites: 1 });
+    expect(runGate(p, '1').code).toBe(1);
+  });
+
+  // Guard against a crash BEFORE the suite ran (counts at zero) being read as success.
+  it('fails when no suites/tests ran (crash before execution)', () => {
+    const p = writeReport('empty.json', {
+      numTotalTestSuites: 0,
+      numTotalTests: 0,
+      numPassedTests: 0,
+      numFailedTests: 0,
+      numFailedTestSuites: 0,
+    });
+    expect(runGate(p, '1').code).toBe(1);
+  });
+
+  it('fails when the report is missing', () => {
+    const { code, out } = runGate(join(dir, 'does-not-exist.json'), '1');
+    expect(code).toBe(1);
+    expect(out).toMatch(/could not read\/parse/i);
+  });
+
+  it('fails when the report is unparseable', () => {
+    const p = join(dir, 'bad.json');
+    writeFileSync(p, '{ not valid json');
+    expect(runGate(p, '1').code).toBe(1);
+  });
+
+  it('fails when expected counters are absent', () => {
+    const p = writeReport('partial.json', { startTime: 1, success: true });
+    expect(runGate(p, '1').code).toBe(1);
+  });
+
+  it('fails when no report path argument is given', () => {
+    expect(runGate(null).code).toBe(1);
+  });
+});

--- a/fe-next/scripts/ci/assert-vitest-passed.mjs
+++ b/fe-next/scripts/ci/assert-vitest-passed.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * assert-vitest-passed.mjs — result-gated pass/fail for the sharded CI test step.
+ *
+ * Context: shard 6 intermittently fails CI with "Worker exited unexpectedly" /
+ * "Worker forks emitted error" AFTER every test has already passed. It is a
+ * worker-process crash during teardown (open-handle / native-module class),
+ * NOT a test failure and NOT a V8 heap OOM (raising the heap had zero effect —
+ * see reverted commit 0c573641). The crash makes vitest exit non-zero, which
+ * red-flags an otherwise-green run and blocks every merge.
+ *
+ * This gate decides success from vitest's JSON report instead of its exit code:
+ * the step passes iff the report proves a full suite ran with ZERO failed tests.
+ * A real test failure still fails CI — this only tolerates a post-success
+ * teardown crash. It can never mask a genuine failure:
+ *
+ *   - report missing / unparseable      -> FAIL (cannot confirm success)
+ *   - zero suites or zero tests ran      -> FAIL (suite didn't actually execute)
+ *   - any failed test or failed suite    -> FAIL
+ *   - all tests passed, vitest rc != 0   -> PASS, with a loud warning (the crash)
+ *   - all tests passed, vitest rc == 0   -> PASS
+ *
+ * Usage: node assert-vitest-passed.mjs <report.json> <vitestExitCode>
+ */
+import { readFileSync } from 'node:fs';
+
+const reportPath = process.argv[2];
+const vitestRc = process.argv[3] ?? '';
+
+if (!reportPath) {
+  console.error('::error::assert-vitest-passed: no report path argument provided. FAIL.');
+  process.exit(1);
+}
+
+let report;
+try {
+  report = JSON.parse(readFileSync(reportPath, 'utf8'));
+} catch (err) {
+  console.error(
+    `::error::assert-vitest-passed: could not read/parse vitest JSON report at "${reportPath}" ` +
+      `(${err.message}). Cannot confirm tests passed — treating as FAILURE.`,
+  );
+  process.exit(1);
+}
+
+const num = (key) => (typeof report[key] === 'number' ? report[key] : NaN);
+const numFailedTests = num('numFailedTests');
+const numFailedTestSuites = num('numFailedTestSuites');
+const numTotalTests = num('numTotalTests');
+const numTotalTestSuites = num('numTotalTestSuites');
+const numPassedTests = num('numPassedTests');
+
+// The report must carry the counters we gate on; their absence means we cannot
+// trust it, so fail rather than guess.
+if ([numFailedTests, numFailedTestSuites, numTotalTests, numTotalTestSuites].some(Number.isNaN)) {
+  console.error(
+    '::error::assert-vitest-passed: vitest JSON report is missing expected counters ' +
+      '(numFailedTests/numFailedTestSuites/numTotalTests/numTotalTestSuites). FAIL.',
+  );
+  process.exit(1);
+}
+
+// A crash BEFORE the suite ran would leave these at zero — never treat that as success.
+if (numTotalTestSuites <= 0 || numTotalTests <= 0) {
+  console.error(
+    `::error::assert-vitest-passed: report shows no work ran ` +
+      `(suites=${numTotalTestSuites}, tests=${numTotalTests}). The suite did not execute — FAIL.`,
+  );
+  process.exit(1);
+}
+
+if (numFailedTests > 0 || numFailedTestSuites > 0) {
+  console.error(
+    `::error::assert-vitest-passed: ${numFailedTests} failed test(s) across ` +
+      `${numFailedTestSuites} failed suite(s). Real test failure — FAIL.`,
+  );
+  process.exit(1);
+}
+
+// All tests passed. If vitest itself exited non-zero, it is the post-success
+// worker/teardown crash we are deliberately tolerating.
+if (vitestRc !== '' && vitestRc !== '0') {
+  console.warn(
+    `::warning::assert-vitest-passed: vitest exited ${vitestRc} but all ${numPassedTests}/${numTotalTests} ` +
+      `tests passed across ${numTotalTestSuites} suites. Tolerating a post-success worker crash ` +
+      `(open-handle/teardown). If this warning is frequent, root-cause the leaking test file.`,
+  );
+}
+
+console.log(
+  `✅ assert-vitest-passed: ${numPassedTests}/${numTotalTests} tests passed across ${numTotalTestSuites} suites.`,
+);
+process.exit(0);

--- a/fe-next/vitest.config.ts
+++ b/fe-next/vitest.config.ts
@@ -92,6 +92,7 @@ export default defineConfig({
       'shared/**/*.test.{ts,tsx}',
       'stores/**/*.test.{ts,tsx}',
       'server/**/*.test.{ts,tsx}',
+      'scripts/**/*.test.{ts,tsx}',
       '__tests__/**/*.test.{ts,tsx}',
     ],
     exclude: [


### PR DESCRIPTION
## Problem

`test (6)` (and the `ci-success` rollup) fails on **every** push to `master` — not just PRs. Each time, **all 4559 tests pass** and only the vitest worker fork crashes with `Worker exited unexpectedly` *after* the suite completes. It's a worker-process crash during teardown (open-handle / native-module class), which makes vitest exit non-zero and red-flags an otherwise-green run, blocking all merges.

This is **not** a V8 heap OOM: a prior fix that lowered `maxForks` and raised the per-fork heap had **zero effect** and was reverted (`0c573641`). Confirmed against `master` itself (run on base commit `b6531d1` fails identically), so it is environmental and pre-existing.

## Approach: decide pass/fail from the JSON report, not the exit code

The gating frontend test step now emits a JSON report and judges success from it:

- **`fe-next/scripts/ci/assert-vitest-passed.mjs`** — passes iff a full suite ran with zero failed tests/suites. It **fails closed** on a missing / unparseable / empty report and on any real failure, so a genuine test failure can never be masked. Only a *post-success* crash (vitest `rc != 0` with zero failed tests) is tolerated, and it emits a loud `::warning::` so the underlying worker-crash stays visible.
- **`.github/workflows/ci.yml`** — runs vitest with `--reporter=json --outputFile.json=…`, captures its exit code, then invokes the gate.
- **`fe-next/vitest.config.ts`** — adds `scripts/**` to the test `include` so the gate's own tests run in CI.

This does not touch the previously-reverted heap/fork knobs, and it only neutralizes the specific false-positive (green tests + teardown crash). A real regression still fails CI.

## Testing

- **9 unit tests** (`assert-vitest-passed.test.ts`), written test-first, covering: all-pass, tolerated post-success crash, real test failure, failed suite, zero-suites-ran, missing report, unparseable report, missing counters, no-arg. All green under Vitest.
- **Validated against a real vitest 4 JSON report**: confirmed the reporter emits the exact fields the gate reads (`numFailedTests`, `numFailedTestSuites`, `numTotalTests`, `numTotalTestSuites`, `numPassedTests`) and that `--outputFile.json` works; the gate correctly tolerates a simulated `rc=1` with a present green report.
- ESLint clean on changed files; `ci.yml` parses as valid YAML.

## Known limitation

The gate only helps if vitest flushes the JSON report **before** the crash-induced exit. The CI crash logs print the full summary line (an `onFinished` step, same phase as the JSON reporter), so the report should be written — but if a future crash happens earlier, the gate fails closed (safe: it never reports a false pass). If that occurs, the fallback is to root-cause the leaking test file (likely a pixi/canvas ticker or sql-wasm handle) or mark the shard non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6fXvK67jR2w6HErfB4CcR)_