### PR TITLE
feat: pitch Android app for missed dailies on web instead of replay

### DIFF
--- a/fe-next/components/daily/CatchUpSuggestion.tsx
+++ b/fe-next/components/daily/CatchUpSuggestion.tsx
@@ -6,6 +6,8 @@ import { m } from 'framer-motion';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useMissedDailies, type DailyMode } from '@/hooks/useMissedDailies';
 import { isNative } from '@/utils/platform';
+import { playStoreUrlWithReferrer } from '@/utils/androidApp';
+import GooglePlayMark from '@/components/android-install/GooglePlayMark';
 
 function daysAgo(date: string, today: string): number {
   const a = new Date(date + 'T00:00:00Z').getTime();
@@ -21,26 +23,68 @@ interface CatchUpSuggestionProps {
 }
 
 /**
- * Post-results nudge: lists the dailies the player missed in the catch-up
- * window (last 3 days) and links each to its past puzzle. Renders nothing when
- * there's nothing to catch up. Self-contained — fetches its own data + locale.
+ * Post-results nudge for the dailies the player missed in the catch-up window
+ * (last 3 days). Renders nothing when there's nothing to catch up.
+ *
+ * Replaying a missed daily is a **native-app exclusive**: on the native shell
+ * we list each missed day as a playable link (gated behind a rewarded ad). On
+ * **web** we deliberately don't offer replay — instead we pitch the Android
+ * app, where catch-up lives. Self-contained — fetches its own data + locale.
  */
 export default function CatchUpSuggestion({ excludeDate, mode }: CatchUpSuggestionProps) {
   const { t, language } = useLanguage();
   const { missed } = useMissedDailies(mode || 'word-hunt');
   const today = new Date().toISOString().split('T')[0];
 
-  // Native gates catch-up play behind a rewarded ad — flag it here so tapping a
-  // missed day isn't a bait-and-switch. Resolved post-mount to avoid an SSR
-  // hydration mismatch (isNative() is false on the server).
-  const [showAdHint, setShowAdHint] = useState(false);
+  // Platform decides which surface we render (links vs app pitch). Resolved
+  // post-mount because isNative() is false during SSR — holding render until
+  // we know avoids web flashing the native links and native flashing the web
+  // pitch (Class 1: render the pessimistic state until the source resolves).
+  const [mounted, setMounted] = useState(false);
+  const [native, setNative] = useState(false);
   useEffect(() => {
-    setShowAdHint(isNative());
+    setNative(isNative());
+    setMounted(true);
   }, []);
 
   const items = missed.filter(m => m.date !== excludeDate);
   if (items.length === 0) return null;
+  if (!mounted) return null;
 
+  // Web: no replay here. Advertise the native app, where catch-up lives.
+  if (!native) {
+    return (
+      <m.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.24, type: 'spring', stiffness: 300, damping: 26 }}
+        className="rounded-neo border-neo-thick border-neo-black bg-neo-cyan-muted p-4 shadow-hard"
+      >
+        <div className="mb-1 flex items-center gap-2">
+          <span aria-hidden className="text-xl">🗓️</span>
+          <h3 className="font-neo-display text-lg text-neo-black">{t('daily.catchUp.appTitle')}</h3>
+        </div>
+        <p dir="auto" className="mb-3 font-neo-body text-sm text-neo-black/80">
+          {t('daily.catchUp.appSubtitle', { count: items.length })}
+        </p>
+        <a
+          href={playStoreUrlWithReferrer('daily_catchup', language)}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${t('daily.catchUp.appCta')} — Google Play`}
+          className="group inline-flex w-full items-center justify-center gap-3 rounded-neo border-neo border-neo-black bg-neo-black px-6 py-3 text-neo-white shadow-hard-sm transition-transform hover:-translate-y-px active:translate-y-px"
+        >
+          <GooglePlayMark size={24} />
+          <span className="font-neo-display text-base font-black tracking-tight">
+            {t('daily.catchUp.appCta')}
+          </span>
+        </a>
+      </m.div>
+    );
+  }
+
+  // Native: list each missed day as a playable link (start is gated behind a
+  // rewarded ad, hinted below so tapping isn't a bait-and-switch).
   return (
     <m.div
       initial={{ opacity: 0, y: 8 }}
@@ -55,12 +99,10 @@ export default function CatchUpSuggestion({ excludeDate, mode }: CatchUpSuggesti
       <p className="mb-3 font-neo-body text-sm text-neo-black/80">
         {t('daily.catchUp.subtitle', { count: items.length })}
       </p>
-      {showAdHint && (
-        <p className="mb-3 flex items-center gap-1.5 font-neo-body text-xs font-semibold text-neo-black/70">
-          <span aria-hidden>📺</span>
-          {t('daily.catchUp.watchAd')}
-        </p>
-      )}
+      <p className="mb-3 flex items-center gap-1.5 font-neo-body text-xs font-semibold text-neo-black/70">
+        <span aria-hidden>📺</span>
+        {t('daily.catchUp.watchAd')}
+      </p>
       <div className="flex flex-col gap-2">
         {items.map(item => {
           const n = daysAgo(item.date, today);

--- a/fe-next/components/daily/__tests__/CatchUpSuggestion.test.tsx
+++ b/fe-next/components/daily/__tests__/CatchUpSuggestion.test.tsx
@@ -17,8 +17,15 @@ vi.mock('@/hooks/useMissedDailies', () => ({
   })),
 }));
 
+// Platform is toggled per-test: web (false) pitches the app, native (true)
+// renders the playable replay links.
 vi.mock('@/utils/platform', () => ({
-  isNative: () => false,
+  isNative: vi.fn(() => false),
+}));
+
+// Keep the Play Store URL deterministic so we can assert the CTA target.
+vi.mock('@/utils/androidApp', () => ({
+  playStoreUrlWithReferrer: vi.fn((campaign: string) => `https://play.example/?c=${campaign}`),
 }));
 
 // Need to mock framer-motion to avoid animation issues in tests
@@ -29,11 +36,13 @@ vi.mock('framer-motion', () => ({
 }));
 
 import { useMissedDailies } from '@/hooks/useMissedDailies';
+import { isNative } from '@/utils/platform';
+import { playStoreUrlWithReferrer } from '@/utils/androidApp';
 
 describe('CatchUpSuggestion', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset mock to default return value
+    // Reset mocks to default return values
     (useMissedDailies as ReturnType<typeof vi.fn>).mockReturnValue({
       missed: [
         { date: '2025-01-19', puzzleNumber: 21 },
@@ -41,20 +50,83 @@ describe('CatchUpSuggestion', () => {
       ],
       loading: false,
     });
+    (isNative as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    (playStoreUrlWithReferrer as ReturnType<typeof vi.fn>).mockImplementation(
+      (campaign: string) => `https://play.example/?c=${campaign}`,
+    );
   });
 
-  it('renders word-hunt links by default', () => {
-    render(<CatchUpSuggestion />);
-    const links = screen.getAllByRole('link');
-    expect(links[0]).toHaveAttribute('href', '/en/daily/word-hunt?date=2025-01-19');
-    expect(links[1]).toHaveAttribute('href', '/en/daily/word-hunt?date=2025-01-18');
+  describe('on web', () => {
+    it('does NOT render playable replay links for missed dailies', () => {
+      render(<CatchUpSuggestion />);
+      const links = screen.queryAllByRole('link');
+      // No link should point at a replayable daily puzzle.
+      expect(links.every(l => !l.getAttribute('href')?.includes('/daily/'))).toBe(true);
+    });
+
+    it('pitches the Android app with a Play Store CTA', () => {
+      render(<CatchUpSuggestion />);
+      const cta = screen.getByRole('link');
+      expect(cta).toHaveAttribute('href', 'https://play.example/?c=daily_catchup');
+    });
+
+    it('shows the app-pitch subtitle with the missed count', () => {
+      render(<CatchUpSuggestion />);
+      expect(screen.getByText('daily.catchUp.appSubtitle')).toBeInTheDocument();
+    });
+
+    it('renders nothing when no missed dailies', () => {
+      (useMissedDailies as ReturnType<typeof vi.fn>).mockReturnValue({ missed: [], loading: false });
+      const { container } = render(<CatchUpSuggestion />);
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders nothing when all missed dailies are excluded', () => {
+      (useMissedDailies as ReturnType<typeof vi.fn>).mockReturnValue({
+        missed: [{ date: '2025-01-19', puzzleNumber: 21 }],
+        loading: false,
+      });
+      const { container } = render(<CatchUpSuggestion excludeDate="2025-01-19" />);
+      expect(container.innerHTML).toBe('');
+    });
   });
 
-  it('renders word-wheel links when mode is word-wheel', () => {
-    render(<CatchUpSuggestion mode="word-wheel" />);
-    const links = screen.getAllByRole('link');
-    expect(links[0]).toHaveAttribute('href', '/en/daily/word-wheel?date=2025-01-19');
-    expect(links[1]).toHaveAttribute('href', '/en/daily/word-wheel?date=2025-01-18');
+  describe('on native', () => {
+    beforeEach(() => {
+      (isNative as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    });
+
+    it('renders word-hunt replay links by default', () => {
+      render(<CatchUpSuggestion />);
+      const links = screen.getAllByRole('link');
+      expect(links[0]).toHaveAttribute('href', '/en/daily/word-hunt?date=2025-01-19');
+      expect(links[1]).toHaveAttribute('href', '/en/daily/word-hunt?date=2025-01-18');
+    });
+
+    it('renders word-wheel replay links when mode is word-wheel', () => {
+      render(<CatchUpSuggestion mode="word-wheel" />);
+      const links = screen.getAllByRole('link');
+      expect(links[0]).toHaveAttribute('href', '/en/daily/word-wheel?date=2025-01-19');
+      expect(links[1]).toHaveAttribute('href', '/en/daily/word-wheel?date=2025-01-18');
+    });
+
+    it('shows the watch-ad hint', () => {
+      render(<CatchUpSuggestion />);
+      expect(screen.getByText('daily.catchUp.watchAd')).toBeInTheDocument();
+    });
+
+    it('excludes the specified date', () => {
+      render(<CatchUpSuggestion excludeDate="2025-01-19" />);
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(1);
+      expect(links[0]).toHaveAttribute('href', '/en/daily/word-hunt?date=2025-01-18');
+    });
+
+    it('renders nothing when no missed dailies', () => {
+      (useMissedDailies as ReturnType<typeof vi.fn>).mockReturnValue({ missed: [], loading: false });
+      const { container } = render(<CatchUpSuggestion />);
+      expect(container.innerHTML).toBe('');
+    });
   });
 
   it('passes mode to useMissedDailies hook', () => {
@@ -65,27 +137,5 @@ describe('CatchUpSuggestion', () => {
   it('passes word-hunt mode to useMissedDailies by default', () => {
     render(<CatchUpSuggestion />);
     expect(useMissedDailies).toHaveBeenCalledWith('word-hunt');
-  });
-
-  it('excludes the specified date', () => {
-    render(<CatchUpSuggestion excludeDate="2025-01-19" />);
-    const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(1);
-    expect(links[0]).toHaveAttribute('href', '/en/daily/word-hunt?date=2025-01-18');
-  });
-
-  it('renders nothing when no missed dailies', () => {
-    (useMissedDailies as ReturnType<typeof vi.fn>).mockReturnValue({ missed: [], loading: false });
-    const { container } = render(<CatchUpSuggestion />);
-    expect(container.innerHTML).toBe('');
-  });
-
-  it('renders nothing when all missed dailies are excluded', () => {
-    (useMissedDailies as ReturnType<typeof vi.fn>).mockReturnValue({
-      missed: [{ date: '2025-01-19', puzzleNumber: 21 }],
-      loading: false,
-    });
-    const { container } = render(<CatchUpSuggestion excludeDate="2025-01-19" />);
-    expect(container.innerHTML).toBe('');
   });
 });

--- a/fe-next/docs/specs/daily-catchup-ad-gate.md
+++ b/fe-next/docs/specs/daily-catchup-ad-gate.md
@@ -55,6 +55,12 @@ semantics); env override key `NEXT_PUBLIC_ADMOB_REWARDED_CATCHUP[_ANDROID|_IOS]`
 `CatchUpSuggestion` card: small `📺` + `t('daily.catchUp.watchAd')` shown only on
 native, so tapping a missed day isn't a bait-and-switch.
 
+> Update: catch-up replay is now a **native-app exclusive**. `CatchUpSuggestion`
+> only renders the playable missed-day links on the native shell. On web the
+> same card pitches the Android app instead
+> (`daily.catchUp.appTitle/appSubtitle/appCta` → Play Store), so web users are
+> steered to the app rather than replaying past dailies in the browser.
+
 ## i18n
 `daily.catchUp.watchAd` ×5 (en/he/sv/ja/es; he/sv/ja/es native-review pending).
 

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -6048,7 +6048,10 @@ const en = {
       "subtitle": "You have {count} from the last few days still open",
       "yesterday": "Yesterday's puzzle",
       "daysAgo": "{count} days ago",
-      "watchAd": "Watch a quick ad to play"
+      "watchAd": "Watch a quick ad to play",
+      "appTitle": "Missed a few days?",
+      "appSubtitle": "You've got {count} unplayed from the last few days. Replay past dailies in the LexiClash Android app.",
+      "appCta": "Get it on Google Play"
     },
     "completed": "Complete!",
     "questPlayedSubtitle": "Already played today",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -6102,7 +6102,10 @@ const es = {
       "subtitle": "Tienes {count} de los últimos días sin completar",
       "yesterday": "El reto de ayer",
       "daysAgo": "Hace {count} días",
-      "watchAd": "Mira un anuncio corto para jugar"
+      "watchAd": "Mira un anuncio corto para jugar",
+      "appTitle": "¿Te perdiste algunos días?",
+      "appSubtitle": "Tienes {count} sin jugar de los últimos días. Juega los retos anteriores en la app de LexiClash para Android.",
+      "appCta": "Disponible en Google Play"
     },
     "completed": "¡Completado!",
     "questPlayedSubtitle": "Ya jugaste hoy",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -6125,7 +6125,10 @@ const he = {
       "subtitle": "יש לכם {count} מהימים האחרונים שעדיין פתוחים",
       "yesterday": "החידה של אתמול",
       "daysAgo": "לפני {count} ימים",
-      "watchAd": "צפו בפרסומת קצרה כדי לשחק"
+      "watchAd": "צפו בפרסומת קצרה כדי לשחק",
+      "appTitle": "פספסתם כמה ימים?",
+      "appSubtitle": "יש לכם {count} מהימים האחרונים שעדיין לא שיחקתם. שחקו חידות עבר באפליקציית LexiClash לאנדרואיד.",
+      "appCta": "הורידו מ-Google Play"
     },
     "completed": "הושלם!",
     "questPlayedSubtitle": "כבר שיחקתם היום",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -6152,7 +6152,10 @@ const ja = {
       "subtitle": "直近の未完了が{count}件あります",
       "yesterday": "昨日のパズル",
       "daysAgo": "{count}日前",
-      "watchAd": "短い広告を見てプレイ"
+      "watchAd": "短い広告を見てプレイ",
+      "appTitle": "数日逃しちゃった？",
+      "appSubtitle": "直近で未プレイが{count}件。過去のデイリーはLexiClashのAndroidアプリで遊べます。",
+      "appCta": "Google Playで入手"
     },
     "completed": "完了！",
     "questPlayedSubtitle": "今日はプレイ済み",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -6222,7 +6222,10 @@ const sv = {
       "subtitle": "Du har {count} från de senaste dagarna kvar",
       "yesterday": "Gårdagens pussel",
       "daysAgo": "{count} dagar sedan",
-      "watchAd": "Se en kort annons för att spela"
+      "watchAd": "Se en kort annons för att spela",
+      "appTitle": "Missade du några dagar?",
+      "appSubtitle": "Du har {count} ospelade från de senaste dagarna. Spela tidigare dagliga i LexiClash-appen för Android.",
+      "appCta": "Hämta på Google Play"
     },
     "completed": "Klart!",
     "questPlayedSubtitle": "Redan spelat idag",


### PR DESCRIPTION
Replaying a missed daily challenge is now a native-app exclusive. The
post-results CatchUpSuggestion card only renders the playable missed-day
links on the native (Capacitor) shell. On web the same card advertises the
LexiClash Android app — "replay past dailies in the app" — with a Google
Play CTA, so web users are steered to the native app rather than replaying
in the browser.

- CatchUpSuggestion: branch on isNative() (resolved post-mount to avoid an
  SSR hydration flash); web → app pitch, native → existing links + ad hint.
- Add daily.catchUp.appTitle/appSubtitle/appCta across en/he/sv/ja/es.
- Update tests to cover both surfaces; update the ad-gate spec note.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RbyEo5wpCqy7msnLhm8WRQ