### PR TITLE
feat(i18n): show Russian in the in-game language selectors

### DIFF
--- a/fe-next/components/QuickLanguageSwitcher.tsx
+++ b/fe-next/components/QuickLanguageSwitcher.tsx
@@ -26,6 +26,7 @@ const LANGUAGE_OPTIONS: LanguageOption[] = [
   { code: 'sv', flag: '🇸🇪', labelKey: 'joinView.swedish' },
   { code: 'ja', flag: '🇯🇵', labelKey: 'joinView.japanese' },
   { code: 'es', flag: '🇪🇸', labelKey: 'joinView.spanish' },
+  { code: 'ru', flag: '🇷🇺', labelKey: 'joinView.russian' },
 ];
 
 interface QuickLanguageSwitcherProps {

--- a/fe-next/components/__tests__/QuickLanguageSwitcher.test.tsx
+++ b/fe-next/components/__tests__/QuickLanguageSwitcher.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/contexts/LanguageContext', () => ({
         'joinView.swedish': 'Svenska',
         'joinView.japanese': '日本語',
         'joinView.spanish': 'Español',
+        'joinView.russian': 'Русский',
       };
       return translations[key] || key;
     },
@@ -45,7 +46,7 @@ describe('QuickLanguageSwitcher', () => {
     expect(trigger).toHaveAttribute('aria-label', 'Change Language');
   });
 
-  it('should show all 5 language options when opened', async () => {
+  it('should show all 6 language options when opened (incl. Russian)', async () => {
     render(<QuickLanguageSwitcher />);
 
     // Click to open the dropdown
@@ -59,6 +60,7 @@ describe('QuickLanguageSwitcher', () => {
       expect(screen.getByText('Svenska')).toBeInTheDocument();
       expect(screen.getByText('日本語')).toBeInTheDocument();
       expect(screen.getByText('Español')).toBeInTheDocument();
+      expect(screen.getByText('Русский')).toBeInTheDocument();
     });
   });
 

--- a/fe-next/components/daily/LanguageDropdown.tsx
+++ b/fe-next/components/daily/LanguageDropdown.tsx
@@ -14,6 +14,8 @@ export const LANGUAGE_OPTIONS: { code: Language; flag: string; name: string }[] 
   { code: 'sv', flag: '🇸🇪', name: 'Svenska' },
   { code: 'ja', flag: '🇯🇵', name: '日本語' },
   { code: 'es', flag: '🇪🇸', name: 'Español' },
+  // ru intentionally omitted: daily-word generation (bulk-generate route) does not
+  // produce Russian puzzles, so the daily picker must not offer a language with no content.
 ];
 
 interface LanguageDropdownProps {

--- a/fe-next/components/daily/results/constants.ts
+++ b/fe-next/components/daily/results/constants.ts
@@ -23,6 +23,7 @@ export const LANGUAGE_OPTIONS: LanguageOption[] = [
   { code: 'sv', flag: '🇸🇪', name: 'Svenska' },
   { code: 'ja', flag: '🇯🇵', name: '日本語' },
   { code: 'es', flag: '🇪🇸', name: 'Español' },
+  // ru intentionally omitted: no Russian daily-word content (see LanguageDropdown).
 ];
 
 /**

--- a/fe-next/components/join/LanguageSelector.tsx
+++ b/fe-next/components/join/LanguageSelector.tsx
@@ -31,6 +31,7 @@ const LANGUAGE_OPTIONS: LanguageOption[] = [
   { code: 'sv', flag: '🇸🇪', labelKey: 'joinView.swedish' },
   { code: 'ja', flag: '🇯🇵', labelKey: 'joinView.japanese' },
   { code: 'es', flag: '🇪🇸', labelKey: 'joinView.spanish' },
+  { code: 'ru', flag: '🇷🇺', labelKey: 'joinView.russian' },
 ];
 
 /**

--- a/fe-next/host/components/pre-game/AdvancedSettingsModal.tsx
+++ b/fe-next/host/components/pre-game/AdvancedSettingsModal.tsx
@@ -43,6 +43,7 @@ const LANGUAGE_OPTIONS: { code: Language; flag: string; labelKey: string }[] = [
   { code: 'sv', flag: '🇸🇪', labelKey: 'joinView.swedish' },
   { code: 'ja', flag: '🇯🇵', labelKey: 'joinView.japanese' },
   { code: 'es', flag: '🇪🇸', labelKey: 'joinView.spanish' },
+  { code: 'ru', flag: '🇷🇺', labelKey: 'joinView.russian' },
 ];
 
 export const AdvancedSettingsModal = memo<AdvancedSettingsModalProps>(function AdvancedSettingsModal({

--- a/fe-next/translations/en.js
+++ b/fe-next/translations/en.js
@@ -1638,6 +1638,7 @@ const en = {
     "swedish": "Swedish",
     "japanese": "Japanese",
     "spanish": "Spanish",
+    "russian": "Russian",
     "generateNewCode": "New code",
     "createNewRoom": "Create a room!",
     "howToPlay": "How to play",

--- a/fe-next/translations/es.js
+++ b/fe-next/translations/es.js
@@ -1687,6 +1687,7 @@ const es = {
     "swedish": "Sueco",
     "japanese": "Japonés",
     "spanish": "Español",
+    "russian": "Русский",
     "generateNewCode": "Nuevo código",
     "createNewRoom": "¡Crea una sala!",
     "howToPlay": "Cómo jugar",

--- a/fe-next/translations/he.js
+++ b/fe-next/translations/he.js
@@ -1665,6 +1665,7 @@ const he = {
     "swedish": "Svenska",
     "japanese": "日本語",
     "spanish": "Español",
+    "russian": "Русский",
     "generateNewCode": "קוד חדש",
     "createNewRoom": "צרו חדר!",
     "howToPlay": "איך משחקים?",

--- a/fe-next/translations/ja.js
+++ b/fe-next/translations/ja.js
@@ -1651,6 +1651,7 @@ const ja = {
     "swedish": "Svenska",
     "japanese": "日本語",
     "spanish": "Español",
+    "russian": "Русский",
     "generateNewCode": "新コード",
     "createNewRoom": "ルーム作成！",
     "howToPlay": "遊び方",

--- a/fe-next/translations/ru.js
+++ b/fe-next/translations/ru.js
@@ -11478,6 +11478,7 @@ const ru = {
     "swedish": "Шведский",
     "japanese": "Японский",
     "spanish": "Испанский",
+    "russian": "Русский",
     "generateNewCode": "Новый код",
     "createNewRoom": "Создай комнату!",
     "howToPlay": "Как играть",

--- a/fe-next/translations/sv.js
+++ b/fe-next/translations/sv.js
@@ -1809,6 +1809,7 @@ const sv = {
     "swedish": "Svenska",
     "japanese": "日本語",
     "spanish": "Español",
+    "russian": "Русский",
     "generateNewCode": "Ny kod",
     "createNewRoom": "Skapa ett rum!",
     "howToPlay": "Hur spelar man",


### PR DESCRIPTION
Russian (6th locale) was merged but **missing from the language picker** — 5 selector components hardcode their own 5-language arrays instead of the central `lib/languageConfig.ts` (Class-3 dual-source-of-truth).

**Fix:** add ru to the 3 game-language selectors (QuickLanguageSwitcher, join/LanguageSelector, host pre-game AdvancedSettingsModal) + `joinView.russian` label key in all 6 translation files (autonym Русский; en "Russian").

**Deliberately excluded** from the 2 daily-challenge selectors (daily/LanguageDropdown, daily/results/constants) — the daily-word generator produces no Russian puzzles, so offering ru there would be a dead option.

**Test:** QuickLanguageSwitcher asserts all 6 options incl. Русский; 33 selector tests pass; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)