### PR TITLE
fix(ru): use Cyrillic tiles on Russian boards instead of Hebrew

### DIFF
--- a/fe-next/utils/__tests__/russianBoard.test.ts
+++ b/fe-next/utils/__tests__/russianBoard.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { generateRandomTable } from '@/utils/utils';
+import { generateDailyGrid } from '@/utils/dailyChallenge/gridGeneration';
+import { generateCustomChallengeGrid } from '@/utils/customChallengeGrid';
+
+const cellsOf = (grid: string[][]): string[] => grid.flat();
+// A Cyrillic board must contain ONLY Cyrillic letters — никаких Hebrew tiles.
+const isCyrillic = (ch: string): boolean => /^[А-ЯЁ]$/.test(ch);
+const HEBREW = /[֐-׿]/;
+
+/**
+ * Regression: Russian boards were leaking Hebrew letters because the frontend
+ * grid generators routed 'ru' into the Hebrew `else` fallback (only the backend
+ * generator had been given a `ru` branch). See screenshot bug report.
+ */
+describe('Russian board generation (frontend generators)', () => {
+  it('GIVEN ru WHEN generateRandomTable THEN every cell is Cyrillic, never Hebrew', () => {
+    for (let i = 0; i < 25; i++) {
+      const cells = cellsOf(generateRandomTable(5, 5, 'ru'));
+      for (const cell of cells) {
+        expect(HEBREW.test(cell)).toBe(false);
+        expect(isCyrillic(cell)).toBe(true);
+      }
+    }
+  });
+
+  it('GIVEN ru board THEN never produces Ё or hard-sign Ъ (dead/foldable tiles)', () => {
+    for (let i = 0; i < 25; i++) {
+      const cells = cellsOf(generateRandomTable(5, 5, 'ru'));
+      expect(cells.includes('Ё')).toBe(false);
+      expect(cells.includes('Ъ')).toBe(false);
+    }
+  });
+
+  it('GIVEN ru WHEN generateDailyGrid THEN every cell is Cyrillic, never Hebrew', () => {
+    const cells = cellsOf(generateDailyGrid('2026-06-30', 'ru', 5, 5));
+    for (const cell of cells) {
+      expect(HEBREW.test(cell)).toBe(false);
+      expect(isCyrillic(cell)).toBe(true);
+    }
+  });
+
+  it('GIVEN ru WHEN generateCustomChallengeGrid THEN filler cells are Cyrillic, never Hebrew', () => {
+    const cells = cellsOf(generateCustomChallengeGrid(5, 5, 'ru', 'СЛОВО'));
+    for (const cell of cells) {
+      expect(HEBREW.test(cell)).toBe(false);
+      expect(isCyrillic(cell)).toBe(true);
+    }
+  });
+});

--- a/fe-next/utils/consts.ts
+++ b/fe-next/utils/consts.ts
@@ -73,6 +73,32 @@ export const spanishBaseLetters: string[] = 'ABCDEFGHIJKLMNÑOPQRSTUVWXYZ'.split
 export const spanishAccentedLetters: string[] = ['Á', 'É', 'Í', 'Ó', 'Ú', 'Ü'];
 export const spanishLetters: string[] = [...spanishBaseLetters, ...spanishAccentedLetters];
 
+// Russian (Cyrillic) — mirror of backend/utils/gameUtils.ts so the client board
+// generators (single-player word hunt, daily, custom challenge) produce real
+// Cyrillic tiles instead of falling through to the Hebrew `else`. Board uses
+// UPPERCASE (en/sv/es convention); validation lowercases the guess. Hard sign Ъ
+// is excluded — it never starts a word and is a dead tile.
+export const russianLetters: string[] =
+  'АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЫЬЭЮЯ'.split('');
+
+// Frequency-weighted pool for board generation (counts ≈ Russian letter
+// frequency %), so common vowels/consonants surface more often → playable
+// boards. Same approach as spanishLetterPool / the backend russianLetterPool.
+// Ё is intentionally absent: it folds to Е (ё→е) at validate time, so the board
+// never shows a tile that can't form a stored word.
+export const russianLetterPool: string[] = (() => {
+  const weights: Record<string, number> = {
+    О: 11, Е: 8, А: 8, И: 7, Н: 7, Т: 6, С: 5, Р: 5, В: 5, Л: 4,
+    К: 3, М: 3, Д: 3, П: 3, У: 3, Я: 2, Ы: 2, Ь: 2, Г: 2, З: 2, Б: 2,
+    Ч: 1, Й: 1, Х: 1, Ж: 1, Ш: 1, Ю: 1, Ц: 1, Щ: 1, Э: 1, Ф: 1,
+  };
+  const pool: string[] = [];
+  for (const [letter, count] of Object.entries(weights)) {
+    for (let i = 0; i < count; i++) pool.push(letter);
+  }
+  return pool;
+})();
+
 // HIRAGANA board tiles — single source of truth in shared/constants/japaneseLetters.
 // Japanese gameplay is phonetic-kana, not kanji (logographs can't be a Boggle grid).
 // Consumed by every frontend JA board generator (single-player, custom challenge,

--- a/fe-next/utils/customChallengeGrid.ts
+++ b/fe-next/utils/customChallengeGrid.ts
@@ -9,6 +9,7 @@ import {
   hebrewLetters,
   swedishLetters,
   spanishLetters,
+  russianLetterPool,
   japaneseLetters,
 } from './consts';
 import type { Language, LetterGrid } from '@/types';
@@ -216,11 +217,16 @@ export function generateCustomChallengeGrid(
     letters = swedishLetters;
   } else if (language === 'es') {
     letters = spanishLetters;
+  } else if (language === 'ru') {
+    letters = russianLetterPool;
   } else if (language === 'ja') {
     // Japanese uses different embedding strategy
     return embedJapaneseWord(targetWord, rows, cols);
-  } else {
+  } else if (language === 'he') {
     letters = hebrewLetters;
+  } else {
+    // Unknown language must not silently become a Hebrew board. Default English.
+    letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
   }
 
   // Normalize Hebrew final letters to regular letters for grid display

--- a/fe-next/utils/dailyChallenge/gridGeneration.ts
+++ b/fe-next/utils/dailyChallenge/gridGeneration.ts
@@ -8,6 +8,7 @@ import {
   hebrewLetters,
   swedishLetters,
   spanishLetters,
+  russianLetterPool,
   japaneseLetters,
   kanjiCompounds,
   DIFFICULTIES,
@@ -81,10 +82,16 @@ export function generateDailyGrid(
     letters = swedishLetters;
   } else if (language === 'es') {
     letters = spanishLetters;
+  } else if (language === 'ru') {
+    letters = russianLetterPool;
   } else if (language === 'ja') {
     return generateSeededJapaneseGrid(random, rows, cols);
-  } else {
+  } else if (language === 'he') {
     letters = hebrewLetters;
+  } else {
+    // Unknown language must not silently become a Hebrew board (Russian leaked
+    // Hebrew tiles before the 'ru' branch existed). Default to English.
+    letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   }
 
   const lettersArray = typeof letters === 'string' ? letters.split('') : letters;
@@ -231,10 +238,15 @@ export function generateDailyPuzzle(
     letters = swedishLetters;
   } else if (language === 'es') {
     letters = spanishLetters;
+  } else if (language === 'ru') {
+    letters = russianLetterPool;
   } else if (language === 'ja') {
     return generateJapaneseDailyPuzzle(dateString, language, random, rows, cols, preSelectedWord);
-  } else {
+  } else if (language === 'he') {
     letters = hebrewLetters;
+  } else {
+    // Unknown language must not silently become a Hebrew board. Default English.
+    letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
   }
 
   // Select target word

--- a/fe-next/utils/utils.ts
+++ b/fe-next/utils/utils.ts
@@ -1,4 +1,4 @@
-import { hebrewLetters, swedishLetters, spanishLetters, japaneseLetters, kanjiCompounds, DIFFICULTIES, DEFAULT_DIFFICULTY, AVATAR_COLORS, AVATAR_EMOJIS, AVATAR_IMAGE_IDS } from "./consts";
+import { hebrewLetters, swedishLetters, spanishLetters, russianLetterPool, japaneseLetters, kanjiCompounds, DIFFICULTIES, DEFAULT_DIFFICULTY, AVATAR_COLORS, AVATAR_EMOJIS, AVATAR_IMAGE_IDS } from "./consts";
 import type { Language, LetterGrid, GridPosition, Avatar } from "@/types";
 
 // Import and re-export word normalization functions from shared module
@@ -181,11 +181,18 @@ export function generateRandomTable(
       letters = swedishLetters;
     } else if (language === 'es') {
       letters = spanishLetters;
+    } else if (language === 'ru') {
+      letters = russianLetterPool;
     } else if (language === 'ja') {
       // For Japanese, generate a board with embedded Kanji compounds
       return generateJapaneseTable(rows, cols);
-    } else {
+    } else if (language === 'he') {
       letters = hebrewLetters;
+    } else {
+      // Unknown/undefined language must NOT silently become Hebrew — that leaked
+      // Hebrew (and, before this branch existed, a Hebrew board onto Russian
+      // players). Hebrew requires an explicit 'he'; everything else → English.
+      letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     }
 
     // If we have words to embed, use enhanced generation


### PR DESCRIPTION
The frontend grid generators (single-player word hunt, daily challenge,
custom challenge) only had en/sv/es/ja branches; Russian fell through the
`else` into hebrewLetters, so Russian boards rendered Hebrew tiles. Only
the backend generator had been given a 'ru' branch.

Add russianLetters + frequency-weighted russianLetterPool to the frontend
consts (mirroring backend/utils/gameUtils.ts), wire an explicit 'ru' branch
into generateRandomTable, generateDailyGrid, generateSeededDailyPuzzle and
generateCustomChallengeGrid, and make Hebrew require an explicit 'he' so an
unknown language can never silently produce a Hebrew board again.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XxZ66x9ECapE9Mh9DV4Yax