### PR TITLE
fix(landing): correct language count and gate live home stats

### DIFF
--- a/fe-next/components/landing/home/HomeSocialStrip.tsx
+++ b/fe-next/components/landing/home/HomeSocialStrip.tsx
@@ -19,24 +19,61 @@ interface HomeSocialStripProps {
   t: (key: string, params?: Record<string, string | number>) => string;
 }
 
+interface StatCell {
+  key: string;
+  label: string;
+  color: string;
+  value?: string;
+  loading?: boolean;
+}
+
 /**
- * HomeSocialStrip — a tight 4-cell stat bar (Online · Games today · Modes ·
- * Languages). Condenses `LandingSocialProofBar` into the hub grammar: one navy
- * card, hairline dividers, each stat number in a cycling brand hue.
+ * HomeSocialStrip — a tight stat bar (Online · Games today · Modes · Languages).
+ * Condenses `LandingSocialProofBar` into the hub grammar: one navy card, hairline
+ * dividers, each stat number in a cycling brand hue.
+ *
+ * The two live cells (Online, Games today) are credibility-gated like the desktop
+ * proof bar: while live stats resolve the Online cell skeletons (never a stale
+ * "0"), and once resolved each live cell only renders when it has genuine
+ * activity. A bald "0 online / 0 games today" reads as broken, so we drop those
+ * cells and let the always-true trust stats (Modes, Languages) carry the strip.
+ * The grid tracks the visible cell count so the layout stays balanced.
  */
 export function HomeSocialStrip({ activePlayers, gamesToday, gameModes, languages, liveStatsLoading, t }: HomeSocialStripProps) {
-  const cells = [
-    { value: formatLiveShort(activePlayers), label: t('landing.home.online'), color: 'text-neo-lime', loading: liveStatsLoading },
-    { value: formatLiveShort(gamesToday), label: t('landing.home.gamesToday'), color: 'text-neo-cyan' },
-    { value: String(gameModes), label: t('landing.home.modes'), color: 'text-neo-pink' },
-    { value: String(languages), label: t('landing.home.languages'), color: 'text-neo-purple' },
-  ];
+  const cells: StatCell[] = [];
+
+  // Online — live over WebSocket. Skeleton while loading; otherwise show only
+  // when someone is actually in a live room.
+  if (liveStatsLoading) {
+    cells.push({ key: 'online', label: t('landing.home.online'), color: 'text-neo-lime', loading: true });
+  } else if (activePlayers > 0) {
+    cells.push({ key: 'online', label: t('landing.home.online'), color: 'text-neo-lime', value: formatLiveShort(activePlayers) });
+  }
+
+  // Games today — SSR-provided count; hide while it is still 0.
+  if (gamesToday > 0) {
+    cells.push({ key: 'gamesToday', label: t('landing.home.gamesToday'), color: 'text-neo-cyan', value: formatLiveShort(gamesToday) });
+  }
+
+  // Always-credible trust stats.
+  if (gameModes > 0) {
+    cells.push({ key: 'modes', label: t('landing.home.modes'), color: 'text-neo-pink', value: String(gameModes) });
+  }
+  if (languages > 0) {
+    cells.push({ key: 'languages', label: t('landing.home.languages'), color: 'text-neo-purple', value: String(languages) });
+  }
+
+  if (cells.length === 0) return null;
+
+  // Static class names (no interpolation) so Tailwind's JIT keeps them.
+  const colsClass =
+    cells.length >= 4 ? 'grid-cols-4' : cells.length === 3 ? 'grid-cols-3' : 'grid-cols-2';
 
   return (
-    <div className="grid grid-cols-4 overflow-hidden rounded-neo-lg border-2 border-black bg-neo-navy-light shadow-hard">
+    <div className={cn('grid overflow-hidden rounded-neo-lg border-2 border-black bg-neo-navy-light shadow-hard', colsClass)}>
       {cells.map((c, i) => (
         <div
-          key={c.label}
+          key={c.key}
           className={cn('px-1 py-2.5 text-center', i < cells.length - 1 && 'border-e border-white/10')}
         >
           {c.loading ? (

--- a/fe-next/components/landing/home/__tests__/HomeSocialStrip.test.tsx
+++ b/fe-next/components/landing/home/__tests__/HomeSocialStrip.test.tsx
@@ -41,4 +41,32 @@ describe('HomeSocialStrip', () => {
     expect(screen.getByText('4')).toBeInTheDocument(); // modes
     expect(screen.getByText('5')).toBeInTheDocument(); // languages
   });
+
+  it('drops the live cells when there is no activity — never paints a bald "0"', () => {
+    // GIVEN a quiet moment: nobody in live rooms and no games logged yet today,
+    // with live stats already resolved (not loading).
+    render(
+      <HomeSocialStrip activePlayers={0} gamesToday={0} gameModes={4} languages={6} t={t} />,
+    );
+    // THEN the misleading zero cells are omitted entirely...
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+    expect(screen.queryByText('Online')).not.toBeInTheDocument();
+    expect(screen.queryByText('Games today')).not.toBeInTheDocument();
+    // ...and the always-credible trust stats still show.
+    expect(screen.getByText('Modes')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('Languages')).toBeInTheDocument();
+    expect(screen.getByText('6')).toBeInTheDocument();
+  });
+
+  it('surfaces the online cell as soon as there is real activity', () => {
+    render(
+      <HomeSocialStrip activePlayers={7} gamesToday={0} gameModes={4} languages={6} t={t} />,
+    );
+    // Online appears with its real count...
+    expect(screen.getByText('Online')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    // ...but games-today stays hidden while it is still 0.
+    expect(screen.queryByText('Games today')).not.toBeInTheDocument();
+  });
 });

--- a/fe-next/hooks/__tests__/useLandingStats.test.tsx
+++ b/fe-next/hooks/__tests__/useLandingStats.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SUPPORTED_GAME_LANGUAGES } from '@/lib/languageConfig';
+
+// The hook composes a live-room socket hook + a Supabase round-trip. Neither is
+// relevant to the static-count assertions below, so stub both.
+vi.mock('../useLiveRoomStats', () => ({
+  useLiveRoomStats: () => ({
+    activePlayers: 0,
+    openRooms: 0,
+    totalPlayers: 0,
+    isLoading: false,
+    refresh: () => {},
+  }),
+}));
+vi.mock('@/lib/supabase', () => ({ supabase: null }));
+
+import { useLandingStats } from '../useLandingStats';
+
+describe('useLandingStats', () => {
+  it('reports the real number of supported game languages — not a stale hardcode', () => {
+    // GIVEN the app ships SUPPORTED_GAME_LANGUAGES (en, he, sv, ja, es, ru)
+    // WHEN the landing stats resolve
+    const { result } = renderHook(() => useLandingStats({ initialGamesToday: 0 }));
+    // THEN the languages stat matches the single source of truth, not "5".
+    expect(result.current.languages).toBe(SUPPORTED_GAME_LANGUAGES.length);
+    expect(result.current.languages).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/fe-next/hooks/useLandingStats.ts
+++ b/fe-next/hooks/useLandingStats.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useLiveRoomStats } from './useLiveRoomStats';
 import { supabase } from '@/lib/supabase';
+import { SUPPORTED_GAME_LANGUAGES } from '@/lib/languageConfig';
 
 interface UseLandingStatsOptions {
   /** Pre-fetched server value — skips client fetch */
@@ -41,7 +42,9 @@ export function useLandingStats(options: UseLandingStatsOptions = {}) {
     activePlayers,
     gamesToday,
     gameModes: 4,   // static: Solo, Multiplayer, Daily Challenge, Adventure
-    languages: 5,   // static: en, he, sv, ja, es
+    // Derive from the single source of truth so the count never drifts when a
+    // language ships (it silently read "5" after Russian was added).
+    languages: SUPPORTED_GAME_LANGUAGES.length,
     loading: isLoading,
   };
 }

--- a/fe-next/lib/landing/fetchLandingData.ts
+++ b/fe-next/lib/landing/fetchLandingData.ts
@@ -20,6 +20,7 @@ import { createSupabasePublicClient } from '@/lib/supabaseServer';
 import type { TopPlayer } from '@/hooks/useTopPlayers';
 import { fetchGameModeStats, getCardOrder, type GameModeStats, type LandingGameMode } from './fetchGameModeStats';
 import { cachedWithTtl } from '@/lib/cache/ttlCache';
+import { SUPPORTED_GAME_LANGUAGES } from '@/lib/languageConfig';
 
 export interface LandingInitialData {
   topPlayers: TopPlayer[];
@@ -33,7 +34,9 @@ export interface LandingInitialData {
 }
 
 const TOP_PLAYERS_LIMIT = 5;
-const VALID_LANGUAGES = new Set(['en', 'he', 'sv', 'ja', 'es']);
+// Source of truth for shipped game languages — keep in lockstep so a newly
+// launched locale (e.g. `ru`) gets real landing data instead of the `en` fallback.
+const VALID_LANGUAGES = new Set<string>(SUPPORTED_GAME_LANGUAGES);
 
 /**
  * Landing data is identical for every visitor of a given language and is


### PR DESCRIPTION
The home hub stat strip showed a stale "5 languages" and bald "0" cells:
- languages was hardcoded to 5 in useLandingStats; derive from
  SUPPORTED_GAME_LANGUAGES (now 6 — Russian shipped).
- VALID_LANGUAGES in fetchLandingData omitted 'ru', so Russian visitors
  silently fell back to English landing data; source it from the same list.
- HomeSocialStrip now credibility-gates the live cells (Online, Games today)
  like the desktop proof bar: skeleton while loading, and once resolved only
  render a live cell when it has real activity. No more "0 online / 0 games"
  reading as broken; the grid tracks the visible cell count.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011SeEwbZ39WuYi5yBr1oFvu