### PR TITLE
fix(teacher-access): stop swallowing failed trial approval emails

### DIFF
--- a/fe-next/app/api/admin/teacher-access/[id]/approve/route.ts
+++ b/fe-next/app/api/admin/teacher-access/[id]/approve/route.ts
@@ -47,12 +47,19 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
   }
 
   // Email is best-effort — the approval (DB state) is the source of truth and
-  // must not be undone by a flaky mail provider, so failures are swallowed.
+  // must not be undone by a flaky mail provider, so failures don't 500. But
+  // sendEmail reports provider rejections (bad key, unverified sender domain,
+  // Resend API error) via a resolved { ok:false } result rather than a throw,
+  // so we must inspect that result and log it — otherwise a failed trial email
+  // vanishes with zero trace (silent no-op).
   try {
     const tpl = teacherAccessConfirmation({ full_name: row.full_name, locale: row.locale, message, trialExpiresAt });
-    await sendEmail({ to: row.email, subject: tpl.subject, html: tpl.html });
+    const sent = await sendEmail({ to: row.email, subject: tpl.subject, html: tpl.html });
+    if (!sent.ok) {
+      console.error('[teacher-access approve] email send failed for', row.email, '-', sent.error);
+    }
   } catch (e) {
-    console.error('[teacher-access approve] email send failed', e);
+    console.error('[teacher-access approve] email send threw', e);
   }
 
   return NextResponse.json({ ok: true });

--- a/fe-next/app/api/admin/teacher-access/[id]/resend/route.ts
+++ b/fe-next/app/api/admin/teacher-access/[id]/resend/route.ts
@@ -25,11 +25,19 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
     return NextResponse.json({ ok: false, error: 'not approved' }, { status: 400 });
   }
 
+  // The email IS the whole operation here, so any failure must surface as a
+  // non-2xx. sendEmail signals a provider rejection via a resolved { ok:false }
+  // result (it only throws on unexpected errors), so we handle BOTH: a false
+  // result and a thrown exception.
   try {
     const tpl = teacherAccessConfirmation({ full_name: row.full_name, locale: row.locale, message, trialExpiresAt: row.trial_expires_at });
-    await sendEmail({ to: row.email, subject: tpl.subject, html: tpl.html });
+    const sent = await sendEmail({ to: row.email, subject: tpl.subject, html: tpl.html });
+    if (!sent.ok) {
+      console.error('[teacher-access resend] email send failed for', row.email, '-', sent.error);
+      return NextResponse.json({ ok: false, error: sent.error || 'email send failed' }, { status: 502 });
+    }
   } catch (e) {
-    console.error('[teacher-access resend] email send failed', e);
+    console.error('[teacher-access resend] email send threw', e);
     return NextResponse.json({ ok: false, error: 'email send failed' }, { status: 502 });
   }
 

--- a/fe-next/app/api/admin/teacher-access/__tests__/admin.test.ts
+++ b/fe-next/app/api/admin/teacher-access/__tests__/admin.test.ts
@@ -93,6 +93,20 @@ describe('admin teacher-access endpoints', () => {
     expect(res.status).toBe(200);
   });
 
+  it('approve logs the reason when sendEmail reports failure via result.ok=false (no silent swallow)', async () => {
+    // Resend does NOT throw on a rejected send — it resolves { ok:false, error }.
+    // The route must notice that and log it, otherwise a failed trial email vanishes.
+    const row = { id: 'req-1', user_id: null, email: 'x@y.com', full_name: 'X', locale: 'en' };
+    (createClient as any).mockReturnValue(mockSupabase(adminProfile, row));
+    (sendEmail as any).mockResolvedValueOnce({ ok: false, error: 'domain not verified' });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await approve(req(), { params: Promise.resolve({ id: 'req-1' }) });
+    expect(res.status).toBe(200); // approval (DB state) still stands
+    expect(errSpy).toHaveBeenCalled();
+    expect(errSpy.mock.calls.flat().join(' ')).toContain('domain not verified');
+    errSpy.mockRestore();
+  });
+
   it('decline writes admin_note and status', async () => {
     const row = { id: 'req-1', user_id: 'u-1', email: 'x@y.com', full_name: 'X', locale: 'en' };
     const sb = mockSupabase(adminProfile, row);
@@ -136,6 +150,14 @@ describe('admin teacher-access endpoints', () => {
     const row = { id: 'req-1', user_id: null, email: 'x@y.com', full_name: 'X', locale: 'en', status: 'approved' };
     (createClient as any).mockReturnValue(mockSupabase(adminProfile, row));
     (sendEmail as any).mockRejectedValueOnce(new Error('smtp down'));
+    const res = await resend(req(), { params: Promise.resolve({ id: 'req-1' }) });
+    expect(res.status).toBe(502);
+  });
+
+  it('resend surfaces 502 when sendEmail resolves { ok:false } (Resend rejects without throwing)', async () => {
+    const row = { id: 'req-1', user_id: null, email: 'x@y.com', full_name: 'X', locale: 'en', status: 'approved' };
+    (createClient as any).mockReturnValue(mockSupabase(adminProfile, row));
+    (sendEmail as any).mockResolvedValueOnce({ ok: false, error: 'domain not verified' });
     const res = await resend(req(), { params: Promise.resolve({ id: 'req-1' }) });
     expect(res.status).toBe(502);
   });


### PR DESCRIPTION
sendEmail reports provider rejections (missing/invalid RESEND_API_KEY,
unverified sender domain, Resend API error) via a resolved { ok:false }
result rather than a throw. Both the approve and resend routes only
guarded against thrown exceptions and ignored the returned ok flag, so a
failed trial email vanished with zero trace:

- approve returned 200 with no log
- resend returned 200 even though the email is its entire purpose (its
  502 path was effectively dead code)

Inspect the SendEmailResult.ok flag in both routes: approve now logs the
provider error (email stays best-effort, DB approval is still the source
of truth), and resend now returns 502 on a { ok:false } result as well as
on a throw. Classic Class 4 silent-failure fix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016vuudGYf6KKsc7BQ7MnZGB