### PR TITLE
fix(daily): add RTL-safe exit button to Word Wheel sub-game

### DIFF
--- a/fe-next/components/daily/WordWheelChallenge.tsx
+++ b/fe-next/components/daily/WordWheelChallenge.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import dynamic from 'next/dynamic';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { AnimatePresence, m } from 'framer-motion';
 import { Star, Type, Timer } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { PageLoader } from '@/components/ui/PageLoader';
+import { ConfirmationDialog } from '@/components/ui/ConfirmationDialog';
+import { buildQuitDialogConfig } from './survival/quitDialogConfig';
+import logger from '@/utils/logger';
 import WordWheelGame, { type WordWheelGameResult } from './WordWheelGame';
 import WordWheelResults from './WordWheelResults';
 import TabbedDailyLeaderboard from './TabbedDailyLeaderboard';
@@ -107,6 +110,7 @@ const STAGE_AMBIENT_BG =
 
 const WordWheelChallenge: React.FC = () => {
   const { t, language } = useLanguage();
+  const router = useRouter();
   const isPractice = usePracticeFlag();
   const { setGameActive } = useSoundEffects();
   const { profile, isAuthenticated } = useAuth();
@@ -126,6 +130,31 @@ const WordWheelChallenge: React.FC = () => {
   const [effects, setEffects] = useState<WordWheelEffect[]>([]);
   const [canvasSize, setCanvasSize] = useState({ width: 400, height: 600 });
   const [guestFingerprint, setGuestFingerprint] = useState<string | null>(null);
+  const [showExitConfirm, setShowExitConfirm] = useState(false);
+
+  // Mid-game exit. The Word Wheel had no exit affordance at all — the player
+  // was trapped once the timer started (no top-nav back button, worst under
+  // RTL). Tapping the in-HUD exit opens a confirm; confirming leaves for the
+  // daily hub. Reuses the shared defensive quit-dialog config (never throws on
+  // a bad locale bundle) with the ad-free "progress will be lost" message.
+  const quitDialog = useMemo(
+    () => buildQuitDialogConfig(t, {
+      descriptionKey: 'wordHunt.quitConfirmMessage',
+      fallback: { description: "Your progress won't be saved." },
+    }),
+    [t],
+  );
+  const handleExitClick = useCallback(() => setShowExitConfirm(true), []);
+  const handleExitConfirm = useCallback(() => {
+    setShowExitConfirm(false);
+    try {
+      router.push(`/${language}/daily`);
+    } catch (err) {
+      // Never let a nav throw strand the player on the nav-hidden game surface.
+      logger.error('Word Wheel exit navigation failed; forcing hard nav', err);
+      if (typeof window !== 'undefined') window.location.assign(`/${language}/daily`);
+    }
+  }, [router, language]);
 
   // Catch-up ad gate — mirrors DailyChallenge pattern. Per-date unlock so a
   // single ad watch covers the whole session for that date.
@@ -630,6 +659,7 @@ const WordWheelChallenge: React.FC = () => {
               puzzleDate={catchupDate || getDailyChallengeDate()}
               currentPlayerId={isAuthenticated && profile ? profile.id : null}
               currentGuestFingerprint={!isAuthenticated ? guestFingerprint : null}
+              onExit={handleExitClick}
             />
           </m.div>
         )}
@@ -660,6 +690,21 @@ const WordWheelChallenge: React.FC = () => {
           </m.div>
         )}
       </AnimatePresence>
+
+      {/* Mid-game exit confirmation. Rendered at the stage root (outside the
+          phase branches) so it overlays the wheel; strings come from the shared
+          defensive builder so a broken locale bundle can't crash render. */}
+      <ConfirmationDialog
+        open={showExitConfirm}
+        onOpenChange={setShowExitConfirm}
+        title={quitDialog.title}
+        description={quitDialog.description}
+        confirmText={quitDialog.confirmText}
+        cancelText={quitDialog.cancelText}
+        onConfirm={handleExitConfirm}
+        variant="danger"
+        analyticsId="word_wheel_quit_confirm"
+      />
     </div>
   );
 };

--- a/fe-next/components/daily/WordWheelGame.tsx
+++ b/fe-next/components/daily/WordWheelGame.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { m, AnimatePresence, useReducedMotion } from 'framer-motion';
-import { Clock, Delete, RotateCcw, Flame, TrendingUp, ChevronUp, Check, Trophy } from 'lucide-react';
+import { Clock, Delete, RotateCcw, Flame, TrendingUp, ChevronUp, Check, Trophy, ArrowLeft } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
 import { selectWheelRadius } from '@/lib/wordWheel/wheelGeometry';
@@ -67,6 +67,13 @@ interface WordWheelGameProps {
   currentPlayerId?: string | null;
   /** Current guest fingerprint — same self-filter for unauthenticated players. */
   currentGuestFingerprint?: string | null;
+  /**
+   * Fired when the player taps the in-HUD exit affordance. The Word Wheel had
+   * no exit control at all (the player was trapped mid-game — worst under RTL,
+   * where there was no top-nav back button to fall back on); the parent owns the
+   * quit-confirm dialog + navigation. Omit to hide the button.
+   */
+  onExit?: () => void;
 }
 
 
@@ -82,7 +89,7 @@ interface RivalScore {
 const WordWheelGame: React.FC<WordWheelGameProps> = ({
   puzzle, duration, onComplete, onValidateWord, onEffect, language, paused = false, practice = false,
   hideCompetitive = false, onWordFound, isDesktop = false,
-  puzzleDate, currentPlayerId = null, currentGuestFingerprint = null,
+  puzzleDate, currentPlayerId = null, currentGuestFingerprint = null, onExit,
 }) => {
   const { t } = useLanguage();
   // `useReducedMotion` returns `true` when the user has set the OS-level
@@ -803,16 +810,34 @@ const WordWheelGame: React.FC<WordWheelGameProps> = ({
 
       {/* ── Timer & Score Bar ── */}
       <div className="w-full space-y-1.5">
-        <div className={cn('flex items-center w-full gap-2', practice ? 'justify-center' : 'justify-between')}>
-          {/* Countdown clock — only in the timed game. Practice has no timer, so
-              a static "2:00" that never moves just reads as broken; we drop it
-              entirely (the "End run" CTA below replaces the progress bar). */}
-          {!practice && (
-            <div data-testid="wheel-timer" className={cn('flex items-center gap-1.5 font-neo-display font-black text-lg sm:text-xl shrink-0', timerColor, timerPulse)}>
-              <Clock className="w-4 h-4 sm:w-5 sm:h-5" />
-              <span className="tabular-nums">{minutes}:{seconds.toString().padStart(2, '0')}</span>
-            </div>
-          )}
+        <div className="flex items-center w-full gap-2 justify-between">
+          {/* Start cluster: exit affordance + countdown. Laid out in-flow with
+              flexbox (NOT absolute left/right) so it flips correctly under RTL —
+              in Hebrew the whole cluster sits at the visual right (the start of
+              the row) and the arrow is mirrored via rtl:rotate-180, instead of
+              an absolutely-positioned control drifting off-screen. */}
+          <div className="flex items-center gap-2 shrink-0">
+            {onExit && (
+              <button
+                type="button"
+                onClick={onExit}
+                aria-label={t('common.quit')}
+                data-testid="wheel-exit"
+                className="flex items-center justify-center w-8 h-8 rounded-full border-2 border-neo-cream/10 bg-neo-black/50 text-neo-white hover:bg-neo-black/70 active:scale-95 transition-all duration-150 shrink-0"
+              >
+                <ArrowLeft className="w-4 h-4 rtl:rotate-180" />
+              </button>
+            )}
+            {/* Countdown clock — only in the timed game. Practice has no timer, so
+                a static "2:00" that never moves just reads as broken; we drop it
+                entirely (the "End run" CTA below replaces the progress bar). */}
+            {!practice && (
+              <div data-testid="wheel-timer" className={cn('flex items-center gap-1.5 font-neo-display font-black text-lg sm:text-xl shrink-0', timerColor, timerPulse)}>
+                <Clock className="w-4 h-4 sm:w-5 sm:h-5" />
+                <span className="tabular-nums">{minutes}:{seconds.toString().padStart(2, '0')}</span>
+              </div>
+            )}
+          </div>
           <div className="flex items-center gap-2 sm:gap-3 min-w-0">
             {/* Combo counter — reserved slot avoids horizontal layout shift in top bar.
                 Dropped entirely in the practice hub (hideCompetitive) — no combo pressure. */}

--- a/fe-next/components/daily/__tests__/WordWheelChallenge.adFailureFreePlay.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelChallenge.adFailureFreePlay.test.tsx
@@ -24,6 +24,9 @@ vi.mock('framer-motion', () => ({
 }));
 vi.mock('next/navigation', () => ({
   useSearchParams: () => ({ get: (k: string) => (k === 'date' ? '2026-04-24' : null) }),
+  // WordWheelChallenge now calls useRouter() for the mid-game exit nav; this
+  // local mock overrides the global one, so it must provide it too.
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn(), back: vi.fn(), forward: vi.fn(), refresh: vi.fn() }),
 }));
 vi.mock('@/contexts/LanguageContext', () => ({ useLanguage: () => ({ t: (k: string) => k, language: 'en' }) }));
 vi.mock('@/contexts/SoundEffectsContext', () => ({ useSoundEffects: () => ({ setGameActive: vi.fn() }) }));

--- a/fe-next/components/daily/__tests__/WordWheelChallenge.exit.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelChallenge.exit.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Bug: the Word Wheel sub-game had NO exit/back affordance during play. Once
+ * the timer started the player was trapped — worst under Hebrew/RTL, where
+ * there was no top-nav back button to fall back on either. (Its sibling, Word
+ * Hunt, has SurvivalHeader's quit button; Word Wheel had nothing.)
+ *
+ * Fix: WordWheelGame renders an in-HUD exit button (in-flow flex, RTL-safe) that
+ * calls onExit; WordWheelChallenge owns the confirm dialog (shared defensive
+ * quit-dialog config — never throws on a bad locale) and, on confirm, navigates
+ * to the daily hub.
+ *
+ * These tests verify the Challenge-level wiring: exit → dialog with the right
+ * (ad-free) copy → confirm → navigate.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const { pushSpy } = vi.hoisted(() => ({ pushSpy: vi.fn() }));
+
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => {
+    const Stub = () => null;
+    Stub.displayName = 'DynamicStub';
+    return Stub;
+  },
+}));
+
+vi.mock('framer-motion', () => ({
+  m: new Proxy({}, { get: () => ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div> }),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Stable router spy (overrides the global next/navigation mock).
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushSpy, replace: vi.fn(), prefetch: vi.fn(), back: vi.fn(), forward: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/en/daily/word-wheel',
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({ locale: 'en' }),
+}));
+
+const DICT: Record<string, string> = {
+  'daily.play': 'Play',
+  'daily.quitConfirmTitle': 'Leave mid-game?',
+  'wordHunt.quitConfirmMessage': 'Your progress will be lost!',
+  'daily.imSure': 'Leave anyway',
+  'common.cancel': 'Cancel',
+  'common.quit': 'Quit',
+};
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (k: string) => DICT[k] ?? k, language: 'en', dir: 'ltr' }),
+}));
+vi.mock('@/contexts/SoundEffectsContext', () => ({ useSoundEffects: () => ({ setGameActive: vi.fn() }) }));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ profile: null, isAuthenticated: false }) }));
+vi.mock('@/contexts/NavigationContext', () => ({ useHideNavigation: () => vi.fn() }));
+vi.mock('@/utils/growthTracking', () => ({ trackModalInteraction: vi.fn() }));
+
+vi.mock('@/utils/dailyChallenge', () => ({
+  getDailyChallengeDate: () => '2026-04-15',
+  getPuzzleNumber: () => 42,
+  hasPlayedWordWheelToday: () => false,
+  getTodaysWordWheelResult: () => null,
+  saveWordWheelResult: vi.fn(),
+  hasPlayedWordHuntToday: () => false,
+  getDailyStreak: () => ({ currentStreak: 0 }),
+  updateDailyStreak: vi.fn(() => ({ currentStreak: 1, longestStreak: 1, lastPlayedDate: null, totalDailiesCompleted: 1 })),
+}));
+vi.mock('@/utils/dailyChallenge/wordWheelGeneration', () => ({
+  generateWordWheelPuzzle: () => ({ centerLetter: 'A', outerLetters: ['B', 'C', 'D', 'E', 'F', 'G'], validWords: [] }),
+}));
+vi.mock('@/utils/guestManager', () => ({ getGuestFingerprint: () => 'test-fp' }));
+vi.mock('@/hooks/useRewardedAd', () => ({
+  useRewardedAd: () => ({ showAd: vi.fn(), isAdAvailable: false, isPlaceholderCooldown: false }),
+}));
+
+// WordWheelGame stub that surfaces the onExit prop the fix threads through.
+vi.mock('../WordWheelGame', () => ({
+  __esModule: true,
+  default: (props: { onExit?: () => void }) => (
+    <button data-testid="wheel-exit-trigger" onClick={() => props.onExit?.()}>go</button>
+  ),
+}));
+vi.mock('../WordWheelResults', () => ({ __esModule: true, default: () => <div data-testid="word-wheel-results" /> }));
+vi.mock('../TabbedDailyLeaderboard', () => ({ __esModule: true, default: () => <div data-testid="tabbed-daily-leaderboard" /> }));
+
+import WordWheelChallenge from '../WordWheelChallenge';
+
+async function reachPlaying() {
+  render(<WordWheelChallenge />);
+  const playBtn = await waitFor(() => screen.getByRole('button', { name: 'Play' }));
+  fireEvent.click(playBtn);
+  return waitFor(() => screen.getByTestId('wheel-exit-trigger'));
+}
+
+describe('WordWheelChallenge — mid-game exit', () => {
+  beforeEach(() => pushSpy.mockClear());
+
+  it('opens a confirm dialog with ad-free copy when the exit button is tapped', async () => {
+    const exit = await reachPlaying();
+    fireEvent.click(exit);
+
+    // Shared defensive config: title from daily.quitConfirmTitle, description
+    // from wordHunt.quitConfirmMessage (NOT the ad-mentioning daily.quitConfirm).
+    await waitFor(() => expect(screen.getByText('Leave mid-game?')).toBeInTheDocument());
+    expect(screen.getByText('Your progress will be lost!')).toBeInTheDocument();
+    // Navigation must NOT fire until the player confirms.
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the daily hub only after confirming', async () => {
+    const exit = await reachPlaying();
+    fireEvent.click(exit);
+
+    const confirm = await waitFor(() => screen.getByRole('button', { name: 'Leave anyway' }));
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(pushSpy).toHaveBeenCalledWith('/en/daily'));
+  });
+});

--- a/fe-next/components/daily/__tests__/WordWheelChallenge.exit.test.tsx
+++ b/fe-next/components/daily/__tests__/WordWheelChallenge.exit.test.tsx
@@ -88,7 +88,9 @@ import WordWheelChallenge from '../WordWheelChallenge';
 
 async function reachPlaying() {
   render(<WordWheelChallenge />);
-  const playBtn = await waitFor(() => screen.getByRole('button', { name: 'Play' }));
+  // The ready-screen Play control is a framer-motion `m.button`, which the
+  // pass-through mock above renders as a <div> — so match by text, not role.
+  const playBtn = await waitFor(() => screen.getByText('Play'));
   fireEvent.click(playBtn);
   return waitFor(() => screen.getByTestId('wheel-exit-trigger'));
 }

--- a/fe-next/components/daily/survival/__tests__/quitDialogConfig.test.ts
+++ b/fe-next/components/daily/survival/__tests__/quitDialogConfig.test.ts
@@ -86,4 +86,41 @@ describe('buildQuitDialogConfig', () => {
     expect(() => buildQuitDialogConfig(t)).not.toThrow();
     expect(buildQuitDialogConfig(t)).toEqual(GENERIC_QUIT_DIALOG);
   });
+
+  // --- key overrides (Word Wheel reuses this helper with a different message) ---
+
+  it('resolves overridden keys when provided (Word Wheel description)', () => {
+    const dict: Record<string, string> = {
+      'daily.quitConfirmTitle': 'לצאת באמצע המשחק?',
+      'wordHunt.quitConfirmMessage': 'ההתקדמות שלך תאבד!',
+      'daily.imSure': 'צא בכל זאת',
+      'common.cancel': 'ביטול',
+    };
+    const t = (key: string) => dict[key];
+
+    const config = buildQuitDialogConfig(t, { descriptionKey: 'wordHunt.quitConfirmMessage' });
+    expect(config.title).toBe('לצאת באמצע המשחק?');
+    // The overridden key is used — NOT the default daily.quitConfirm (which the
+    // dict above doesn't even define).
+    expect(config.description).toBe('ההתקדמות שלך תאבד!');
+    expect(config.confirmText).toBe('צא בכל זאת');
+  });
+
+  it('falls back to a per-field override fallback when the overridden key is missing', () => {
+    const t = (key: string) => key; // every key missing (echoes path)
+
+    const config = buildQuitDialogConfig(t, {
+      descriptionKey: 'wordHunt.quitConfirmMessage',
+      fallback: { description: "Your progress won't be saved." },
+    });
+    // Missing key → the supplied ad-free fallback, not the generic ad message.
+    expect(config.description).toBe("Your progress won't be saved.");
+    // Non-overridden fields still fall back to the generic floor.
+    expect(config.title).toBe(GENERIC_QUIT_DIALOG.title);
+  });
+
+  it('default call is unchanged (backward compatible)', () => {
+    const t = (key: string) => key;
+    expect(buildQuitDialogConfig(t)).toEqual(GENERIC_QUIT_DIALOG);
+  });
 });

--- a/fe-next/components/daily/survival/quitDialogConfig.ts
+++ b/fe-next/components/daily/survival/quitDialogConfig.ts
@@ -64,16 +64,40 @@ function resolveString(t: TranslateFn, key: string, fallback: string): string {
 }
 
 /**
- * Build the Daily Challenge quit-confirmation dialog config. Guaranteed to
- * return four non-empty strings and to never throw, regardless of the state of
- * the active locale bundle.
+ * Optional per-call overrides. Lets a second surface (e.g. the Word Wheel)
+ * reuse this defensive builder with different translation keys and/or ad-free
+ * fallback copy, without duplicating the resolution logic.
  */
-export function buildQuitDialogConfig(t: TranslateFn): QuitDialogConfig {
-  if (typeof t !== 'function') return { ...GENERIC_QUIT_DIALOG };
+export interface QuitDialogKeys {
+  titleKey?: string;
+  descriptionKey?: string;
+  confirmKey?: string;
+  cancelKey?: string;
+  /** Per-field generic fallbacks (the English floor) when a key is unusable. */
+  fallback?: Partial<QuitDialogConfig>;
+}
+
+/**
+ * Build a quit-confirmation dialog config. Guaranteed to return four non-empty
+ * strings and to never throw, regardless of the state of the active locale
+ * bundle. Called with no options it produces the Word Hunt config unchanged;
+ * pass `keys` to point specific fields at different translation keys (with an
+ * optional ad-free fallback) for other surfaces like the Word Wheel.
+ */
+export function buildQuitDialogConfig(t: TranslateFn, keys: QuitDialogKeys = {}): QuitDialogConfig {
+  const {
+    titleKey = 'daily.quitConfirmTitle',
+    descriptionKey = 'daily.quitConfirm',
+    confirmKey = 'daily.imSure',
+    cancelKey = 'common.cancel',
+    fallback,
+  } = keys;
+  const floor: QuitDialogConfig = { ...GENERIC_QUIT_DIALOG, ...(fallback ?? {}) };
+  if (typeof t !== 'function') return { ...floor };
   return {
-    title: resolveString(t, 'daily.quitConfirmTitle', GENERIC_QUIT_DIALOG.title),
-    description: resolveString(t, 'daily.quitConfirm', GENERIC_QUIT_DIALOG.description),
-    confirmText: resolveString(t, 'daily.imSure', GENERIC_QUIT_DIALOG.confirmText),
-    cancelText: resolveString(t, 'common.cancel', GENERIC_QUIT_DIALOG.cancelText),
+    title: resolveString(t, titleKey, floor.title),
+    description: resolveString(t, descriptionKey, floor.description),
+    confirmText: resolveString(t, confirmKey, floor.confirmText),
+    cancelText: resolveString(t, cancelKey, floor.cancelText),
   };
 }


### PR DESCRIPTION
## Summary

Two reported Hebrew-locale bugs in the Daily Challenge sub-games. Investigation found:

### Bug 2 — Word Wheel (גלגל המילים): no exit button at all ✅ fixed here
This was the real, unaddressed issue. The Word Wheel playing view rendered `WordWheelGame` **with no exit/back affordance anywhere** — once the timer started the player was trapped, worst under Hebrew/RTL where there's no top-nav back button to fall back on either. (Its sibling, Word Hunt, has `SurvivalHeader`'s quit button; Word Wheel had nothing — so it wasn't a mispositioned button, it was a *missing* one.)

**Fix:**
- `WordWheelGame` gains an optional `onExit` and renders an in-HUD exit button at the **start** of the timer/score row. It's laid out **in-flow with flexbox (not absolute `left`/`right`)**, so it flips correctly under RTL — in Hebrew the cluster sits at the visual right (the start of the row) and the arrow is mirrored via `rtl:rotate-180`, instead of an absolutely-positioned control drifting off-screen.
- `WordWheelChallenge` owns the quit-confirm dialog + navigation to the daily hub, guarded so a nav throw can't strand the player (hard-nav fallback).

### Bug 1 — Word Hunt (צייד המילים) exit crash → already fixed on master
The Word Hunt exit-crash was resolved by the merged **#680** (`buildQuitDialogConfig` + hardened `handleQuitConfirm`, present at both dialog sites; no uncovered quit path remains). Rather than fabricate a change, this PR gives the **Word Wheel the same crash-proof treatment**: `buildQuitDialogConfig` now accepts optional key overrides + per-field fallbacks (backward compatible), and the Word Wheel reuses it with the ad-free `wordHunt.quitConfirmMessage` copy. So **both sub-games now pop the same shared, defensive `ConfirmationDialog` that never throws on a bad locale bundle.**

## RTL correctness
The exit control uses logical flex ordering + `rtl:rotate-180` (the same pattern as Word Hunt's `SurvivalHeader`), so the button is visible and correctly placed in both LTR and RTL — no physical `left`/`right` offsets that push it off-screen in Hebrew.

## Tests
- Extended `quitDialogConfig` unit tests for the new override/fallback paths (verified).
- Added a `WordWheelChallenge` test: the exit button opens the dialog with the ad-free copy, and navigation fires **only after confirm**.

## Verification note
The frontend dependency tree isn't installed in this environment, so the pure `buildQuitDialogConfig` logic was verified via a standalone type-stripped Node run (all assertions pass); the component test follows the existing `WordWheelChallenge` test's mocking pattern. A manual/RTL device pass on the button placement is still worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmoN6BgG3CGmSDUoCMB3z6)_