### PR TITLE
fix(blast): make HUD mascot a transient celebration, not a permanent overlay

### DIFF
--- a/fe-next/components/blast/legacy/BlastView.tsx
+++ b/fe-next/components/blast/legacy/BlastView.tsx
@@ -8,7 +8,7 @@ import { useHideNavigation } from '@/contexts/NavigationContext';
 import { trackGameStart } from '@/utils/growthTracking';
 import { trackBlastRunEnded } from '@/components/blast/legacy/utils/blastTelemetry';
 import { useHasRealAdProvider } from '@/hooks/useHasRealAdProvider';
-import { AdaptiveMotion } from '@/components/motion/AdaptiveMotion';
+import { AdaptiveMotion, AdaptiveAnimatePresence } from '@/components/motion/AdaptiveMotion';
 import { BlastGame } from './BlastGame';
 import { BlastResultsSummary } from './BlastResultsSummary';
 import { BlastPregameBuffModal, type BlastPregameBuff } from './BlastPregameBuffModal';
@@ -406,13 +406,28 @@ export function BlastView() {
             onHighlightStart={handleHighlightStart}
             onQuit={exitGuard.requestExit}
           />
-          <div className="absolute top-3 right-3 z-50">
-            <BlastMascotHud
-              state={mascot.state}
-              enabled={mascotPref.enabled}
-              onToggle={mascotPref.toggle}
-            />
-          </div>
+          {/* Transient celebration: the mascot pops in on a reaction and
+              auto-hides after a beat so it never sits over the score/HUD. When
+              the player has muted it, the (dimmed) frame stays put so the
+              unmute affordance remains reachable. */}
+          <AdaptiveAnimatePresence>
+            {(mascot.visible || !mascotPref.enabled) && (
+              <AdaptiveMotion.div
+                key="blast-mascot-hud"
+                initial={{ opacity: 0, scale: 0.6 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.6 }}
+                transition={{ type: 'spring', stiffness: 400, damping: 24 }}
+                className="absolute top-3 right-3 z-50"
+              >
+                <BlastMascotHud
+                  state={mascot.state}
+                  enabled={mascotPref.enabled}
+                  onToggle={mascotPref.toggle}
+                />
+              </AdaptiveMotion.div>
+            )}
+          </AdaptiveAnimatePresence>
           <ModeCoach mode="blast" />
         </>
       )}

--- a/fe-next/lib/blast/__tests__/useBlastMascot.test.tsx
+++ b/fe-next/lib/blast/__tests__/useBlastMascot.test.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { render, act } from '@testing-library/react';
 import { useBlastMascot } from '../useBlastMascot';
+import { MASCOT_VISIBLE_MS } from '../mascotState';
 
 function Probe({
   onMount,
@@ -16,7 +17,13 @@ function Probe({
   React.useEffect(() => {
     onMount(api);
   }, [api, onMount]);
-  return <div data-testid="probe" data-state={api.state} />;
+  return (
+    <div
+      data-testid="probe"
+      data-state={api.state}
+      data-visible={String(api.visible)}
+    />
+  );
 }
 
 describe('useBlastMascot', () => {
@@ -66,5 +73,71 @@ describe('useBlastMascot', () => {
       captured!.fire({ kind: 'wave-fail' });
     });
     expect(getByTestId('probe').getAttribute('data-state')).toBe('sad-supportive');
+  });
+
+  describe('transient visibility — celebrate briefly, then get out of the way', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('starts hidden so the mascot never occludes the HUD at rest', () => {
+      let captured: ReturnType<typeof useBlastMascot> | null = null;
+      render(<Probe onMount={(api) => (captured = api)} />);
+      expect(captured!.visible).toBe(false);
+    });
+
+    it('reveals on a reaction, then auto-hides after MASCOT_VISIBLE_MS', () => {
+      let captured: ReturnType<typeof useBlastMascot> | null = null;
+      const { getByTestId } = render(
+        <Probe onMount={(api) => (captured = api)} />,
+      );
+      act(() => {
+        captured!.fire({ kind: 'word-submitted', wordLength: 4, gemLetterUsed: false });
+      });
+      expect(getByTestId('probe').getAttribute('data-visible')).toBe('true');
+
+      act(() => {
+        vi.advanceTimersByTime(MASCOT_VISIBLE_MS + 1);
+      });
+      expect(getByTestId('probe').getAttribute('data-visible')).toBe('false');
+    });
+
+    it('a new reaction before the timer elapses extends the visible window', () => {
+      let captured: ReturnType<typeof useBlastMascot> | null = null;
+      const { getByTestId } = render(
+        <Probe onMount={(api) => (captured = api)} />,
+      );
+      act(() => {
+        captured!.fire({ kind: 'word-submitted', wordLength: 4, gemLetterUsed: false });
+      });
+      // wave-fail bypasses cooldown, so it retriggers a fresh visible window.
+      act(() => {
+        vi.advanceTimersByTime(MASCOT_VISIBLE_MS - 100);
+        captured!.fire({ kind: 'wave-fail' });
+      });
+      // Old timer would have fired here; the refreshed one should keep it up.
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(getByTestId('probe').getAttribute('data-visible')).toBe('true');
+    });
+
+    it('does not reveal when an event is cooldown-blocked (no real transition)', () => {
+      let captured: ReturnType<typeof useBlastMascot> | null = null;
+      const { getByTestId } = render(
+        <Probe onMount={(api) => (captured = api)} />,
+      );
+      act(() => {
+        captured!.fire({ kind: 'word-submitted', wordLength: 4, gemLetterUsed: false });
+      });
+      act(() => {
+        vi.advanceTimersByTime(MASCOT_VISIBLE_MS + 1);
+      });
+      expect(getByTestId('probe').getAttribute('data-visible')).toBe('false');
+      // Within global cooldown → blocked → must not re-reveal.
+      act(() => {
+        captured!.fire({ kind: 'word-submitted', wordLength: 6, gemLetterUsed: false });
+      });
+      expect(getByTestId('probe').getAttribute('data-visible')).toBe('false');
+    });
   });
 });

--- a/fe-next/lib/blast/mascotState.ts
+++ b/fe-next/lib/blast/mascotState.ts
@@ -46,6 +46,13 @@ export const MASCOT_GIF_PATHS: Record<MascotState, string> = {
 export const GLOBAL_COOLDOWN_MS = 4000;
 export const STATE_COOLDOWN_MS = 10000;
 
+/**
+ * How long the HUD mascot stays on screen after a reaction before auto-hiding.
+ * The mascot is a transient celebration — it pops in, reacts, and gets out of
+ * the way so it never permanently occludes the score/HUD.
+ */
+export const MASCOT_VISIBLE_MS = 2000;
+
 const WORD_LEN_CHEER_MIN = 4;
 const WORD_LEN_WOW = 6;
 const WORD_LEN_AWE_MIN = 7;

--- a/fe-next/lib/blast/useBlastMascot.ts
+++ b/fe-next/lib/blast/useBlastMascot.ts
@@ -8,10 +8,11 @@
  * time. The pure reducer is tested separately; this hook is a thin React shell
  * with idempotent dispatch + bus integration.
  */
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import {
   reduceMascotEvent,
   createInitialMascotState,
+  MASCOT_VISIBLE_MS,
   type MascotEvent,
   type MascotReducerState,
 } from './mascotState';
@@ -19,19 +20,47 @@ import { subscribeMascotEvents } from './mascotBus';
 
 export interface BlastMascotApi {
   state: MascotReducerState['current'];
+  /** True only during the brief celebration window after a real reaction. */
+  visible: boolean;
   /** Direct fire — usually use the bus via emitMascotEvent. */
   fire: (event: MascotEvent) => void;
 }
 
 export function useBlastMascot(): BlastMascotApi {
   const [reducerState, setReducerState] = useState<MascotReducerState>(createInitialMascotState);
+  const [visible, setVisible] = useState(false);
+
+  // Mirror reducer state in a ref so `fire` can detect a real transition
+  // without reading stale closure state or mutating state inside an updater.
+  const stateRef = useRef(reducerState);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fire = useCallback((event: MascotEvent) => {
-    setReducerState((prev) => reduceMascotEvent(prev, event, Date.now()));
+    const prev = stateRef.current;
+    const next = reduceMascotEvent(prev, event, Date.now());
+    // Cooldown-blocked / no-op events return the same object — don't re-reveal.
+    if (next === prev) return;
+
+    stateRef.current = next;
+    setReducerState(next);
+
+    // A real reaction fired: pop the mascot in, then auto-hide so it never
+    // sits over the HUD. A fresh reaction refreshes the window.
+    setVisible(true);
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    hideTimerRef.current = setTimeout(() => setVisible(false), MASCOT_VISIBLE_MS);
   }, []);
 
   // Subscribe to the bus so any handler can emit without prop-drilling.
   useEffect(() => subscribeMascotEvents(fire), [fire]);
 
-  return { state: reducerState.current, fire };
+  // Clear the pending hide timer on unmount.
+  useEffect(
+    () => () => {
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    },
+    [],
+  );
+
+  return { state: reducerState.current, visible, fire };
 }


### PR DESCRIPTION
The Blast mascot HUD was mounted permanently in the top-right corner during
play, sitting on top of the score avatar and never getting out of the way.

Now the mascot is hidden at rest and only pops in for a brief window
(MASCOT_VISIBLE_MS) after a real reaction, then auto-hides — so it celebrates
for a beat without occluding the score/HUD. A muted mascot keeps its dimmed
frame so the unmute affordance stays reachable.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016pdE6TW4mD2T9qKwcqeyrf