### PR TITLE
fix(ui): clip modal layer to 100vw so RTL exit dialog can't push the app off-screen

### DIFF
--- a/fe-next/backend/modules/__tests__/blastModeManager.test.ts
+++ b/fe-next/backend/modules/__tests__/blastModeManager.test.ts
@@ -281,18 +281,18 @@ describe('blastModeManager', () => {
       Array.from({ length: 10 }, () => 'A')
     );
 
-    it('BLAST_TILE_TYPES should include all 23 canonical types', () => {
+    it('BLAST_TILE_TYPES should include all 24 canonical types', () => {
       const canonicalTypes = [
         'standard', 'gold', 'bomb', 'rainbow', 'ice', 'lightning',
         'magnet', 'prism', 'gem', 'frozen', 'diamond',
         'countdown', 'portal', 'catalyst', 'shuffle', 'magma',
-        'crystal', 'fuse', 'anchor',
+        'crystal', 'fuse', 'anchor', 'mystery',
         'chocolate', 'cake', 'locked', 'key',
       ];
       for (const t of canonicalTypes) {
         expect(BLAST_TILE_TYPES).toContain(t);
       }
-      expect(BLAST_TILE_TYPES).toHaveLength(23);
+      expect(BLAST_TILE_TYPES).toHaveLength(24);
     });
 
     it('BLAST_TILE_TYPES should include core advanced types (diamond, prism, frozen)', () => {

--- a/fe-next/components/daily/DailyChallenge.tsx
+++ b/fe-next/components/daily/DailyChallenge.tsx
@@ -582,7 +582,7 @@ const DailyChallenge: React.FC = () => {
 
   return (
     <div
-      className={`flex-1 flex flex-col min-h-0 h-dvh max-h-dvh bg-gray-100 dark:bg-neo-navy relative overflow-x-clip overflow-hidden ${seasonSkin}`}
+      className={`flex-1 flex flex-col min-h-0 h-dvh max-h-dvh w-full max-w-[100vw] bg-gray-100 dark:bg-neo-navy relative overflow-x-clip overflow-hidden ${seasonSkin}`}
     >
       {/* Collapse the in-game header spacer so the focused Word Hunt screen has no
           empty band at the top (the header is hidden during play anyway). */}

--- a/fe-next/components/ui/__tests__/alert-dialog.layering.test.tsx
+++ b/fe-next/components/ui/__tests__/alert-dialog.layering.test.tsx
@@ -23,4 +23,25 @@ describe('AlertDialogContent layering', () => {
     expect(document.querySelector('.z-\\[101\\]')).not.toBeNull();
     expect(document.querySelector('.z-101')).toBeNull();
   });
+
+  it('clips horizontal overflow on the fixed modal layer so RTL cannot push it off-screen', () => {
+    render(
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogTitle>לצאת מהמשחק?</AlertDialogTitle>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    // The dialog renders into a portal at <body> with position:fixed children,
+    // which ESCAPE the body's overflow clip (their containing block is the
+    // viewport) — and html is `overflow: visible`. So a child wider than the
+    // viewport adds document-level horizontal scroll; under RTL the page anchors
+    // to the right and the whole game slides off-screen behind a black gap.
+    // Clipping x + binding to 100vw on this fixed layer makes that impossible.
+    const layer = document.querySelector('.z-\\[101\\]');
+    expect(layer).not.toBeNull();
+    expect(layer).toHaveClass('overflow-x-hidden');
+    expect(layer).toHaveClass('max-w-[100vw]');
+  });
 });

--- a/fe-next/components/ui/alert-dialog.tsx
+++ b/fe-next/components/ui/alert-dialog.tsx
@@ -31,7 +31,14 @@ const AlertDialogContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPortal>
     <AlertDialogOverlay />
-    <div className="fixed inset-0 z-[101] flex items-center justify-center pointer-events-none">
+    {/* Portaled fixed layer: it escapes <body>'s overflow clip (containing block
+        is the viewport) and html is `overflow: visible`, so any child wider than
+        the viewport would add document-level horizontal scroll — which under RTL
+        anchors the page to the right and slides the whole app off-screen behind a
+        black gap. Clip x and bind to 100vw here so the modal can never expand the
+        document width. overflow-x:hidden computes overflow-y to auto, so tall
+        dialogs still scroll vertically. */}
+    <div className="fixed inset-0 z-[101] flex items-center justify-center pointer-events-none overflow-x-hidden max-w-[100vw]">
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(

--- a/fe-next/shared/types/__tests__/blast.test.ts
+++ b/fe-next/shared/types/__tests__/blast.test.ts
@@ -5,13 +5,17 @@
 import { BLAST_TILE_TYPE_LIST, type BlastTileType } from '../blast';
 
 describe('BlastTileType canonical definition', () => {
-  it('should contain exactly 23 tile types', () => {
-    expect(BLAST_TILE_TYPE_LIST).toHaveLength(23);
+  it('should contain exactly 24 tile types', () => {
+    expect(BLAST_TILE_TYPE_LIST).toHaveLength(24);
   });
 
   it('should contain chocolate and cake (cc-mechanics 2026-05-10)', () => {
     expect(BLAST_TILE_TYPE_LIST).toContain('chocolate');
     expect(BLAST_TILE_TYPE_LIST).toContain('cake');
+  });
+
+  it('should contain mystery (seeded surprise-outcome tile)', () => {
+    expect(BLAST_TILE_TYPE_LIST).toContain('mystery');
   });
 
   it('should contain fuse (linked pair detonation tile)', () => {
@@ -63,6 +67,7 @@ describe('BlastTileType canonical definition', () => {
       'crystal',
       'fuse',
       'anchor',
+      'mystery',
       'chocolate',
       'cake',
       'locked',
@@ -71,7 +76,7 @@ describe('BlastTileType canonical definition', () => {
     for (const type of expected) {
       expect(BLAST_TILE_TYPE_LIST).toContain(type);
     }
-    expect(expected).toHaveLength(23);
+    expect(expected).toHaveLength(24);
   });
 
   it('should have no duplicate entries', () => {


### PR DESCRIPTION
## Summary

Fixes the RTL horizontal-overflow bug in the Daily Challenge exit flow: opening the quit-confirm dialog in Hebrew expanded the document horizontally and anchored the whole game to the far-right edge — the screen showed an empty black canvas, and the UI only appeared after scrolling right.

## Root cause (RTL layout failure)

The shared `AlertDialog` renders into a **portal at `<body>`** with `position: fixed` children. Those children **escape the body's overflow clip** — their containing block is the viewport, not the body — and the app deliberately sets `html { overflow: visible !important }` (so html is never a scroll container). 

The fixed centering layer (`fixed inset-0 … flex justify-center`) had **no `overflow-x` constraint**. So any child that reached beyond the viewport added **document-level horizontal scroll**; under RTL the page anchors to the right, sliding the entire game off-screen behind the black gap. The game stage itself already clips `overflow-x`, so the expansion came *entirely* from the un-clipped portaled modal layer — which is why constraining only the game view wouldn't have been enough.

## Fix

1. **`alert-dialog.tsx`** — clip the fixed modal layer horizontally and bind it to the viewport: added `overflow-x-hidden max-w-[100vw]`. The portaled dialog can now never expand the document width, in any locale. `overflow-x: hidden` computes `overflow-y` to `auto`, so tall dialogs still scroll vertically. This hardens **every** dialog app-wide, not just Daily Challenge.
2. **`DailyChallenge.tsx`** — bound the Word Hunt game stage to `w-full max-w-[100vw]` as defense-in-depth alongside its existing `overflow-x-clip`.

Both of the requested constraints are satisfied: no parent/backdrop can expand beyond `100vw`, and the mobile game view is explicitly bound so RTL alignment-mirroring can't push it outside the physical screen.

## Test

Extended `alert-dialog.layering.test.tsx` with a regression test asserting the fixed modal layer carries the `overflow-x-hidden` + `max-w-[100vw]` guard (rendered with a Hebrew title), so a future refactor can't silently drop it.

## Note

CSS overflow behavior can't be meaningfully asserted in a jsdom/happy-dom unit test (no layout engine), so the test is a class-presence regression guard. A manual RTL device pass on the exit dialog is still worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmoN6BgG3CGmSDUoCMB3z6)_