### PR TITLE
test: make count assertions derive from source so they stop going stale

### DIFF
--- a/fe-next/backend/modules/__tests__/blastModeManager.test.ts
+++ b/fe-next/backend/modules/__tests__/blastModeManager.test.ts
@@ -281,7 +281,11 @@ describe('blastModeManager', () => {
       Array.from({ length: 10 }, () => 'A')
     );
 
-    it('BLAST_TILE_TYPES should include all 24 canonical types', () => {
+    // Subset guard only — no hardcoded total. Adding a tile to the source must
+    // not break this test (a magic count here duplicated the one in
+    // shared/types/blast.test.ts and drifted independently, blocking unrelated
+    // PRs). Removing a documented tile still fails via toContain.
+    it('BLAST_TILE_TYPES should include every canonical type', () => {
       const canonicalTypes = [
         'standard', 'gold', 'bomb', 'rainbow', 'ice', 'lightning',
         'magnet', 'prism', 'gem', 'frozen', 'diamond',
@@ -292,7 +296,6 @@ describe('blastModeManager', () => {
       for (const t of canonicalTypes) {
         expect(BLAST_TILE_TYPES).toContain(t);
       }
-      expect(BLAST_TILE_TYPES).toHaveLength(24);
     });
 
     it('BLAST_TILE_TYPES should include core advanced types (diamond, prism, frozen)', () => {

--- a/fe-next/components/offline/__tests__/OfflineDownloadManager.test.tsx
+++ b/fe-next/components/offline/__tests__/OfflineDownloadManager.test.tsx
@@ -33,6 +33,10 @@ vi.mock('@/contexts/LanguageContext', () => ({
 }));
 
 import { OfflineDownloadManager } from '../OfflineDownloadManager';
+// Source of truth for the supported-locale count. The component renders one row
+// per locale; deriving from `locales` keeps this test correct when a locale is
+// added/removed instead of drifting against a hardcoded number.
+import { locales } from '@/i18n/config';
 
 describe('OfflineDownloadManager', () => {
   beforeEach(() => {
@@ -103,7 +107,7 @@ describe('OfflineDownloadManager', () => {
     render(<OfflineDownloadManager />);
     await waitFor(() => {
       const downloadButtons = screen.getAllByText('offlineDownload.downloadButton');
-      expect(downloadButtons.length).toBe(6); // 6 languages
+      expect(downloadButtons.length).toBe(locales.length); // one per supported locale
     });
   });
 

--- a/fe-next/lib/offline/__tests__/offlineCapableModes.test.ts
+++ b/fe-next/lib/offline/__tests__/offlineCapableModes.test.ts
@@ -5,8 +5,9 @@ import {
   isOfflineCapable,
   offlineCapableRoutes,
 } from '../offlineCapableModes';
-
-const LOCALES = ['en', 'he', 'sv', 'ja', 'es'];
+// Source of truth for supported locales — derive loops/counts from it so adding
+// a locale can't leave this test asserting a stale hardcoded set or total.
+import { locales } from '@/i18n/config';
 
 describe('offlineCapableModes', () => {
   describe('OFFLINE_CAPABLE_MODES', () => {
@@ -80,7 +81,7 @@ describe('offlineCapableModes', () => {
 
   describe('isOfflineCapable', () => {
     it('returns true for every offline-capable mode across locales', () => {
-      for (const loc of LOCALES) {
+      for (const loc of locales) {
         for (const seg of OFFLINE_CAPABLE_MODES) {
           expect(isOfflineCapable(`/${loc}/${seg}`)).toBe(true);
         }
@@ -156,8 +157,10 @@ describe('offlineCapableModes', () => {
       expect(routes).toContain('/en/crossword');
       expect(routes).toContain('/en/blast/v2');
       expect(routes).toContain('/ru/daily');
-      // 6 locales x 9 modes (7 original + crossword + wordfall)
-      expect(routes).toHaveLength(54);
+      // One route per (locale × offline mode entry) — derived from the sources so
+      // it never drifts when a locale or a mode is added (7 original modes +
+      // crossword + wordfall = OFFLINE_MODES entries).
+      expect(routes).toHaveLength(locales.length * OFFLINE_MODES.length);
     });
   });
 });

--- a/fe-next/shared/types/__tests__/blast.test.ts
+++ b/fe-next/shared/types/__tests__/blast.test.ts
@@ -5,8 +5,12 @@
 import { BLAST_TILE_TYPE_LIST, type BlastTileType } from '../blast';
 
 describe('BlastTileType canonical definition', () => {
-  it('should contain exactly 24 tile types', () => {
-    expect(BLAST_TILE_TYPE_LIST).toHaveLength(24);
+  // NOTE: intentionally no hardcoded total-count assertion. A magic number here
+  // drifts every time a tile is added (and silently blocks unrelated PRs once it
+  // lands red on master). The real invariants — required members present, retired
+  // members absent, no duplicates — are asserted below and never go stale.
+  it('is a non-empty canonical list', () => {
+    expect(BLAST_TILE_TYPE_LIST.length).toBeGreaterThan(0);
   });
 
   it('should contain chocolate and cake (cc-mechanics 2026-05-10)', () => {
@@ -46,6 +50,9 @@ describe('BlastTileType canonical definition', () => {
     expect(BLAST_TILE_TYPE_LIST).toContain('catalyst');
   });
 
+  // Subset guard: every documented canonical tile must be present. Adding a NEW
+  // tile to the source does NOT break this (no exact-length assertion) — it only
+  // fails if a documented tile is removed, which is the case worth catching.
   it('should contain all expected tile types', () => {
     const expected: BlastTileType[] = [
       'standard',
@@ -76,7 +83,6 @@ describe('BlastTileType canonical definition', () => {
     for (const type of expected) {
       expect(BLAST_TILE_TYPE_LIST).toContain(type);
     }
-    expect(expected).toHaveLength(24);
   });
 
   it('should have no duplicate entries', () => {


### PR DESCRIPTION
## Summary

Follow-up that kills the recurring class of failure we hit repeatedly this session: **hardcoded-count tests that a prior feature PR forgot to bump** (the `ru` locale, the `mystery` blast tile). Each drifted from its source, landed red on `master`, and then blocked *unrelated* PRs' CI. This makes those counts derive from their source of truth so they can't go stale.

## Changes (test-only — no production code)

- **`offlineCapableModes.test.ts`** — the biggest offender. The `isOfflineCapable` loop iterated a **hardcoded 5-entry `LOCALES` array that was already missing `ru`**; it now iterates the real `locales`. The precache-route count asserts `locales.length * OFFLINE_MODES.length` instead of a magic `54`. Adding a locale **or** a mode now auto-updates.
- **`OfflineDownloadManager.test.tsx`** — asserts one download button per `locales.length` instead of a magic `6`.
- **`blast.test.ts` + `blastModeManager.test.ts`** — dropped the drift-prone total-count assertions (a magic `24` duplicated across two files that drifted independently). The **real invariants are kept and never go stale**: required members present (`toContain`), retired members absent (`not.toContain`), and no duplicates. Adding a tile no longer breaks an unrelated PR.

## Why this shape

For counts that are a function of a real collection (`locales`, `OFFLINE_MODES`), deriving from that collection is exact **and** self-updating. For the blast tile list — where the "source" is the list itself — a total-count assertion is just a magic number that drifts; the membership/dedup guards catch the cases actually worth catching (a required tile removed, a retired tile resurrected, duplicates) without failing on benign additions.

All four derivations resolve to the same values the old numbers asserted (`locales.length` = 6, `OFFLINE_MODES.length` = 9 → 54), so behavior is unchanged today — only the future-proofing differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmoN6BgG3CGmSDUoCMB3z6)_