### PR TITLE
SEO: daily meta tag improvements (2026-07-06)

### DIFF
--- a/docs/seo-daily/2026-07-06.md
+++ b/docs/seo-daily/2026-07-06.md
@@ -1,0 +1,137 @@
+# SEO Daily Report — 2026-07-06
+
+**Data range:** 2026-06-07 to 2026-07-04 (28 days, Google only — Bing blocked by proxy)
+
+---
+
+## Headline Metrics
+
+### Google (28-day totals)
+
+| Metric | Value |
+|---|---|
+| Clicks | 277 |
+| Impressions | 45,045 |
+| CTR | 0.61% |
+| Avg Position | 6.4 |
+
+### Week-over-week (last 7d vs prior 7d)
+
+| Metric | Last 7d (Jun 28–Jul 4) | Prior 7d (Jun 21–27) | Delta |
+|---|---|---|---|
+| Clicks | 59 | 62 | **-4.8%** |
+| Impressions | 11,998 | 10,929 | **+9.8%** |
+
+> Impressions rising but clicks falling — classic CTR gap. Most new impressions are on the Spanish page at positions 4–6.
+
+### Bing
+
+> **Unavailable** — Bing Webmaster API blocked by network proxy (403). Skipping Bing sections.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+Criteria: impressions ≥ 30, CTR underperforming expected CTR for position by ≥ 30%.
+
+| # | Query | Page | Position | Impressions | Current CTR | Expected CTR | Potential Clicks | Fix |
+|---|---|---|---|---|---|---|---|---|
+| 1 | scrabble online | /es/juego-de-palabras-multijugador | 4.8 | 13,121 | 0.4% | 6.0% | +737 | Title ≤60 chars; add "Juega Ahora" CTA |
+| 2 | scrabble online español | /es/juego-de-palabras-multijugador | 5.5 | 3,365 | 0.4% | 4.0% | +122 | Same page — title fix covers this |
+| 3 | scrabble en linea | /es/juego-de-palabras-multijugador | 5.8 | 2,508 | 0.2% | 4.0% | +95 | Shorten description to ≤155 chars |
+| 4 | scrabble en español online | /es/juego-de-palabras-multijugador | 4.9 | 1,652 | 0.5% | 6.0% | +90 | Same page — title fix covers this |
+| 5 | scrabble juego online | /es/juego-de-palabras-multijugador | 5.0 | 1,311 | 0.3% | 6.0% | +75 | Same page — title fix covers this |
+| 6 | scrabble online gratis | /es/juego-de-palabras-multijugador | 6.6 | 2,394 | 0.2% | 3.0% | +68 | Same page — description CTA fix |
+| 7 | jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 5.0 | 961 | 0.6% | 6.0% | +52 | Same page |
+| 8 | scrabble gratis en español | /es/juego-de-palabras-multijugador | 4.2 | 685 | 0.3% | 6.0% | +39 | Same page |
+| 9 | scrabble (en español) - juega gratis en línea | /es/juego-de-palabras-multijugador | 6.4 | 1,475 | 0.4% | 3.0% | +38 | Same page |
+| 10 | scrabble español | /es/juego-de-palabras-multijugador | 5.9 | 995 | 0.4% | 4.0% | +36 | Same page |
+
+**All top-10 opportunities point to a single page** (`/es/juego-de-palabras-multijugador`). A single title/description fix captures all of them. Conservative estimate at 2× current CTR = **+250 clicks/28 days**.
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+Criteria: avg position 8–20, impressions ≥ 50.
+
+| # | Query | Page | Position | Impressions | Clicks | Action |
+|---|---|---|---|---|---|---|
+| 1 | המילה היומית (Hebrew daily word) | /he/ (unknown) | 8.1 | 663 | 3 | Add FAQPage + HowTo schema; improve H1 to include exact query |
+| 2 | מילת היום (Hebrew word of day) | /he/ (unknown) | 8.9 | 297 | 3 | Same as above — consolidate Hebrew daily word content |
+| 3 | סקריבל בעברית (Hebrew Scrabble) | /he/ (unknown) | 8.8 | 168 | 0 | Hebrew page: add SoftwareApplication schema |
+| 4 | jugar scrabble | /es/juego-de-palabras-multijugador | 8.1 | 100 | 0 | Already on target page — internal links from other pages |
+| 5 | online scrabble | (unknown) | 8.1 | 66 | 1 | Create or strengthen English landing page |
+| 6 | מילה ביום (Hebrew word per day) | /he/ (unknown) | 10.4 | 50 | 0 | Consolidate Hebrew daily word queries — one authoritative page |
+
+> **Hebrew cluster** (rows 1–3, 6) is the biggest rank-up opportunity: 4 queries, 1,178 impressions total, near page-1 but getting almost no clicks. One Hebrew page improvement could push all 4 onto page 1.
+
+---
+
+## Bing Parity Gaps
+
+> **Skipped** — Bing API unavailable (proxy blocked). Run `curl -x "" https://ssl.bing.com/...` on a non-proxied machine to pull Bing data.
+
+---
+
+## GEO / AI Visibility Recommendations (FAQPage Schema)
+
+These question queries have search intent that AI overviews and featured snippets can capture. Recommended FAQ Q&A pairs for the Spanish page (`/es/juego-de-palabras-multijugador`):
+
+| Query | Impressions | Position | Status |
+|---|---|---|---|
+| best word games 2026 | 17 | 6.1 | No FAQPage schema found |
+| best boggle app | 14 | 6.6 | No FAQPage schema found |
+| best online word games 2026 | 5 | 5.4 | No FAQPage schema found |
+| how many words start with y | 5 | 10.0 | No FAQPage schema found |
+| what are the best free word games online | 4 | 16.5 | No FAQPage schema found |
+
+**Draft FAQ pairs to add to the Spanish page and a new English `/en/multiplayer-word-game-online` FAQ section:**
+
+**Q: ¿Cómo se juega Scrabble online gratis en español?**
+A: Entra en LexiClash, elige el modo multijugador, crea una sala y comparte el enlace con tus amigos. Sin registro ni descarga — empiezas a jugar en menos de 10 segundos.
+
+**Q: ¿Cuál es la mejor alternativa a Scrabble en español online?**
+A: LexiClash es una alternativa gratuita a Scrabble en español que permite jugar en tiempo real con hasta 50 jugadores, sin instalar ninguna aplicación.
+
+**Q: ¿Qué juegos de palabras online son gratuitos en 2026?**
+A: LexiClash es gratuito en todos los modos: multijugador en tiempo real, modo diario y modo solitario. No requiere registro ni tarjeta de crédito.
+
+> **English GEO gap**: "best word games 2026" (17 imp, pos 6.1) and "best boggle app" (14 imp, pos 6.6) rank in English but have no English FAQPage or structured data. Adding FAQPage schema on the English page could capture AI overview placement.
+
+---
+
+## Rising & Falling Queries (7d vs prior 7d)
+
+### Rising (>+30% impressions, ≥20 imp)
+
+| Query | Prior 7d | Last 7d | Delta | Notes |
+|---|---|---|---|---|
+| lexi game | 6 | 48 | +700% | New branded query — investigate source |
+| scrabble en linea gratis | 4 | 24 | +500% | Seasonal uptick |
+| jugar a scrabble | 25 | 121 | +384% | Surge — opportunity to capture |
+| scrabble en español | 82 | 357 | +335% | **Major surge — top priority** |
+| scrabble online en español gratis | 10 | 42 | +320% | Same page — CTR fix critical now |
+| jugar a scrabble online | 6 | 21 | +250% | Rising demand |
+| jugar scrabble online gratis sin registrarse en español | 12 | 37 | +208% | Long-tail — description should mirror this |
+| word games like boggle | 11 | 33 | +200% | English opportunity |
+| סקריבל בעברית | 31 | 77 | +148% | Hebrew Scrabble rising |
+
+### Falling (>-30% impressions, ≥20 imp)
+
+| Query | Prior 7d | Last 7d | Delta | Notes |
+|---|---|---|---|---|
+| מילת היום | 80 | 31 | -61% | Hebrew daily word falling — investigate page changes |
+| scrable español (typo variant) | 21 | 10 | -52% | Normal variance |
+| scrabble online svenska | 71 | 44 | -38% | Swedish falling — watch |
+| alfapet online gratis | 34 | 23 | -32% | Swedish falling |
+
+---
+
+## Today's Actions (3-bullet summary)
+
+1. **[DONE via PR]** Fix Spanish page (`/es/juego-de-palabras-multijugador`) title (79→59 chars) and description (169→148 chars). This is the single highest-ROI change: ~737 potential additional clicks/28d from "scrabble online" alone. All top-10 CTR opportunities map to this one page.
+
+2. **[DONE via PR]** Fix Swedish page (`/sv/swedish-multiplayer-word-game`) title — reorder to lead with "Scrabble" (the higher-volume query) rather than "Alfapet". Targets "scrabble svenska" (1,145 imp, 0.1% CTR) and "scrabble online svenska" (270 imp, 1.1% CTR vs 8% expected).
+
+3. **[TODO — manual]** Add FAQPage JSON-LD to the Spanish and English landing pages. The "scrabble en español" query is +335% week-over-week; FAQ schema can capture AI overview placement before that surge peaks. Draft Q&A pairs are in the GEO section above. Also investigate why "מילת היום" (Hebrew daily word) dropped -61% this week — possible page regression or SERP feature change.

--- a/docs/seo-daily/2026-07-06.md
+++ b/docs/seo-daily/2026-07-06.md
@@ -76,28 +76,26 @@ Criteria: avg position 8–20, impressions ≥ 50.
 
 ## GEO / AI Visibility Recommendations (FAQPage Schema)
 
-These question queries have search intent that AI overviews and featured snippets can capture. Recommended FAQ Q&A pairs for the Spanish page (`/es/juego-de-palabras-multijugador`):
+These question queries have search intent that AI overviews and featured snippets can capture. Post-run source-code audit confirmed all three key pages **already have FAQPage + HowTo JSON-LD schemas**.
 
-| Query | Impressions | Position | Status |
+| Query | Impressions | Position | Schema Status |
 |---|---|---|---|
-| best word games 2026 | 17 | 6.1 | No FAQPage schema found |
-| best boggle app | 14 | 6.6 | No FAQPage schema found |
-| best online word games 2026 | 5 | 5.4 | No FAQPage schema found |
-| how many words start with y | 5 | 10.0 | No FAQPage schema found |
-| what are the best free word games online | 4 | 16.5 | No FAQPage schema found |
+| best word games 2026 | 17 | 6.1 | ✅ English home has FAQPage (7 Q&As incl. "best free online word games in 2026") |
+| best boggle app | 14 | 6.6 | ✅ English home FAQPage covers this implicitly |
+| best online word games 2026 | 5 | 5.4 | ✅ Covered by home FAQPage |
+| how many words start with y | 5 | 10.0 | ❌ Not answered anywhere — add a Q&A to English page |
+| what are the best free word games online | 4 | 16.5 | ✅ Covered by home FAQPage |
 
-**Draft FAQ pairs to add to the Spanish page and a new English `/en/multiplayer-word-game-online` FAQ section:**
+**Schema inventory (confirmed):**
+- `/es/juego-de-palabras-multijugador`: BreadcrumbList + VideoGame/SoftwareApplication + FAQPage (7 Q&As) + HowTo (3 steps)
+- `/sv/swedish-multiplayer-word-game`: FAQPage (6 Q&As) + HowTo (3 steps)
+- `/en/` (home): FAQPage (7 Q&As)
 
-**Q: ¿Cómo se juega Scrabble online gratis en español?**
-A: Entra en LexiClash, elige el modo multijugador, crea una sala y comparte el enlace con tus amigos. Sin registro ni descarga — empiezas a jugar en menos de 10 segundos.
+**The low CTR despite good schema and ranking is not a missing-schema problem.** Likely cause: positions 1–3 for "scrabble online" are dominated by the official Hasbro/EA Scrabble app and established competitors with strong brand recognition. Even with perfect title/description, CTR at position 4–5 for a branded query may ceiling at 1–2%, not 6%. The title fix (truncation was hiding the brand name) is still the highest-ROI action available.
 
-**Q: ¿Cuál es la mejor alternativa a Scrabble en español online?**
-A: LexiClash es una alternativa gratuita a Scrabble en español que permite jugar en tiempo real con hasta 50 jugadores, sin instalar ninguna aplicación.
+**One genuine gap:** "how many words start with y" (pos 10, 5 imp) is not answered anywhere. A single FAQ entry on the English page — "How many words start with Y?" with a direct numerical answer — could capture a featured snippet. Low effort, potential outsized return.
 
-**Q: ¿Qué juegos de palabras online son gratuitos en 2026?**
-A: LexiClash es gratuito en todos los modos: multijugador en tiempo real, modo diario y modo solitario. No requiere registro ni tarjeta de crédito.
-
-> **English GEO gap**: "best word games 2026" (17 imp, pos 6.1) and "best boggle app" (14 imp, pos 6.6) rank in English but have no English FAQPage or structured data. Adding FAQPage schema on the English page could capture AI overview placement.
+> **Correction vs. earlier draft**: Initial draft incorrectly stated "No FAQPage schema found" for Spanish/English pages. Source-code audit (post-run) confirmed schemas are present.
 
 ---
 
@@ -134,4 +132,4 @@ A: LexiClash es gratuito en todos los modos: multijugador en tiempo real, modo d
 
 2. **[DONE via PR]** Fix Swedish page (`/sv/swedish-multiplayer-word-game`) title — reorder to lead with "Scrabble" (the higher-volume query) rather than "Alfapet". Targets "scrabble svenska" (1,145 imp, 0.1% CTR) and "scrabble online svenska" (270 imp, 1.1% CTR vs 8% expected).
 
-3. **[TODO — manual]** Add FAQPage JSON-LD to the Spanish and English landing pages. The "scrabble en español" query is +335% week-over-week; FAQ schema can capture AI overview placement before that surge peaks. Draft Q&A pairs are in the GEO section above. Also investigate why "מילת היום" (Hebrew daily word) dropped -61% this week — possible page regression or SERP feature change.
+3. **[TODO — manual]** All key pages already have FAQPage schema (confirmed post-run). Real GEO gap: add one FAQ entry on the English home page for "How many words start with Y?" (pos 10, featured-snippet candidate). Also investigate why "מילת היום" (Hebrew daily word) dropped -61% this week — possible page regression or SERP feature change. Hebrew cluster (4 queries, 1,178 imp, pos 8–10) is the biggest rank-up opportunity if you can push one Hebrew page to page 1.

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,12 +27,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Scrabble Online en Español Gratis — Sin Turnos Lentos, Tiempo Real | LexiClash',
-    description: 'Juega scrabble en español online gratis, sin turnos lentos. Crea sala en segundos, invita amigos y compite en tiempo real — hasta 50 jugadores, sin registro ni descarga.',
+    title: 'Scrabble Online en Español Gratis | Juega Ahora — LexiClash',
+    description: 'Juega Scrabble online gratis en español sin registro. Hasta 50 jugadores en tiempo real — crea sala en segundos y compite con amigos. Sin descarga.',
     keywords: 'jugar scrabble en español online gratis, scrabble en español online gratis, scrabble online español, cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Scrabble Online en Español Gratis — Sin Turnos Lentos, Tiempo Real | LexiClash',
-      description: 'Juega scrabble en español online gratis, sin turnos lentos. Crea sala en segundos, invita amigos y compite en tiempo real — hasta 50 jugadores, sin registro ni descarga.',
+      title: 'Scrabble Online en Español Gratis | Juega Ahora — LexiClash',
+      description: 'Juega Scrabble online gratis en español sin registro. Hasta 50 jugadores en tiempo real — crea sala en segundos y compite con amigos. Sin descarga.',
       locale: 'es_ES',
       type: 'website',
       url: pageUrl,
@@ -47,8 +47,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online en Español Gratis — Sin Turnos Lentos | LexiClash',
-      description: 'Juega scrabble en español online gratis, sin turnos lentos. Crea sala en segundos, invita amigos y compite en tiempo real — hasta 50 jugadores, sin registro ni descarga.',
+      title: 'Scrabble Online en Español Gratis | Juega Ahora — LexiClash',
+      description: 'Juega Scrabble online gratis en español sin registro. Hasta 50 jugadores en tiempo real — crea sala en segundos y compite con amigos. Sin descarga.',
       images: [`${BASE_URL}/og-image-es-multiplayer.webp`],
     },
     alternates: {

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -16,11 +16,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Alfapet & Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
+    title: 'Scrabble Online Svenska Gratis | Alfapet & Ordspel — LexiClash',
     description: 'Spela Alfapet och Scrabble online på svenska gratis — utan väntan på tur. 2–50 spelare i realtid, ingen app, ingen registrering. Starta nu →',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
-      title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',
+      title: 'Scrabble Online Svenska Gratis | Alfapet & Ordspel — LexiClash',
       description: 'Spela Scrabble och Alfapet online på svenska gratis — utan registrering, upp till 50 spelare i realtid. Skapa rum och tävla direkt!',
       locale: 'sv_SE',
       type: 'website',
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',
+      title: 'Scrabble Online Svenska Gratis | Alfapet & Ordspel — LexiClash',
       description: 'Spela Alfapet och Scrabble online på svenska i realtid. Skapa rum, bjud in med länk, tävla direkt. Gratis.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },


### PR DESCRIPTION
## Summary

Daily automated SEO optimization based on GSC data (2026-06-07 to 2026-07-04, 948 queries, 45,045 impressions).

All top-10 CTR opportunities map to two pages. Fixing their titles/descriptions is the single highest-ROI change available.

## Changes

### 1. Spanish page — `/es/juego-de-palabras-multijugador`

**Old title (79 chars — truncated in SERPs):**
`Scrabble Online en Español Gratis — Sin Turnos Lentos, Tiempo Real | LexiClash`

**New title (59 chars):**
`Scrabble Online en Español Gratis | Juega Ahora — LexiClash`

**Old description (169 chars — over 155 limit):**
`Juega scrabble en español online gratis, sin turnos lentos. Crea sala en segundos, invita amigos y compite en tiempo real — hasta 50 jugadores, sin registro ni descarga.`

**New description (148 chars):**
`Juega Scrabble online gratis en español sin registro. Hasta 50 jugadores en tiempo real — crea sala en segundos y compite con amigos. Sin descarga.`

**Why:** "scrabble online" ranks at position 4.8 with 13,121 impressions but only 0.4% CTR (expected 6%). The title was being truncated by Google, hiding the brand. Conservative 2× CTR lift = ~250 extra clicks/28d.

### 2. Swedish page — `/sv/swedish-multiplayer-word-game`

**Old title:**
`Alfapet & Scrabble Online Svenska Gratis — Spela Nu | LexiClash`

**New title:**
`Scrabble Online Svenska Gratis | Alfapet & Ordspel — LexiClash`

**Why:** "scrabble svenska" (1,145 imp, pos 7.0, 0.1% CTR) and "scrabble online svenska" (270 imp, pos 3.4, 1.1% CTR vs 8% expected) are both top queries. Leading with "Scrabble" rather than "Alfapet" better matches the higher-volume search terms.

### 3. Daily SEO report

Added `docs/seo-daily/2026-07-06.md` with full 28-day metrics, CTR opportunities, rank-up opportunities, rising/falling query analysis, and GEO/FAQ schema recommendations.

## Expected CTR Uplift

| Query | Impressions | Current CTR | Expected CTR | Potential Clicks |
|---|---|---|---|---|
| scrabble online | 13,121 | 0.4% | 6.0% | +737 |
| scrabble online español | 3,365 | 0.4% | 4.0% | +122 |
| scrabble en linea | 2,508 | 0.2% | 4.0% | +95 |
| scrabble en español online | 1,652 | 0.5% | 6.0% | +90 |
| **Conservative (2× current CTR)** | | | | **~+250 clicks/28d** |

---
_Generated by [Claude Code](https://claude.ai/code/session_01QN9xY2CS64igCjvF2zTDQk)_