### PR TITLE
fix(landing): shield dashboard hydration gap to stop profile + daily CTA flicker

### DIFF
--- a/fe-next/components/landing/LandingView.tsx
+++ b/fe-next/components/landing/LandingView.tsx
@@ -47,6 +47,7 @@ import Header from '@/components/Header';
 import { getPerfVariant } from '@/utils/perfVariant';
 import { useEvents } from '@/hooks/useEvents';
 import type { LandingInitialData } from '@/lib/landing/fetchLandingData';
+import { isDashboardProfileLoading } from '@/lib/landing/dashboardReadiness';
 
 const EventBanner = dynamic(() => import('@/components/events/EventBanner'), { ssr: false });
 const AuthModal = dynamic(() => import('@/components/auth/AuthModal'), { ssr: false });
@@ -70,7 +71,13 @@ const LandingView: React.FC<LandingViewProps> = ({ initialData, onStartOnboardin
   const { t, language } = useLanguage();
   const router = useRouter();
   const { playTrack, TRACKS } = useMusic();
-  const { isAuthenticated, isAdmin, profile, loading: authLoading } = useAuth();
+  const { isAuthenticated, isAdmin, profile, user, loading: authLoading } = useAuth();
+  // Cold-start guard: the auth session resolves (`authLoading` → false) and sets
+  // `user` before the separate profile fetch lands, so the top bar would paint the
+  // guest "Player" default then snap to the real name. Keep the profile-derived UI
+  // in its skeleton state until the profile actually resolves for a signed-in
+  // session (guests get the neutral state immediately). See pitfall Class 1.
+  const dashboardProfileLoading = isDashboardProfileLoading(authLoading, user, profile);
   const isMobilePortrait = useMobilePortrait();
   // The in-content InlineBannerAd below is a WEB monetization slot. On native it
   // would register a banner-coordinator 'slot' (priority > the bottom anchor),
@@ -218,7 +225,7 @@ const LandingView: React.FC<LandingViewProps> = ({ initialData, onStartOnboardin
         <HomeHub
           className="md:hidden"
           profile={profile}
-          authLoading={authLoading}
+          authLoading={dashboardProfileLoading}
           language={language}
           isAdmin={isAdmin}
           liveRoomStats={liveRoomStats}

--- a/fe-next/components/landing/home/HomeDailyHero.tsx
+++ b/fe-next/components/landing/home/HomeDailyHero.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Flame, ArrowRight, ArrowLeft, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { NeoSkeleton } from '@/components/ui/skeleton';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { trackLandingCtaClick } from '@/utils/growthTracking';
 import { useDailyChallengeStats, type PreloadedDailyStats } from '@/hooks/useDailyChallengeStats';
@@ -46,6 +47,12 @@ export function HomeDailyHero({ preloadedStats }: HomeDailyHeroProps) {
   const countdown = mounted ? stats.countdown : '';
   const hasPlayed = mounted ? stats.hasPlayed : false;
   const hasSolved = mounted ? stats.hasSolved : false;
+  // The CTA (Play ↔ View results) hinges entirely on `hasPlayed`, which for an
+  // authed player only becomes known once their daily snapshot resolves. Until
+  // then — and pre-mount — render a skeleton pill instead of the optimistic
+  // "Play" default, so the button never snaps from Play → View results after the
+  // fetch lands (pitfall Class 1: render the pessimistic state until it resolves).
+  const ctaLoading = !mounted || stats.loading;
   // Prefer the chest-authoritative streak threaded through `preloadedStats`
   // (all daily modes + freezes) so the fire icon matches the weekly chest; fall
   // back to the hook's localStorage value when no preloaded streak is supplied.
@@ -141,25 +148,39 @@ export function HomeDailyHero({ preloadedStats }: HomeDailyHeroProps) {
       </div>
 
       {/* CTA pill — once today's daily is played it flips from the lime "Play"
-          prompt to a calmer "View results" so it never invites a replay it can't grant. */}
-      <span
-        className={cn(
-          'absolute end-3.5 top-3.5 inline-flex items-center gap-1.5 rounded-neo-pill border-2 border-black px-3 py-[7px] font-neo-display text-[13px] font-bold uppercase shadow-hard transition-transform group-hover:translate-x-0.5 md:end-5 md:top-5 md:px-4 md:py-2 md:text-sm',
-          hasPlayed ? 'bg-neo-navy-light text-neo-cream' : 'bg-neo-lime text-neo-navy',
-        )}
-      >
-        {hasPlayed ? (
-          <>
-            {t('daily.viewResults')}
-            {hasSolved && <Check className="h-3.5 w-3.5" strokeWidth={3} aria-hidden="true" />}
-          </>
-        ) : (
-          <>
-            {t('daily.play')}
-            <Arrow className="h-3.5 w-3.5" strokeWidth={3} aria-hidden="true" />
-          </>
-        )}
-      </span>
+          prompt to a calmer "View results" so it never invites a replay it can't
+          grant. While the outcome is still resolving we paint a skeleton pill (same
+          footprint) rather than guess "Play" — otherwise it would visibly snap to
+          "View results" for a player who has already completed today's challenge. */}
+      {ctaLoading ? (
+        <span
+          data-testid="daily-cta-skeleton"
+          aria-hidden="true"
+          className="absolute end-3.5 top-3.5 md:end-5 md:top-5"
+        >
+          <NeoSkeleton variant="default" width={104} height={34} className="rounded-neo-pill border-2 border-black" />
+        </span>
+      ) : (
+        <span
+          data-testid="daily-cta"
+          className={cn(
+            'absolute end-3.5 top-3.5 inline-flex items-center gap-1.5 rounded-neo-pill border-2 border-black px-3 py-[7px] font-neo-display text-[13px] font-bold uppercase shadow-hard transition-transform group-hover:translate-x-0.5 md:end-5 md:top-5 md:px-4 md:py-2 md:text-sm',
+            hasPlayed ? 'bg-neo-navy-light text-neo-cream' : 'bg-neo-lime text-neo-navy',
+          )}
+        >
+          {hasPlayed ? (
+            <>
+              {t('daily.viewResults')}
+              {hasSolved && <Check className="h-3.5 w-3.5" strokeWidth={3} aria-hidden="true" />}
+            </>
+          ) : (
+            <>
+              {t('daily.play')}
+              <Arrow className="h-3.5 w-3.5" strokeWidth={3} aria-hidden="true" />
+            </>
+          )}
+        </span>
+      )}
     </Link>
   );
 }

--- a/fe-next/components/landing/home/__tests__/HomeDailyHero.test.tsx
+++ b/fe-next/components/landing/home/__tests__/HomeDailyHero.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { HomeDailyHero } from '../HomeDailyHero';
+import type { DailyChallengeStats } from '@/hooks/useDailyChallengeStats';
+
+// next primitives → plain DOM so the CTA text/skeletons are queryable in jsdom.
+vi.mock('next/image', () => ({
+  // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+  default: (props: any) => <img {...props} />,
+}));
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const T_MAP: Record<string, string> = {
+  'daily.title': 'Daily Challenge',
+  'daily.play': 'PLAY',
+  'daily.viewResults': 'VIEW RESULTS',
+  'landing.home.todaysPuzzle': "Today's Puzzle",
+};
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (key === 'landing.home.puzzleNo') return `Daily #${params?.n ?? 0}`;
+      if (key === 'landing.home.resetsIn') return `Resets in ${params?.time ?? ''}`;
+      if (key === 'landing.home.dayStreak') return `${params?.n ?? 0}d`;
+      return T_MAP[key] ?? key;
+    },
+    language: 'en',
+    dir: 'ltr',
+  }),
+}));
+
+// The hook under test's *contract* — the component must gate on `loading`.
+let mockStats: DailyChallengeStats;
+vi.mock('@/hooks/useDailyChallengeStats', () => ({
+  useDailyChallengeStats: () => mockStats,
+}));
+
+vi.mock('@/hooks/useWeeklyChest', () => ({
+  useWeeklyChest: () => ({
+    loading: false,
+    currentStreak: 0,
+    completedDates: [] as string[],
+    cycleStart: '',
+  }),
+}));
+
+vi.mock('@/utils/dailyChallenge/storage', () => ({
+  getLastSevenDaysCompletion: () => [] as string[],
+}));
+
+vi.mock('@/utils/growthTracking', () => ({
+  trackLandingCtaClick: vi.fn(),
+}));
+
+function baseStats(over: Partial<DailyChallengeStats> = {}): DailyChallengeStats {
+  return {
+    countdown: '05:00:00',
+    hasPlayed: false,
+    hasSolved: false,
+    streak: 0,
+    puzzleNumber: 173,
+    isClient: true,
+    loading: false,
+    ...over,
+  };
+}
+
+describe('HomeDailyHero — CTA hydration gate', () => {
+  beforeEach(() => {
+    mockStats = baseStats();
+  });
+
+  it('shows a skeleton for the CTA while the daily status is still loading — never the optimistic PLAY default', () => {
+    mockStats = baseStats({ loading: true, hasPlayed: false, hasSolved: false });
+    render(<HomeDailyHero preloadedStats={{ hasPlayed: false, hasSolved: null, currentStreak: 0, loading: true }} />);
+
+    expect(screen.getByTestId('daily-cta-skeleton')).toBeInTheDocument();
+    // The buggy behaviour was rendering PLAY here, which then snapped to VIEW RESULTS.
+    expect(screen.queryByText('PLAY')).not.toBeInTheDocument();
+    expect(screen.queryByText('VIEW RESULTS')).not.toBeInTheDocument();
+  });
+
+  it('renders VIEW RESULTS once a completed daily resolves', () => {
+    mockStats = baseStats({ loading: false, hasPlayed: true, hasSolved: true });
+    render(<HomeDailyHero preloadedStats={{ hasPlayed: true, hasSolved: true, currentStreak: 3, loading: false }} />);
+
+    expect(screen.queryByTestId('daily-cta-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByText('VIEW RESULTS')).toBeInTheDocument();
+    expect(screen.queryByText('PLAY')).not.toBeInTheDocument();
+  });
+
+  it('renders PLAY once a not-yet-played daily resolves', () => {
+    mockStats = baseStats({ loading: false, hasPlayed: false, hasSolved: false });
+    render(<HomeDailyHero preloadedStats={{ hasPlayed: false, hasSolved: null, currentStreak: 0, loading: false }} />);
+
+    expect(screen.queryByTestId('daily-cta-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByText('PLAY')).toBeInTheDocument();
+    expect(screen.queryByText('VIEW RESULTS')).not.toBeInTheDocument();
+  });
+});

--- a/fe-next/hooks/__tests__/useDailyChallengeStats.loading.test.tsx
+++ b/fe-next/hooks/__tests__/useDailyChallengeStats.loading.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDailyChallengeStats } from '@/hooks/useDailyChallengeStats';
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ language: 'en' }),
+}));
+
+vi.mock('@/hooks/useSafeTimeout', () => ({
+  useInterval: () => {},
+}));
+
+// Control the localStorage-backed daily helpers so we can isolate the
+// preloaded-server-snapshot resolution path (the source of the CTA flicker).
+const mockGetWordHuntStatusToday = vi.fn();
+vi.mock('@/utils/dailyChallenge', () => ({
+  getDailyChallengeDate: () => '2026-07-06',
+  getPuzzleNumber: () => 173,
+  getSecondsUntilNextDaily: () => 3600,
+  formatCountdown: () => '01:00:00',
+  getWordHuntStatusToday: (...args: unknown[]) => mockGetWordHuntStatusToday(...args),
+  getDailyStreak: () => ({ currentStreak: 0 }),
+}));
+
+describe('useDailyChallengeStats — loading contract', () => {
+  beforeEach(() => {
+    mockGetWordHuntStatusToday.mockReset();
+    mockGetWordHuntStatusToday.mockReturnValue(null);
+  });
+
+  it('stays loading while an authed server snapshot is still pending', () => {
+    // preloadedStats.loading === true and no local status → the outcome is unknown,
+    // so the hook must report loading (consumers render the pessimistic state).
+    const { result } = renderHook(() =>
+      useDailyChallengeStats({ hasPlayed: false, hasSolved: null, currentStreak: 0, loading: true }),
+    );
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('resolves (loading=false) once the server snapshot lands', () => {
+    const { result } = renderHook(() =>
+      useDailyChallengeStats({ hasPlayed: true, hasSolved: true, currentStreak: 4, loading: false }),
+    );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.hasPlayed).toBe(true);
+  });
+
+  it('resolves immediately from local status even if the server snapshot is still loading', () => {
+    mockGetWordHuntStatusToday.mockReturnValue({ solved: true });
+    const { result } = renderHook(() =>
+      useDailyChallengeStats({ hasPlayed: false, hasSolved: null, currentStreak: 0, loading: true }),
+    );
+    // Local completion is authoritative for "I played today on this device".
+    expect(result.current.loading).toBe(false);
+    expect(result.current.hasPlayed).toBe(true);
+    expect(result.current.hasSolved).toBe(true);
+  });
+});

--- a/fe-next/hooks/useDailyChallengeStats.ts
+++ b/fe-next/hooks/useDailyChallengeStats.ts
@@ -28,6 +28,14 @@ export interface DailyChallengeStats {
   streak: number;
   puzzleNumber: number;
   isClient: boolean;
+  /**
+   * True until today's win/loss outcome is *known* — i.e. an authed player's
+   * server snapshot is still in flight and no local completion exists yet.
+   * Consumers must render the pessimistic/skeleton state while this is true
+   * instead of the optimistic "not played → Play" default, which would flip to
+   * "View results" once the snapshot lands (the CTA-flicker bug, pitfall Class 1).
+   */
+  loading: boolean;
 }
 
 /**
@@ -50,6 +58,11 @@ export function useDailyChallengeStats(preloadedStats?: PreloadedDailyStats): Da
   const [streak, setStreak] = useState<number>(preloadedStats?.currentStreak ?? 0);
   const [puzzleNumber, setPuzzleNumber] = useState<number>(preloadedStats?.puzzleNumber ?? 0);
   const [isClient, setIsClient] = useState(false);
+  // Outcome-resolution flag. Seeds pessimistically to `true` so SSR + the first
+  // client frame both paint the not-yet-known state; the mount effect flips it to
+  // `false` the moment the outcome is known (local completion, resolved server
+  // snapshot, or a guest with no server fetch pending).
+  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
     setIsClient(true);
@@ -68,6 +81,7 @@ export function useDailyChallengeStats(preloadedStats?: PreloadedDailyStats): Da
       setHasSolved(localStatus.solved);
       setStreak(getDailyStreak().currentStreak);
       setPuzzleNumber(preloadedStats?.puzzleNumber || getPuzzleNumber(date));
+      setLoading(false);
       return;
     }
 
@@ -76,6 +90,7 @@ export function useDailyChallengeStats(preloadedStats?: PreloadedDailyStats): Da
       setHasSolved(preloadedStats.hasSolved ?? false);
       setStreak(preloadedStats.currentStreak);
       setPuzzleNumber(preloadedStats.puzzleNumber || getPuzzleNumber(date));
+      setLoading(false);
       return;
     }
 
@@ -83,6 +98,11 @@ export function useDailyChallengeStats(preloadedStats?: PreloadedDailyStats): Da
     setHasPlayed(false);
     setHasSolved(false);
     setStreak(getDailyStreak().currentStreak);
+    // Keep loading=true ONLY while an authed server snapshot is genuinely still
+    // in flight (`preloadedStats.loading`). With no preloaded feed at all,
+    // localStorage is the sole source of truth and it has already resolved here,
+    // so the outcome is known — don't strand consumers in a skeleton forever.
+    setLoading(preloadedStats?.loading ?? false);
   }, [language, preloadedStats]);
 
   // Refresh outcome when the tab regains focus (player may have just finished a
@@ -94,6 +114,9 @@ export function useDailyChallengeStats(preloadedStats?: PreloadedDailyStats): Da
       setHasPlayed(!!status);
       setHasSolved(status?.solved ?? false);
       setStreak(getDailyStreak().currentStreak);
+      // A focus/visibility refresh reads the freshest local truth synchronously —
+      // the outcome is known, so clear any lingering loading state.
+      setLoading(false);
     };
     const onVisible = () => document.visibilityState === 'visible' && refresh();
     document.addEventListener('visibilitychange', onVisible);
@@ -112,7 +135,7 @@ export function useDailyChallengeStats(preloadedStats?: PreloadedDailyStats): Da
     isClient ? 1000 : null,
   );
 
-  return { countdown, hasPlayed, hasSolved, streak, puzzleNumber, isClient };
+  return { countdown, hasPlayed, hasSolved, streak, puzzleNumber, isClient, loading };
 }
 
 export default useDailyChallengeStats;

--- a/fe-next/lib/landing/__tests__/dashboardReadiness.test.ts
+++ b/fe-next/lib/landing/__tests__/dashboardReadiness.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { isDashboardProfileLoading } from '../dashboardReadiness';
+
+/**
+ * The dashboard top bar must render the pessimistic (skeleton) state until the
+ * signed-in player's profile actually lands — never the guest "Player" default
+ * that would then snap to their real username (cold-start flicker, pitfall
+ * Class 1: dual source of truth + async resolution).
+ */
+describe('isDashboardProfileLoading', () => {
+  const profile = { id: 'u1', display_name: 'Maya' } as any;
+  const user = { id: 'u1' } as any;
+
+  it('is loading while auth itself is still resolving', () => {
+    expect(isDashboardProfileLoading(true, null, null)).toBe(true);
+  });
+
+  it('is loading for a signed-in session whose profile row has not arrived yet', () => {
+    // The exact cold-start gap: `user` is set, `loading` already flipped false,
+    // but `profile` is still null while fetchUserData is in flight.
+    expect(isDashboardProfileLoading(false, user, null)).toBe(true);
+  });
+
+  it('is resolved once the profile lands for a signed-in user', () => {
+    expect(isDashboardProfileLoading(false, user, profile)).toBe(false);
+  });
+
+  it('is NOT loading for a guest (no session) — they get the neutral state, not an endless skeleton', () => {
+    expect(isDashboardProfileLoading(false, null, null)).toBe(false);
+  });
+});

--- a/fe-next/lib/landing/dashboardReadiness.ts
+++ b/fe-next/lib/landing/dashboardReadiness.ts
@@ -1,0 +1,37 @@
+/**
+ * Dashboard hydration-readiness helpers.
+ *
+ * Keep side-effect-free + framework-free so they're unit-testable and shared by
+ * the home surfaces (top bar profile, daily hero) that must shield the view
+ * during the profile/challenge hydration gap.
+ */
+
+import type { ProfileData } from '@/contexts/auth/authTypes';
+import type { User } from '@supabase/supabase-js';
+
+/**
+ * Should the dashboard treat the player's profile as still loading?
+ *
+ * The auth `loading` flag alone is insufficient: on cold-start the initial
+ * session resolves (`loading` → false) and `user` is set, but `profile` is
+ * fetched separately and lands 1–3s later. Rendering during that window paints
+ * the guest "Player" default, which then snaps to the real username — the
+ * reported flicker.
+ *
+ * Rule: keep loading TRUE until the profile actually resolves for a signed-in
+ * session, while a guest (no `user`) is never "loading" — they get the neutral
+ * state immediately instead of an endless skeleton.
+ *
+ * @param authLoading - `loading` from the auth context (session still resolving)
+ * @param user        - the authenticated session user, or null for a guest
+ * @param profile     - the resolved profile row, or null while it is in flight
+ */
+export function isDashboardProfileLoading(
+  authLoading: boolean,
+  user: User | null,
+  profile: ProfileData | null,
+): boolean {
+  if (authLoading) return true;
+  // Signed-in session whose profile row hasn't arrived yet → still pessimistic.
+  return !!user && !profile;
+}


### PR DESCRIPTION
## Problem

Two home-dashboard surfaces rendered **optimistic defaults before their async data resolved**, then visibly snapped to the real values — a textbook instance of the repo's own **pitfall Class 1 (dual source of truth + async resolution)**.

1. **Profile top bar** — on cold start the auth session resolves (`loading` → `false`) and `user` is set, but the profile row is fetched *separately* and lands 1–3s later. During that gap the top bar painted the guest **"Player"** default, then flipped to the real username.
2. **Daily Challenge CTA** — the **"Play" ↔ "View results"** pill hinges on `hasPlayed`, which for an authed player is only known once their daily snapshot resolves. The CTA defaulted to **"Play"** while loading, so a player who had *already completed* today's daily saw it snap to **"View results"** after a few seconds.

## Root cause

- The initial-session auth path fires `fetchUserData` **without awaiting it** and clears `loading` immediately, while the `SIGNED_IN` event path *does* await the profile first — a Class 3 asymmetric-paths divergence. So `authLoading` is `false` while `profile` is still `null`.
- `useDailyChallengeStats` never surfaced a loading signal, so `HomeDailyHero` had no way to distinguish "not played" from "outcome not yet known" and defaulted to the optimistic `Play` state.

## Fix

Render the **pessimistic (skeleton) state until each source resolves**, per the Class 1 checklist — done at the dashboard layer so there's no global auth-loading behaviour change:

- **Profile:** new pure helper `isDashboardProfileLoading(authLoading, user, profile)` stays `true` for a signed-in session until its profile actually resolves; guests (no `user`) still get the neutral state instantly (never an endless skeleton). Wired into `LandingView` → `HomeHub`/`HomeTopBar`, which already render name/level/coins skeletons off this flag.
- **Daily CTA:** `useDailyChallengeStats` now exposes a `loading` flag (true only while an authed server snapshot is genuinely in flight and no local completion exists; local completion and guests resolve immediately). `HomeDailyHero` renders a skeleton pill while loading instead of guessing "Play", so the button never flips Play → View results.

Both transitions now go **skeleton → correct value**, with no intermediate wrong state.

## Tests

TDD (RED → GREEN):

- `lib/landing/__tests__/dashboardReadiness.test.ts` — the profile-loading rule across auth-resolving / cold-start-gap / resolved / guest.
- `hooks/__tests__/useDailyChallengeStats.loading.test.tsx` — the hook's `loading` contract (pending server snapshot stays loading; resolves on snapshot; local completion resolves immediately).
- `components/landing/home/__tests__/HomeDailyHero.test.tsx` — CTA renders a skeleton while loading (never "PLAY"), then "VIEW RESULTS" / "PLAY" once resolved.

All touched suites green (263 tests), `tsc --noEmit` clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTD74av6aJmAsZhgUq8aZ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTD74av6aJmAsZhgUq8aZ5)_