### PR TITLE
fix(consent): stop blocking consent modal from trapping users (zero-signups investigation)

### DIFF
--- a/fe-next/utils/__tests__/cookieConsent.storageResilience.test.ts
+++ b/fe-next/utils/__tests__/cookieConsent.storageResilience.test.ts
@@ -1,0 +1,58 @@
+/**
+ * cookieConsent — storage-resilience guard.
+ *
+ * The consent modal (fixed inset-0, blocking) closes only after its
+ * Accept/Decline handler runs `setConsentState` to completion. Before this
+ * guard, `setConsentState` called `localStorage.setItem` with no try/catch —
+ * so in any context where the write throws (iOS Safari private mode, many
+ * in-app / social webviews with partitioned or blocked storage) the handler
+ * threw before closing the modal, permanently trapping the user behind the
+ * consent wall with every Play / Sign-up button unreachable.
+ *
+ * A consent DECISION must always apply in-session (dispatch the change event so
+ * PostHog opts in/out and the modal closes) even when it cannot be PERSISTED.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setConsentState, acceptAll, declineAll, resetConsent } from '../cookieConsent';
+
+const CONSENT_EVENT = 'cookie-consent-change';
+
+describe('cookieConsent — resilience when localStorage.setItem throws', () => {
+  let setItemSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    // Simulate blocked/partitioned storage: reads work, writes throw.
+    setItemSpy = vi
+      .spyOn(window.localStorage, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+  });
+
+  afterEach(() => {
+    setItemSpy.mockRestore();
+  });
+
+  it('setConsentState does not throw when the write fails', () => {
+    expect(() => setConsentState({ analytics: true, advertising: true })).not.toThrow();
+    expect(setItemSpy).toHaveBeenCalled(); // prove the throwing write path was exercised
+  });
+
+  it('setConsentState still dispatches the change event so listeners (PostHog opt-in) fire', () => {
+    const handler = vi.fn();
+    window.addEventListener(CONSENT_EVENT, handler);
+    setConsentState({ analytics: true, advertising: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+    const detail = (handler.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail.analytics).toBe(true);
+    window.removeEventListener(CONSENT_EVENT, handler);
+  });
+
+  it('acceptAll / declineAll / resetConsent do not throw when the write fails', () => {
+    expect(() => acceptAll()).not.toThrow();
+    expect(() => declineAll()).not.toThrow();
+    expect(() => resetConsent()).not.toThrow();
+  });
+});

--- a/fe-next/utils/cookieConsent.ts
+++ b/fe-next/utils/cookieConsent.ts
@@ -26,19 +26,50 @@ const DEFAULT_STATE: ConsentState = {
   timestamp: 0,
 };
 
+/**
+ * Storage in some contexts (iOS Safari private mode, many in-app / social
+ * webviews with partitioned or blocked storage) throws on write — and
+ * occasionally on read. A consent DECISION must still apply in-session (so the
+ * blocking modal closes and PostHog opts in/out) even when it can't be
+ * PERSISTED. These helpers never throw; a failed persist just means the choice
+ * is re-asked next session, which is far better than trapping the user behind
+ * the consent wall with every signup entry point unreachable.
+ */
+function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+function safeSetItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // best-effort persistence — see note above
+  }
+}
+function safeRemoveItem(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // best-effort — see note above
+  }
+}
+
 /** Check if user has made any consent decision */
 export function hasConsentDecision(): boolean {
   if (typeof window === 'undefined') return false;
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const stored = safeGetItem(STORAGE_KEY);
   // Also check legacy key for migration
-  if (!stored && localStorage.getItem('cookie-consent')) return true;
+  if (!stored && safeGetItem('cookie-consent')) return true;
   return stored !== null;
 }
 
 /** Migrate from legacy cookie-consent (accept/decline) to v2 granular format */
 function migrateLegacyConsent(): ConsentState | null {
   if (typeof window === 'undefined') return null;
-  const legacy = localStorage.getItem('cookie-consent');
+  const legacy = safeGetItem('cookie-consent');
   if (!legacy) return null;
 
   const accepted = legacy === 'accepted';
@@ -50,8 +81,8 @@ function migrateLegacyConsent(): ConsentState | null {
   };
 
   // Save in new format and remove legacy key
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-  localStorage.removeItem('cookie-consent');
+  safeSetItem(STORAGE_KEY, JSON.stringify(state));
+  safeRemoveItem('cookie-consent');
   return state;
 }
 
@@ -59,7 +90,7 @@ function migrateLegacyConsent(): ConsentState | null {
 export function getConsentState(): ConsentState {
   if (typeof window === 'undefined') return DEFAULT_STATE;
 
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const stored = safeGetItem(STORAGE_KEY);
   if (stored) {
     try {
       const parsed = JSON.parse(stored) as ConsentState;
@@ -94,7 +125,11 @@ export function setConsentState(state: Partial<Omit<ConsentState, 'essential' | 
     timestamp: Date.now(),
   };
 
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  // Persist best-effort. A failed write must NOT prevent the decision from
+  // applying in-session below — otherwise the blocking consent modal never
+  // closes (its Accept/Decline handler throws before setVisible(false)),
+  // trapping the user with every Play / Sign-up button unreachable.
+  safeSetItem(STORAGE_KEY, JSON.stringify(updated));
 
   // Update Google Consent Mode v2
   updateGoogleConsent(updated);
@@ -116,8 +151,8 @@ export function declineAll(): void {
 /** Reset consent (user wants to re-choose) */
 export function resetConsent(): void {
   if (typeof window === 'undefined') return;
-  localStorage.removeItem(STORAGE_KEY);
-  localStorage.removeItem('cookie-consent');
+  safeRemoveItem(STORAGE_KEY);
+  safeRemoveItem('cookie-consent');
 
   // Reset Google Consent Mode to denied
   updateGoogleConsent(DEFAULT_STATE);


### PR DESCRIPTION
## Investigation: why signups dropped to ~0 "in the last few days"

Traced to **`f54721c2` (Jul 6) — `fix(consent): convert cookie notice to blocking modal`**, which replaced the ignorable bottom-banner cookie notice with a **full-screen blocking modal** mounted globally over every page (`app/[locale]/layout.tsx:676`).

### Why this crushes signups
1. **Hard top-of-funnel wall.** The modal is `fixed inset-0` with a click-capturing backdrop, body-scroll lock, focus-trap, and no Escape/backdrop dismiss. Every new visitor (i.e. the entire signup population, who have no stored consent) must interact with it before they can reach any Play / Sign-up / Google-login button. The old banner was non-blocking and could be ignored.
2. **Metric suppression.** Signups are tracked as PostHog `signup_completed`, and PostHog is opt-out by default (`PostHogProvider.tsx:48,62`; default `analytics:false`). The modal makes "Decline All" a prominent, required, one-click choice → `opt_out_capturing()` → the user's subsequent signup fires no PostHog event.
3. **Permanent trap (the concrete bug fixed here).** `setConsentState` wrote to `localStorage` with **no error handling**, and the Accept/Decline handler closes the modal only *after* it returns. Where `localStorage.setItem` throws — iOS Safari private mode and many in-app/social webviews with partitioned/blocked storage, a large share of ad/social traffic — the handler throws before `setVisible(false)`, leaving the modal up forever with every signup entry point unreachable. The old banner degraded gracefully; the new modal did not.

### Ruled out
- Auth flow (`lib/supabase.ts`, `auth/callback/*`), `AuthContext`, `growthTracking`, PostHog init — no recent changes.
- Recent DB migrations are quick-play only; the `handle_new_user` trigger was not touched (not a broken profiles-insert).

## The fix
Per the chosen direction (keep the modal, harden it): guard all raw `localStorage` access in `utils/cookieConsent.ts` behind `safeGetItem` / `safeSetItem` / `safeRemoveItem` helpers that never throw. A consent decision now always applies in-session (dispatches the change event so PostHog opts in/out and the modal closes) even when it can't be persisted — a failed persist just re-asks next session instead of trapping the visitor.

## Tests
Added `utils/__tests__/cookieConsent.storageResilience.test.ts` (RED→GREEN): with `localStorage.setItem` throwing, `setConsentState` / `acceptAll` / `declineAll` / `resetConsent` no longer throw and still dispatch the `cookie-consent-change` event. All existing CookieConsent tests pass; `tsc --noEmit` and eslint clean on changed files.

## How to confirm the diagnosis with data
`select count(*) from auth.users where created_at > now() - interval '4 days';`
- `> 0` → real users are signing up but the consent wall + PostHog opt-out was suppressing the tracked metric (and this fix removes the trap for blocked-storage users).
- `= 0` → users are being walled/trapped out entirely; this fix removes the hardest failure mode. Consider also softening the blocking behavior if the number stays low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019b3udTnkFZvbZr78AKqdQB)_