### PR TITLE
test: repair three pre-existing master test failures

### DIFF
--- a/fe-next/app/[locale]/__tests__/PageClient.inviteAutoOpen.test.tsx
+++ b/fe-next/app/[locale]/__tests__/PageClient.inviteAutoOpen.test.tsx
@@ -41,10 +41,13 @@ vi.mock('@/components/CrazyGamesSDK', () => ({
   detectCrazyGamesSync: () => false,
 }));
 
-// Avoid PostHog network calls from trackInviteLanded.
+// Avoid PostHog network calls. PageClient also fires trackGrowthEvent
+// ('landing_view') from a mount effect, so the mock must expose it too —
+// otherwise the mounted component throws "No trackGrowthEvent export".
 vi.mock('@/utils/growthTracking', () => ({
   trackInviteLanded: vi.fn(),
   trackInviteRedirectFired: vi.fn(),
+  trackGrowthEvent: vi.fn(),
 }));
 
 describe('HomePageClient new-user room invite', () => {

--- a/fe-next/components/singleplayer/game/hooks/__tests__/useSinglePlayerCore.quitTracking.test.ts
+++ b/fe-next/components/singleplayer/game/hooks/__tests__/useSinglePlayerCore.quitTracking.test.ts
@@ -22,7 +22,7 @@ vi.mock('@/contexts/AccessibilityContext', () => ({
   useSuppressTimerUrgency: () => false,
 }));
 vi.mock('@/contexts/SoundEffectsContext', () => ({
-  useSoundEffects: () => ({ playSound: vi.fn(), stopSound: vi.fn(), playWordFound: vi.fn(), playWordError: vi.fn(), playCountdownBeep: vi.fn(), stopAllMusic: vi.fn() }),
+  useSoundEffects: () => ({ playSound: vi.fn(), stopSound: vi.fn(), playWordFound: vi.fn(), playWordError: vi.fn(), playCountdownBeep: vi.fn(), stopAllMusic: vi.fn(), setGameActive: vi.fn() }),
 }));
 vi.mock('@/hooks/useGameMusic', () => ({ useGameMusic: () => ({ startMusic: vi.fn(), stopMusic: vi.fn() }) }));
 vi.mock('@/hooks/useEarthquakeFireRound', () => ({ useEarthquakeFireRound: () => ({ fireRoundActive: false, fireRoundRemaining: 0, earthquakeState: null, startFireRound: vi.fn() }) }));
@@ -45,10 +45,26 @@ vi.mock('@/hooks/useKeyboardWordInput', () => ({ useKeyboardWordInput: () => ({ 
 vi.mock('@/utils/singlePlayerAchievements', () => ({ checkLiveAchievements: () => [], createAchievementState: () => ({}) }));
 vi.mock('@/shared/utils/scoring', () => ({ getComboBonus: () => 0, calculateWordScore: () => 5 }));
 vi.mock('@/lib/cosy/cosyGameplay', () => ({ shouldPlayCountdownBeep: () => false }));
-vi.mock('./useBotSimulation', () => ({ useBotSimulation: () => ({ botScores: [], simulateBotWord: vi.fn() }) }));
-vi.mock('./useSpamDetection', () => ({ useSpamDetection: () => ({ checkSpam: vi.fn() }) }));
-vi.mock('./useSinglePlayerEffects', () => ({ useSinglePlayerEffects: vi.fn() }));
-vi.mock('./buildGameResults', () => ({
+// These siblings live one level up from __tests__/, and useSinglePlayerCore
+// imports them as './…'. vi.mock resolves relative to THIS test file, so the
+// specifier must be '../…' to actually intercept core's import — with './…' the
+// mock silently no-ops and the REAL hooks run (network heartbeat, undefined refs).
+// Match the hooks' real return shapes — core destructures botWords/resetBots/
+// initializeBotUsedWords and checkSubmission/resetSpamDetection, so a partial
+// mock leaves those undefined and the rendered hook throws when it calls them.
+vi.mock('../useBotSimulation', () => ({ useBotSimulation: () => ({ botScores: [], botWords: [], resetBots: vi.fn(), initializeBotUsedWords: vi.fn() }) }));
+vi.mock('../useSpamDetection', () => ({ useSpamDetection: () => ({ checkSubmission: vi.fn(() => ({ allowed: true })), resetSpamDetection: vi.fn() }) }));
+// Core reads effects.gameStartTimeRef/lastWordFoundTimeRef/showLandscapeTutorial/
+// dismissLandscapeTutorial, so the mock must return that shape (not bare undefined).
+vi.mock('../useSinglePlayerEffects', () => ({
+  useSinglePlayerEffects: () => ({
+    showLandscapeTutorial: false,
+    dismissLandscapeTutorial: vi.fn(),
+    lastWordFoundTimeRef: { current: 0 },
+    gameStartTimeRef: { current: 0 },
+  }),
+}));
+vi.mock('../buildGameResults', () => ({
   buildGameResults: vi.fn(),
   buildFallbackResults: vi.fn(),
   emitSinglePlayerGameEnd: vi.fn(),
@@ -67,7 +83,9 @@ import type { SinglePlayerGameState } from '../../../SinglePlayerView';
 
 const baseSettings: SinglePlayerGameState = {
   mode: 'classic',
-  difficulty: 'medium',
+  // DIFFICULTIES is keyed EASY/MEDIUM/HARD (uppercase) — a lowercase 'medium'
+  // yields an undefined config and a "reading 'rows'" crash on the classic path.
+  difficulty: 'MEDIUM',
   language: 'en',
   timerSeconds: 180,
   gridSize: 4,

--- a/fe-next/lib/tutorial/modeCoachContent.test.ts
+++ b/fe-next/lib/tutorial/modeCoachContent.test.ts
@@ -52,13 +52,19 @@ describe('modeCoachContent', () => {
     expect(MODE_COACH.blast.tier).toBe('rich');
   });
 
-  it('every rich step declares an animated demo type (not a plain icon)', () => {
+  // The rich tier is defined by being animation-FORWARD: it must LEAD with an
+  // animated gesture demo and never degrade into an all-static coach (that is
+  // what the `simple` tier is for). A rich coach MAY still close with one static
+  // info step where no gesture demo fits the copy — e.g. wordHunt's "Short words
+  // cost no try" rule — so the contract is "leads animated + has ≥1 animated
+  // demo", not "every single step is animated".
+  it('every rich coach leads with an animated demo and is never all-static', () => {
     for (const mode of ALL_COACH_MODES) {
       const c = MODE_COACH[mode];
       if (c.tier !== 'rich') continue;
-      for (const step of c.steps) {
-        expect(step.demo, `${mode} rich step needs a demo`).not.toBe('icon');
-      }
+      expect(c.steps[0]?.demo, `${mode} rich coach must OPEN with an animated demo`).not.toBe('icon');
+      const animated = c.steps.filter((step) => step.demo !== 'icon');
+      expect(animated.length, `${mode} rich coach needs ≥1 animated demo`).toBeGreaterThan(0);
     }
   });
 


### PR DESCRIPTION
## Problem

Three test suites are red on `master` (Vitest shards 3 & 4), which blocks the `ci-success` gate on every open PR — including unrelated ones. None involve product code; each is a stale or incorrect **test** that drifted from the source it exercises. Reproduced locally on a clean `master` checkout.

## Fixes (test-only — no product/source files touched)

### 1. `app/[locale]/__tests__/PageClient.inviteAutoOpen.test.tsx`
`PageClient` fires `trackGrowthEvent('landing_view', …)` from a mount effect, but the `@/utils/growthTracking` mock only exported `trackInviteLanded`/`trackInviteRedirectFired` → *"No `trackGrowthEvent` export is defined on the mock."* Added `trackGrowthEvent` to the mock.

### 2. `components/singleplayer/game/hooks/__tests__/useSinglePlayerCore.quitTracking.test.ts`
Several mock defects that surfaced one after another once each was fixed:
- **`useSoundEffects` mock** was missing `setGameActive` (destructured in core, called by the effects hook's mount effect) → *"setGameActive is not a function"*.
- **Sibling mocks used `'./…'`**, which `vi.mock` resolves relative to `__tests__/`, so they never intercepted core's `'./…'` imports — the **real** hooks ran (network heartbeat to `:3000`, undefined refs). Corrected to `'../…'`.
- **Mock return shapes were wrong**: core reads `effects.gameStartTimeRef` / `lastWordFoundTimeRef` / `showLandscapeTutorial` / `dismissLandscapeTutorial`, `useBotSimulation`'s `resetBots` / `initializeBotUsedWords` / `botWords`, and `useSpamDetection`'s `checkSubmission` / `resetSpamDetection` (the mock had returned a non-existent `checkSpam`). Filled in the real shapes.
- **`baseSettings.difficulty` was `'medium'`** but `DIFFICULTIES` is keyed `EASY`/`MEDIUM`/`HARD` → *"Cannot read properties of undefined (reading 'rows')"*. Changed to `'MEDIUM'`.

### 3. `lib/tutorial/modeCoachContent.test.ts`
Commit `f881ce1` added a trailing static info step to the **rich** wordHunt coach (`"Short words cost no try"`, `demo: 'icon'`) — a rule no gesture demo faithfully fits. The stale *"every rich step is animated"* invariant no longer held. Relaxed it to the rule that actually defines the tier: **a rich coach must lead with an animated demo and have at least one — never degrade to all-static**. This still fails a genuinely broken (all-icon) rich coach, and keeps the shipped info step.

## Testing
- All three suites pass locally (`11 tests`).
- `tsc --noEmit` clean for the changed files.

## Note
This PR is intentionally separate from #705 (the Word Tower toast-cleanup fix) so that change stays scoped. Merging this should turn the `ci-success` gate green for open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXWjoUvvkq9pB3PK3xm1f

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeXWjoUvvkq9pB3PK3xm1f)_