### PR TITLE
SEO: daily meta tag improvements (2026-07-08)

### DIFF
--- a/docs/seo-daily/2026-07-08.md
+++ b/docs/seo-daily/2026-07-08.md
@@ -97,8 +97,9 @@ Very low volume (max 3 impr/query). Top: "online multiplayer word games like han
 
 ## Today's Actions
 
-1. ✅ **`/es/juego-de-palabras-multijugador`** — title + description (meta, OG, Twitter) rewritten. Old desc buried "gratis" mid-sentence; new: front-loads "sin registro, sin descarga" — the #1 CTR drivers for free-game queries. Potential: +717 clicks/28d if CTR moves from 0.3% → 2% on the "scrabble online" cluster.
-2. 📋 **Tomorrow: Hebrew rank-up** — Add internal link from `/he/hebrew-multiplayer-word-game` to `/he/daily`. "המילה היומית" + "מילת היום" + "מילה יומית" = 966 combined impr at pos 8-10; one push lands all three.
-3. 📋 **Tomorrow: education internal link** — `/en/best-online-word-games` "CLASSROOMS / EDU" card (line 360) has no `<Link>` href. Wire it to `/en/education` — founder priority + rank-up for "best word games 2026" at pos 6.1.
-4. 📋 **"lexi game" surge** — Add "Lexi Game" as alt-name or keyword to homepage `<title>` or JSON-LD. +983% 7d trend = brand shorthand gaining traction.
+1. ✅ **`/es/juego-de-palabras-multijugador`** — title trimmed 79→57 chars (was truncated in SERPs), description trimmed 169→127 chars (was truncated). New title: *"Scrabble Online en Español Gratis — Juega Ya | LexiClash"*. New desc front-loads zero-friction signals (sin registro, sin descarga). Applied to title/OG/Twitter. Potential: +717 clicks/28d if CTR lifts from 0.3% → 2% on the "scrabble online" cluster.
+2. ✅ **`/sv/swedish-multiplayer-word-game`** — reordered "Scrabble" before "Alfapet" in title/OG/Twitter (matches high-impression query "scrabble svenska" 1,112 impr at 0.09% CTR). Title trimmed 64→65 chars (still slightly over; further trim next cycle if needed). Refreshed description for tighter CTA.
+3. 📋 **Tomorrow: Hebrew rank-up** — Add internal link from `/he/hebrew-multiplayer-word-game` to `/he/daily`. "המילה היומית" + "מילת היום" + "מילה יומית" = 966 combined impr at pos 8-10; one push lands all three.
+4. 📋 **Tomorrow: education internal link** — `/en/best-online-word-games` "CLASSROOMS / EDU" card has no `<Link>` href. Wire it to `/en/education` — founder priority + rank-up for "best word games 2026" at pos 6.1.
+5. 📋 **"lexi game" surge** — Add "Lexi Game" as alt-name or keyword to homepage `<title>` or JSON-LD. +983% 7d trend = brand shorthand gaining traction.
 

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,12 +27,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Scrabble Online en Español Gratis — Sin Turnos Lentos, Tiempo Real | LexiClash',
-    description: 'Juega scrabble en español online gratis, sin turnos lentos. Crea sala en segundos, invita amigos y compite en tiempo real — hasta 50 jugadores, sin registro ni descarga.',
+    title: 'Scrabble Online en Español Gratis — Juega Ya | LexiClash',
+    description: 'Juega Scrabble en español gratis ahora. Sin registro ni descarga. Hasta 50 jugadores en tiempo real. ¡Crea tu sala en segundos!',
     keywords: 'jugar scrabble en español online gratis, scrabble en español online gratis, scrabble online español, cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Scrabble Online en Español Gratis — Sin Turnos Lentos, Tiempo Real | LexiClash',
-      description: 'Juega scrabble en español online gratis, sin turnos lentos. Crea sala en segundos, invita amigos y compite en tiempo real — hasta 50 jugadores, sin registro ni descarga.',
+      title: 'Scrabble Online en Español Gratis — Juega Ya | LexiClash',
+      description: 'Juega Scrabble en español gratis ahora. Sin registro ni descarga. Hasta 50 jugadores en tiempo real. ¡Crea tu sala en segundos!',
       locale: 'es_ES',
       type: 'website',
       url: pageUrl,
@@ -47,8 +47,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online en Español Gratis — Sin Turnos Lentos | LexiClash',
-      description: 'Juega scrabble en español online gratis, sin turnos lentos. Crea sala en segundos, invita amigos y compite en tiempo real — hasta 50 jugadores, sin registro ni descarga.',
+      title: 'Scrabble Online en Español Gratis — Juega Ya | LexiClash',
+      description: 'Juega Scrabble en español gratis ahora. Sin registro ni descarga. Hasta 50 jugadores en tiempo real. ¡Crea tu sala en segundos!',
       images: [`${BASE_URL}/og-image-es-multiplayer.webp`],
     },
     alternates: {

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -16,12 +16,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Alfapet & Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
-    description: 'Spela Alfapet och Scrabble online på svenska gratis — utan väntan på tur. 2–50 spelare i realtid, ingen app, ingen registrering. Starta nu →',
+    title: 'Scrabble & Alfapet Online Svenska Gratis — Spela Nu | LexiClash',
+    description: 'Spela Scrabble & Alfapet gratis på svenska. Utan registrering, utan app. 2–50 spelare i realtid. Starta ett spel direkt →',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
-      title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',
-      description: 'Spela Scrabble och Alfapet online på svenska gratis — utan registrering, upp till 50 spelare i realtid. Skapa rum och tävla direkt!',
+      title: 'Scrabble & Alfapet Online Svenska Gratis | LexiClash',
+      description: 'Spela Scrabble & Alfapet gratis på svenska. Utan registrering, utan app. 2–50 spelare i realtid. Starta ett spel direkt →',
       locale: 'sv_SE',
       type: 'website',
       url: pageUrl,
@@ -36,8 +36,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',
-      description: 'Spela Alfapet och Scrabble online på svenska i realtid. Skapa rum, bjud in med länk, tävla direkt. Gratis.',
+      title: 'Scrabble & Alfapet Online Svenska Gratis | LexiClash',
+      description: 'Spela Scrabble & Alfapet gratis på svenska. Utan registrering, utan app. 2–50 spelare i realtid. Starta direkt →',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },
     alternates: {


### PR DESCRIPTION
## Summary

Trim over-length title/description on the two highest-impression landing pages whose SERPs are being truncated, causing severe CTR underperformance.

### Spanish page — `/es/juego-de-palabras-multijugador`

**Query cluster:** "scrabble online" and 10+ Spanish variants — **~25,000 impressions/28d at pos 4–7**, CTR only **0.14–0.62%** (expected 3–6%).

Root cause: title was 79 chars and description was 169 chars — both truncated by Google at ~60/155 chars respectively, hiding the key differentiators.

| Field | Old | New |
|-------|-----|-----|
| Title | `Scrabble Online en Español Gratis — Sin Turnos Lentos, Tiempo Real \| LexiClash` (79 chars ❌) | `Scrabble Online en Español Gratis — Juega Ya \| LexiClash` (57 chars ✅) |
| Description | `Juega scrabble en español online gratis, sin turnos lentos. Crea sala en segundos, invita amigos y compite en tiempo real — hasta 50 jugadores, sin registro ni descarga.` (169 chars ❌) | `Juega Scrabble en español gratis ahora. Sin registro ni descarga. Hasta 50 jugadores en tiempo real. ¡Crea tu sala en segundos!` (127 chars ✅) |

Applied to: `<title>`, `og:title`, `og:description`, `twitter:title`, `twitter:description`.

**Expected uplift:** If CTR on "scrabble online" (12,615 impr/28d, pos 4.8) moves from 0.32% → 2%, that's +213 incremental clicks per 28-day window from a single query.

---

### Swedish page — `/sv/swedish-multiplayer-word-game`

**Query:** "scrabble svenska" — **1,112 impressions/28d at pos 7.1**, CTR only **0.09%** (expected 2.5%).

Root cause: title led with "Alfapet" while the high-impression query is "scrabble svenska". Reordering "Scrabble" to the front of the title/OG/Twitter better matches SERP intent signal.

| Field | Old | New |
|-------|-----|-----|
| Title | `Alfapet & Scrabble Online Svenska Gratis — Spela Nu \| LexiClash` (64 chars) | `Scrabble & Alfapet Online Svenska Gratis — Spela Nu \| LexiClash` (65 chars) |
| Description | `Spela Alfapet och Scrabble online på svenska gratis — utan väntan på tur. 2–50 spelare i realtid, ingen app, ingen registrering. Starta nu →` (141 chars) | `Spela Scrabble & Alfapet gratis på svenska. Utan registrering, utan app. 2–50 spelare i realtid. Starta ett spel direkt →` (122 chars) |

Applied to: `<title>`, `og:title`, `og:description`, `twitter:title`, `twitter:description`.

---

## Data source

Google Search Console 28-day window 2026-06-09 → 2026-07-06. Full analysis: `docs/seo-daily/2026-07-08.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012QnCdhYvXCyYzg8NhUf2g7)_