### PR TITLE
test(ui): fix stale Mascot.cosy EnhancedEmptyState assertion

### DIFF
--- a/fe-next/components/ui/__tests__/Mascot.cosy.test.tsx
+++ b/fe-next/components/ui/__tests__/Mascot.cosy.test.tsx
@@ -68,9 +68,12 @@ describe('Cosy hook on path-based renderers', () => {
     expect(container.querySelector('[data-mascot-bg="dark"]')).not.toBeNull();
   });
 
-  it('EnhancedEmptyState tags an opaque mascotSrc as dark', () => {
+  it('EnhancedEmptyState tags an opaque mascot variant as dark', () => {
+    // EnhancedEmptyState takes a mascotVariant (the raw-src `mascotSrc` prop was
+    // dropped when EmptyState was consolidated into it); the opaque `oops` art
+    // still resolves to a dark bg so the cosy CSS frames it.
     const { container } = render(
-      <EnhancedEmptyState title="Nothing here" mascotSrc="/mascot/oops.webp" />,
+      <EnhancedEmptyState title="Nothing here" mascotVariant="oops" />,
     );
     expect(container.querySelector('[data-mascot-bg="dark"]')).not.toBeNull();
   });


### PR DESCRIPTION
## Problem

`components/ui/__tests__/Mascot.cosy.test.tsx` is red on `master` (Vitest shard 5):

```
FAIL  Cosy hook on path-based renderers > EnhancedEmptyState tags an opaque mascotSrc as dark
AssertionError: expected null not to be null
```

This is a stale test, not a product bug. `EnhancedEmptyState`'s raw-src `mascotSrc` prop was removed when `EmptyState` was consolidated into it (commits `fc527d8` / `222a9ae` / `64ef521`) — it now renders an animated mascot via a `mascotVariant` prop. The test still passed `mascotSrc="/mascot/oops.webp"`, which the component ignores, so no `<Mascot>` rendered and the `[data-mascot-bg]` hook was absent → `null`.

## Fix

Switch the test to the current API, `mascotVariant="oops"`. This preserves the original intent exactly: `oops` is an opaque variant that resolves to a `dark` background (`mascotData` bg map), so the cosy stylesheet frames it — and `<Mascot variant="oops">` emits `data-mascot-bg="dark"`.

Test-only change; no product/source files touched.

## Testing
- `Mascot.cosy.test.tsx` passes locally (10 tests).

## Context

Follow-up to #706 — same class of pre-existing stale-test drift on `master`, surfaced on a different shard as `master` advanced. Kept separate from #705 (Word Tower toast fix) so that change stays scoped. Merging this should clear the last red test shard for open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXWjoUvvkq9pB3PK3xm1f

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeXWjoUvvkq9pB3PK3xm1f)_