### PR TITLE
fix(quick-play): stop Word Wheel board crushing into the HUD in Quick Game

### DIFF
--- a/fe-next/app/[locale]/quick-play/PageClient.tsx
+++ b/fe-next/app/[locale]/quick-play/PageClient.tsx
@@ -38,7 +38,14 @@ function QuickPlayGate() {
 export default function QuickPlayPageClient() {
   return (
     <Suspense fallback={<LoadingFallback />}>
-      <div className="min-h-screen bg-neo-navy">
+      {/* Participate in the app layout's bounded flex-column height chain
+          (`<main>` → children wrapper are `flex-1 flex flex-col min-h-0`), the
+          same chain the Daily Challenge route relies on. A `min-h-screen` block
+          here (the old shell) breaks that chain: the Word Wheel's `flex-1` root
+          becomes inert and its `[container-type:size]` wheel cluster collapses,
+          crushing the board into the top HUD. `overflow-y-auto` keeps shorter
+          phases (wheel select / results) scrollable within the bounded height. */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-neo-navy">
         <QuickPlayGate />
       </div>
     </Suspense>

--- a/fe-next/components/quick-play/adapters/QuickModeAdapter.tsx
+++ b/fe-next/components/quick-play/adapters/QuickModeAdapter.tsx
@@ -37,19 +37,31 @@ export function QuickModeAdapter({ config, onDone, onQuit }: QuickModeAdapterPro
   switch (config.mode) {
     case 'wheel-rush': {
       if (!wordSet.current) wordSet.current = new Set(config.words ?? []);
+      // Bounded flex-column stage — parity with the Daily Challenge playing
+      // wrapper (WordWheelChallenge). WordWheelGame's mobile root is `flex-1`
+      // and its wheel cluster uses `[container-type:size]`; both need a
+      // definite-height flex-column ancestor. Rendered bare (the old Quick Game
+      // path) the container-query block-size collapses to ~0 and the board flies
+      // up into the timer/HUD — the crush this route showed under RTL/Hebrew.
+      // `justify-start pt-3` gives clearance from the top HUD, `overflow-y-auto
+      // overscroll-contain` lets it scroll on short viewports instead of
+      // overlapping, and `pb-bottom-stack` keeps the found-words list clear of
+      // the bottom nav/banner. Direction-agnostic: fixes LTR and RTL alike.
       return (
-        <WordWheelGame
-          puzzle={config.wheel as never}
-          duration={config.durationSec}
-          language={config.language as never}
-          hideCompetitive
-          onEffect={() => undefined}
-          onValidateWord={async (word: string) => wordSet.current!.has(word.toLowerCase())}
-          onComplete={(r: { wordsFound: string[]; score: number; timeSeconds: number }) =>
-            finish(fromWordWheel(r, config))
-          }
-          onExit={onQuit}
-        />
+        <div className="relative flex flex-1 flex-col items-center justify-start min-h-0 overflow-y-auto overscroll-contain pt-3 sm:pt-4 pb-bottom-stack">
+          <WordWheelGame
+            puzzle={config.wheel as never}
+            duration={config.durationSec}
+            language={config.language as never}
+            hideCompetitive
+            onEffect={() => undefined}
+            onValidateWord={async (word: string) => wordSet.current!.has(word.toLowerCase())}
+            onComplete={(r: { wordsFound: string[]; score: number; timeSeconds: number }) =>
+              finish(fromWordWheel(r, config))
+            }
+            onExit={onQuit}
+          />
+        </div>
       );
     }
     case 'word-hunt':

--- a/fe-next/components/quick-play/adapters/__tests__/QuickModeAdapter.wheelLayout.test.tsx
+++ b/fe-next/components/quick-play/adapters/__tests__/QuickModeAdapter.wheelLayout.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { QuickModeAdapter } from '../QuickModeAdapter';
+import type { QuickRoundConfig } from '../../types';
+
+// Mock the (dynamically imported) Word Wheel so we can assert the wrapper the
+// adapter mounts it into, not the wheel's internals.
+vi.mock('@/components/daily/WordWheelGame', () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-word-wheel">wheel</div>,
+}));
+
+const wheelConfig: QuickRoundConfig = {
+  mode: 'wheel-rush',
+  seed: 's-1',
+  language: 'en',
+  durationSec: 90,
+  grid: [],
+  wheel: {
+    centerLetter: 'A',
+    outerLetters: ['B', 'C', 'D', 'E', 'F', 'G'],
+    allLetters: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+    puzzleDate: '2026-07-08',
+    language: 'en',
+    puzzleNumber: 1,
+  },
+  words: ['bad', 'cab'],
+  totalWords: 10,
+  perfectScore: 100,
+};
+
+describe('QuickModeAdapter — Word Wheel layout', () => {
+  it('mounts the Word Wheel inside a bounded flex-column stage so the wheel cluster cannot collapse into the top HUD', async () => {
+    render(<QuickModeAdapter config={wheelConfig} onDone={vi.fn()} onQuit={vi.fn()} />);
+
+    const wheel = await screen.findByTestId('mock-word-wheel');
+    const stage = wheel.parentElement as HTMLElement;
+
+    // Root cause of the RTL Quick Game crush: WordWheelGame's mobile root is
+    // `flex-1` and its wheel cluster uses `[container-type:size]` — both need a
+    // definite-height flex-column ancestor. Rendered bare (as before) the
+    // container-query block-size collapses to ~0 and the board flies up into the
+    // timer/HUD. The stage must re-establish the same bounded flex column the
+    // Daily Challenge playing wrapper provides.
+    expect(stage.className).toMatch(/(^|\s)flex-1(\s|$)/);
+    expect(stage.className).toMatch(/flex-col/);
+    expect(stage.className).toMatch(/min-h-0/);
+    expect(stage.className).toMatch(/overflow-y-auto/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the severe layout breakage where launching **Word Wheel (גלגל המילים)** from the **Quick Game (משחק מהיר)** route crushed the entire wheel — center letter, outer nodes, and controls — vertically and flung it into the top HUD (timer, progress bar, back button), overlapping and making them unreadable. Surfaced under Hebrew/RTL, but the cause is direction-agnostic.

## Root cause

The Quick Game path mounted `WordWheelGame` into a **`min-h-screen` block** shell (`app/[locale]/quick-play/PageClient.tsx`) with **no wrapper** in `QuickModeAdapter`.

- `WordWheelGame`'s mobile root is `flex-1`, and its wheel cluster uses `[container-type:size]` with `100cqb` units. **Both require a definite-height flex-column ancestor.**
- In a `display:block` parent, `flex-1` is inert (no flex context) and there is no bounded height to feed the container query — so `container-type: size` collapses the cluster's block-size to ~0 and the board spills upward into the HUD.
- Only Word Wheel broke: the sibling Quick modes (`classic`/`blast`/`word-hunt`) root at `h-full`, which resolves off the `min-h-screen` floor. Word Wheel has no `h-full`, only `flex-1`.

The Daily Challenge route renders the *same* `WordWheelGame` correctly because it participates in the app layout's bounded flex chain (`<main> → children wrapper` are `flex-1 flex flex-col min-h-0`) and wraps the game in a centered, bounded playing wrapper.

## Changes

- **`PageClient.tsx`** — the Quick Play shell now participates in the layout's bounded flex-column height chain (`flex min-h-0 flex-1 flex-col overflow-y-auto`) instead of being a `min-h-screen` block. `overflow-y-auto` keeps the shorter wheel-select / results phases scrollable within the bounded height. This restores a definite height for every mode (the `h-full` modes now also fit correctly above the bottom nav/banner instead of running 100vh underneath them).
- **`QuickModeAdapter.tsx`** — the `wheel-rush` case now wraps `WordWheelGame` in the same bounded, centered, scroll-safe stage the Daily Challenge playing wrapper uses (`flex flex-1 flex-col items-center justify-start min-h-0 overflow-y-auto overscroll-contain pt-3 sm:pt-4 pb-bottom-stack`). This keeps the board vertically centered, clear of the top HUD, and clear of the bottom nav/banner.

The board container now maintains a centered, safe vertical layout that cannot be crushed into the status-bar HUD, and respects screen-height scaling across devices — in both LTR and RTL.

## Testing

- Added `QuickModeAdapter.wheelLayout.test.tsx` (TDD): asserts the Word Wheel is mounted inside a bounded flex-column stage (`flex-1` / `flex-col` / `min-h-0` / `overflow-y-auto`) — it fails on the old bare-mount and passes with the wrapper.
- `components/quick-play/` suite: **46 passed**.
- `components/daily/` suite (shared `WordWheelGame`): **550 passed**.
- ESLint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyvdxJtzDeNVoFNjPvA7wq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyvdxJtzDeNVoFNjPvA7wq)_