### PR TITLE
fix(daily): stop #189↔#190 catch-up ping-pong that locked the Daily Hub

### DIFF
--- a/fe-next/components/daily/CatchUpSuggestion.tsx
+++ b/fe-next/components/daily/CatchUpSuggestion.tsx
@@ -47,6 +47,17 @@ export default function CatchUpSuggestion({ excludeDate, mode }: CatchUpSuggesti
     setMounted(true);
   }, []);
 
+  // Suppress the nudge on a catch-up's OWN results screen. `excludeDate` is
+  // always the puzzle currently being viewed; when it's a *past* date we're
+  // already inside a catch-up, not on today's results. Re-surfacing the nudge
+  // there is a UI-locking trap: two unsolved past dailies (a failed Word Hunt
+  // never counts as "solved", so it stays "missed") mutually offer each other,
+  // and because each item only swaps the `?date=` search param in place, every
+  // tap just re-renders the already-played results to the *other* date — the
+  // #189<->#190 ping-pong. The nudge belongs only on today's results, so any
+  // navigation into a historical puzzle stays put instead of fighting back.
+  if (excludeDate && excludeDate < today) return null;
+
   const items = missed.filter(m => m.date !== excludeDate);
   if (items.length === 0) return null;
   if (!mounted) return null;

--- a/fe-next/components/daily/__tests__/CatchUpSuggestion.test.tsx
+++ b/fe-next/components/daily/__tests__/CatchUpSuggestion.test.tsx
@@ -115,11 +115,35 @@ describe('CatchUpSuggestion', () => {
       expect(screen.getByText('daily.catchUp.watchAd')).toBeInTheDocument();
     });
 
-    it('excludes the specified date', () => {
-      render(<CatchUpSuggestion excludeDate="2025-01-19" />);
+    it('still shows missed replay links on today\'s results (excludeDate = today)', () => {
+      const iso = (offsetDays: number) => {
+        const d = new Date();
+        d.setUTCDate(d.getUTCDate() - offsetDays);
+        return d.toISOString().split('T')[0];
+      };
+      const today = iso(0);
+      (useMissedDailies as ReturnType<typeof vi.fn>).mockReturnValue({
+        missed: [
+          { date: iso(1), puzzleNumber: 101 },
+          { date: iso(2), puzzleNumber: 100 },
+        ],
+        loading: false,
+      });
+      render(<CatchUpSuggestion excludeDate={today} />);
       const links = screen.getAllByRole('link');
-      expect(links).toHaveLength(1);
-      expect(links[0]).toHaveAttribute('href', '/en/daily/word-hunt?date=2025-01-18');
+      expect(links).toHaveLength(2);
+      expect(links[0]).toHaveAttribute('href', `/en/daily/word-hunt?date=${iso(1)}`);
+      expect(links[1]).toHaveAttribute('href', `/en/daily/word-hunt?date=${iso(2)}`);
+    });
+
+    // Regression: the #189<->#190 tap ping-pong that locked the Daily Hub UI.
+    // On a catch-up's OWN results screen (excludeDate is a past date), the nudge
+    // must NOT re-surface — otherwise two unsolved past dailies mutually offer
+    // each other and every tap just swaps the in-place results between them,
+    // trapping the player. The nudge belongs only on today's results.
+    it('suppresses the nudge entirely on a catch-up (past-date) results screen', () => {
+      const { container } = render(<CatchUpSuggestion excludeDate="2025-01-19" />);
+      expect(container.innerHTML).toBe('');
     });
 
     it('renders nothing when no missed dailies', () => {


### PR DESCRIPTION
## Summary

Fixes the Daily Hub interaction lock where tapping a missed daily challenge (e.g. **#189**) on a Word Hunt results screen made the "Ta igen missade dagliga" / "Catch up missed dailies" card violently flicker between **#189** and **#190** on every touch release, trapping the player.

## Root cause

The reported "event bubbling / `stopPropagation`" theory doesn't match the code — the missed-challenge items are plain Next.js `<Link>` elements with no parent touch/click handler to bubble into. The real mechanism is a navigation ping-pong:

1. The catch-up nudge (`CatchUpSuggestion`) also renders on a **catch-up's own results screen**, where it offers the *other* unsolved past daily (excluding only the current one via `excludeDate`).
2. A **failed** Word Hunt never counts as `solved`, and `/api/daily/missed` keeps unsolved dates in the "missed" list — so two failed past dailies (#189 and #190) mutually reference each other permanently.
3. Each item's `<Link href="…?date=X">` only swaps the `?date=` **search param in place**. On an already-played date this re-renders the results view to the other date (which re-shows the card pointing back), so a single finger tap flips #189 ⇄ #190 endlessly. The rest of the screen stays mounted, which is exactly why it reads as a flicker rather than a full navigation.

## Fix

`excludeDate` is always the date of the puzzle currently being viewed. On **today's** results it equals today; on a **catch-up** results screen it's a past date. So we suppress the nudge whenever `excludeDate < today` — the "catch up missed dailies" prompt now lives only on today's results, and navigating into a historical puzzle stays put instead of fighting back to today's context.

```tsx
// CatchUpSuggestion.tsx
if (excludeDate && excludeDate < today) return null;
```

One line, self-contained in the presentation layer; the missed-list semantics and the retry/replay flows are untouched.

## Testing

- Added a regression test that asserts the nudge is suppressed on a catch-up (past-date) results screen (reproduces the #189↔#190 trap), plus a test confirming it still renders on today's results.
- Verified RED (1 failing) without the guard → GREEN (13 passing) with it.
- `CatchUpSuggestion`, `WordHuntResultsContent` (×3) and `/api/daily/missed` route suites: **29 passing**.
- Project `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgAHGtbtum1WQGBMYvwGee

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgAHGtbtum1WQGBMYvwGee)_