### PR TITLE
refactor(lobby): declutter waiting room — emote by avatar, ad→builder, drop daily promo

### DIFF
--- a/fe-next/components/avatar/AvatarBuilderModal.tsx
+++ b/fe-next/components/avatar/AvatarBuilderModal.tsx
@@ -13,6 +13,7 @@ import AvatarRenderer from './AvatarRenderer';
 import { getAvatarTier, type Tier } from './AvatarTierEffects';
 import AvatarEquipBurst from './AvatarEquipBurst';
 import GlowUpButton from './GlowUpButton';
+import { LobbyAvatarRewardButton } from './LobbyAvatarRewardButton';
 import { planEquipBurst, type EquipBurst } from '@/lib/avatar/equipBurst';
 import FloatingCoinAnimation from '@/components/game/FloatingCoinAnimation';
 import CategoryOptions from './AvatarBuilderCategoryOptions';
@@ -243,6 +244,15 @@ export default function AvatarBuilderModal({
 
         {/* Admin-only: AI Glow-Up of the built avatar (Track B) */}
         <GlowUpButton previewRef={previewRef} config={config} />
+
+        {/* Optional reward: watch a short ad to unlock a random premium avatar
+            part (1/day). This is where the old lobby "watch ad" CTA now lives —
+            in-context, right where you're browsing parts, and purely opt-in.
+            Self-hides when unavailable (no ad provider / anon / all owned), so
+            the row collapses cleanly. */}
+        <div className="flex justify-center px-3 pb-1 shrink-0 empty:hidden" data-testid="avatar-builder-reward-slot">
+          <LobbyAvatarRewardButton />
+        </div>
 
         {/* Category Tabs — scroll-snap row, icon-only on narrow, icon+label when room */}
         <div className="relative shrink-0">

--- a/fe-next/components/avatar/DailyPartClaimModal.tsx
+++ b/fe-next/components/avatar/DailyPartClaimModal.tsx
@@ -25,7 +25,10 @@ export function DailyPartClaimModal({
     <>
       <div
         data-testid="avatar-daily-claim-modal"
-        className="fixed inset-0 z-[90] flex items-center justify-center bg-neo-navy/80 p-4 animate-in fade-in-0 duration-300"
+        // z above the avatar builder (z-[110]): this claim offer is launched
+        // from a reward button INSIDE the builder, so it must overlay it, not
+        // hide behind it. Still fine standalone in the lobby (nothing higher).
+        className="fixed inset-0 z-[120] flex items-center justify-center bg-neo-navy/80 p-4 animate-in fade-in-0 duration-300"
       >
         <div
           className="relative w-full max-w-sm rounded-neo border-neo-thick border-black bg-neo-navy-light p-6 shadow-hard-lg animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-2 duration-300"

--- a/fe-next/components/avatar/__tests__/AvatarBuilderModal.test.tsx
+++ b/fe-next/components/avatar/__tests__/AvatarBuilderModal.test.tsx
@@ -24,10 +24,21 @@ vi.mock('@/components/motion/AdaptiveMotion', () => {
 vi.mock('../AvatarRenderer', () => ({ __esModule: true, default: () => <div data-testid="avatar-renderer" /> }));
 vi.mock('../PartPreview', () => ({ __esModule: true, default: () => <div data-testid="part-preview" /> }));
 
+// The relocated "watch ad → unlock a premium part" reward now lives in the
+// builder. Stub it (heavy ad/auth deps) — the builder just needs to mount it.
+vi.mock('../LobbyAvatarRewardButton', () => ({
+  LobbyAvatarRewardButton: () => <div data-testid="avatar-daily-reward" />,
+}));
+
 describe('AvatarBuilderModal', () => {
   const defaultProps = { isOpen: true, onClose: vi.fn(), onSave: vi.fn(), premium: null as null };
 
   beforeEach(() => vi.clearAllMocks());
+
+  it('surfaces the daily avatar-part reward inside the builder', () => {
+    render(<AvatarBuilderModal {...defaultProps} />);
+    expect(screen.getByTestId('avatar-daily-reward')).toBeInTheDocument();
+  });
 
   it('renders when isOpen=true', () => {
     render(<AvatarBuilderModal {...defaultProps} />);

--- a/fe-next/host/components/HostPreGameView.tsx
+++ b/fe-next/host/components/HostPreGameView.tsx
@@ -8,7 +8,6 @@ import { useCrazyGames } from '@/components/CrazyGamesSDK';
 import { useSocket } from '../../utils/SocketContext';
 import { useGameActions, useGameMode, useHostSelectedGameMode } from '@/hooks/gameState';
 import { useAuth } from '@/contexts/AuthContext';
-import { LobbyAvatarRewardButton } from '@/components/avatar/LobbyAvatarRewardButton';
 import { EmoteTray } from '@/player/components/lobby/EmoteTray';
 import { useLobbyEmotes } from '@/hooks/useLobbyEmotes';
 import { useLobbyAdGate } from '@/hooks/useLobbyAdGate';
@@ -209,14 +208,13 @@ function HostPreGameView({
   // the expression lives ON the avatar, the same affordance every player has.
   const { sendEmote, cooldownActive } = useLobbyEmotes({ socket });
 
-  // Self-only lobby actions rendered beneath the roster avatars: an emote picker
-  // (change your avatar's emotion) + the rewarded daily-avatar-part claim. The
-  // avatar-part ad replaces the redundant "+20 gold" lobby ad — an ad that earns
-  // a piece of the avatar, surfaced right where the avatar lives.
+  // Self-only lobby action rendered beneath the roster avatars: an emote picker
+  // that changes your avatar's emotion (server-echoed to the room). The rewarded
+  // daily-avatar-part claim moved OUT of the lobby and INTO the avatar builder —
+  // in-context, opt-in, and no longer competing with the emote for attention.
   const selfRosterActions = (
     <div className="flex flex-col items-center gap-2 pt-1">
       <EmoteTray onEmote={sendEmote} t={t} disabled={cooldownActive} compact />
-      <LobbyAvatarRewardButton />
     </div>
   );
 

--- a/fe-next/player/components/PlayerWaitingView.tsx
+++ b/fe-next/player/components/PlayerWaitingView.tsx
@@ -8,8 +8,6 @@ import { Users, Crown, Bot, LogOut, Plus, Check, Pencil, X, Camera, Zap } from '
 import Avatar from '../../components/Avatar';
 import AvatarBuilderModal from '../../components/avatar/AvatarBuilderModal';
 import { useAvatarPremium } from '@/hooks/useAvatarPremium';
-import { LobbyRewardCluster } from '@/components/lobby/LobbyRewardCluster';
-import { LobbyDailyEmber } from '@/components/lobby/LobbyDailyEmber';
 import { LobbyAutoStartStatus } from '@/components/lobby/LobbyAutoStartStatus';
 import { QuickLanguageSwitcher } from '@/components/QuickLanguageSwitcher';
 import RoomChat from '../../components/RoomChat';
@@ -175,6 +173,9 @@ const PlayerWaitingView: React.FC<PlayerWaitingViewProps> = ({
               customAvatar={currentAvatar}
               size="2xl"
               className="w-full h-full"
+              // Mirror the player's own lobby emote on the big hero face so a
+              // tapped emote (tray just below) has an obvious, immediate effect.
+              mood={emotesByUsername[username]?.emote}
             />
           </div>
           <div className="absolute inset-0 rounded-full bg-neo-black/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
@@ -262,19 +263,17 @@ const PlayerWaitingView: React.FC<PlayerWaitingViewProps> = ({
 
           <LobbyAutoStartStatus readyCount={readyCount} readyTotal={readyTotal} t={t} />
 
-          <LobbyRewardCluster surface="player_waiting" className="mt-3" />
+          {/* Emote picker sits right beside your avatar+name so it reads as
+              "react as ME" — tapping a face swaps the hero avatar above (and
+              your roster tile) for the whole room. Compact: a single trigger
+              that expands the emoji row inline on tap. Was previously buried
+              under the roster, where its link to your own avatar was unclear. */}
+          <div className="mt-3">
+            <EmoteTray onEmote={sendEmote} t={t} disabled={cooldownActive} compact />
+          </div>
         </div>
       </div>
     </m.div>
-  );
-
-  // Ambient daily-challenge awareness. Rendered as a SIBLING of the hero card
-  // (not inside it) because the hero card is `overflow-hidden` — nesting would
-  // clip the tap-popover. Own status only; never navigates out of the room.
-  const renderDailyEmber = (): React.ReactElement => (
-    <div className="px-1" data-testid="lobby-daily-ember-slot">
-      <LobbyDailyEmber />
-    </div>
   );
 
   // ==================== Player Roster ====================
@@ -372,14 +371,6 @@ const PlayerWaitingView: React.FC<PlayerWaitingViewProps> = ({
           </div>
         ))}
       </div>
-
-      {/* Compact emote — one button that expands the emoji row on tap; tapping a
-          face reacts on your own avatar (above) for the whole room. No permanent
-          labelled row. Lives here (not the overflow-hidden hero card) so the
-          expanded row isn't clipped. */}
-      <div className="px-1 pt-1">
-        <EmoteTray onEmote={sendEmote} t={t} disabled={cooldownActive} compact />
-      </div>
     </section>
   );
 
@@ -411,10 +402,13 @@ const PlayerWaitingView: React.FC<PlayerWaitingViewProps> = ({
   const renderMobileContent = (): React.ReactElement => (
     <div className="flex-1 flex flex-col overflow-hidden px-3 py-2 gap-2 min-h-0">
       <section className="shrink-0">{renderHeroCard()}</section>
-      <div className="shrink-0">{renderDailyEmber()}</div>
       <div className="shrink-0">{renderPlayerRoster()}</div>
       <div className="shrink-0">{renderModeTips()}</div>
-      <section className="flex-1 min-h-0 pb-1">
+      {/* Chat gets the tallest slot in the column: it's the only flex-1 child and
+          carries a min height so it stays comfortably usable even before the
+          fixed sections above collapse. Removing the daily-ember + reward rows
+          freed the vertical space it now claims. */}
+      <section className="flex-1 min-h-[38vh] pb-1">
         {/* overflow-y-auto (not -hidden): on a short screen the chat panel is the
             flex-fill that gets squeezed — its content (e.g. the guest age-gate)
             then scrolls WITHIN the panel instead of being clipped. The page itself
@@ -482,7 +476,6 @@ const PlayerWaitingView: React.FC<PlayerWaitingViewProps> = ({
             leftContent={
               <>
                 {renderHeroCard()}
-                {renderDailyEmber()}
                 {renderPlayerRoster()}
                 {renderModeTips()}
               </>

--- a/fe-next/player/components/__tests__/PlayerWaitingView.test.tsx
+++ b/fe-next/player/components/__tests__/PlayerWaitingView.test.tsx
@@ -217,6 +217,19 @@ describe('PlayerWaitingView', () => {
     });
   });
 
+  describe('Lobby cleanup — removed reward/daily clutter', () => {
+    it('does NOT render the redundant "+20 gold" reward cluster', () => {
+      // The gold ad was removed; the avatar-part reward moved into the builder.
+      render(<PlayerWaitingView {...defaultProps} />);
+      expect(screen.queryByTestId('lobby-reward-cluster')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the daily-challenge promotion ember', () => {
+      render(<PlayerWaitingView {...defaultProps} />);
+      expect(screen.queryByTestId('lobby-daily-ember-slot')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Existing Functionality', () => {
     it('should not render room code in header (removed)', () => {
       render(<PlayerWaitingView {...defaultProps} />);


### PR DESCRIPTION
## Summary

Cleans up the multiplayer waiting-room UI based on feedback that the screen was cluttered and the emote affordance was unclear.

Before, the player waiting room stacked: hero card → daily-challenge ember → roster → how-to-play → chat, with a "watch ad for +20 gold" reward and a lone emote trigger buried under the roster.

### Changes

- **Emote is now near the avatar.** The compact emote picker moved from below the roster into the hero card, right beside your avatar + name. The big hero avatar now also mirrors your own emote (`mood`), so tapping a face has an obvious, immediate effect — "react as me" — instead of an unclear link to a tile lower down.
- **Removed the redundant "watch ad for +20 gold" reward** from the lobby. The opt-in "watch ad → unlock a random premium avatar part" reward now lives **inside the avatar builder**, in-context where you actually browse parts. It also self-hides when unavailable (no ad provider / anonymous / all parts owned).
  - Removed the same avatar-part reward from the **host** lobby so it isn't shown twice (host and player both reach it via the builder now).
  - Bumped the daily-part claim modal's z-index above the avatar builder so the offer overlays it correctly.
- **Removed the daily-challenge promotion ember** from the lobby.
- **Chat gets more height** — it's the sole flex-fill child and now carries a min height, absorbing the vertical space freed by the removed rows.

### Notes

- `LobbyRewardCluster` and `LobbyDailyEmber` are no longer wired into either lobby view; they remain as standalone, still-tested components (no production consumers).

## Testing

- `vitest` — updated/extended `PlayerWaitingView`, `AvatarBuilderModal`, and host lobby suites; all affected suites green (81 tests across the touched areas).
- `tsc --noEmit` — clean.
- `eslint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01743pzU1yEDBT3u8hbHNhiR)_