### PR TITLE
feat(ads): add global bottom banner to Brain & Daily Challenge hubs

### DIFF
--- a/fe-next/app/[locale]/brain/PageClient.tsx
+++ b/fe-next/app/[locale]/brain/PageClient.tsx
@@ -45,6 +45,12 @@ import BrainScoreShareCard from '@/components/brain/BrainScoreShareCard';
 // nothing when closed, so first-paint HTML is unchanged.
 const AuthModal = dynamic(() => import('@/components/auth/AuthModal'), { ssr: false });
 import PageLoader from '@/components/ui/PageLoader';
+// Same reusable bottom banner slot the home dashboard/landing screen uses. On
+// native it reserves its own in-flow height and overlays the AdMob banner; on
+// web it renders the dev-only placeholder (null in production). Embedded at the
+// structural bottom of the hub so it never covers a drill card, the score hero,
+// or the analytics charts.
+import InlineBannerAd from '@/components/ads/InlineBannerAd';
 
 /**
  * Header component for Brain Training page
@@ -511,6 +517,12 @@ export default function BrainTrainingPageClient() {
         >
           <ScientificTipsCarousel />
         </m.div>
+
+        {/* Global bottom banner — reused from the home dashboard. The content
+            container already reserves the fixed-bottom stack (nav + banner) via
+            body.screen-fit, and the slot below adds its own in-flow height, so
+            the ad never overlaps the tips carousel or the charts above it. */}
+        <InlineBannerAd variant="content" webZone="menu" className="mt-2" />
       </div>
 
       {/* First Game Celebration Modal */}

--- a/fe-next/app/[locale]/brain/__tests__/adBanner.test.tsx
+++ b/fe-next/app/[locale]/brain/__tests__/adBanner.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Brain hub — global bottom banner placement
+ * Pins the ad-placement expansion (2026-07): the same reusable banner slot the
+ * landing/home dashboard uses is embedded at the STRUCTURAL BOTTOM of the Brain
+ * (cognitive training) hub, below the scientific-tips carousel, so it never
+ * covers a drill card, the brain-score hero, or the analytics charts.
+ */
+import { vi, type MockedFunction } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import BrainTrainingPage from '../PageClient';
+import { useAuth } from '@/contexts/AuthContext';
+import { useBrainScore } from '@/hooks/useBrainScore';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useTheme } from '@/utils/ThemeContext';
+import { useRouter } from 'next/navigation';
+import { MusicProvider } from '@/contexts/MusicContext';
+import { SoundEffectsProvider } from '@/contexts/SoundEffectsContext';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+vi.mock('@/contexts/AuthContext');
+vi.mock('@/hooks/useBrainScore');
+vi.mock('@/contexts/LanguageContext');
+vi.mock('@/utils/ThemeContext');
+vi.mock('@/contexts/HapticsContext', () => ({
+  useHapticsConfig: () => ({ isEnabled: true, toggle: vi.fn() }),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+}));
+vi.mock('@/contexts/NavigationContext', () => ({
+  useNavigation: () => ({
+    isInGame: false,
+    setIsInGame: vi.fn(),
+    activeTab: 'brain',
+    setActiveTab: vi.fn(),
+  }),
+  useHideNavigation: () => vi.fn(),
+  NavigationProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// The banner slot itself is exercised by its own unit tests. Here we only assert
+// it is embedded at the bottom of the hub, so render a lightweight stand-in.
+vi.mock('@/components/ads/InlineBannerAd', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => (
+    <div data-testid="hub-bottom-banner" data-variant={String(props.variant)} />
+  ),
+}));
+
+const mockUseAuth = useAuth as MockedFunction<typeof useAuth>;
+const mockUseBrainScore = useBrainScore as MockedFunction<typeof useBrainScore>;
+const mockUseLanguage = useLanguage as MockedFunction<typeof useLanguage>;
+const mockUseTheme = useTheme as MockedFunction<typeof useTheme>;
+const mockUseRouter = useRouter as MockedFunction<typeof useRouter>;
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const AllTheProviders = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <MusicProvider>
+      <SoundEffectsProvider>{children}</SoundEffectsProvider>
+    </MusicProvider>
+  </QueryClientProvider>
+);
+
+const authedUser = {
+  user: { id: 'user-1' } as any,
+  profile: { id: 'user-1', username: 'test' } as any,
+  rankedProgress: null,
+  loading: false,
+  isSupabaseEnabled: true,
+  isAuthenticated: true,
+  isGuest: false,
+  isAdmin: false,
+  isTeacher: false,
+  canPlayRanked: false,
+  gamesUntilRanked: 10,
+  needsProfileCustomization: false,
+  setupProfile: vi.fn(),
+  updateProfile: vi.fn(),
+  refreshProfile: vi.fn(),
+};
+
+const makeBrainScore = (gamesAnalyzed: number) => ({
+  id: 'bs-1',
+  userId: 'user-1',
+  overallScore: 642,
+  tier: 'advanced' as const,
+  tierProgress: 50,
+  gamesAnalyzed,
+  drillsCompleted: 3,
+  currentStreak: 2,
+  longestStreak: 5,
+  lastActivityAt: null,
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-12T00:00:00Z',
+  domains: {
+    processingSpeed: { score: 60, trend: 'improving' as const },
+    workingMemory: { score: 55, trend: 'stable' as const },
+    attention: { score: 70, trend: 'improving' as const },
+    flexibility: { score: 65, trend: 'declining' as const },
+    vocabulary: { score: 80, trend: 'improving' as const },
+  },
+});
+
+describe('Brain hub bottom banner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    mockUseRouter.mockReturnValue({ push: vi.fn() } as any);
+    mockUseLanguage.mockReturnValue({
+      language: 'en',
+      setLanguage: vi.fn(),
+      t: (key: string) => key,
+      dir: 'ltr',
+      currentFlag: '🇺🇸',
+    } as any);
+    mockUseTheme.mockReturnValue({ theme: 'dark', toggleTheme: vi.fn() } as any);
+    mockUseAuth.mockReturnValue(authedUser as any);
+    mockUseBrainScore.mockReturnValue({
+      brainScore: makeBrainScore(8) as any,
+      recentGameScores: [],
+      drillProgress: [],
+      brainScoreHistory: [],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+      initializeBrainScore: vi.fn(),
+    } as any);
+  });
+
+  it('embeds the reusable banner slot with the content variant on the main dashboard', async () => {
+    render(<BrainTrainingPage />, { wrapper: AllTheProviders });
+    const banner = await screen.findByTestId('hub-bottom-banner');
+    expect(banner).toBeInTheDocument();
+    // Non-game hub → content banner unit, never the in-flow game unit.
+    expect(banner.getAttribute('data-variant')).toBe('content');
+  });
+
+  it('renders the banner AFTER the brain-score hero (structural bottom of the hub)', async () => {
+    render(<BrainTrainingPage />, { wrapper: AllTheProviders });
+    const banner = await screen.findByTestId('hub-bottom-banner');
+    const heroLabel = screen.getByText('brain.score');
+    // compareDocumentPosition returns FOLLOWING (4) when `banner` follows `heroLabel`.
+    const rel = heroLabel.compareDocumentPosition(banner);
+    expect(rel & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/fe-next/components/daily/DailyChallengeLanding.tsx
+++ b/fe-next/components/daily/DailyChallengeLanding.tsx
@@ -24,6 +24,10 @@ import { FloatingDecorations } from './landing/FloatingDecorations';
 import WeeklyChestCard from './WeeklyChestCard';
 import WeeklyChestModal from './WeeklyChestModal';
 import DailyInsightStack from './DailyInsightStack';
+// Same reusable bottom banner slot the home dashboard/landing screen uses. On
+// native it reserves its own in-flow height and overlays the AdMob banner; on
+// web it renders the dev-only placeholder (null in production).
+import InlineBannerAd from '@/components/ads/InlineBannerAd';
 
 interface DailyChallengeLandingProps {
   onSelectWordHunt: () => void;
@@ -394,6 +398,15 @@ export function DailyChallengeLanding({
           />
         </m.div>
       )}
+
+      {/* Global bottom banner — reused from the home dashboard, embedded at the
+          structural bottom of the hub. The container's `pb-bottom-stack` already
+          reserves the fixed-bottom stack (nav + banner), and this slot adds its
+          own in-flow height, so the ad never covers a quest card, the weekly
+          chest, or the leaderboard rows above it. */}
+      <div className="w-full">
+        <InlineBannerAd variant="content" webZone="menu" />
+      </div>
     </m.div>
   );
 }

--- a/fe-next/components/daily/__tests__/DailyChallengeLanding.adBanner.test.tsx
+++ b/fe-next/components/daily/__tests__/DailyChallengeLanding.adBanner.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * DailyChallengeLanding — global bottom banner placement
+ * Pins the ad-placement expansion (2026-07): the same reusable banner slot the
+ * landing/home dashboard uses is embedded at the STRUCTURAL BOTTOM of the Daily
+ * Challenge hub, below the leaderboard teaser, so it never covers a quest card,
+ * the weekly chest, or the leaderboard rows.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockUseAuth = vi.fn();
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (k: string) => k, isRTL: false, language: 'en', dir: 'ltr' }),
+  LanguageProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/utils/dailyChallenge/storage', () => ({
+  hasPlayedToday: vi.fn(() => false),
+  getWordHuntStatusToday: vi.fn(() => null),
+  hasPlayedWordWheelToday: vi.fn(() => false),
+}));
+
+vi.mock('@/utils/guestManager', () => ({
+  getGuestFingerprint: vi.fn(() => 'fp'),
+}));
+
+vi.mock('@/hooks/useDailyChallengeStatus', () => ({
+  useDailyChallengeStatus: () => ({
+    loading: false,
+    hasPlayed: false,
+    hasSolved: false,
+    currentStreak: 0,
+    refresh: vi.fn(),
+  }),
+}));
+
+// The banner slot itself is exercised by its own unit tests. Here we only assert
+// it is embedded at the bottom of the hub, so render a lightweight stand-in.
+vi.mock('@/components/ads/InlineBannerAd', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => (
+    <div data-testid="hub-bottom-banner" data-variant={String(props.variant)} />
+  ),
+}));
+
+// Stub heavy/animated children
+vi.mock('@/components/daily/WeeklyChestCard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="weekly-chest-card-stub" />,
+}));
+vi.mock('@/components/daily/WeeklyChestModal', () => ({
+  __esModule: true,
+  default: () => <div data-testid="weekly-chest-modal-stub" />,
+}));
+vi.mock('@/components/daily/DailyInsightStack', () => ({
+  __esModule: true,
+  default: () => <div data-testid="insight-stack-stub" />,
+}));
+vi.mock('@/components/daily/TabbedDailyLeaderboard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="leaderboard-stub" />,
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/en/daily',
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock('framer-motion', () => ({
+  __esModule: true,
+  m: new Proxy({}, {
+    get: (_t: unknown, prop: string) => {
+      return ({ children, ...rest }: React.PropsWithChildren<Record<string, unknown>>) =>
+        React.createElement(prop, rest, children);
+    },
+  }),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReducedMotion: () => false,
+}));
+
+import { DailyChallengeLanding } from '../DailyChallengeLanding';
+
+const props = {
+  onSelectWordHunt: vi.fn(),
+  onSelectWordWheel: vi.fn(),
+  currentLanguage: 'en' as const,
+};
+
+describe('DailyChallengeLanding bottom banner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: { id: 'u1' } });
+  });
+
+  it('embeds the reusable banner slot with the content variant', () => {
+    render(<DailyChallengeLanding {...props} />);
+    const banner = screen.getByTestId('hub-bottom-banner');
+    expect(banner).toBeTruthy();
+    // Non-game hub → content banner unit, never the in-flow game unit.
+    expect(banner.getAttribute('data-variant')).toBe('content');
+  });
+
+  it('renders the banner AFTER the leaderboard (structural bottom of the hub)', () => {
+    render(<DailyChallengeLanding {...props} />);
+    const banner = screen.getByTestId('hub-bottom-banner');
+    const leaderboard = screen.getByTestId('leaderboard-stub');
+    // compareDocumentPosition returns FOLLOWING (4) when `banner` follows `leaderboard`.
+    const rel = leaderboard.compareDocumentPosition(banner);
+    expect(rel & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Expands ad placement and keeps layout uniform across major hubs by reusing the existing global bottom banner slot (`InlineBannerAd` — the same reusable placement wrapper the home dashboard/landing screen uses via `LandingView`) and embedding it at the structural bottom of two more screens:

1. **Brain / Cognitive Training Hub** (`app/[locale]/brain`) — below the scientific-tips carousel on the main dashboard.
2. **Daily Challenge Hub** (`DailyChallengeLanding`, rendered at `/daily`) — below the leaderboard teaser.

## How it works

- Both embeds use `<InlineBannerAd variant="content" webZone="menu" />` — the **content** banner unit (non‑game), routed through the `slot` banner owner. That owner is **not route-gated**, so the banner shows even though `/brain` and `/daily` sit on the anchored-banner blocklist (`isAllowedAdBannerRoute`). This is the same mechanism the post-game `ResultsBannerSlot` already relies on to render on blocked routes.
- On **native** the component reserves its own in-flow slot and overlays the AdMob banner on top of it; on **web** it renders the dev-only placeholder (null in production).

## Layout / occlusion safety (no content covered)

Each hub's scroll container already reserves the fixed-bottom stack **conditionally**, and the embedded slot adds its own in-flow height on top, so the banner never overlaps a drill card, the score hero, the analytics charts, a quest card, the weekly chest, or the leaderboard rows:

- **Brain:** the page scrolls at `body.screen-fit`, which reserves `--bottom-stack-height` (nav + banner) whenever `has-admob-banner` / `has-global-bottom-nav` is set.
- **Daily:** the landing container already carries `pb-bottom-stack` (= `padding-bottom: var(--bottom-stack-height)`), which includes `--admob-banner-height`.

This intentionally avoids adding a second fixed reservation, which would re-introduce the known "blank band under the ad" double-reservation bug documented in the codebase.

## Testing

- New TDD tests (written first, RED → GREEN) pin the banner's presence (with the `content` variant) and its **structural placement** below the last content section of each hub:
  - `app/[locale]/brain/__tests__/adBanner.test.tsx`
  - `components/daily/__tests__/DailyChallengeLanding.adBanner.test.tsx`
- Brain (`app/[locale]/brain/__tests__/`) + ads (`components/ads/__tests__/`) suites: **17 files, 136 tests green**; all `DailyChallengeLanding.*` tests that don't hit an unrelated pre-existing phantom-dependency load error pass.
- `eslint` and `tsc --noEmit` clean on the changed files.

> Note: some daily test files fail to *load* in this environment due to a pre-existing phantom-dependency (`@radix-ui/react-visually-hidden` imported directly by `WordWheelWordsModal.tsx` under pnpm strict mode). Verified this reproduces on the base branch **before** these changes — it is unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFqyuBc7xBzSRzrWMEf8gq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFqyuBc7xBzSRzrWMEf8gq)_