### PR TITLE
feat: scroll to top of page on every route change

### DIFF
--- a/fe-next/app/[locale]/layout.tsx
+++ b/fe-next/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { ConditionalProviders } from '../conditional-providers';
 import { loadTranslation } from '@/translations/loadTranslation';
 import AutoHideFooter from '@/components/AutoHideFooter';
 import GlobalBottomNav from '@/components/GlobalBottomNav';
+import ScrollToTopOnNavigate from '@/components/ScrollToTopOnNavigate';
 import InGameAudioButton from '@/components/InGameAudioButton';
 import GoogleConsentMode from '@/components/GoogleConsentMode';
 import GoogleAnalytics from '@/components/GoogleAnalytics';
@@ -646,6 +647,11 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
                     </ul>
                 </nav>
                 <ConditionalProviders lang={validLocale} initialTranslations={initialTranslations}>
+                    {/* Pin every new route to the top of the page — the app's scroll
+                        container is <body class="screen-fit">, so without this a stale
+                        offset (or a child's mount-time auto-scroll) can open a page at
+                        the footer. */}
+                    <ScrollToTopOnNavigate />
                     {/* VersionChecker needs to be inside providers to access LanguageContext */}
                     <VersionChecker />
                     {/* Auto-recovers stale-deploy chunk 404s that escape error boundaries

--- a/fe-next/components/ScrollToTopOnNavigate.tsx
+++ b/fe-next/components/ScrollToTopOnNavigate.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+/**
+ * Pins the page to the top on every client-side route change.
+ *
+ * The app's scroll container is `<body class="screen-fit">` (overflow-y:auto).
+ * Because `html { overflow: visible }`, the viewport propagates the body's
+ * overflow — so the element the browser treats as "the scroller" varies by
+ * platform. On navigation a stale scroll offset can persist, or a newly mounted
+ * child's auto-scroll (e.g. a chat list, a game board) drags the document down,
+ * landing the user at the footer — the documented "page opens at the footer" bug.
+ *
+ * Explicitly resetting every candidate scroll container to the top on each
+ * pathname change guarantees new pages always start at the top, independent of
+ * which element the browser scrolls and of whether Next.js's own scroll handling
+ * fired against the propagated body scroller.
+ *
+ * Anchor navigations (URL with a `#hash`) are left untouched so anchor links
+ * still jump to their target rather than being yanked back to the top.
+ */
+export default function ScrollToTopOnNavigate(): null {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    // Respect in-page anchor jumps — don't override a hash-targeted scroll.
+    if (window.location.hash) return;
+
+    window.scrollTo(0, 0);
+    // Reset both the propagated body scroller and the documentElement so the
+    // reset lands regardless of which one the UA is actually scrolling.
+    if (document.scrollingElement) document.scrollingElement.scrollTop = 0;
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+  }, [pathname]);
+
+  return null;
+}

--- a/fe-next/components/__tests__/ScrollToTopOnNavigate.test.tsx
+++ b/fe-next/components/__tests__/ScrollToTopOnNavigate.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * ScrollToTopOnNavigate Tests
+ *
+ * Every client-side route change must land the user at the TOP of the new page.
+ * The app's scroll container is <body class="screen-fit"> (overflow-y:auto), so a
+ * stale scroll offset — or a child's mount-time auto-scroll — could otherwise leave
+ * the new page opened at the footer (the documented "page opens at the footer" bug).
+ *
+ * Anchor navigations (URL carries a #hash) are exempt so anchor links still jump
+ * to their target.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+// Controllable pathname mock — updated per render to simulate navigation.
+let mockPathname = '/en';
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+import ScrollToTopOnNavigate from '../ScrollToTopOnNavigate';
+
+describe('ScrollToTopOnNavigate', () => {
+  let scrollToSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockPathname = '/en';
+    scrollToSpy = vi.fn();
+    // happy-dom doesn't implement window.scrollTo — install a spy to observe it.
+    Object.defineProperty(window, 'scrollTo', { value: scrollToSpy, writable: true, configurable: true });
+    window.location.hash = '';
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+  });
+
+  it('scrolls the page to the top on initial mount', () => {
+    // GIVEN a fresh mount on a route
+    render(<ScrollToTopOnNavigate />);
+
+    // THEN the window is pinned to the top
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('resets the body scroll container to the top on mount', () => {
+    // GIVEN the body scroll container is scrolled down (previous page state)
+    document.body.scrollTop = 999;
+    document.documentElement.scrollTop = 999;
+
+    // WHEN the component mounts on a new route
+    render(<ScrollToTopOnNavigate />);
+
+    // THEN every candidate scroll container is reset to the top
+    expect(document.body.scrollTop).toBe(0);
+    expect(document.documentElement.scrollTop).toBe(0);
+  });
+
+  it('scrolls to the top again when the pathname changes', () => {
+    // GIVEN a mounted component on /en
+    const { rerender } = render(<ScrollToTopOnNavigate />);
+    scrollToSpy.mockClear();
+
+    // WHEN the user navigates to a different route
+    mockPathname = '/en/multiplayer';
+    rerender(<ScrollToTopOnNavigate />);
+
+    // THEN the new page is scrolled to the top
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('does NOT scroll when the URL carries a #hash (anchor navigation)', () => {
+    // GIVEN the destination URL targets an in-page anchor
+    window.location.hash = '#faq';
+
+    // WHEN the component mounts
+    render(<ScrollToTopOnNavigate />);
+
+    // THEN the browser's native anchor scroll is left untouched
+    expect(scrollToSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing (no DOM footprint)', () => {
+    const { container } = render(<ScrollToTopOnNavigate />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

A lot of the time when a user navigates to a new page, it opens scrolled down at the **footer** instead of the top of the page.

### Root cause

The app's scroll container is `<body class="screen-fit">` (`overflow-y: auto`), and `html { overflow: visible }` makes the viewport propagate the body's overflow — so which element the browser treats as "the scroller" varies by platform. On navigation the previous page's scroll offset can persist, or a newly mounted child's mount-time auto-scroll (a chat list, a game board, etc.) drags the document down. Either way the new page lands at the footer. This matches the "page opens at the footer" bug already documented in the adventure `WorldMap`/`LevelGrid` scroll tests. Nothing reset scroll globally on route change.

## Change

- Add `components/ScrollToTopOnNavigate.tsx` — a small client component that, on every `usePathname()` change, pins **every candidate scroll container** (`window`, `document.scrollingElement`, `document.body`, `document.documentElement`) back to the top. This is robust to whichever element the UA actually scrolls and to whether Next.js's own scroll handling fired against the propagated body scroller.
- Mount it in `app/[locale]/layout.tsx` (inside the providers), so it applies to **all** locale routes.
- In-page anchor navigations (URL with a `#hash`) are intentionally left untouched, so anchor links still jump to their target instead of being yanked to the top.

## Tests

`components/__tests__/ScrollToTopOnNavigate.test.tsx` (written first, TDD) covers:
- scrolls to the top on initial mount
- resets the body scroll container (`body`/`documentElement` `scrollTop`) to the top
- scrolls to the top again when the pathname changes (navigation)
- does **not** scroll when the URL carries a `#hash` (anchor navigation)
- renders nothing (no DOM footprint)

Verified the suite fails without the implementation (3/5 red) and passes with it (5/5 green). `tsc --noEmit` and `eslint` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCy7WCXrUpx4Gg5L8ziVBh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCy7WCXrUpx4Gg5L8ziVBh)_