### PR TITLE
SEO: daily meta tag improvements (2026-07-12)

### DIFF
--- a/docs/seo-daily/2026-07-12.md
+++ b/docs/seo-daily/2026-07-12.md
@@ -1,0 +1,114 @@
+# SEO Daily Report — 2026-07-12
+
+**Date range:** 2026-06-13 → 2026-07-10 (28 days)  
+**Bing:** unavailable (egress proxy blocked `ssl.bing.com`; Bing section omitted)
+
+---
+
+## Headline Metrics
+
+| Metric | 28-day total | Last 7d | Prior 7d | Δ |
+|---|---|---|---|---|
+| Clicks | 256 | — | — | — |
+| Impressions | 44,109 | (computed from query set) | (computed from query set) | -11.8% |
+| Avg CTR | 0.58% | — | — | — |
+| Avg Position | 15.2 | — | — | — |
+| Unique queries | 1,037 | 592 | 531 | +11.5% |
+| Unique pages | 387 | — | — | — |
+
+**7d vs prior 7d (query impression totals):** clicks +17.2%, impressions -11.8%  
+**Potential click uplift from CTR fixes (78 flagged queries):** ~1,618 extra clicks/28d
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+Queries with ≥30 impressions underperforming expected CTR for their position by ≥30%.
+
+| Query | Page | Avg Pos | Impressions | Actual CTR | Expected CTR | Suggested Fix |
+|---|---|---|---|---|---|---|
+| scrabble online | /es/juego-de-palabras-multijugador | 4.9 | 12,340 | 0.3% | 6% | Shorten title to ≤60 chars; lead description with question hook; add CTA arrow |
+| scrabble online español | /es/juego-de-palabras-multijugador | 5.4 | 3,214 | 0.4% | 4% | Same page fix; title truncation is likely hiding "Gratis" |
+| scrabble en linea | /es/juego-de-palabras-multijugador | 5.8 | 2,303 | 0.3% | 4% | Same page fix |
+| scrabble online gratis | /es/juego-de-palabras-multijugador | 6.9 | 2,165 | 0.1% | 3% | Same page fix |
+| scrabble en español online | /es/juego-de-palabras-multijugador | 5.0 | 1,630 | 0.6% | 4% | Same page fix |
+| scrabble (en español) - juega gratis en línea | /es/juego-de-palabras-multijugador | 6.2 | 1,417 | 0.4% | 3% | Same page fix |
+| scrabble juego online | /es/juego-de-palabras-multijugador | 4.9 | 1,269 | 0.2% | 6% | Same page fix; massive underperformance at pos 5 |
+| scrabble español | /es/juego-de-palabras-multijugador | 5.9 | 1,158 | 0.3% | 4% | Same page fix |
+| scrabble svenska | /sv/swedish-multiplayer-word-game | 7.2 | 1,149 | 0.1% | 2% | Reorder title to lead with "Scrabble Svenska"; description hook |
+| jugar scrabble en español gratis | /es/juego-de-palabras-multijugador | 5.3 | 953 | 0.6% | 4% | Same page fix |
+
+**Root cause (Spanish page):** Title is 75 chars (Google truncates at ~60px/57 chars), cutting off at "Sin Descarga". Users see an incomplete title — the word "Gratis" and "Sin Descarga" benefit are hidden. Description is feature-oriented rather than intent-matching with a hook.
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+Queries at avg position 8–20 with ≥50 impressions. Small content/link improvements push them to page 1.
+
+| Query | Page | Avg Pos | Impressions | Clicks | Suggested Action |
+|---|---|---|---|---|---|
+| המילה היומית | /he/hamila-hayomit | 8.2 | 630 | — | Shorten/clarify title; add FAQ schema entries matching query intent |
+| מילת היום | /he/hamila-hayomit | 8.9 | 239 | — | Internal links from /he homepage to /he/hamila-hayomit |
+| סקריבל בעברית | /he/hebrew-multiplayer-word-game | 8.6 | 167 | — | Add "סקריבל" more prominently to H1/H2 |
+| מילה ביום | /he/hamila-hayomit | 10.0 | 68 | — | Add "מילה ביום" as FAQ answer/subheading |
+| games like boggle | /en/* | 9.7 | 63 | — | Add explicit H2 "Games Like Boggle" + FAQPage entry |
+| online scrabble | /en/* | 9.0 | 61 | — | Internal link from homepage to English multiplayer page |
+| word games like boggle | /en/* | 9.2 | 60 | — | Same page as "games like boggle"; combine |
+| ordhjulet | /sv/* | 9.4 | 60 | — | Swedish daily word page title/meta review |
+| juegos de palabras | /es/juego-de-palabras-multijugador | 18.8 | 50 | — | Create dedicated /es landing page for broad "juegos de palabras" query; currently too generic for pos 18 page |
+
+---
+
+## Bing Parity Gaps
+
+**SKIPPED** — `ssl.bing.com` is blocked by the session's egress proxy. Bing Webmaster API could not be reached. Recommend running from a machine without proxy filtering or adding `ssl.bing.com:443` to the proxy allowlist.
+
+---
+
+## GEO / AI Visibility Recommendations
+
+All four main landing pages already have FAQPage schema. Recommendations are to add/update specific Q&A pairs matching high-intent queries AI overviews would summarize:
+
+| Page | Recommended FAQ entry | Query it targets |
+|---|---|---|
+| /es/juego-de-palabras-multijugador | Q: "¿Cómo jugar Scrabble online gratis en español?" A: "Ve a LexiClash, crea una sala en 10 segundos, comparte el enlace y empieza a jugar — sin registro ni descarga." | jugar scrabble en español gratis |
+| /es/juego-de-palabras-multijugador | Q: "¿Es LexiClash igual que Scrabble?" A: "LexiClash es una alternativa a Scrabble online en tiempo real — en lugar de esperar turnos, todos los jugadores buscan palabras a la vez." | scrabble online español |
+| /he/hamila-hayomit | Q: "מה זה המילה היומית?" A: "המילה היומית היא פאזל מילים יומי חינמי של LexiClash — אותו לוח לכל העולם, מתחלף בחצות." | המילה היומית, מילת היום |
+| /he/hamila-hayomit | Q: "איך משחקים את המילה היומית?" A: "פותחים את LexiClash, בוחרים 'מילה יומית', ומנסים למצוא את מילת היום מהאותיות שבלוח. ללא הרשמה." | מילה ביום |
+| /sv/swedish-multiplayer-word-game | Q: "Hur spelar man Scrabble svenska online?" A: "Gå till LexiClash, skapa ett rum, bjud in vänner med en länk och börja spela Scrabble på svenska direkt — utan registrering." | scrabble svenska |
+| /en/* | Q: "What are games like Boggle I can play online?" A: "LexiClash is the closest free online Boggle alternative — real-time multiplayer, no download, 2–50 players." | games like boggle, word games like boggle |
+
+---
+
+## Rising / Falling Queries (7d vs prior 7d)
+
+### Rising (>30% impression delta, ≥10 impressions)
+
+| Query | Prior 7d imps | Last 7d imps | Δ% | Pos |
+|---|---|---|---|---|
+| juego de palabras en ingles | 2 | 10 | +400% | — |
+| boggle online free | 4 | 13 | +225% | — |
+| scrabble på svenska | 4 | 11 | +175% | — |
+| ordhjul | 19 | 47 | +147% | — |
+| jugar scrabble online en español | 6 | 14 | +133% | — |
+
+### Falling (>30% impression drop, ≥10 impressions)
+
+| Query | Prior 7d imps | Last 7d imps | Δ% | Note |
+|---|---|---|---|---|
+| juegos para aprender ingles | 19 | 3 | -84% | Possible seasonal / algo shift |
+| scrable español | 11 | 2 | -82% | Typo variant; low value |
+| boggle like game | 10 | 2 | -80% | Rank-up candidate |
+| scrabble online en español gratis | 39 | 11 | -72% | Key query falling — monitor |
+| jugar al scrabble | 77 | 30 | -61% | Significant; check SERP changes |
+
+**Alert:** "scrabble online en español gratis" (39→11 imps, -72%) and "jugar al scrabble" (77→30 imps, -61%) are meaningful drops for top Spanish queries. May indicate a ranking dip in Spain/LATAM — monitor next 7 days.
+
+---
+
+## Today's Actions
+
+1. **PR opened (`seo/daily-2026-07-12`):** Fixes meta title + description on Spanish multiplayer page (covers 8 of top 10 CTR opps, ~1,500 extra clicks/28d potential) and Swedish page (scrabble svenska CTR opp). Also tightens Hebrew daily word title for rank-up on "המילה היומית".
+2. **Monitor falling queries:** "scrabble online en español gratis" and "jugar al scrabble" dropped 61–72% week-over-week — check Google Search Console coverage + SERP positions manually.
+3. **Bing unblocked:** Add `ssl.bing.com:443` to egress proxy allowlist so tomorrow's run can include Bing parity analysis.

--- a/fe-next/app/[locale]/hamila-hayomit/page.tsx
+++ b/fe-next/app/[locale]/hamila-hayomit/page.tsx
@@ -23,8 +23,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   // Definition/guide intent — deliberately NOT a second "play here" title, so this
   // page does not cannibalize /he/daily (the play-intent doorway) on the SERP.
-  const title = 'מה זה "המילה היומית"? מדריך + פאזל מילת היום החינמי | LexiClash';
-  const description = 'מה זה "המילה היומית"? כל מה שצריך לדעת על מילת היום — פאזל המילים היומי החינמי של LexiClash: אותו לוח לכל העולם, ציד מילים וגלגל מילים, שיתוף תוצאות וטבלת מובילים. הסבר מלא + משחק, ללא הרשמה.';
+  const title = 'המילה היומית — מדריך + פאזל מילים יומי חינמי | LexiClash';
+  const description = 'המילה היומית של LexiClash — פאזל מילים חינמי ללא הרשמה. אותו לוח לכל העולם בחצות, ציד מילים וגלגל מילים, שיתוף תוצאות וטבלת מובילים. מדריך מלא + משחק.';
 
   return {
     title,

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,12 +27,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Scrabble Online en Español Gratis — Sin Registro, Sin Descarga | LexiClash',
-    description: 'Scrabble online gratis en español — sin registro, sin descarga. Crea sala en 10 segundos, invita amigos y juega en tiempo real. Hasta 50 jugadores.',
+    title: 'Scrabble Online Gratis en Español — Juega Ya | LexiClash',
+    description: '¿Buscas Scrabble online gratis en español? Juega en tiempo real sin esperar turnos — sin registro, sin descarga. Crea sala en 10 s. Hasta 50 jugadores →',
     keywords: 'jugar scrabble en español online gratis, scrabble en español online gratis, scrabble online español, cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Scrabble Online en Español Gratis — Sin Registro, Sin Descarga | LexiClash',
-      description: 'Scrabble online gratis en español — sin registro, sin descarga. Crea sala en 10 segundos, invita amigos y juega en tiempo real. Hasta 50 jugadores.',
+      title: 'Scrabble Online Gratis en Español — Juega Ya | LexiClash',
+      description: '¿Buscas Scrabble online gratis en español? Juega en tiempo real sin esperar turnos — sin registro, sin descarga. Crea sala en 10 s. Hasta 50 jugadores →',
       locale: 'es_ES',
       type: 'website',
       url: pageUrl,
@@ -47,8 +47,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online en Español Gratis — Sin Registro, Sin Descarga | LexiClash',
-      description: 'Scrabble online gratis en español — sin registro, sin descarga. Crea sala en 10 segundos, invita amigos y juega en tiempo real. Hasta 50 jugadores.',
+      title: 'Scrabble Online Gratis en Español — Juega Ya | LexiClash',
+      description: '¿Buscas Scrabble online gratis en español? Juega en tiempo real sin esperar turnos — sin registro, sin descarga. Crea sala en 10 s. Hasta 50 jugadores →',
       images: [`${BASE_URL}/og-image-es-multiplayer.webp`],
     },
     alternates: {

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -16,12 +16,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Alfapet & Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
-    description: 'Spela Alfapet och Scrabble online på svenska gratis — utan väntan på tur. 2–50 spelare i realtid, ingen app, ingen registrering. Starta nu →',
+    title: 'Scrabble Svenska Online Gratis — Alfapet | Spela Nu | LexiClash',
+    description: 'Spela Scrabble online på svenska gratis — ingen registrering, utan väntan på tur. Alfapet & Boggle i realtid, 2–50 spelare, ingen app. Starta nu →',
     keywords: 'ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
-      title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',
-      description: 'Spela Scrabble och Alfapet online på svenska gratis — utan registrering, upp till 50 spelare i realtid. Skapa rum och tävla direkt!',
+      title: 'Scrabble Svenska Online Gratis — Alfapet | LexiClash',
+      description: 'Spela Scrabble online på svenska gratis — ingen registrering, utan väntan på tur. Alfapet & Boggle i realtid, 2–50 spelare, ingen app. Starta nu →',
       locale: 'sv_SE',
       type: 'website',
       url: pageUrl,
@@ -36,8 +36,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',
-      description: 'Spela Alfapet och Scrabble online på svenska i realtid. Skapa rum, bjud in med länk, tävla direkt. Gratis.',
+      title: 'Scrabble Svenska Online Gratis — Alfapet | LexiClash',
+      description: 'Spela Scrabble online på svenska gratis — ingen registrering, utan väntan på tur. Alfapet & Boggle i realtid, 2–50 spelare, ingen app. Starta nu →',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },
     alternates: {


### PR DESCRIPTION
## Summary

Daily SEO run (2026-07-12) identified 78 CTR underperformers across 44,109 impressions. Top fix: the Spanish multiplayer page title was 75 chars — Google truncates at ~57 chars, hiding "Gratis" and the "Sin Descarga" benefit. Three meta-tag-only fixes are included here; full analysis in `docs/seo-daily/2026-07-12.md`.

---

## Changes

### 1. Spanish page — `/es/juego-de-palabras-multijugador`

**Covers:** "scrabble online" (12,340 imps, pos 4.9), "scrabble online español" (3,214), "scrabble en linea" (2,303), "scrabble online gratis" (2,165), and 4 more — 8 of the top 10 CTR opportunities all point to this page.

| Field | Old | New |
|---|---|---|
| `<title>` | `Scrabble Online en Español Gratis — Sin Registro, Sin Descarga \| LexiClash` (**75 chars, truncated**) | `Scrabble Online Gratis en Español — Juega Ya \| LexiClash` (**57 chars ✓**) |
| `<meta description>` | `Scrabble online gratis en español — sin registro, sin descarga. Crea sala en 10 segundos, invita amigos y juega en tiempo real. Hasta 50 jugadores.` | `¿Buscas Scrabble online gratis en español? Juega en tiempo real sin esperar turnos — sin registro, sin descarga. Crea sala en 10 s. Hasta 50 jugadores →` |

**Expected CTR uplift:** pos 4.9 should yield ~6% CTR; current is 0.3%. Even reaching 1–2% = +85–210 extra clicks/28d on the top query alone. Combined across all 8 Spanish queries: ~1,500 extra clicks/28d potential.

---

### 2. Swedish page — `/sv/swedish-multiplayer-word-game`

**Covers:** "scrabble svenska" (1,149 imps, pos 7.2, 0.1% CTR vs 2% expected)

| Field | Old | New |
|---|---|---|
| `<title>` | `Alfapet & Scrabble Online Svenska Gratis — Spela Nu \| LexiClash` | `Scrabble Svenska Online Gratis — Alfapet \| Spela Nu \| LexiClash` |
| `<meta description>` | `Spela Alfapet och Scrabble online på svenska gratis — utan väntan på tur…` | `Spela Scrabble online på svenska gratis — ingen registrering, utan väntan på tur. Alfapet & Boggle i realtid…` |

"Scrabble Svenska" now leads the title (exact query match) instead of "Alfapet & Scrabble".

---

### 3. Hebrew daily word page — `/he/hamila-hayomit`

**Covers:** "המילה היומית" (630 imps, pos 8.2 — rank-up opportunity)

| Field | Old | New |
|---|---|---|
| `<title>` | `מה זה "המילה היומית"? מדריך + פאזל מילת היום החינמי \| LexiClash` | `המילה היומית — מדריך + פאזל מילים יומי חינמי \| LexiClash` |
| `<meta description>` | `מה זה "המילה היומית"? כל מה שצריך לדעת על מילת היום…` | `המילה היומית של LexiClash — פאזל מילים חינמי ללא הרשמה. אותו לוח לכל העולם בחצות…` |

Title leads with the exact query phrase. Guide/informational intent preserved (no cannibalization with `/he/daily`).

---

## Daily Report

`docs/seo-daily/2026-07-12.md` — 28-day headline metrics, 78 CTR opportunities, 9 rank-up opportunities, rising/falling query trends, and GEO/AI FAQ schema recommendations.

**Note:** Bing analysis skipped — `ssl.bing.com` is blocked by the session egress proxy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHmEUdPQyZodUnUxaTeDyR)_