### PR TITLE
Merge teacher dashboard into boggle-new

### DIFF
--- a/fe-next/app/api/webhook/lemonsqueezy/route.ts
+++ b/fe-next/app/api/webhook/lemonsqueezy/route.ts
@@ -1,0 +1,235 @@
+/**
+ * Lemon Squeezy Webhook Handler
+ * Processes subscription lifecycle events and updates Supabase.
+ * Ported from standalone teacher-dashboard repo.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { LemonSqueezyClient } from '@/lib/lemonsqueezy'
+import { upsertSubscription, logSubscriptionEvent, type Tier } from '@/lib/subscriptions'
+
+// Webhook payload shape — using `any` for relationships to allow flexible access
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type WebhookPayload = any
+
+/** Safely extract variant ID from various payload shapes */
+function getVariantId(p: WebhookPayload): string | undefined {
+  const rid =
+    p?.data?.relationships?.variant?.data?.id ??
+    p?.data?.attributes?.variant_id ??
+    p?.data?.attributes?.first_order_item?.variant_id
+  return rid != null ? String(rid) : undefined
+}
+
+/** Map Lemon Squeezy variant IDs to tier names */
+function getTierFromVariantId(variantId: string | undefined): Tier {
+  if (!variantId) return 'free'
+  const proVariantId = process.env.LEMONSQUEEZY_VARIANT_ID_PRO
+  if (proVariantId && variantId === proVariantId) return 'pro'
+  return 'free'
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const rawBody = await request.text()
+    const signature = request.headers.get('x-signature') ?? ''
+
+    if (!LemonSqueezyClient.validateWebhookSignature(rawBody, signature)) {
+      console.error('[LemonSqueezy] Invalid webhook signature')
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+    }
+
+    const payload: WebhookPayload = JSON.parse(rawBody)
+    const eventName = payload.meta?.event_name as string
+    const userId = payload.meta?.custom_data?.user_id as string | undefined
+
+    console.log(`[LemonSqueezy] Event: ${eventName}`, { userId })
+
+    switch (eventName) {
+      case 'order_created':
+        await handleOrderCreated(payload, userId)
+        break
+      case 'subscription_created':
+        await handleSubscriptionCreated(payload, userId)
+        break
+      case 'subscription_updated':
+        await handleSubscriptionUpdated(payload, userId)
+        break
+      case 'subscription_cancelled':
+        await handleSubscriptionCancelled(payload, userId)
+        break
+      case 'subscription_expired':
+        await handleSubscriptionExpired(payload, userId)
+        break
+      default:
+        console.log(`[LemonSqueezy] Unhandled event: ${eventName}`)
+    }
+
+    await logSubscriptionEvent({
+      userId,
+      eventType: eventName,
+      subscriptionId: String(payload?.data?.id ?? ''),
+      payload: { event_name: eventName, user_id: userId },
+    })
+
+    return NextResponse.json({ received: true })
+  } catch (error) {
+    console.error('[LemonSqueezy] Webhook error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+async function handleOrderCreated(payload: WebhookPayload, userId?: string) {
+  const variantId = getVariantId(payload)
+  const tier = getTierFromVariantId(variantId)
+  const orderId = String(payload?.data?.id ?? '')
+
+  if (!userId) {
+    // Try to get user from order attributes
+    const customData = payload?.data?.attributes?.custom_data as Record<string, unknown> | undefined
+    const fallbackUserId = customData?.user_id as string | undefined
+    if (!fallbackUserId) {
+      console.warn('[LemonSqueezy] order_created — no user_id in custom_data')
+      return
+    }
+    await upsertSubscription({
+      userId: fallbackUserId,
+      tier,
+      status: 'active',
+      lemonSqueezyOrderId: orderId,
+      lemonSqueezyVariantId: variantId,
+    })
+    return
+  }
+
+  await upsertSubscription({
+    userId,
+    tier,
+    status: 'active',
+    lemonSqueezyOrderId: orderId,
+    lemonSqueezyVariantId: variantId,
+  })
+}
+
+async function handleSubscriptionCreated(payload: WebhookPayload, userId?: string) {
+  const variantId = getVariantId(payload)
+  const tier = getTierFromVariantId(variantId)
+  const subscriptionId = String(payload?.data?.id ?? '')
+  const attributes = payload?.data?.attributes ?? {}
+  const currentPeriodEnd = attributes?.ends_at as string | null ?? null
+
+  if (!userId) {
+    const customData = attributes?.custom_data as Record<string, unknown> | undefined
+    const fallbackUserId = customData?.user_id as string | undefined
+    if (!fallbackUserId) {
+      console.warn('[LemonSqueezy] subscription_created — no user_id')
+      return
+    }
+    await upsertSubscription({
+      userId: fallbackUserId,
+      tier,
+      status: 'active',
+      lemonSqueezySubscriptionId: subscriptionId,
+      lemonSqueezyVariantId: variantId,
+      currentPeriodEnd,
+    })
+    return
+  }
+
+  await upsertSubscription({
+    userId,
+    tier,
+    status: 'active',
+    lemonSqueezySubscriptionId: subscriptionId,
+    lemonSqueezyVariantId: variantId,
+    currentPeriodEnd,
+  })
+}
+
+async function handleSubscriptionUpdated(payload: WebhookPayload, userId?: string) {
+  const variantId = getVariantId(payload)
+  const tier = getTierFromVariantId(variantId)
+  const subscriptionId = String(payload?.data?.id ?? '')
+  const attributes = payload?.data?.attributes ?? {}
+  const status = String(attributes?.status ?? 'active')
+  const currentPeriodEnd = attributes?.ends_at as string | null ?? null
+  const cancelAtPeriodEnd = Boolean(attributes?.cancelled ?? false)
+
+  if (!userId) {
+    const customData = attributes?.custom_data as Record<string, unknown> | undefined
+    const fallbackUserId = customData?.user_id as string | undefined
+    if (!fallbackUserId) return
+    await upsertSubscription({
+      userId: fallbackUserId,
+      tier,
+      status: status as Tier['status'],
+      lemonSqueezySubscriptionId: subscriptionId,
+      lemonSqueezyVariantId: variantId,
+      currentPeriodEnd,
+      cancelAtPeriodEnd,
+    })
+    return
+  }
+
+  await upsertSubscription({
+    userId,
+    tier,
+    status: status as Tier['status'],
+    lemonSqueezySubscriptionId: subscriptionId,
+    lemonSqueezyVariantId: variantId,
+    currentPeriodEnd,
+    cancelAtPeriodEnd,
+  })
+}
+
+async function handleSubscriptionCancelled(payload: WebhookPayload, userId?: string) {
+  const subscriptionId = String(payload?.data?.id ?? '')
+  const attributes = payload?.data?.attributes ?? {}
+
+  if (!userId) {
+    const customData = attributes?.custom_data as Record<string, unknown> | undefined
+    const fallbackUserId = customData?.user_id as string | undefined
+    if (!fallbackUserId) return
+    await upsertSubscription({
+      userId: fallbackUserId,
+      tier: 'free',
+      status: 'canceled',
+      lemonSqueezySubscriptionId: subscriptionId,
+      cancelAtPeriodEnd: true,
+    })
+    return
+  }
+
+  await upsertSubscription({
+    userId,
+    tier: 'free',
+    status: 'canceled',
+    lemonSqueezySubscriptionId: subscriptionId,
+    cancelAtPeriodEnd: true,
+  })
+}
+
+async function handleSubscriptionExpired(payload: WebhookPayload, userId?: string) {
+  const subscriptionId = String(payload?.data?.id ?? '')
+  const attributes = payload?.data?.attributes ?? {}
+
+  if (!userId) {
+    const customData = attributes?.custom_data as Record<string, unknown> | undefined
+    const fallbackUserId = customData?.user_id as string | undefined
+    if (!fallbackUserId) return
+    await upsertSubscription({
+      userId: fallbackUserId,
+      tier: 'free',
+      status: 'canceled',
+      lemonSqueezySubscriptionId: subscriptionId,
+    })
+    return
+  }
+
+  await upsertSubscription({
+    userId,
+    tier: 'free',
+    status: 'canceled',
+    lemonSqueezySubscriptionId: subscriptionId,
+  })
+}

--- a/fe-next/lib/lemonsqueezy.ts
+++ b/fe-next/lib/lemonsqueezy.ts
@@ -1,0 +1,222 @@
+/**
+ * Lemon Squeezy Client
+ * Handles checkout URL generation and webhook signature validation.
+ * Ported from standalone teacher-dashboard repo.
+ */
+
+import { createHmac, timingSafeEqual } from 'crypto'
+
+// ---- Types ----
+
+export interface CheckoutAttributes {
+  url: string
+  [key: string]: unknown
+}
+
+export interface CheckoutResponse {
+  data: {
+    id: string
+    attributes: CheckoutAttributes
+  }
+}
+
+export interface LemonSqueezyWebhookPayload {
+  meta: {
+    event_name: string
+    custom_data?: {
+      user_id?: string
+    }
+    [key: string]: unknown
+  }
+  data: {
+    id: string
+    type: string
+    attributes: Record<string, unknown>
+    relationships?: Record<string, unknown>
+  }
+  [key: string]: unknown
+}
+
+// ---- Tier configuration ----
+
+export type TierId = 'free' | 'pro'
+
+export interface TierConfig {
+  id: TierId
+  name: string
+  price_monthly_usd: number
+  classes_limit: number | null // null = unlimited
+  students_limit_per_class: number | null
+  features: string[]
+  /** Lemon Squeezy Variant ID — set via env LEMONSQUEEZY_VARIANT_ID_<TIER> */
+  variantId: string | undefined
+}
+
+const TIER_CONFIGS: Record<TierId, TierConfig> = {
+  free: {
+    id: 'free',
+    name: 'Free',
+    price_monthly_usd: 0,
+    classes_limit: 2,
+    students_limit_per_class: 30,
+    features: [
+      'Up to 2 classes',
+      '30 students per class',
+      'Basic word tracking',
+      'Daily progress reports',
+    ],
+    variantId: undefined,
+  },
+  pro: {
+    id: 'pro',
+    name: 'Teacher Pro',
+    price_monthly_usd: 5,
+    classes_limit: null,
+    students_limit_per_class: null,
+    features: [
+      'Unlimited classes',
+      'Unlimited students',
+      'Advanced analytics',
+      'Custom word lists',
+      'Priority support',
+      'Export data (CSV/PDF)',
+      'Classroom duel mode',
+    ],
+    variantId: process.env.LEMONSQUEEZY_VARIANT_ID_PRO,
+  },
+}
+
+export function getTierConfig(tier: TierId): TierConfig {
+  return TIER_CONFIGS[tier]
+}
+
+export function getAllTiers(): TierConfig[] {
+  return Object.values(TIER_CONFIGS)
+}
+
+// ---- Lemon Squeezy API Client ----
+
+export const LEMONSQUEEZY_API_BASE = 'https://api.lemonsqueezy.com/v1'
+
+export function getLemonSqueezyClient() {
+  const apiKey = process.env.LEMONSQUEEZY_API_KEY
+  if (!apiKey) {
+    throw new Error('LEMONSQUEEZY_API_KEY is not configured')
+  }
+
+  return new LemonSqueezyClient(apiKey)
+}
+
+export class LemonSqueezyClient {
+  private apiKey: string
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey
+  }
+
+  private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const url = `${LEMONSQUEEZY_API_BASE}${path}`
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+        ...options.headers,
+      },
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(`Lemon Squeezy API error: ${response.status} ${error}`)
+    }
+
+    return response.json()
+  }
+
+  /**
+   * Create a checkout URL for a given tier.
+   * Returns the full checkout URL that redirects the user to Lemon Squeezy.
+   */
+  async createCheckout({
+    userId,
+    tier,
+    email,
+    redirectUrl,
+  }: {
+    userId: string
+    tier: TierId
+    email?: string
+    redirectUrl?: string
+  }): Promise<string> {
+    const config = getTierConfig(tier)
+    const variantId = config.variantId
+
+    if (!variantId) {
+      throw new Error(`No variant ID configured for tier: ${tier}`)
+    }
+
+    const storeId = process.env.LEMONSQUEEZY_STORE_ID
+    if (!storeId) {
+      throw new Error('LEMONSQUEEZY_STORE_ID is not configured')
+    }
+
+    const response = await this.request<CheckoutResponse>('/checkouts', {
+      method: 'POST',
+      body: JSON.stringify({
+        data: {
+          type: 'checkouts',
+          attributes: {
+            product_options: {
+              redirect_url: redirectUrl || `${process.env.NEXT_PUBLIC_APP_URL}/teacher?checkout=success`,
+            },
+            checkout_data: {
+              email: email ?? '',
+              custom: {
+                user_id: userId,
+              },
+            },
+          },
+          relationships: {
+            store: {
+              data: {
+                type: 'stores',
+                id: storeId,
+              },
+            },
+            variant: {
+              data: {
+                type: 'variants',
+                id: variantId,
+              },
+            },
+          },
+        },
+      }),
+    })
+
+    return response.data.attributes.url
+  }
+
+  /**
+   * Validate a Lemon Squeezy webhook signature.
+   * Uses the webhook secret from env.
+   */
+  static validateWebhookSignature(rawBody: string, signature: string): boolean {
+    const secret = process.env.LEMONSQUEEZY_WEBHOOK_SECRET
+    if (!secret) {
+      console.warn('[LemonSqueezy] WEBHOOK_SECRET not configured — skipping signature validation')
+      return true
+    }
+
+    const hmac = createHmac('sha256', secret)
+    hmac.update(rawBody)
+    const digest = hmac.digest('hex')
+
+    try {
+      return timingSafeEqual(Buffer.from(digest), Buffer.from(signature))
+    } catch {
+      return false
+    }
+  }
+}

--- a/fe-next/lib/subscriptions.ts
+++ b/fe-next/lib/subscriptions.ts
@@ -1,0 +1,177 @@
+/**
+ * Subscription management for LexiClash teachers.
+ * Ported from standalone teacher-dashboard repo.
+ *
+ * Reads subscription state from the `subscriptions` table in Supabase.
+ * Provides tier checking and limit enforcement.
+ */
+
+import { createClient } from '@/utils/supabase/server'
+import { type TierConfig, getTierConfig } from './lemonsqueezy'
+
+export type SubscriptionStatus = 'active' | 'past_due' | 'canceled' | 'paused' | 'trialing'
+export type Tier = 'free' | 'pro'
+
+export interface TeacherSubscription {
+  tier: Tier
+  status: SubscriptionStatus
+  classes_limit: number | null // null = unlimited
+  students_limit_per_class: number | null
+  current_period_end: string | null
+  cancel_at_period_end: boolean
+  has_pro: boolean
+}
+
+/**
+ * Check a teacher's current subscription status.
+ * Defaults to 'free' tier if no record exists.
+ */
+export async function checkTeacherSubscription(
+  userId: string
+): Promise<TeacherSubscription> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('subscriptions')
+    .select('*')
+    .eq('user_id', userId)
+    .single()
+
+  // No subscription record → free tier
+  if (error || !data) {
+    const freeConfig = getTierConfig('free')
+    return {
+      tier: 'free',
+      status: 'active',
+      classes_limit: freeConfig.classes_limit,
+      students_limit_per_class: freeConfig.students_limit_per_class,
+      current_period_end: null,
+      cancel_at_period_end: false,
+      has_pro: false,
+    }
+  }
+
+  return {
+    tier: data.tier as Tier,
+    status: data.status as SubscriptionStatus,
+    classes_limit: data.tier === 'pro' ? null : getTierConfig('free').classes_limit,
+    students_limit_per_class: data.tier === 'pro' ? null : getTierConfig('free').students_limit_per_class,
+    current_period_end: data.current_period_end,
+    cancel_at_period_end: data.cancel_at_period_end,
+    has_pro: data.tier === 'pro' && data.status === 'active',
+  }
+}
+
+/**
+ * Check if a teacher can create a new class.
+ * Returns { allowed, reason, currentCount, limit }.
+ */
+export async function canCreateClass(
+  userId: string
+): Promise<{
+  allowed: boolean
+  reason?: string
+  currentCount: number
+  limit: number | null
+}> {
+  const supabase = await createClient()
+  const subscription = await checkTeacherSubscription(userId)
+
+  // Count current classes
+  const { count } = await supabase
+    .from('classes')
+    .select('*', { count: 'exact', head: true })
+    .eq('teacher_id', userId)
+
+  const currentCount = count || 0
+
+  // Pro users have unlimited classes
+  if (subscription.has_pro) {
+    return { allowed: true, currentCount, limit: null }
+  }
+
+  const limit = subscription.classes_limit ?? 2
+
+  if (currentCount >= limit) {
+    return {
+      allowed: false,
+      reason: `You've reached the free tier limit of ${limit} classes. Upgrade to Pro for unlimited classes.`,
+      currentCount,
+      limit,
+    }
+  }
+
+  return { allowed: true, currentCount, limit }
+}
+
+/**
+ * Upsert a subscription record (called from webhook handler).
+ */
+export async function upsertSubscription({
+  userId,
+  tier,
+  status,
+  lemonSqueezySubscriptionId,
+  lemonSqueezyOrderId,
+  lemonSqueezyVariantId,
+  currentPeriodEnd,
+  cancelAtPeriodEnd,
+}: {
+  userId: string
+  tier: Tier
+  status: SubscriptionStatus
+  lemonSqueezySubscriptionId?: string | null
+  lemonSqueezyOrderId?: string | null
+  lemonSqueezyVariantId?: string | null
+  currentPeriodEnd?: string | null
+  cancelAtPeriodEnd?: boolean
+}): Promise<void> {
+  const supabase = await createClient()
+
+  const { error } = await supabase.from('subscriptions').upsert(
+    {
+      user_id: userId,
+      tier,
+      status,
+      lemon_squeezy_subscription_id: lemonSqueezySubscriptionId ?? null,
+      lemon_squeezy_order_id: lemonSqueezyOrderId ?? null,
+      lemon_squeezy_variant_id: lemonSqueezyVariantId ?? null,
+      current_period_end: currentPeriodEnd ?? null,
+      cancel_at_period_end: cancelAtPeriodEnd ?? false,
+    },
+    { onConflict: 'user_id' }
+  )
+
+  if (error) {
+    console.error('[Subscription] Failed to upsert:', error)
+    throw error
+  }
+}
+
+/**
+ * Log a subscription event (called from webhook handler).
+ */
+export async function logSubscriptionEvent({
+  userId,
+  eventType,
+  subscriptionId,
+  payload,
+}: {
+  userId?: string | null
+  eventType: string
+  subscriptionId?: string | null
+  payload: Record<string, unknown>
+}): Promise<void> {
+  const supabase = await createClient()
+
+  const { error } = await supabase.from('subscription_events').insert({
+    user_id: userId ?? null,
+    event_type: eventType,
+    subscription_id: subscriptionId ?? null,
+    payload,
+  })
+
+  if (error) {
+    console.error('[Subscription] Failed to log event:', error)
+  }
+}

--- a/fe-next/supabase/migrations/20260714000000_add_subscriptions.sql
+++ b/fe-next/supabase/migrations/20260714000000_add_subscriptions.sql
@@ -1,0 +1,64 @@
+-- Lemon Squeezy subscription tracking for LexiClash
+-- Tiers: free (default), pro ($5/class/mo)
+-- Merged from standalone teacher-dashboard repo
+
+create table if not exists public.subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade unique,
+  tier text not null default 'free' check (tier in ('free', 'pro')),
+  status text not null default 'active' check (status in ('active', 'past_due', 'canceled', 'paused', 'trialing')),
+  lemon_squeezy_subscription_id text,
+  lemon_squeezy_order_id text,
+  lemon_squeezy_variant_id text,
+  current_period_end timestamptz,
+  cancel_at_period_end boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.subscription_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete set null,
+  event_type text not null,
+  subscription_id text,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_subscriptions_user_id on public.subscriptions(user_id);
+create index if not exists idx_subscription_events_user_id on public.subscription_events(user_id);
+create index if not exists idx_subscription_events_event_type on public.subscription_events(event_type);
+
+-- Enable RLS
+alter table public.subscriptions enable row level security;
+alter table public.subscription_events enable row level security;
+
+-- Policies: users can only read their own subscriptions
+create policy "Users can read own subscription"
+  on public.subscriptions for select
+  using (auth.uid() = user_id);
+
+-- Service role can do everything (server-side code uses service role key)
+create policy "Service role full access on subscriptions"
+  on public.subscriptions
+  using (true)
+  with check (true);
+
+create policy "Service role full access on subscription_events"
+  on public.subscription_events
+  using (true)
+  with check (true);
+
+-- Trigger to update updated_at
+create or replace function public.update_subscriptions_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger set_subscriptions_updated_at
+  before update on public.subscriptions
+  for each row
+  execute function public.update_subscriptions_updated_at();


### PR DESCRIPTION
## What

Ported the standalone teacher dashboard functionality into boggle-new:

- **Supabase migration**: subscriptions + subscription_events tables with RLS
- **LemonSqueezy lib**: checkout creation, tier config, webhook signature validation
- **Subscription management**: tier checking, class limits, upsert + event logging
- **Webhook endpoint**: handles subscription lifecycle events

## Why

Standalone teacher dashboard repo was duplicating functionality. This brings the missing pieces (subscriptions/payments) directly into the main codebase.

## Next
- Port pricing page
- Delete standalone lexiclash-teacher-dashboard repo
- Run migration on production DB