### PR TITLE
fix(audio): stop duplicate mute control overlapping the menu button

### DIFF
--- a/fe-next/components/MusicControls.tsx
+++ b/fe-next/components/MusicControls.tsx
@@ -9,6 +9,7 @@ import { useSoundEffects } from '../contexts/SoundEffectsContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Button } from './ui/button';
 import { useHapticsConfig } from '../contexts/HapticsContext';
+import { useRegisterHeaderAudioControl } from '@/contexts/NavigationContext';
 import { resolveMasterMuteClick } from '@/lib/audio/masterMuteToggle';
 import { Reveal } from '@/components/ui/Reveal';
 
@@ -26,6 +27,15 @@ const MusicControls: React.FC = memo(() => {
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0, right: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
   const isRTL = language === 'he';
+
+  // This IS the header's on-screen sound control. Register it so the global
+  // in-game mute FAB (InGameAudioButton) stands down while a header sound
+  // control is visible. Without this hand-off, screens that render <Header />
+  // directly (landing, word-craft, gem-hunt) keep the header — and this
+  // control — visible while `isInGame` is true, so the fixed FAB would show a
+  // SECOND mute control that overlaps the menu button. Degrades to a no-op
+  // outside a NavigationProvider (isolated tests).
+  useRegisterHeaderAudioControl();
 
   // Prevent hydration mismatch by only rendering dynamic icon after mount
   useEffect(() => {

--- a/fe-next/components/__tests__/MusicControls.headerAudioControl.test.tsx
+++ b/fe-next/components/__tests__/MusicControls.headerAudioControl.test.tsx
@@ -1,0 +1,95 @@
+import { vi } from 'vitest';
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * MusicControls is the header's sound control. The global in-game mute FAB
+ * (InGameAudioButton) is meant to appear ONLY when the header — and thus its
+ * MusicControls — is hidden during gameplay. On screens that render <Header />
+ * directly (landing, word-craft, gem-hunt) the header stays visible, so without
+ * an explicit hand-off the FAB and the header control both show and the fixed
+ * FAB overlaps the menu button ("sound control shows twice / hides the menu").
+ *
+ * Fix: MusicControls registers an in-header audio control while mounted (the same
+ * mechanism the MP LobbyAudioButton uses), so the FAB stands down whenever a
+ * header sound control is on screen — regardless of the isInGame flag.
+ */
+
+// Stub framer-motion to a passthrough so we don't need the real motion runtime.
+vi.mock('framer-motion', () => ({
+  m: new Proxy({}, {
+    get: () => (props: React.PropsWithChildren<Record<string, unknown>>) => {
+      const { children, ...rest } = props;
+      const safe: Record<string, unknown> = {};
+      Object.keys(rest).forEach((k) => {
+        if (!['initial', 'animate', 'exit', 'transition', 'whileHover', 'whileTap'].includes(k)) {
+          safe[k] = (rest as Record<string, unknown>)[k];
+        }
+      });
+      return React.createElement('div', safe, children);
+    },
+  }),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+const musicState = {
+  volume: 0.5,
+  isMuted: false,
+  isPlaying: false,
+  audioUnlocked: true,
+  setVolume: vi.fn(),
+  toggleMute: vi.fn(),
+  unlockAudio: vi.fn(),
+};
+
+const sfxState = {
+  sfxVolume: 0.5,
+  sfxMuted: false,
+  setSfxVolume: vi.fn(),
+  toggleSfxMute: vi.fn(),
+};
+
+vi.mock('../../contexts/MusicContext', () => ({ useMusic: () => musicState }));
+vi.mock('../../contexts/SoundEffectsContext', () => ({ useSoundEffects: () => sfxState }));
+vi.mock('../../contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (k: string) => k, language: 'en' }),
+}));
+vi.mock('../../contexts/HapticsContext', () => ({
+  useHapticsConfig: () => ({ enabled: false, setEnabled: vi.fn() }),
+}));
+
+// Spy on the header-audio-control registration.
+const registerCleanup = vi.fn();
+const registerHeaderAudioControl = vi.fn(() => registerCleanup);
+vi.mock('@/contexts/NavigationContext', () => ({
+  useRegisterHeaderAudioControl: (active = true) => {
+    React.useEffect(() => {
+      if (!active) return;
+      return registerHeaderAudioControl();
+    }, [active]);
+  },
+}));
+
+// Import AFTER mocks so the component closes over them.
+import MusicControls from '../MusicControls';
+
+describe('MusicControls — header audio control hand-off', () => {
+  beforeEach(() => {
+    registerCleanup.mockClear();
+    registerHeaderAudioControl.mockClear();
+  });
+  afterEach(cleanup);
+
+  it('registers an in-header audio control while mounted (so the global FAB stands down)', () => {
+    render(<MusicControls />);
+    expect(registerHeaderAudioControl).toHaveBeenCalledTimes(1);
+  });
+
+  it('unregisters on unmount so the FAB can return once the header is gone', () => {
+    const { unmount } = render(<MusicControls />);
+    expect(registerCleanup).not.toHaveBeenCalled();
+    unmount();
+    expect(registerCleanup).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

On the home screen (and other screens that render `<Header />` directly), a **second sound-control button appears in the top corner and overlaps the hamburger menu button** — so the mute control shows twice and the menu button is hidden.

[reported screenshot shows two mute icons flanking the language flag, with the menu button covered]

## Root cause

The global in-game mute FAB (`InGameAudioButton`, mounted once in the locale layout) is meant to appear **only while the header — and its `MusicControls` — is hidden during gameplay**. It gates its visibility on `NavigationContext.isInGame` as a *proxy* for "header is hidden".

That proxy is only valid for screens wrapped in `AutoHideHeader` (which removes the header when `isInGame` is true). But several screens render `<Header />` **directly** and never hide it:

- `LandingView` (home)
- `WordCraftGameScreen`
- `GemHuntPageClient` (also sets `setIsInGame(true)`)

On those screens the header — and its `MusicControls` — stays visible while `isInGame` is true (or stale-true after returning from a game via client-side nav). The fixed FAB then renders a **second** mute control in the top corner (`fixed` top-left in RTL / top-right in LTR), directly overlapping the header's menu button.

## Fix

`NavigationContext` already ships a purpose-built, ref-counted hand-off for exactly this: `useRegisterHeaderAudioControl()` sets `headerAudioControlActive`, and the FAB stands down while it's active. The MP host lobby already uses it (`LobbyAudioButton`), but the **main header sound control never did** — the mechanism existed with no production registrant.

This wires `MusicControls` into that registration. Now, whenever a header sound control is on screen, the FAB stands down — regardless of `isInGame`. This resolves the duplication **systemically** across every screen that keeps the header visible (landing, word-craft, gem-hunt), not per-screen.

- Ref-counted, so the two breakpoint-exclusive `MusicControls` instances in each header (and `EducationHeader`) register/unregister cleanly.
- Degrades to a no-op outside a `NavigationProvider` (isolated component tests), so existing `MusicControls` tests are unaffected.
- During genuine gameplay on `AutoHideHeader` screens the header is unmounted, so no `MusicControls` is registered and the FAB still appears as intended.

## Other places checked
- **Adventure** — its header (with `MusicControls`) only renders in `worldMap`/`levelGrid` (`isInGame` false there); during `playing`/`bossRush` the header is unmounted, so the FAB shows singly. No overlap.
- **EducationHeader** — renders two `MusicControls`, but they're breakpoint-exclusive (`hidden sm:flex` vs `sm:hidden`), not two at once. Same pattern as the main header.
- Confirmed no header renders a `MusicControls` that is breakpoint-hidden yet mounted (which would suppress the FAB while showing no control).

## Testing
- New `MusicControls.headerAudioControl.test.tsx` (TDD): asserts `MusicControls` registers on mount and unregisters on unmount.
- Re-ran related suites — `InGameAudioButton`, `MusicControls.muteBehavior`, `NavigationContext.headerAudioControl`, `LobbyAudioButton`, header suites — all green.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4PSw2TXQPYkYWM3ModMLh

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4PSw2TXQPYkYWM3ModMLh)_