### PR TITLE
grok: emit results_viewed for multiplayer modes (PostHog funnel)

### DIFF
--- a/fe-next/components/results/ResultsMainContent.tsx
+++ b/fe-next/components/results/ResultsMainContent.tsx
@@ -189,6 +189,13 @@ export const ResultsMainContent: React.FC<ResultsMainContentProps> = memo(functi
   const { variant: progressHeaderVariant } = useExperiment('exp-mp-round-progress-header-v1');
 
   useEffect(() => {
+    // Canonical funnel event — same shape as word-wheel / word-hunt / blast so
+    // PostHog mode-split dashboards include classic / survival / wheel-rush.
+    // Fires for every ResultsMainContent mount (MP results path for those modes).
+    trackGrowthEvent('results_viewed', {
+      mode: gameMode ?? 'unknown',
+      score: currentPlayerData?.score ?? 0,
+    });
     if (isMultiplayer) {
       trackGrowthEvent('mp_results_viewed', { gameMode: gameMode ?? 'unknown', language });
     }

--- a/fe-next/components/results/__tests__/ResultsMainContent.resultsViewed.test.tsx
+++ b/fe-next/components/results/__tests__/ResultsMainContent.resultsViewed.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Canonical results_viewed funnel event for multiplayer classic / survival /
+ * wheel-rush. Those modes already fire mp_results_viewed, but PostHog
+ * mode-split dashboards query the shared results_viewed name (same shape as
+ * word-wheel / word-hunt / blast). Without this, classic (~375 starts / 14d)
+ * is invisible on the results funnel.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual('framer-motion');
+  return { ...actual, useReducedMotion: () => false };
+});
+vi.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (k: string) => k, language: 'en', dir: 'ltr' }),
+}));
+vi.mock('@/hooks/useExperiment', () => ({ useExperiment: () => ({ variant: 'control' }) }));
+const trackGrowthEvent = vi.fn();
+vi.mock('@/utils/growthTracking', () => ({
+  trackGrowthEvent: (...args: unknown[]) => trackGrowthEvent(...args),
+}));
+vi.mock('@/components/results/ResultsHeroSection', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/ResultsPodium', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/ConsolationRows', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/ResultsRivalsPanel', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/HighlightsBar', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/MpBragCard', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/ImprovementPanel', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/feedback/GameFeedback', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/multiplayer/NearRankTeaser', () => ({ NearRankTeaser: () => null }));
+vi.mock('@/components/results/ResultsRevengeSection', () => ({ ResultsRevengeSection: () => null }));
+vi.mock('@/components/results/SeriesStandingsBanner', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/results/ResultsWordsSection', () => ({ ResultsWordsSection: () => null }));
+vi.mock('@/components/results/RewardsSummary', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/utils/consolationCrowns', () => ({ assignConsolationCrowns: () => [] }));
+
+import { ResultsMainContent } from '../ResultsMainContent';
+
+const mk = (username: string, score: number) => ({ username, score, allWords: [] });
+const baseProps = {
+  nearMisses: [],
+  isHost: false,
+  onStartGame: vi.fn(),
+  onMarkReady: vi.fn(),
+  onExit: vi.fn(),
+  winStreakData: null,
+  isAuthenticated: true,
+  currentPlayerValidWords: [{ word: 'test', score: 10 }],
+  normalizeUsername: (n: string) => n || '',
+  isBotsOnlyGame: false,
+  isCurrentPlayerReady: false,
+  readyUsernames: [],
+  duplicateRuleDisabled: false,
+  t: (k: string) => k,
+  sortedScores: [mk('bob', 500), mk('alice', 400)],
+  currentPlayerData: mk('bob', 500),
+  currentPlayerRank: 1,
+  isCurrentUserWinner: true,
+  username: 'bob',
+  language: 'en',
+} as any;
+
+beforeEach(() => {
+  trackGrowthEvent.mockClear();
+});
+
+describe('ResultsMainContent — results_viewed instrumentation', () => {
+  it('fires canonical results_viewed on mount with mode + score (classic)', () => {
+    // GIVEN multiplayer classic results
+    // WHEN the results surface mounts
+    render(<ResultsMainContent {...baseProps} gameMode="classic" />);
+
+    // THEN the shared funnel event fires with the same shape as word-wheel/blast
+    expect(trackGrowthEvent).toHaveBeenCalledWith(
+      'results_viewed',
+      expect.objectContaining({ mode: 'classic', score: 500 }),
+    );
+  });
+
+  it('fires results_viewed for survival and wheel-rush modes', () => {
+    render(<ResultsMainContent {...baseProps} gameMode="survival" />);
+    expect(trackGrowthEvent).toHaveBeenCalledWith(
+      'results_viewed',
+      expect.objectContaining({ mode: 'survival', score: 500 }),
+    );
+
+    trackGrowthEvent.mockClear();
+    render(<ResultsMainContent {...baseProps} gameMode="wheel-rush" />);
+    expect(trackGrowthEvent).toHaveBeenCalledWith(
+      'results_viewed',
+      expect.objectContaining({ mode: 'wheel-rush', score: 500 }),
+    );
+  });
+
+  it('still fires mp_results_viewed for multiplayer (does not regress)', () => {
+    render(<ResultsMainContent {...baseProps} gameMode="classic" />);
+    expect(trackGrowthEvent).toHaveBeenCalledWith(
+      'mp_results_viewed',
+      expect.objectContaining({ gameMode: 'classic' }),
+    );
+  });
+
+  it('uses mode unknown and score 0 when props are missing', () => {
+    render(
+      <ResultsMainContent
+        {...baseProps}
+        gameMode={undefined}
+        currentPlayerData={undefined}
+        sortedScores={[mk('solo', 0)]}
+      />,
+    );
+    expect(trackGrowthEvent).toHaveBeenCalledWith(
+      'results_viewed',
+      expect.objectContaining({ mode: 'unknown', score: 0 }),
+    );
+  });
+});

--- a/fe-next/utils/growthTracking.ts
+++ b/fe-next/utils/growthTracking.ts
@@ -217,6 +217,8 @@ export type GrowthEvent =
   | 'wordhunt_results_loaded'
   | 'wordhunt_leaderboard_tap'
   // Multiplayer results page funnel — fills mp_round blind spots.
+  //   results_viewed: also fired on ResultsMainContent mount (canonical mode funnel;
+  //     props { mode, score }) so classic/survival/wheel-rush join word-wheel/blast.
   //   mp_results_viewed: fires on ResultsMainContent mount (isMultiplayer=true).
   //     Props: { gameMode, language }. Baseline reach for round-result funnel.
   //   mp_round_ready_clicked: fires when player marks ready for next round.


### PR DESCRIPTION
grok-4.5 (autonomous via hermes) added the canonical `results_viewed` analytics event to multiplayer results (classic/survival/wheel-rush) — they were invisible in the unified PostHog funnel. Analytics-only, no gameplay/retention impact. Independently verified: fix correct, test passes 4/4, tsc clean. Merged per Ohad's explicit override of never-auto-merge.