### PR TITLE
SEO: daily meta tag improvements (2026-07-21)

### DIFF
--- a/docs/seo-daily/2026-07-21.md
+++ b/docs/seo-daily/2026-07-21.md
@@ -1,0 +1,159 @@
+# SEO Daily Report — 2026-07-21
+
+Data window: **2026-06-22 → 2026-07-19** (28 days, Google Search Console)
+Bing data: **unavailable** (proxy blocks ssl.bing.com in this environment; use Bing Webmaster Tools UI for Bing-specific analysis)
+7d-vs-prior-7d delta: **not available** (GSC API returned 28-day totals only; use GSC date-comparison UI for trends)
+
+---
+
+## Headline Metrics
+
+### Google (28-day totals)
+
+| Metric | Value |
+|---|---|
+| Total clicks | 306 |
+| Total impressions | 47,485 |
+| Avg CTR | 0.64% |
+| Unique queries | 1,220 |
+| Unique pages | 372 |
+
+**Key observation:** The `/es/juego-de-palabras-multijugador` page alone drives **45,244 impressions (95% of total)** but only 303 clicks (0.67% CTR). Fixing CTR on this one page is the highest-leverage action in the entire site.
+
+### Top Pages by Impressions
+
+| Page | Impressions | Clicks | CTR | Avg Position |
+|---|---|---|---|---|
+| /es/juego-de-palabras-multijugador | 45,244 | 303 | 0.67% | 5.7 |
+| /sv/swedish-multiplayer-word-game | 2,597 | 27 | 1.04% | 5.4 |
+| /en/play-boggle-online-free | 2,508 | 44 | 1.75% | 12.4 |
+| /en/blog/best-boggle-alternatives-2026 | 1,508 | 36 | 2.39% | 7.1 |
+| /sv/tools/word-solver | 1,422 | 24 | 1.69% | 7.4 |
+| /en/best-online-word-games | 1,372 | 15 | 1.09% | 8.2 |
+| /es/education/esl-word-games | 1,236 | 40 | 3.24% | 17.5 |
+| /en/leaderboard | 1,120 | 13 | 1.16% | 3.3 |
+| /he/daily | 1,087 | 8 | 0.74% | 8.9 |
+| /es (homepage) | 843 | 64 | 7.59% | 8.7 |
+
+### Bing
+
+Data unavailable (proxy restriction). Check Bing Webmaster Tools manually.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+Queries with impressions ≥ 30 and CTR underperforming position benchmark by ≥ 30%.
+
+| # | Query | Page | Pos | Impressions | Current CTR | Expected CTR | Fix |
+|---|---|---|---|---|---|---|---|
+| 1 | scrabble online | /es/juego-de-palabras-multijugador | 4.9 | 12,275 | 0.32% | 6.0% | **Title truncation** (was 75 chars → fixed to 56) |
+| 2 | scrabble online español | /es/juego-de-palabras-multijugador | 5.2 | 3,348 | 0.54% | 4.0% | Same title fix |
+| 3 | scrabble en linea | /es/juego-de-palabras-multijugador | 5.9 | 2,327 | 0.39% | 4.0% | Same title fix |
+| 4 | scrabble online gratis | /es/juego-de-palabras-multijugador | 7.0 | 2,229 | 0.04% | 3.0% | Same title fix; investigate 0.04% anomaly |
+| 5 | scrabble en español | /es/juego-de-palabras-multijugador | 6.3 | 1,756 | 0.40% | 3.0% | Same title fix |
+| 6 | scrabble en español online | /es/juego-de-palabras-multijugador | 5.2 | 1,658 | 0.42% | 4.0% | Same title fix |
+| 7 | scrabble (en español) - juega gratis en línea | /es/juego-de-palabras-multijugador | 5.1 | 1,448 | 0.62% | 4.0% | Same title fix |
+| 8 | scrabble español | /es/juego-de-palabras-multijugador | 5.9 | 1,345 | 0.22% | 4.0% | Same title fix |
+| 9 | scrabble juego online | /es/juego-de-palabras-multijugador | 4.8 | 1,252 | 0.32% | 6.0% | Same title fix |
+| 10 | scrabble svenska | /sv/swedish-multiplayer-word-game | 6.3 | 1,181 | 0.17% | 3.0% | **Title truncation** (was 63 chars → fixed to 52) |
+
+**Root cause:** The ES page title was 75 characters — Google truncates at ~55–60 pixels (≈55 chars for wide chars). Users see a cut-off title with no clear value proposition. The SV page title (63 chars) had the same issue.
+
+**Estimated CTR uplift from title fix on ES page:** If CTR rises from 0.67% to 2% on 45,244 impressions: +600 clicks/28 days (+214%).
+
+---
+
+## Top 10 Rank-Up Opportunities (Google)
+
+Queries at avg position 8–20 with impressions ≥ 50. Small on-page improvements can push to page 1.
+
+| # | Query | Page | Pos | Impressions | Clicks | Suggested Action |
+|---|---|---|---|---|---|---|
+| 1 | המילה היומית | /he/daily | 8.4 | 497 | 1 | Add FAQPage schema (Q: מה זו המילה היומית?); strengthen H1 |
+| 2 | מילת היום | /he/daily | 9.8 | 206 | 4 | Add alt query to title: "מילת היום & המילה היומית" |
+| 3 | סקריבל בעברית | /he/blog/hebrew-word-games-guide | 8.3 | 159 | 0 | Add H2 with exact phrase; internal link from /he/daily |
+| 4 | lexi game | /en | 8.1 | 156 | 0 | Add "Lexi game" to H2 or FAQ on homepage |
+| 5 | jugar scrabble | /es/juego-de-palabras-multijugador | 8.1 | 131 | 3 | "Jugar Scrabble" now in title via fix; monitor |
+| 6 | boggle online free | /en/play-boggle-online-free | 8.7 | 121 | 1 | Description fix landed (was 199 chars → 141); add FAQPage schema |
+| 7 | games like boggle | /en/blog/best-boggle-alternatives-2026 | 9.0 | 100 | 1 | Add "games like boggle" in H1 or meta title |
+| 8 | word games like boggle | /en/blog/best-boggle-alternatives-2026 | 9.3 | 99 | 1 | Combine into H1: "Games Like Boggle & Word Games Like Boggle" |
+| 9 | boggle game online | /en/play-boggle-online-free | 11.8 | 74 | 1 | Add H2: "Play Boggle Game Online Free" |
+| 10 | online scrabble | /es/juego-de-palabras-multijugador | 9.1 | 72 | 0 | "online scrabble" — covered by ES title fix |
+
+---
+
+## Bing Parity Gaps
+
+**Unavailable** — Bing Webmaster API blocked by proxy. Action: check manually in Bing Webmaster Tools for queries ranking ≤10 on Google but missing on Bing.
+
+---
+
+## GEO / AI Visibility Recommendations
+
+AI search engines (ChatGPT, Perplexity, Google AI Overviews) heavily weight pages with FAQPage schema and clear, direct answer paragraphs.
+
+### Priority 1 — `/es/juego-de-palabras-multijugador` (95% of impressions)
+
+**Already has** `FaqAccordion` component. Verify FAQ questions exactly match user queries. Recommended additions/changes:
+
+| Q | A (≤40 words) |
+|---|---|
+| ¿Es gratis Scrabble online en español? | Sí, LexiClash es completamente gratis. Sin registro, sin descarga. Entra en lexiclash.live, crea una sala en 10 segundos y juega con amigos. |
+| ¿Cómo jugar Scrabble en línea en español? | Entra a lexiclash.live → pulsa "Crear sala" → comparte el enlace → ¡juega! Sin apps ni cuentas. Hasta 50 jugadores en tiempo real. |
+| ¿Necesito descargar algo para jugar Scrabble online? | No. LexiClash funciona en cualquier navegador — móvil, tablet o PC. Sin descargas ni instalaciones. |
+| ¿Cuántos jugadores pueden jugar Scrabble online a la vez? | Hasta 50 jugadores en la misma sala en tiempo real. |
+
+### Priority 2 — `/he/daily` (497 impressions on "המילה היומית", 0 schema)
+
+Add `FAQPage` JSON-LD to `/he/daily`:
+
+| Q | A |
+|---|---|
+| מה זו המילה היומית? | משחק מילים יומי בעברית — כל יום לוח חדש, 10 ניסיונות לנחש, אותו פאזל לכולם. חינמי ללא הרשמה. |
+| איך משחקים במילה היומית? | פותחים את lexiclash.live/he/daily, מסדרים את האותות למילה, ומשתפים את התוצאות. |
+| כמה פעמים ביום אפשר לשחק? | פעם אחת ביום — פאזל חדש בחצות. |
+
+### Priority 3 — `/en/play-boggle-online-free` (page has FAQs — verify schema is emitted)
+
+Check that the `faqs` array at line ~58 is rendered as `FAQPage` JSON-LD. Confirm in GSC Rich Results Test.
+
+---
+
+## Changes Applied Today (PR: `seo/daily-2026-07-21`)
+
+### Fix 1 — ES page title (highest impact)
+
+| | Value | Chars |
+|---|---|---|
+| **Old title** | `Scrabble Online en Español Gratis — Multijugador en Tiempo Real \| LexiClash` | 75 |
+| **New title** | `Scrabble Online en Español Gratis — Jugar Ya \| LexiClash` | 56 |
+| **Old description** | `Scrabble online en español gratis — sala en 10 seg, hasta 50 jugadores en tiempo real. Sin registro, sin descarga. ¡Empieza ahora →` | 131 |
+| **New description** | `Juega Scrabble online gratis en español — sin registro, sin descarga. Crea sala en 10 seg, invita amigos y compite en tiempo real. Hasta 50 jugadores.` | 150 |
+| **Expected CTR uplift** | ~+600 clicks/28 days if CTR moves from 0.67% → 2% | |
+
+### Fix 2 — SV page title
+
+| | Value | Chars |
+|---|---|---|
+| **Old title** | `Alfapet & Scrabble Online Svenska Gratis — Spela Nu \| LexiClash` | 63 |
+| **New title** | `Scrabble & Alfapet Online Svenska Gratis \| LexiClash` | 52 |
+| **Old description** | `Alfapet spel online på svenska — gratis, utan registrering. Spela Scrabble eller Alfapet med 2–50 spelare i realtid. Ingen app, ingen väntan. Starta nu →` | 153 |
+| **New description** | `Spela Scrabble & Alfapet online på svenska gratis — utan registrering. Skapa rum, bjud in vänner och tävla i realtid. Upp till 50 spelare. Starta nu →` | 150 |
+| **Note** | Query "scrabble svenska" is #1 term; moved it to front of title | |
+
+### Fix 3 — Boggle page description
+
+| | Value | Chars |
+|---|---|---|
+| **Old description** | `Play boggle online free — unlimited games, no download, no signup. Solo or real-time multiplayer with 2-20+ friends. 4x4, 5x5, 6x6 grids, daily challenges, boss battles. Free boggle game online 2026.` | 199 |
+| **New description** | `Play Boggle online free — no download, no signup. Solo vs bots or multiplayer with 2–20+ friends. Daily puzzles & boss battles. Free forever.` | 141 |
+| **Note** | Was 199 chars (truncated at 155); now within limit | |
+
+---
+
+## Today's Actions (3-bullet summary)
+
+- **SHIPPED:** Title fix on ES scrabble page (75→56 chars) — highest-leverage action, affects 95% of all impressions; expect measurable CTR lift within 1–2 weeks of Google re-crawl
+- **SHIPPED:** SV title front-loads "Scrabble" query (63→52 chars) + boggle description trimmed from 199→141 chars; all three changes in PR `seo/daily-2026-07-21`
+- **NEXT:** Add FAQPage JSON-LD to `/he/daily` (497 impressions on "המילה היומית", zero schema, zero rank-3+ clicks) and verify the existing boggle FAQ schema emits correctly in GSC Rich Results Test

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,12 +27,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Scrabble Online en Español Gratis — Multijugador en Tiempo Real | LexiClash',
-    description: 'Scrabble online en español gratis — sala en 10 seg, hasta 50 jugadores en tiempo real. Sin registro, sin descarga. ¡Empieza ahora →',
+    title: 'Scrabble Online en Español Gratis — Jugar Ya | LexiClash',
+    description: 'Juega Scrabble online gratis en español — sin registro, sin descarga. Crea sala en 10 seg, invita amigos y compite en tiempo real. Hasta 50 jugadores.',
     keywords: 'jugar scrabble en español online gratis, scrabble en español online gratis, scrabble online español, cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Scrabble Online en Español Gratis — Multijugador en Tiempo Real | LexiClash',
-      description: 'Scrabble online en español gratis — sala en 10 seg, hasta 50 jugadores en tiempo real. Sin registro, sin descarga.',
+      title: 'Scrabble Online en Español Gratis — Jugar Ya | LexiClash',
+      description: 'Juega Scrabble online gratis en español — sin registro, sin descarga. Crea sala en 10 seg, invita amigos y compite en tiempo real. Hasta 50 jugadores.',
       locale: 'es_ES',
       type: 'website',
       url: pageUrl,
@@ -47,8 +47,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Scrabble Online en Español Gratis — Sin Registro, Sin Descarga | LexiClash',
-      description: 'Scrabble online gratis en español — sin registro, sin descarga. Crea sala en 10 segundos, invita amigos y juega en tiempo real. Hasta 50 jugadores.',
+      title: 'Scrabble Online en Español Gratis — Jugar Ya | LexiClash',
+      description: 'Juega Scrabble online gratis en español — sin registro, sin descarga. Crea sala en 10 seg, invita amigos y compite en tiempo real. Hasta 50 jugadores.',
       images: [`${BASE_URL}/og-image-es-multiplayer.webp`],
     },
     alternates: {

--- a/fe-next/app/[locale]/play-boggle-online-free/page.tsx
+++ b/fe-next/app/[locale]/play-boggle-online-free/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   return {
     title: 'Play Boggle Online Free — No Download, No Signup | LexiClash',
-    description: 'Play boggle online free — unlimited games, no download, no signup. Solo or real-time multiplayer with 2-20+ friends. 4x4, 5x5, 6x6 grids, daily challenges, boss battles. Free boggle game online 2026.',
+    description: 'Play Boggle online free — no download, no signup. Solo vs bots or multiplayer with 2–20+ friends. Daily puzzles & boss battles. Free forever.',
     keywords: 'play boggle online free no download, boggle online free no download, play boggle online free, free boggle online no download, free online boggle no download, boggle game free no download, play boggle word shake free no download, play boggle online free with other players, boggle alternatives 2026, games like boggle online free, word game no download, boggle word shake free, word games online free, word making games, word hunt game online, free word game no download, word puzzle game free',
     openGraph: {
       title: 'Play Boggle Online Free - No Download Needed | LexiClash',

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -16,12 +16,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/sv/swedish-multiplayer-word-game`;
 
   return {
-    title: 'Alfapet & Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
-    description: 'Alfapet spel online på svenska — gratis, utan registrering. Spela Scrabble eller Alfapet med 2–50 spelare i realtid. Ingen app, ingen väntan. Starta nu →',
+    title: 'Scrabble & Alfapet Online Svenska Gratis | LexiClash',
+    description: 'Spela Scrabble & Alfapet online på svenska gratis — utan registrering. Skapa rum, bjud in vänner och tävla i realtid. Upp till 50 spelare. Starta nu →',
     keywords: 'alfapet spel online, ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
-      title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',
-      description: 'Spela Scrabble och Alfapet online på svenska gratis — utan registrering, upp till 50 spelare i realtid. Skapa rum och tävla direkt!',
+      title: 'Scrabble & Alfapet Online Svenska Gratis | LexiClash',
+      description: 'Spela Scrabble & Alfapet online på svenska gratis — utan registrering. Skapa rum, bjud in vänner och tävla i realtid. Upp till 50 spelare.',
       locale: 'sv_SE',
       type: 'website',
       url: pageUrl,
@@ -36,8 +36,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',
-      description: 'Spela Alfapet och Scrabble online på svenska i realtid. Skapa rum, bjud in med länk, tävla direkt. Gratis.',
+      title: 'Scrabble & Alfapet Online Svenska Gratis | LexiClash',
+      description: 'Spela Scrabble & Alfapet online på svenska gratis — utan registrering. Skapa rum, bjud in vänner och tävla i realtid.',
       images: [`${BASE_URL}/og-image-sv.webp`],
     },
     alternates: {


### PR DESCRIPTION
## Summary

Three pages with truncated/overlong meta tags causing severe CTR underperformance. The ES scrabble page alone drives **95% of all site impressions (45,244/28d)** at only 0.67% CTR — a title that was 75 chars (truncated in SERPs) is the primary culprit.

## Changes

### Fix 1 — `/es/juego-de-palabras-multijugador` (highest impact)

| | Before | After |
|---|---|---|
| **Title** | `Scrabble Online en Español Gratis — Multijugador en Tiempo Real \| LexiClash` (**75 chars**, truncated) | `Scrabble Online en Español Gratis — Jugar Ya \| LexiClash` (**56 chars** ✓) |
| **Description** | `Scrabble online en español gratis — sala en 10 seg, hasta 50 jugadores en tiempo real. Sin registro, sin descarga. ¡Empieza ahora →` (131 chars) | `Juega Scrabble online gratis en español — sin registro, sin descarga. Crea sala en 10 seg, invita amigos y compite en tiempo real. Hasta 50 jugadores.` (150 chars) |

Top query "scrabble online": 12,275 impressions, pos 4.9, **0.32% CTR vs 6% expected**. Estimated +600 clicks/28d if CTR reaches 2%.

### Fix 2 — `/sv/swedish-multiplayer-word-game`

| | Before | After |
|---|---|---|
| **Title** | `Alfapet & Scrabble Online Svenska Gratis — Spela Nu \| LexiClash` (**63 chars**, truncated) | `Scrabble & Alfapet Online Svenska Gratis \| LexiClash` (**52 chars** ✓) |
| **Description** | `Alfapet spel online på svenska — gratis, utan registrering. Spela Scrabble eller Alfapet med 2–50 spelare i realtid. Ingen app, ingen väntan. Starta nu →` (153 chars) | `Spela Scrabble & Alfapet online på svenska gratis — utan registrering. Skapa rum, bjud in vänner och tävla i realtid. Upp till 50 spelare. Starta nu →` (150 chars) |

"scrabble svenska": 1,181 impressions, pos 6.3, **0.17% CTR vs 3% expected**. "Scrabble" moved to front of title to match top query.

### Fix 3 — `/en/play-boggle-online-free`

| | Before | After |
|---|---|---|
| **Description** | `Play boggle online free — unlimited games, no download, no signup. Solo or real-time multiplayer with 2-20+ friends. 4x4, 5x5, 6x6 grids, daily challenges, boss battles. Free boggle game online 2026.` (**199 chars**, 44 over limit) | `Play Boggle online free — no download, no signup. Solo vs bots or multiplayer with 2–20+ friends. Daily puzzles & boss battles. Free forever.` (**141 chars** ✓) |

## Expected CTR Uplift

| Page | Impressions/28d | Current CTR | Conservative target | Extra clicks/28d |
|---|---|---|---|---|
| ES scrabble | 45,244 | 0.67% | 2.0% | +600 |
| SV word game | 2,597 | 1.04% | 2.0% | +25 |
| Boggle | 2,508 | 1.75% | 2.5% | +19 |

Full analysis: `docs/seo-daily/2026-07-21.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbVMcvPdekVpsxoErKi8Us)_