### PR TITLE
SEO: daily meta tag improvements (2026-07-29)

### DIFF
--- a/docs/seo-daily/2026-07-29.md
+++ b/docs/seo-daily/2026-07-29.md
@@ -1,0 +1,139 @@
+# SEO Daily Report — 2026-07-29
+
+## Headline Metrics
+
+### Google (28-day window: 2026-06-30 → 2026-07-27)
+
+| Metric | 28d Total | Last 7d | Prior 7d | Delta |
+|---|---|---|---|---|
+| Clicks | 357 | 93 | 129 | **-27.9%** |
+| Impressions | 50,718 | 12,243 | 13,987 | **-12.5%** |
+| CTR | 0.70% | 0.76% | 0.92% | -0.16pp |
+| Avg Position | 6.6 | — | — | — |
+
+> **Warning:** Clicks are down 28% week-over-week. Impressions down 12%. Site-wide trend is negative — investigate whether this tracks a Google algo update or content-freshness issue.
+
+### Bing
+
+Bing Webmaster API blocked by environment proxy policy (403). Bing data not available this run.
+
+---
+
+## Top 10 CTR Opportunities (Google)
+
+Queries with ≥30 impressions where actual CTR is ≥30% below position-band expected CTR.
+
+| # | Query | Page | Pos | Imps | CTR | Exp CTR | Gap | Fix |
+|---|---|---|---|---|---|---|---|---|
+| 1 | scrabble online | /es/juego-de-palabras-multijugador | 4.9 | 12,051 | 0.3% | 6% | 96% | Shorten title (77→62 chars), it truncates in SERP |
+| 2 | scrabble online español | /es/juego-de-palabras-multijugador | 5.0 | 3,419 | 0.6% | 6% | 89% | Same page — title fix benefits all scrabble queries |
+| 3 | scrabble en español | /es/juego-de-palabras-multijugador | 6.2 | 2,999 | 0.4% | 4% | 90% | Same page title fix |
+| 4 | scrabble en linea | /es/juego-de-palabras-multijugador | 5.9 | 2,352 | 0.5% | 4% | 87% | Same page title fix |
+| 5 | scrabble online gratis | /es/juego-de-palabras-multijugador | 6.9 | 2,215 | 0.0% | 3% | 100% | Same — also add "gratis" earlier in desc |
+| 6 | scrabble en español online | /es/juego-de-palabras-multijugador | 5.8 | 1,669 | 0.2% | 4% | 96% | Same page |
+| 7 | scrabble (en español) - juega gratis en línea | /es/juego-de-palabras-multijugador | 4.7 | 1,580 | 0.4% | 6% | 94% | Query = Scrabble.com's own brand name — structural brand-vs-clone issue |
+| 8 | scrabble español | /es/juego-de-palabras-multijugador | 5.8 | 1,438 | 0.1% | 4% | 97% | Same page |
+| 9 | scrabble juego online | /es/juego-de-palabras-multijugador | 5.0 | 1,211 | 0.3% | 6% | 94% | Same page |
+| 10 | scrabble svenska | /sv/swedish-multiplayer-word-game | 6.1 | 1,162 | 0.3% | 4% | 90% | Tighten desc — lead with "Alfapet online" |
+
+**Root cause pattern for rows 1–9:** All land on the same Spanish page. The title is 77 chars — Google truncates it, severing the `| LexiClash` brand. Fixing the title to ≤60 chars is a single edit that improves all 9 rows simultaneously.
+
+---
+
+## Top 10 Rank-Up Opportunities (pos 8–20, ≥50 impressions)
+
+| # | Query | Page | Pos | Imps | Clicks | Suggested Action |
+|---|---|---|---|---|---|---|
+| 1 | המילה היומית (Hebrew daily word) | /he/daily | 8.5 | 299 | 0 | Add FAQPage JSON-LD + static H1 (page is client-only, no schema) |
+| 2 | מילת היום (Hebrew word of day) | /he/daily | 9.9 | 243 | 0 | Same as above |
+| 3 | boggle online | /en/play-boggle-online-free | 17.1 | 224 | — | Add more internal links; page ranks for "play boggle online free" (pos 9.9) but not head term |
+| 4 | lexi game | /en | 8.7 | 196 | 0 | Brand query — add "LexiClash (Lexi Game)" to homepage title/desc |
+| 5 | jugar scrabble | /es/juego-de-palabras-multijugador | 8.2 | 134 | 3 | Covered by title fix above |
+| 6 | boggle game online | /en/play-boggle-online-free | 9.4 | 132 | 1 | Tighten desc (currently 202 chars, truncated) |
+| 7 | ordhjulet | /sv/daily-word-wheel | 9.2 | 126 | 0 | Add FAQPage schema; rising +159% week-over-week |
+| 8 | word games like boggle | /en/blog/best-boggle-alternatives-2026 | 9.3 | 125 | 0 | Add FAQ answer block targeting this query phrase |
+| 9 | games like boggle | /en/blog/best-boggle-alternatives-2026 | 8.6 | 115 | 0 | Same blog post — add explicit H2 "Games Like Boggle" |
+| 10 | online scrabble | /es/juego-de-palabras-multijugador | 8.2 | 73 | 0 | Covered by Spanish page fixes |
+
+---
+
+## Bing Parity Gaps
+
+Bing API unavailable (proxy blocked). Skipping this section.
+
+---
+
+## Rising / Falling Queries (7d vs prior 7d)
+
+### Rising (>30% impression increase)
+
+| Query | Prior 7d imps | Last 7d imps | Delta | Clicks |
+|---|---|---|---|---|
+| ordhjulet (Swedish word wheel) | 22 | 57 | +159% | 0 |
+| סקריבל בעברית (Hebrew Scrabble) | 74 | 133 | +80% | 2 |
+| scrabble en español gratis | 31 | 54 | +74% | 0 |
+| daily word wheel | 85 | 142 | +67% | 4 |
+| scrabble online en español | 66 | 108 | +64% | 1 |
+| lexi game | 28 | 43 | +54% | 0 |
+| jugar a scrabble | 37 | 56 | +51% | 0 |
+| free boggle online | 83 | 122 | +47% | 1 |
+
+**Action:** "ordhjulet" and "daily word wheel" are both surging. The Swedish daily word wheel page `/sv/daily-word-wheel` at pos 9.2 could hit page 1 with FAQPage schema.
+
+### Falling (>30% impression drop)
+
+| Query | Prior 7d imps | Last 7d imps | Delta |
+|---|---|---|---|
+| juegos de vocabulario en ingles | 28 | 5 | -82% |
+| free boggle game | 43 | 9 | -79% |
+| boggle free online | 60 | 13 | -78% |
+| אנגרמות (Hebrew anagrams) | 52 | 12 | -77% |
+| boggle game free online | 25 | 6 | -76% |
+| jugar a scrabble online | 29 | 7 | -76% |
+| scrable on line | 40 | 16 | -60% |
+| jugar scrabble online gratis sin registrarse en español | 74 | 32 | -57% |
+
+**Note:** English boggle queries are dropping sharply. "boggle online" is already at pos 17 — the site may have slipped further. Priority to fix the English boggle page description (fix #2 below).
+
+---
+
+## GEO / AI Visibility Recommendations
+
+These pages handle question-style queries but lack FAQ schema:
+
+### 1. `/he/daily` — Hebrew daily word (HIGH PRIORITY)
+- **Queries:** "המילה היומית" (299 imps, pos 8.5, 0 clicks), "מילת היום" (243 imps, pos 9.9, 0 clicks)
+- **Problem:** Page is fully client-side rendered (DailyRedirect component). Zero static H1, zero JSON-LD schema. Google cannot extract structured content → no rich results, no AI answer box.
+- **Fix:** Add FAQPage JSON-LD in `generateMetadata` / server component. Draft schema:
+```json
+{
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type": "Question", "name": "מהי המילה היומית?",
+     "acceptedAnswer": {"@type": "Answer", "text": "המילה היומית היא פאזל מילים יומי בעברית — ניחשו מילה בת 5 אותיות ב-10 ניסיונות. אותו לוח לכולם, חינם, ללא הרשמה."}},
+    {"@type": "Question", "name": "האם המילה היומית חינמית?",
+     "acceptedAnswer": {"@type": "Answer", "text": "כן, המילה היומית חינמית לחלוטין ואינה דורשת הרשמה."}},
+    {"@type": "Question", "name": "כמה ניסיונות יש לנחש את מילת היום?",
+     "acceptedAnswer": {"@type": "Answer", "text": "יש לכם 10 ניסיונות לנחש את מילת היום."}}
+  ]
+}
+```
+
+### 2. `/sv/daily-word-wheel` — Ordhjulet (MEDIUM PRIORITY)
+- **Queries:** "ordhjulet" surging +159% to 57 impressions at pos 9.2 (near page 1). Zero clicks.
+- **Fix:** Add FAQPage schema; draft Q&As:
+  - Q: Vad är ordhjulet? A: Ordhjulet är ett dagligt ordspel på svenska — hitta så många ord som möjligt i bokstavshjulet.
+  - Q: Är ordhjulet gratis? A: Ja, ordhjulet är helt gratis och kräver ingen registrering.
+
+### 3. `/en/blog/best-boggle-alternatives-2026` — FAQ gap
+- Ranks pos 9.3 for "word games like boggle" and pos 8.6 for "games like boggle" with 0 clicks.
+- The post already has FAQPage schema — but the FAQ answers don't directly address "games like boggle" as a phrase.
+- Add explicit H2: **"What Are the Best Games Like Boggle Online?"** with a direct answer paragraph.
+
+---
+
+## Today's Actions
+
+1. **Shorten Spanish page title** (`/es/juego-de-palabras-multijugador`): 77→62 chars so Google stops truncating it — single fix covering 9 queries with 25k+ impressions and 0–0.6% CTR.
+2. **Shorten English boggle meta description** (`/en/play-boggle-online-free`): 202→138 chars, remove keyword stuffing, add action CTA — fixes truncation on the page with the steepest impression decline (-79% for "boggle free online").
+3. **Tighten Swedish description** (`/sv/swedish-multiplayer-word-game`): lead with "Alfapet online" to match the #1 Swedish query at pos 3.6 — should move CTR from 1.4% toward the expected 8%.

--- a/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
+++ b/fe-next/app/[locale]/juego-de-palabras-multijugador/page.tsx
@@ -27,11 +27,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const pageUrl = `${BASE_URL}/es/juego-de-palabras-multijugador`;
 
   return {
-    title: 'Scrabble Online en Español Gratis — Multijugador en Tiempo Real | LexiClash',
+    title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
     description: 'Scrabble online en español gratis — sala en 10 seg, hasta 50 jugadores en tiempo real. Sin registro, sin descarga. ¡Empieza ahora →',
     keywords: 'jugar scrabble en español online gratis, scrabble en español online gratis, scrabble online español, cruzaletras online, apalabrados online gratis, scrabble en linea, scrabble en línea español, jugar scrabble online en español, alternativa a scrabble online español multijugador, juego como scrabble online en español gratis, alternativa scrabble multijugador online, scrabble online en español multijugador, jugar scrabble gratis multijugador, juegos de palabras online multijugador, juego de palabras multijugador, boggle online en español, juego de palabras online gratis, batalla de palabras tiempo real, juegos de letras online',
     openGraph: {
-      title: 'Scrabble Online en Español Gratis — Multijugador en Tiempo Real | LexiClash',
+      title: 'Scrabble Online en Español Gratis — Sin Registro | LexiClash',
       description: 'Scrabble online en español gratis — sala en 10 seg, hasta 50 jugadores en tiempo real. Sin registro, sin descarga.',
       locale: 'es_ES',
       type: 'website',

--- a/fe-next/app/[locale]/play-boggle-online-free/page.tsx
+++ b/fe-next/app/[locale]/play-boggle-online-free/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   return {
     title: 'Play Boggle Online Free — No Download, No Signup | LexiClash',
-    description: 'Play boggle online free — unlimited games, no download, no signup. Solo or real-time multiplayer with 2-20+ friends. 4x4, 5x5, 6x6 grids, daily challenges, boss battles. Free boggle game online 2026.',
+    description: 'Play boggle online free — no download, no signup. Solo or multiplayer with 2–50 players. 4×4 to 6×6 grids, daily challenges. Start now →',
     keywords: 'play boggle online free no download, boggle online free no download, play boggle online free, free boggle online no download, free online boggle no download, boggle game free no download, play boggle word shake free no download, play boggle online free with other players, boggle alternatives 2026, games like boggle online free, word game no download, boggle word shake free, word games online free, word making games, word hunt game online, free word game no download, word puzzle game free',
     openGraph: {
       title: 'Play Boggle Online Free - No Download Needed | LexiClash',

--- a/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
+++ b/fe-next/app/[locale]/swedish-multiplayer-word-game/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   return {
     title: 'Alfapet & Scrabble Online Svenska Gratis — Spela Nu | LexiClash',
-    description: 'Alfapet spel online på svenska — gratis, utan registrering. Spela Scrabble eller Alfapet med 2–50 spelare i realtid. Ingen app, ingen väntan. Starta nu →',
+    description: 'Alfapet online gratis på svenska — utan registrering, utan app. Scrabble eller Alfapet med 2–50 spelare i realtid. Starta ett rum på 10 sekunder →',
     keywords: 'alfapet spel online, ordspel online, multiplayer ordspel, ordspel svenska, wordfeud alternativ, boggle online svenska, scrabble online gratis, ordspel med vänner, ordspel i realtid, ordhjul, ordhjul online, daglig ordhjul',
     openGraph: {
       title: 'Alfapet & Scrabble Online Svenska Gratis | LexiClash',


### PR DESCRIPTION
## Summary

Three meta-only fixes targeting the top CTR-gap queries identified in today's GSC pull (28-day window: 2026-06-30 → 2026-07-27, 50,718 impressions / 357 clicks / 0.7% CTR).

---

## Changes

### 1. `/es/juego-de-palabras-multijugador` — Spanish Scrabble page

**Query context:** 9 scrabble-es queries with 25k+ combined impressions at positions 4–7, CTR 0–0.6% (expected 3–6%). All land on this page.

**Root cause:** Title was 77 chars — Google truncates at ~60, severing the `| LexiClash` brand and cutting off the CTA.

| | Text | Chars |
|---|---|---|
| Old title | `Scrabble Online en Español Gratis — Multijugador en Tiempo Real \| LexiClash` | 77 |
| **New title** | `Scrabble Online en Español Gratis — Sin Registro \| LexiClash` | **62** |

Description unchanged (133 chars, within limit, good CTA).

**Expected uplift:** Fixing truncation on 12k-impression "scrabble online" query alone. Even moving from 0.3% → 1% CTR = +84 clicks/month from that single query.

---

### 2. `/en/play-boggle-online-free` — English Boggle page

**Query context:** "boggle online" at pos 17.1 (224 imps), "boggle game online" at pos 9.4 (132 imps, 0.8% CTR). English boggle queries are down 77–79% week-over-week.

**Root cause:** Description was 202 chars — far over the 155-char limit, keyword-stuffed, truncated heavily in SERP.

| | Text | Chars |
|---|---|---|
| Old desc | `Play boggle online free — unlimited games, no download, no signup. Solo or real-time multiplayer with 2-20+ friends. 4x4, 5x5, 6x6 grids, daily challenges, boss battles. Free boggle game online 2026.` | 202 |
| **New desc** | `Play boggle online free — no download, no signup. Solo or multiplayer with 2–50 players. 4×4 to 6×6 grids, daily challenges. Start now →` | **138** |

Title unchanged (59 chars, within limit).

**Expected uplift:** Clean snippet with action CTA should improve CTR from 0% on the zero-click boggle queries.

---

### 3. `/sv/swedish-multiplayer-word-game` — Swedish Alfapet/Scrabble page

**Query context:** "alfapet online" at pos 3.6, 368 impressions, 1.4% CTR (expected 8% — gap 83%). "scrabble svenska" at pos 6.1, 1,162 impressions, 0.3% CTR.

**Root cause:** Description opened with "Alfapet spel online" — close but not an exact match to the query "alfapet online". Reworded to lead with the exact phrase.

| | Text | Chars |
|---|---|---|
| Old desc | `Alfapet spel online på svenska — gratis, utan registrering. Spela Scrabble eller Alfapet med 2–50 spelare i realtid. Ingen app, ingen väntan. Starta nu →` | 153 |
| **New desc** | `Alfapet online gratis på svenska — utan registrering, utan app. Scrabble eller Alfapet med 2–50 spelare i realtid. Starta ett rum på 10 sekunder →` | **147** |

Title unchanged (64 chars).

**Expected uplift:** Position 3.6 should yield ~6–8% CTR if the snippet matches the query. Currently 1.4% → targeting 4%+ = ~12 additional clicks/month.

---

## Report

Full daily report with all 10 CTR opportunities, 10 rank-up opportunities, rising/falling trends, and GEO/AI recommendations:
`docs/seo-daily/2026-07-29.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_018VTbi6tmWxvjVLJcKx3QXa)_